### PR TITLE
cl21: Fix Issue #98 - Fix verifyOutputBuffer return value in printf

### DIFF
--- a/test_conformance/printf/util_printf.c
+++ b/test_conformance/printf/util_printf.c
@@ -855,14 +855,14 @@ size_t verifyOutputBuffer(char *analysisBuffer,testCase* pTestCase,size_t testId
 
         char* eCorrectBuffer = strstr((char*)pTestCase->_correctBuffer[testId],correctExp);
         if(eCorrectBuffer == NULL)
-            return false;
+            return 1;
 
         eCorrectBuffer+=2;
         exp += 2;
 
         //Exponent always contains at least two digits
         if(strlen(exp) < 2)
-            return false;
+            return 1;
         //Scip leading zeros in the exponent
         while(*exp == '0')
             ++exp;


### PR DESCRIPTION
This patch solves issue #98 by changing return value from false to 1 in function verifyOutputBuffer to indicate mismatches.