### PR TITLE
cl22: Fix resource leak in SVM test

### DIFF
--- a/test_conformance/SVM/test_allocate_shared_buffer.cpp
+++ b/test_conformance/SVM/test_allocate_shared_buffer.cpp
@@ -97,6 +97,10 @@ int test_allocate_shared_buffer(cl_device_id deviceID, cl_context context2, cl_c
           log_error("SVM pointer returned by clEnqueueMapBuffer doesn't match pointer returned by clSVMalloc");
           return -1;
         }
+        err = clEnqueueUnmapMemObject(queues[0], buf, pBufData2, 0, NULL, NULL);
+        test_error(err, "clEnqueueUnmapMemObject failed");
+        err = clFinish(queues[0]);
+        test_error(err, "clFinish failed");
       }
     }
 


### PR DESCRIPTION
The buffer was never unmapped.

Change-Id: If8be7f9f08ae7c26a537039f2bbeeb674cc30059
Signed-off-by: Georgios Pinitas <georgios.pinitas@arm.com>
fix issue: https://github.com/KhronosGroup/OpenCL-CTS/issues/126
