### PR TITLE
cl21: Segfault when passing arguments to test_conformance_spirv_new

### DIFF
--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, const char *argv[])
 {
     gReSeed = 1;
     return runTestHarness(argc, argv,
-                          spirvTestsRegistry::getInstance().getNumTests() + 1,
+                          spirvTestsRegistry::getInstance().getNumTests(),
                           spirvTestsRegistry::getInstance().getTestDefinitions(),
                           false, false, 0);
 }


### PR DESCRIPTION
Fix issue #167