### PR TITLE
cl12: Reuse math_brute_force ulp threshold in spir test

### DIFF
--- a/test_conformance/math_brute_force/FunctionList.c
+++ b/test_conformance/math_brute_force/FunctionList.c
@@ -22,6 +22,34 @@
 
 #define STRINGIFY( _s)                  #_s
 
+// Only use ulps information in spir test
+#ifdef FUNCTION_LIST_ULPS_ONLY
+
+#define ENTRY(      _name, _ulp, _embedded_ulp, _rmode, _type )                 { STRINGIFY(_name), STRINGIFY(_name),                 {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, _rmode, _type }
+#define HALF_ENTRY( _name, _ulp, _embedded_ulp, _rmode, _type )                 { "half_" STRINGIFY(_name), "half_" STRINGIFY(_name), {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, _rmode, _type }
+#define OPERATOR_ENTRY(_name, _operator, _ulp, _embedded_ulp, _rmode, _type)    { STRINGIFY(_name), _operator,                        {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, _rmode, _type }
+#define unaryF                NULL
+#define i_unaryF              NULL
+#define unaryF_u              NULL
+#define macro_unaryF          NULL
+#define binaryF               NULL
+#define binaryF_nextafter     NULL
+#define binaryOperatorF       NULL
+#define binaryF_i             NULL
+#define macro_binaryF         NULL
+#define ternaryF              NULL
+#define unaryF_two_results    NULL
+#define unaryF_two_results_i  NULL
+#define binaryF_two_results_i NULL
+#define mad_function          NULL
+
+#define reference_sqrt        NULL
+#define reference_sqrtl       NULL
+#define reference_divide      NULL
+#define reference_dividel     NULL
+
+#else // FUNCTION_LIST_ULPS_ONLY
+
 #define ENTRY( _name, _ulp, _embedded_ulp, _rmode, _type )                           { STRINGIFY(_name), STRINGIFY(_name),                 {reference_##_name}, {reference_##_name##l}, _ulp, _ulp, _embedded_ulp, _rmode, _type }
 #define HALF_ENTRY( _name, _ulp, _embedded_ulp, _rmode, _type )                        { "half_" STRINGIFY(_name), "half_" STRINGIFY(_name), {reference_##_name}, {NULL},                    _ulp, _ulp, _embedded_ulp, _rmode, _type }
 #define OPERATOR_ENTRY(_name, _operator, _ulp, _embedded_ulp, _rmode, _type)        { STRINGIFY(_name), _operator,                        {reference_##_name}, {reference_##_name##l}, _ulp, _ulp, _embedded_ulp, _rmode, _type }
@@ -62,6 +90,7 @@ extern const vtbl _mad_tbl;             // float mad( float, float, float )
 #define binaryF_two_results_i  &_binary_two_results_i
 #define mad_function        &_mad_tbl
 
