### PR TITLE
cl22: Reuse math_brute_force ulp threshold in spir test

### DIFF
--- a/test_conformance/math_brute_force/FunctionList.c
+++ b/test_conformance/math_brute_force/FunctionList.c
@@ -24,6 +24,36 @@
 
 #define STRINGIFY( _s)                  #_s
 
+// Only use ulps information in spir test
+#ifdef FUNCTION_LIST_ULPS_ONLY
+
+#define ENTRY(      _name, _ulp, _embedded_ulp, _rmode, _type )                 { STRINGIFY(_name), STRINGIFY(_name),                 {NULL}, {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, INFINITY,     _rmode, RELAXED_OFF, _type }
+#define ENTRY_EXT(  _name, _ulp, _embedded_ulp, _relaxed_ulp, _rmode, _type )   { STRINGIFY(_name), STRINGIFY(_name),                 {NULL}, {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, _relaxed_ulp, _rmode, RELAXED_ON,  _type }
+#define HALF_ENTRY( _name, _ulp, _embedded_ulp, _rmode, _type )                 { "half_" STRINGIFY(_name), "half_" STRINGIFY(_name), {NULL}, {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, INFINITY,     _rmode, RELAXED_OFF, _type }
+#define OPERATOR_ENTRY(_name, _operator, _ulp, _embedded_ulp, _rmode, _type)    { STRINGIFY(_name), _operator,                        {NULL}, {NULL}, {NULL}, _ulp, _ulp, _embedded_ulp, INFINITY,     _rmode, RELAXED_OFF, _type }
+#define unaryF                NULL
+#define i_unaryF              NULL
+#define unaryF_u              NULL
+#define macro_unaryF          NULL
+#define binaryF               NULL
+#define binaryF_nextafter     NULL
+#define binaryOperatorF       NULL
+#define binaryF_i             NULL
+#define macro_binaryF         NULL
+#define ternaryF              NULL
+#define unaryF_two_results    NULL
+#define unaryF_two_results_i  NULL
+#define binaryF_two_results_i NULL
+#define mad_function          NULL
+
+#define reference_sqrt        NULL
+#define reference_sqrtl       NULL
+#define reference_divide      NULL
+#define reference_dividel     NULL
+#define reference_relaxed_divide NULL
+
+#else // FUNCTION_LIST_ULPS_ONLY
+
 #define ENTRY(      _name, _ulp, _embedded_ulp, _rmode, _type )                 { STRINGIFY(_name), STRINGIFY(_name),                 {(void*)reference_##_name}, {(void*)reference_##_name##l}, {(void*)reference_##_name},           _ulp, _ulp, _embedded_ulp, INFINITY,     _rmode, RELAXED_OFF, _type }
 #define ENTRY_EXT(  _name, _ulp, _embedded_ulp, _relaxed_ulp, _rmode, _type )   { STRINGIFY(_name), STRINGIFY(_name),                 {(void*)reference_##_name}, {(void*)reference_##_name##l}, {(void*)reference_##relaxed_##_name}, _ulp, _ulp, _embedded_ulp, _relaxed_ulp, _rmode, RELAXED_ON,  _type }
 #define HALF_ENTRY( _name, _ulp, _embedded_ulp, _rmode, _type )                 { "half_" STRINGIFY(_name), "half_" STRINGIFY(_name), {(void*)reference_##_name}, {NULL}, {NULL},                   _ulp, _ulp, _embedded_ulp, INFINITY, _rmode, RELAXED_OFF, _type }
@@ -65,6 +95,7 @@ extern const vtbl _mad_tbl;             // float mad( float, float, float )
 #define binaryF_two_results_i  &_binary_two_results_i
 #define mad_function        &_mad_tbl
 
+#endif // FUNCTION_LIST_ULPS_ONLY
 
 const Func  functionList[] = {
                                     ENTRY( acos,                  4.0f,         4.0f,         FTZ_OFF,     unaryF),

--- a/test_conformance/math_brute_force/FunctionList.h
+++ b/test_conformance/math_brute_force/FunctionList.h
@@ -30,6 +30,10 @@
 
 #include "../../test_common/harness/mt19937.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef union fptr
 {
     void    *p;
@@ -93,6 +97,9 @@ extern const Func  functionList[];
 
 extern const size_t functionListCount;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/test_conformance/spir/CMakeLists.txt
+++ b/test_conformance/spir/CMakeLists.txt
@@ -4,13 +4,17 @@ endfunction()
 
 include_directories(${CLConf_SRC_DIR}/test_common)
 
+# Import function list from math_brute_force
+add_definitions(-DFUNCTION_LIST_ULPS_ONLY)
+
 clconf_add_executable(
     test_spir
     main.cpp
     datagen.cpp
     run_build_test.cpp
     run_services.cpp
-    kernelargs.cpp)
+    kernelargs.cpp
+    ../math_brute_force/FunctionList.c)
 
 target_link_libraries(
     test_spir${CLConf_SUFFIX}

--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -746,7 +746,7 @@ void run_kernel( cl_kernel kernel, cl_command_queue queue, WorkSizeInfo &ws, Tes
 /**
  Compare two test results
  */
-bool compare_results( const TestResult& lhs, const TestResult& rhs )
+bool compare_results( const TestResult& lhs, const TestResult& rhs, float ulps )
 {
     if( lhs.kernelArgs().getArgCount() != rhs.kernelArgs().getArgCount() )
     {
@@ -756,7 +756,7 @@ bool compare_results( const TestResult& lhs, const TestResult& rhs )
 
     for( size_t i = 0 ; i < lhs.kernelArgs().getArgCount(); ++i )
     {
-        if( ! lhs.kernelArgs().getArg(i)->compare( *rhs.kernelArgs().getArg(i)) )
+        if( ! lhs.kernelArgs().getArg(i)->compare( *rhs.kernelArgs().getArg(i), ulps ) )
         {
             log_error("the kernel parameter (%d) is different between SPIR and CL version of the kernel\n", i);
             return false;

--- a/test_conformance/spir/run_services.h
+++ b/test_conformance/spir/run_services.h
@@ -217,6 +217,6 @@ void generate_kernel_data(cl_context context, cl_kernel kernel,
                           WorkSizeInfo &ws, TestResult& res);
 
 void run_kernel(cl_kernel kernel, cl_command_queue queue, WorkSizeInfo &ws, TestResult& result);
-bool compare_results(const TestResult& lhs, const TestResult& rhs);
+bool compare_results(const TestResult& lhs, const TestResult& rhs, float ulps);
 
 #endif


### PR DESCRIPTION
Spir test compares floating-point kernel results bit-by-bit with
correct results. However, for math_brute_force kernels, specification
does not ask for SPIR and OpenCL C path to match bit-to-bit. This patch
reuses ulps threshold from math_brute_force folder for math_brute_force
kernels in spir test. See issue #135