### PR TITLE
cl12: Incorrect value passed to clEnqueueMapImage in basic/hostptr

### DIFF
--- a/test_conformance/basic/test_hostptr.c
+++ b/test_conformance/basic/test_hostptr.c
@@ -228,7 +228,7 @@ test_hostptr(cl_device_id device, cl_context context, cl_command_queue queue, in
         log_info("Mapping the CL_MEM_USE_HOST_PTR image with clEnqueueMapImage...\n");
         size_t row_pitch;
         lock_buffer = clEnqueueMapImage(queue, streams[5], CL_TRUE,
-                                        0, origin, region,
+                                        CL_MAP_READ, origin, region,
                                         &row_pitch, NULL,
                                         0, NULL, NULL, &err);
         test_error(err, "clEnqueueMapImage failed");


### PR DESCRIPTION
0 is passed in for map_flags but valid values are CL_MAP_READ, CL_MAP_WRITE and CL_MAP_WRITE_INVALIDATE_REGION.

Fix is to use CL_MAP_READ in this case.