### PR TITLE
OpenCL 2.2 graphics fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif(MSVC90)
 option(D3D10_IS_SUPPORTED "Run DirectX 10 interop tests" OFF)
 option(D3D11_IS_SUPPORTED "Run DirectX 11 interop tests" OFF)
 option(GL_IS_SUPPORTED "Run OpenGL interop tests" OFF)
+option(GLES_IS_SUPPORTED "Run OpenGL ES interop tests" OFF)
 
 
 #-----------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,9 @@ endif(MSVC90)
 #-----------------------------------------------------------
 # Default Configurable Test Set
 #-----------------------------------------------------------
-set(D3D10_IS_SUPPORTED)
-set(D3D11_IS_SUPPORTED)
-set(GL_IS_SUPPORTED)
+option(D3D10_IS_SUPPORTED "Run DirectX 10 interop tests" OFF)
+option(D3D11_IS_SUPPORTED "Run DirectX 11 interop tests" OFF)
+option(GL_IS_SUPPORTED "Run OpenGL interop tests" OFF)
 
 
 #-----------------------------------------------------------

--- a/test_conformance/gl/CMakeLists.txt
+++ b/test_conformance/gl/CMakeLists.txt
@@ -10,8 +10,6 @@ set (GL_SOURCES
     test_images_2D.cpp
     test_images_3D.cpp
     test_renderbuffer.cpp
-    test_images_2D_info.cpp
-    test_images_3D_info.cpp
     test_renderbuffer_info.cpp
     test_fence_sync.cpp
     helpers.cpp
@@ -26,6 +24,7 @@ set (GL_SOURCES
     ../../test_common/harness/msvc9.c
     ../../test_common/harness/parseParameters.cpp
     ../../test_common/harness/crc32.c
+    ../../test_common/harness/imageHelpers.cpp
     )
 
 if (WIN32)
@@ -59,6 +58,12 @@ add_executable(conformance_test_gl
 set_source_files_properties(
         ${GL_SOURCES}
         PROPERTIES LANGUAGE CXX)
+
+# Add the current folder to the include path, so that
+# test_common/gl/setup_x11.cpp can find testBase.h which is located in this
+# folder.
+target_include_directories(conformance_test_gl
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 TARGET_LINK_LIBRARIES(conformance_test_gl
         ${CLConform_LIBRARIES})

--- a/test_conformance/gl/CMakeLists.txt
+++ b/test_conformance/gl/CMakeLists.txt
@@ -7,8 +7,17 @@ endif(WIN32)
 set (GL_SOURCES
     main.cpp
     test_buffers.cpp
+    test_image_methods.cpp
+    test_images_1D.cpp
+    test_images_1Darray.cpp
     test_images_2D.cpp
+    test_images_2Darray.cpp
     test_images_3D.cpp
+    test_images_depth.cpp
+    test_images_getinfo_common.cpp
+    test_images_multisample.cpp
+    test_images_read_common.cpp
+    test_images_write_common.cpp
     test_renderbuffer.cpp
     test_renderbuffer_info.cpp
     test_fence_sync.cpp

--- a/test_conformance/gl/main.cpp
+++ b/test_conformance/gl/main.cpp
@@ -99,7 +99,7 @@ TEST_FN_REDIRECTOR( renderbuffer_read )
 TEST_FN_REDIRECTOR( renderbuffer_write )
 TEST_FN_REDIRECTOR( renderbuffer_getinfo )
 
-TEST_FN_REDIRECTOR( test_fence_sync )
+TEST_FN_REDIRECTOR( fence_sync )
 
 test_definition test_list[] = {
     TEST_FN_REDIRECT( buffers ),
@@ -132,6 +132,22 @@ test_definition test_list[] = {
     TEST_FN_REDIRECT( renderbuffer_read ),
     TEST_FN_REDIRECT( renderbuffer_write ),
     TEST_FN_REDIRECT( renderbuffer_getinfo )
+};
+
+test_definition test_list32[] = {
+    TEST_FN_REDIRECT( images_read_texturebuffer ),
+    TEST_FN_REDIRECT( images_write_texturebuffer ),
+    TEST_FN_REDIRECT( images_texturebuffer_getinfo ),
+
+    TEST_FN_REDIRECT( fence_sync ),
+    TEST_FN_REDIRECT( images_read_2D_depth ),
+    TEST_FN_REDIRECT( images_write_2D_depth ),
+    TEST_FN_REDIRECT( images_read_2Darray_depth ),
+    TEST_FN_REDIRECT( images_write_2Darray_depth ),
+    TEST_FN_REDIRECT( images_read_2D_multisample ),
+    TEST_FN_REDIRECT( images_read_2Darray_multisample ),
+    TEST_FN_REDIRECT( image_methods_depth ),
+    TEST_FN_REDIRECT( image_methods_multisample )
 };
 
 const int test_num = ARRAY_SIZE( test_list );


### PR DESCRIPTION
* Fixes compilation when setting GL_IS_SUPPORTED:
    * due to CMakeLists.txt referencing non-existent files and missing an include folder;
    * due to gl/main.cpp referencing an undefined variable.
* Add OpenGL tests that are present but were not referenced by CMakeLists.txt;
* Expose the graphics interop test toggles via CMake, allowing the user to enable/disable them without modifying CMakeLists.txt;
* Add such a toggle for OpenGL ES tests.