+#endif // FUNCTION_LIST_ULPS_ONLY
 
 const Func  functionList[] = {
                                     ENTRY( acos,                  4.0f,         4.0f,         FTZ_OFF,     unaryF),

--- a/test_conformance/math_brute_force/FunctionList.h
+++ b/test_conformance/math_brute_force/FunctionList.h
@@ -30,6 +30,10 @@
 #include "../../test_common/harness/compat.h"
 #include "../../test_common/harness/mt19937.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef union fptr
 {
     void    *p;
@@ -82,7 +86,7 @@ typedef struct Func
     float           double_ulps;
     float           float_embedded_ulps;
     int             ftz;
-    const vtbl      *vtbl;
+    const vtbl      *vtbl_ptr;
 }Func;
 
 
@@ -90,6 +94,9 @@ extern const Func  functionList[];
 
 extern const size_t functionListCount;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/test_conformance/math_brute_force/main.c
+++ b/test_conformance/math_brute_force/main.c
@@ -232,7 +232,7 @@ int main (int argc, const char * argv[])
             if( gTestFloat )
             {
                 gTestCount++;
-                if( f->vtbl->TestFunc( f, d )  )
+                if( f->vtbl_ptr->TestFunc( f, d )  )
                 {
                     gFailCount++;
                     error++;
@@ -243,12 +243,12 @@ int main (int argc, const char * argv[])
 
 //            while(1)
             {
-                if( gHasDouble && NULL != f->vtbl->DoubleTestFunc && NULL != f->dfunc.p )
+                if( gHasDouble && NULL != f->vtbl_ptr->DoubleTestFunc && NULL != f->dfunc.p )
                 {
                     gTestCount++;
                     if( gTestFloat )
                         vlog( "    " );
-                    if( f->vtbl->DoubleTestFunc( f, d )  )
+                    if( f->vtbl_ptr->DoubleTestFunc( f, d )  )
                     {
                         gFailCount++;
                         error++;
@@ -259,7 +259,7 @@ int main (int argc, const char * argv[])
             }
 #if defined( __APPLE__ )
             {
-                if( gHasBasicDouble && NULL != f->vtbl->DoubleTestFunc && NULL != f->dfunc.p)
+                if( gHasBasicDouble && NULL != f->vtbl_ptr->DoubleTestFunc && NULL != f->dfunc.p)
                 {
                     int isBasicTest = 0;
                     for( j = 0; j < gNumBasicDoubleFuncs; j++ ) {
@@ -272,7 +272,7 @@ int main (int argc, const char * argv[])
                         gTestCount++;
                         if( gTestFloat )
                             vlog( "    " );
-                        if( f->vtbl->DoubleTestFunc( f, d )  )
+                        if( f->vtbl_ptr->DoubleTestFunc( f, d )  )
                         {
                             gFailCount++;
                             error++;

--- a/test_conformance/spir/CMakeLists.txt
+++ b/test_conformance/spir/CMakeLists.txt
@@ -3,6 +3,9 @@ function (install_spir_artifacts suite_name)
           COMPONENT OpenCLCTS)
 endfunction()
 
+# Import function list from math_brute_force
+add_definitions(-DFUNCTION_LIST_ULPS_ONLY)
+
 add_executable(
     conformance_test_spir
     main.cpp
@@ -10,6 +13,7 @@ add_executable(
     run_build_test.cpp
     run_services.cpp
     kernelargs.cpp
+    ../math_brute_force/FunctionList.c
     ../../test_common/harness/errorHelpers.c
     ../../test_common/harness/kernelHelpers.c
     ../../test_common/harness/mt19937.c

--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -746,7 +746,7 @@ void run_kernel( cl_kernel kernel, cl_command_queue queue, WorkSizeInfo &ws, Tes
 /**
  Compare two test results
  */
-bool compare_results( const TestResult& lhs, const TestResult& rhs )
+bool compare_results( const TestResult& lhs, const TestResult& rhs, float ulps )
 {
     if( lhs.kernelArgs().getArgCount() != rhs.kernelArgs().getArgCount() )
     {
@@ -756,7 +756,7 @@ bool compare_results( const TestResult& lhs, const TestResult& rhs )
 
     for( size_t i = 0 ; i < lhs.kernelArgs().getArgCount(); ++i )
     {
-        if( ! lhs.kernelArgs().getArg(i)->compare( *rhs.kernelArgs().getArg(i)) )
+        if( ! lhs.kernelArgs().getArg(i)->compare( *rhs.kernelArgs().getArg(i), ulps ) )
         {
             log_error("the kernel parameter (%d) is different between SPIR and CL version of the kernel\n", i);
             return false;

--- a/test_conformance/spir/run_services.h
+++ b/test_conformance/spir/run_services.h
@@ -217,6 +217,6 @@ void generate_kernel_data(cl_context context, cl_kernel kernel,
                           WorkSizeInfo &ws, TestResult& res);
 
 void run_kernel(cl_kernel kernel, cl_command_queue queue, WorkSizeInfo &ws, TestResult& result);
-bool compare_results(const TestResult& lhs, const TestResult& rhs);
+bool compare_results(const TestResult& lhs, const TestResult& rhs, float ulps);
 
 #endif


### PR DESCRIPTION
Spir test compares floating-point kernel results bit-by-bit with
correct results. However, for math_brute_force kernels, specification
does not ask for SPIR and OpenCL C path to match bit-to-bit. This patch
reuses ulps threshold from math_brute_force folder for math_brute_force
kernels in spir test. See issue #135 