### PR TITLE
cl21: Khronos Bug 15728 SPIR 1.2 tests fail when some cases are skipped

### DIFF
--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -346,9 +346,11 @@ bool test_suite(cl_device_id device, cl_uint size_t_width, const char *folder,
     {
         std::cout << "Failed tests:" << std::endl;
         std::for_each(ErrList.begin(), ErrList.end(), printError);
+        std::cout << std::endl;
+        return false;
     }
     std::cout << std::endl;
-    return tests_passed == number_of_tests;
+    return true;
 }
 
 static std::string getTestFolder(const std::string& TS)


### PR DESCRIPTION
Fix issue https://github.com/KhronosGroup/OpenCL-CTS/issues/115