### PR TITLE
cl21: Fix Issue 37 - Test compiler - cl_khr_spirv_no_integer_wrap_decoration

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -57,6 +57,7 @@ const char *known_extensions[] = {
     "cl_khr_priority_hints",
     "cl_khr_create_command_queue",
     "cl_khr_il_program",
+    "cl_khr_spirv_no_integer_wrap_decoration",
 };
 
 size_t num_known_extensions = sizeof(known_extensions)/sizeof(char*);


### PR DESCRIPTION
Fix issue https://github.com/KhronosGroup/OpenCL-CTS/issues/37
