### PR TITLE
cl21: Check device address width when deciding which SPIR-V binary to read

### DIFF
--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -30,7 +30,7 @@ const std::string slash = "/";
 #endif
 
 const std::string spvExt = ".spv";
-const std::string addrWidth = (sizeof(void *) == 4) ? "32" : "64";
+std::string gAddrWidth = "";
 
 std::vector<unsigned char> readBinary(const char *file_name)
 {
@@ -58,7 +58,7 @@ std::vector<unsigned char> readBinary(const char *file_name)
 
 std::vector<unsigned char> readSPIRV(const char *file_name)
 {
-    std::string full_name_str = gSpirVPath + slash + file_name + spvExt + addrWidth;
+    std::string full_name_str = gSpirVPath + slash + file_name + spvExt + gAddrWidth;
     return readBinary(full_name_str.c_str());
 }
 
@@ -102,7 +102,7 @@ static int offline_get_program_with_il(clProgramWrapper &prog,
     std::string scriptArgs =
         gOfflineCompilerInput + " "  +
         gOfflineCompilerOutput + " " +
-        addrWidth + " " +
+        gAddrWidth + " " +
         outputTypeStr + " " +
         "-cl-std=CL2.0";
 
@@ -160,11 +160,24 @@ int get_program_with_il(clProgramWrapper &prog,
     return err;
 }
 
+test_status checkAddressWidth(cl_device_id id)
+{
+  cl_uint address_bits;
+  cl_uint err = clGetDeviceInfo(id, CL_DEVICE_ADDRESS_BITS, sizeof(cl_uint), &address_bits, NULL);
+  if(err != CL_SUCCESS){
+    log_error("clGetDeviceInfo failed to get address bits!");
+    return TEST_FAIL;
+  }
+
+  gAddrWidth = address_bits == 32 ? "32" : "64";
+  return TEST_PASS;
+}
+
 int main(int argc, const char *argv[])
 {
     gReSeed = 1;
-    return runTestHarness(argc, argv,
+    return runTestHarnessWithCheck(argc, argv,
                           spirvTestsRegistry::getInstance().getNumTests(),
                           spirvTestsRegistry::getInstance().getTestDefinitions(),
-                          false, false, 0);
+                          false, false, 0, checkAddressWidth);
 }


### PR DESCRIPTION
Previously this was determined by checking `sizeof(void *)` but this causes issues when the device address width differs from the host.