### PR TITLE
 Add basic Travis config for Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: cpp
+
+os:
+  - linux
+
+script:
+  - export TOP=$(pwd)
+  - git clone https://github.com/KhronosGroup/OpenCL-Headers.git
+  - cd OpenCL-Headers
+  - ln -s CL OpenCL # For OSX builds
+  - cd ..
+  - git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+  - cd ${TOP}/OpenCL-ICD-Loader
+  - mkdir build
+  - cd build
+  - cmake -DOPENCL_INCLUDE_DIRS=${TOP}/OpenCL-Headers/ ..
+  - make
+  - cd ${TOP}
+  - ls -l
+  - mkdir build
+  - cd build
+  - cmake -DCL_INCLUDE_DIR=${TOP}/OpenCL-Headers
+          -DCL_LIB_DIR=${TOP}/OpenCL-ICD-Loader/build/lib
+          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=./bin
+          -DOPENCL_LIBRARIES="-lOpenCL -lpthread"
+          ..
+  - make -j2

--- a/CMakeVendor.txt
+++ b/CMakeVendor.txt
@@ -4,11 +4,6 @@
 set(CONFORMANCE_PREFIX "test_conformance_" )
 set(CONFORMNACE_SUFFIX "" )
 
-# Include cmake files to build driver
-# to build driver as a dependency of tests
-# in this example environment variable $OPENCL_DRIVER points to driver base
-# Ex  include($ENV{OPENCL_DRIVER}/driver.cmake)
-
 # We intentionally hardcode "_win32" to ensure backwards compatibility (to avoid breaking HAAVE)
 if(ANDROID)
    if(ARM64_V8A)
@@ -17,5 +12,3 @@ if(ANDROID)
        set(ARCH "32")
    endif(ARM64_V8A)
 endif (ANDROID)
-
-set (CL_INCLUDE_DIR "$ENV{OPENCL_DRIVER}/include/public/")


### PR DESCRIPTION
 Add basic Travis config for Linux builds
    
Performs a single build on Linux using the unified
headers and linking against the ICD.
    
Unified headers are broken for 2.x on OSX (see
https://github.com/KhronosGroup/OpenCL-Headers/issues/31).
Adding OSX builds should hopefully be a one-line change
once this is fixed.