### PR TITLE
cl21: Fix std::vector alignment segfaults on 32-bit

### DIFF
--- a/test_conformance/spirv_new/test_decorate.cpp
+++ b/test_conformance/spirv_new/test_decorate.cpp
@@ -201,8 +201,8 @@ int verify_saturated_results(cl_device_id deviceID,
     size_t in_bytes = sizeof(Ti) * num;
     size_t out_bytes = sizeof(To) * num;
 
-    std::vector<Ti> h_lhs(num);
-    std::vector<Ti> h_rhs(num);
+    std::vector<Ti, align_allocator<Ti>> h_lhs(num);
+    std::vector<Ti, align_allocator<Ti>> h_rhs(num);
 
     To loVal = std::numeric_limits<To>::min();
     To hiVal = std::numeric_limits<To>::max();
@@ -249,7 +249,7 @@ int verify_saturated_results(cl_device_id deviceID,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue cl kernel");
 
-    std::vector<To> h_res(num);
+    std::vector<To, align_allocator<To>> h_res(num);
     err = clEnqueueReadBuffer(queue, res, CL_TRUE, 0, out_bytes, &h_res[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to read to output");
 
@@ -318,7 +318,7 @@ int test_image_decorate(cl_device_id deviceID,
     const int width = 4096;
     const int height = 4096;
 
-    std::vector<cl_uint4> src(width * height);
+    std::vector<cl_uint4, align_allocator<cl_uint4>> src(width * height);
     RandomSeed seed(gRandomSeed);
 
     for (auto &val : src) {
@@ -369,7 +369,7 @@ int test_image_decorate(cl_device_id deviceID,
     err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<cl_uint4> dst(src.size());
+    std::vector<cl_uint4, align_allocator<cl_uint4>> dst(src.size());
     err = clEnqueueReadBuffer(queue, dstBuffer, CL_TRUE, 0, bytes, &dst[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy data back to host");
 
@@ -406,7 +406,7 @@ TEST_SPIRV_FUNC(decorate_nonreadable)
     const int height = 4096;
     cl_int err = CL_SUCCESS;
 
-    std::vector<cl_uint4> src(width * height);
+    std::vector<cl_uint4, align_allocator<cl_uint4>> src(width * height);
     RandomSeed seed(gRandomSeed);
 
     for (auto &val : src) {
@@ -459,7 +459,7 @@ TEST_SPIRV_FUNC(decorate_nonreadable)
     err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<cl_uint4> dst(src.size());
+    std::vector<cl_uint4, align_allocator<cl_uint4>> dst(src.size());
     size_t origin[] = {0, 0, 0};
     size_t region[] = {height, width, 1};
     err = clEnqueueReadImage(queue, dstImage, CL_TRUE, origin, region, 0, 0, &dst[0], 0, NULL, NULL);
@@ -483,8 +483,8 @@ int test_fp_rounding(cl_device_id deviceID,
                      cl_context context,
                      cl_command_queue queue,
                      const char *name,
-                     std::vector<Ti> &h_in,
-                     std::vector<To> &h_out)
+                     std::vector<Ti, align_allocator<Ti>> &h_in,
+                     std::vector<To, align_allocator<To>> &h_out)
 {
     if(std::string(name).find("double") != std::string::npos) {
         if(!is_extension_available(deviceID, "cl_khr_fp64")) {
@@ -523,7 +523,7 @@ int test_fp_rounding(cl_device_id deviceID,
     size_t global = num;
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
 
-    std::vector<To> h_res(num);
+    std::vector<To, align_allocator<To>> h_res(num);
     err = clEnqueueReadBuffer(queue, out, CL_TRUE, 0, out_bytes, &h_res[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to read from output");
 
@@ -580,8 +580,8 @@ inline To round_to_neginf(Ti in)
         typedef cl_##Ti clTi;                                           \
         typedef cl_##To clTo;                                           \
         const int num = 1 << 16;                                        \
-        std::vector<clTi> in(num);                                      \
-        std::vector<clTo>  out(num);                                    \
+        std::vector<clTi, align_allocator<clTi>> in(num);               \
+        std::vector<clTo, align_allocator<clTo>> out(num);              \
         RandomSeed seed(gRandomSeed);                                   \
                                                                         \
         for (int i = 0; i < num; i++) {                                 \

--- a/test_conformance/spirv_new/test_op_composite_construct.cpp
+++ b/test_conformance/spirv_new/test_op_composite_construct.cpp
@@ -17,7 +17,7 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 template<typename T>
 int test_composite_construct(cl_device_id deviceID, cl_context context,
                 cl_command_queue queue, const char *name,
-                std::vector<T> &results,
+                std::vector<T, align_allocator<T>> &results,
                 bool (*notEqual)(const T&, const T&) = isNotEqual<T>)
 {
     clProgramWrapper prog;
@@ -40,7 +40,7 @@ int test_composite_construct(cl_device_id deviceID, cl_context context,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<T> host(num);
+    std::vector<T, align_allocator<T>> host(num);
     err = clEnqueueReadBuffer(queue, mem, CL_TRUE, 0, bytes, &host[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy from cl_buffer");
 
@@ -56,7 +56,7 @@ int test_composite_construct(cl_device_id deviceID, cl_context context,
 TEST_SPIRV_FUNC(op_composite_construct_int4)
 {
     cl_int4 value = {123, 122, 121, 119};
-    std::vector<cl_int4> results(256, value);
+    std::vector<cl_int4, align_allocator<cl_int4>> results(256, value);
     return test_composite_construct(deviceID, context, queue, "composite_construct_int4", results);
 }
 
@@ -69,6 +69,6 @@ TEST_SPIRV_FUNC(op_composite_construct_struct)
     cl_int2 intvals = {2100480000, 2100480000};
     CustomType2 value2 = {intvals, value1};
 
-    std::vector<CustomType2> results(256, value2);
+    std::vector<CustomType2, align_allocator<CustomType2>> results(256, value2);
     return test_composite_construct(deviceID, context, queue, "composite_construct_struct", results);
 }

--- a/test_conformance/spirv_new/test_op_constant.cpp
+++ b/test_conformance/spirv_new/test_op_constant.cpp
@@ -19,7 +19,7 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 template<typename T>
 int test_constant(cl_device_id deviceID, cl_context context,
                   cl_command_queue queue, const char *name,
-                  std::vector<T> &results,
+                  std::vector<T, align_allocator<T>> &results,
                   bool (*notEqual)(const T&, const T&) = isNotEqual<T>)
 {
     if(std::string(name).find("double") != std::string::npos) {
@@ -48,7 +48,7 @@ int test_constant(cl_device_id deviceID, cl_context context,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<T> host(num);
+    std::vector<T, align_allocator<T>> host(num);
     err = clEnqueueReadBuffer(queue, mem, CL_TRUE, 0, bytes, &host[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy from cl_buffer");
 
@@ -64,7 +64,7 @@ int test_constant(cl_device_id deviceID, cl_context context,
 #define TEST_CONSTANT(NAME, type, value)                    \
     TEST_SPIRV_FUNC(op_constant_##NAME##_simple)            \
     {                                                       \
-        std::vector<type> results(1024, (type)value);       \
+        std::vector<type, align_allocator<type>> results(1024, (type)value);       \
         return test_constant(deviceID, context, queue,      \
                              "constant_" #NAME "_simple",   \
                              results);                      \
@@ -98,14 +98,14 @@ TEST_CONSTANT(double  , cl_double , 3.141592653589793)
 TEST_SPIRV_FUNC(op_constant_int4_simple)
 {
     cl_int4 value = {123, 122, 121, 119};
-    std::vector<cl_int4> results(256, value);
+    std::vector<cl_int4, align_allocator<cl_int4>> results(256, value);
     return test_constant(deviceID, context, queue, "constant_int4_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_constant_int3_simple)
 {
     cl_int3 value = {123, 122, 121, 0};
-    std::vector<cl_int3> results(256, value);
+    std::vector<cl_int3, align_allocator<cl_int3>> results(256, value);
     return test_constant(deviceID, context, queue, "constant_int3_simple",
                          results, isVectorNotEqual<cl_int3, 3>);
 }
@@ -113,14 +113,14 @@ TEST_SPIRV_FUNC(op_constant_int3_simple)
 TEST_SPIRV_FUNC(op_constant_struct_int_float_simple)
 {
     AbstractStruct2<int, float> value = {1024, 3.1415};
-    std::vector<AbstractStruct2<int, float> > results(256, value);
+    std::vector<AbstractStruct2<int, float>, align_allocator<AbstractStruct2<int, float>>> results(256, value);
     return test_constant(deviceID, context, queue, "constant_struct_int_float_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_constant_struct_int_char_simple)
 {
-    AbstractStruct2<int, char> value = {2100483600, 128};
-    std::vector<AbstractStruct2<int, char> > results(256, value);
+    AbstractStruct2<int, char> value = {2100483600, (char)128};
+    std::vector<AbstractStruct2<int, char>, align_allocator<AbstractStruct2<int, char>>> results(256, value);
     return test_constant(deviceID, context, queue, "constant_struct_int_char_simple", results);
 }
 
@@ -133,14 +133,14 @@ TEST_SPIRV_FUNC(op_constant_struct_struct_simple)
     cl_int2 intvals = {2100480000, 2100480000};
     CustomType2 value2 = {intvals, value1};
 
-    std::vector<CustomType2> results(256, value2);
+    std::vector<CustomType2, align_allocator<CustomType2>> results(256, value2);
     return test_constant(deviceID, context, queue, "constant_struct_struct_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_constant_half_simple)
 {
     PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);
-    std::vector<cl_float> results(1024, 3.25);
+    std::vector<cl_float, align_allocator<cl_float>> results(1024, 3.25);
     return test_constant(deviceID, context, queue,
                          "constant_half_simple",
                          results);

--- a/test_conformance/spirv_new/test_op_copy_object.cpp
+++ b/test_conformance/spirv_new/test_op_copy_object.cpp
@@ -19,7 +19,7 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 template<typename T>
 int test_copy(cl_device_id deviceID, cl_context context,
               cl_command_queue queue, const char *name,
-              std::vector<T> &results,
+              std::vector<T, align_allocator<T>> &results,
               bool (*notEqual)(const T&, const T&) = isNotEqual<T>)
 {
     if(std::string(name).find("double") != std::string::npos) {
@@ -48,7 +48,7 @@ int test_copy(cl_device_id deviceID, cl_context context,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<T> host(num);
+    std::vector<T, align_allocator<T>> host(num);
     err = clEnqueueReadBuffer(queue, mem, CL_TRUE, 0, bytes, &host[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy from cl_buffer");
 
@@ -64,7 +64,7 @@ int test_copy(cl_device_id deviceID, cl_context context,
 #define TEST_COPY(NAME, type, value)                    \
     TEST_SPIRV_FUNC(op_copy_##NAME##_simple)            \
     {                                                   \
-        std::vector<type> results(1024, (type)value);   \
+        std::vector<type, align_allocator<type>> results(1024, (type)value);   \
         return test_copy(deviceID, context, queue,      \
                          "copy_" #NAME "_simple",       \
                          results);                      \
@@ -94,14 +94,14 @@ TEST_COPY(double  , cl_double , 3.141592653589793)
 TEST_SPIRV_FUNC(op_copy_int4_simple)
 {
     cl_int4 value = {123, 122, 121, 119};
-    std::vector<cl_int4> results(256, value);
+    std::vector<cl_int4, align_allocator<cl_int4>> results(256, value);
     return test_copy(deviceID, context, queue, "copy_int4_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_copy_int3_simple)
 {
     cl_int3 value = {123, 122, 121, 0};
-    std::vector<cl_int3> results(256, value);
+    std::vector<cl_int3, align_allocator<cl_int3>> results(256, value);
     return test_copy(deviceID, context, queue, "copy_int3_simple",
                      results, isVectorNotEqual<cl_int3, 3>);
 }
@@ -109,14 +109,14 @@ TEST_SPIRV_FUNC(op_copy_int3_simple)
 TEST_SPIRV_FUNC(op_copy_struct_int_float_simple)
 {
     AbstractStruct2<int, float> value = {1024, 3.1415};
-    std::vector<AbstractStruct2<int, float> > results(256, value);
+    std::vector<AbstractStruct2<int, float>, align_allocator<AbstractStruct2<int, float>>> results(256, value);
     return test_copy(deviceID, context, queue, "copy_struct_int_float_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_copy_struct_int_char_simple)
 {
-    AbstractStruct2<int, char> value = {2100483600, 128};
-    std::vector<AbstractStruct2<int, char> > results(256, value);
+    AbstractStruct2<int, char> value = {2100483600, (char)128};
+    std::vector<AbstractStruct2<int, char>, align_allocator<AbstractStruct2<int, char>>> results(256, value);
     return test_copy(deviceID, context, queue, "copy_struct_int_char_simple", results);
 }
 
@@ -129,14 +129,14 @@ TEST_SPIRV_FUNC(op_copy_struct_struct_simple)
     cl_int2 intvals = {2100480000, 2100480000};
     CustomType2 value2 = {intvals, value1};
 
-    std::vector<CustomType2> results(256, value2);
+    std::vector<CustomType2, align_allocator<CustomType2>> results(256, value2);
     return test_copy(deviceID, context, queue, "copy_struct_struct_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_copy_half_simple)
 {
     PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);
-    std::vector<cl_float> results(1024, 3.25);
+    std::vector<cl_float, align_allocator<cl_float>> results(1024, 3.25);
     return test_copy(deviceID, context, queue,
                      "copy_half_simple",
                      results);

--- a/test_conformance/spirv_new/test_op_fmath.cpp
+++ b/test_conformance/spirv_new/test_op_fmath.cpp
@@ -25,8 +25,8 @@ int test_fmath(cl_device_id deviceID,
                const char *funcName,
                const char *Tname,
                bool fast_math,
-               std::vector<T> &h_lhs,
-               std::vector<T> &h_rhs)
+               std::vector<T, align_allocator<T>> &h_lhs,
+               std::vector<T, align_allocator<T>> &h_rhs)
 {
 
     if(std::string(Tname).find("double") != std::string::npos) {
@@ -84,7 +84,7 @@ int test_fmath(cl_device_id deviceID,
 
     const char *options = fast_math ? "-cl-fast-relaxed-math" : NULL;
 
-    std::vector<T> h_ref(num);
+    std::vector<T, align_allocator<T>> h_ref(num);
 
     {
         // Run the cl kernel for reference results
@@ -141,7 +141,7 @@ int test_fmath(cl_device_id deviceID,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue cl kernel");
 
-    std::vector<T> h_res(num);
+    std::vector<T, align_allocator<T>> h_res(num);
     err = clEnqueueReadBuffer(queue, res, CL_TRUE, 0, bytes, &h_res[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to read from ref");
 
@@ -161,8 +161,8 @@ int test_fmath(cl_device_id deviceID,
             PASSIVE_REQUIRE_FP16_SUPPORT(deviceID); \
         }                                           \
         const int num = 1 << 20;                    \
-        std::vector<cl_##TYPE> lhs(num);            \
-        std::vector<cl_##TYPE> rhs(num);            \
+        std::vector<cl_##TYPE, align_allocator<cl_##TYPE>> lhs(num);            \
+        std::vector<cl_##TYPE, align_allocator<cl_##TYPE>> rhs(num);            \
                                                     \
         RandomSeed seed(gRandomSeed);               \
                                                     \

--- a/test_conformance/spirv_new/test_op_negate.cpp
+++ b/test_conformance/spirv_new/test_op_negate.cpp
@@ -23,7 +23,7 @@ int test_negation(cl_device_id deviceID,
                   cl_command_queue queue,
                   const char *Tname,
                   const char *funcName,
-                  const std::vector<Tv> &h_in,
+                  const std::vector<Tv, align_allocator<Tv>> &h_in,
                   Tv (*negate)(Tv) = negOp<Tv>)
 {
     if(std::string(Tname).find("double") != std::string::npos) {
@@ -61,7 +61,7 @@ int test_negation(cl_device_id deviceID,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue cl kernel");
 
-    std::vector<Tv> h_out(num);
+    std::vector<Tv, align_allocator<Tv>> h_out(num);
     err = clEnqueueReadBuffer(queue, in, CL_TRUE, 0, bytes, &h_out[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to read from ref");
 
@@ -78,7 +78,7 @@ int test_negation(cl_device_id deviceID,
     TEST_SPIRV_FUNC(OP##_##TYPE)                \
     {                                           \
         int num = 1 << 20;                      \
-        std::vector<Tv> in(num);                \
+        std::vector<Tv, align_allocator<Tv>> in(num);                \
         RandomSeed seed(gRandomSeed);           \
         for (int i = 0; i < num; i++) {         \
             in[i] = genrand<Tv>(seed);          \

--- a/test_conformance/spirv_new/test_op_undef.cpp
+++ b/test_conformance/spirv_new/test_op_undef.cpp
@@ -47,7 +47,7 @@ int test_undef(cl_device_id deviceID, cl_context context,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue kernel");
 
-    std::vector<T> host(num);
+    std::vector<T, align_allocator<T>> host(num);
     err = clEnqueueReadBuffer(queue, mem, CL_TRUE, 0, bytes, &host[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy from cl_buffer");
 

--- a/test_conformance/spirv_new/test_op_vector_extract.cpp
+++ b/test_conformance/spirv_new/test_op_vector_extract.cpp
@@ -17,7 +17,7 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 template<typename Tv, typename Ts>
 int test_extract(cl_device_id deviceID, cl_context context,
                  cl_command_queue queue, const char *name,
-                 const std::vector<Tv> &h_in, const int n)
+                 const std::vector<Tv, align_allocator<Tv>> &h_in, const int n)
 {
     if(std::string(name).find("double") != std::string::npos) {
         if(!is_extension_available(deviceID, "cl_khr_fp64")) {
@@ -35,7 +35,7 @@ int test_extract(cl_device_id deviceID, cl_context context,
     SPIRV_CHECK_ERROR(err, "Failed to create kernel");
 
     int num = (int)h_in.size();
-    std::vector<Ts> h_out(num);
+    std::vector<Ts, align_allocator<Ts>> h_out(num);
 
     size_t in_bytes = num * sizeof(Tv);
     clMemWrapper in = clCreateBuffer(context, CL_MEM_READ_WRITE, in_bytes, NULL, &err);
@@ -82,7 +82,7 @@ int test_extract(cl_device_id deviceID, cl_context context,
         typedef cl_##TYPE##N Tv;                            \
         typedef cl_##TYPE Ts;                               \
         const int num = 1 << 20;                            \
-        std::vector<Tv> in(num);                            \
+        std::vector<Tv, align_allocator<Tv>> in(num);       \
         const char *name = "vector_" #TYPE #N "_extract";   \
                                                             \
         RandomSeed seed(gRandomSeed);                       \

--- a/test_conformance/spirv_new/test_op_vector_insert.cpp
+++ b/test_conformance/spirv_new/test_op_vector_insert.cpp
@@ -17,7 +17,7 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 template<typename Ts, typename Tv>
 int test_insert(cl_device_id deviceID, cl_context context,
                  cl_command_queue queue, const char *name,
-                 const std::vector<Ts> &h_in, const int n)
+                 const std::vector<Ts, align_allocator<Ts>> &h_in, const int n)
 {
     if(std::string(name).find("double") != std::string::npos) {
         if(!is_extension_available(deviceID, "cl_khr_fp64")) {
@@ -34,8 +34,8 @@ int test_insert(cl_device_id deviceID, cl_context context,
     SPIRV_CHECK_ERROR(err, "Failed to create kernel");
 
     int num = (int)h_in.size();
-    std::vector<Tv> h_ref(num);
-    std::vector<Tv> h_out(num);
+    std::vector<Tv, align_allocator<Tv>> h_ref(num);
+    std::vector<Tv, align_allocator<Tv>> h_out(num);
 
     RandomSeed seed(gRandomSeed);
     for (int i = 0; i < num; i++) {
@@ -100,7 +100,7 @@ int test_insert(cl_device_id deviceID, cl_context context,
         typedef cl_##TYPE##N Tv;                            \
         typedef cl_##TYPE Ts;                               \
         const int num = 1 << 20;                            \
-        std::vector<Ts> in(num);                            \
+        std::vector<Ts, align_allocator<Ts>> in(num);                            \
         const char *name = "vector_" #TYPE #N "_insert";    \
                                                             \
         RandomSeed seed(gRandomSeed);                       \

--- a/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
+++ b/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
@@ -22,8 +22,8 @@ int test_vector_times_scalar(cl_device_id deviceID,
                              cl_context context,
                              cl_command_queue queue,
                              const char *Tname,
-                             std::vector<Tv> &h_lhs,
-                             std::vector<Ts> &h_rhs)
+                             std::vector<Tv, align_allocator<Tv>> &h_lhs,
+                             std::vector<Ts, align_allocator<Ts>> &h_rhs)
 {
     if(std::string(Tname).find("double") != std::string::npos) {
         if(!is_extension_available(deviceID, "cl_khr_fp64")) {
@@ -78,7 +78,7 @@ int test_vector_times_scalar(cl_device_id deviceID,
     size_t kernelLen = kernelStr.size();
     const char *kernelBuf = kernelStr.c_str();
 
-    std::vector<Tv> h_ref(num);
+    std::vector<Tv, align_allocator<Tv>> h_ref(num);
     {
         // Run the cl kernel for reference results
         clProgramWrapper prog;
@@ -139,7 +139,7 @@ int test_vector_times_scalar(cl_device_id deviceID,
     err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to enqueue cl kernel");
 
-    std::vector<Tv> h_res(num);
+    std::vector<Tv, align_allocator<Tv>> h_res(num);
     err = clEnqueueReadBuffer(queue, res, CL_TRUE, 0, res_bytes, &h_res[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to read from ref");
 
@@ -161,8 +161,8 @@ int test_vector_times_scalar(cl_device_id deviceID,
         typedef cl_##TYPE##N Tv;                                \
         typedef cl_##TYPE Ts;                                   \
         const int num = 1 << 20;                                \
-        std::vector<Tv> lhs(num);                               \
-        std::vector<Ts> rhs(num);                               \
+        std::vector<Tv, align_allocator<Tv>> lhs(num);                               \
+        std::vector<Ts, align_allocator<Ts>> rhs(num);                               \
                                                                 \
         RandomSeed seed(gRandomSeed);                           \
                                                                 \

--- a/test_conformance/spirv_new/types.hpp
+++ b/test_conformance/spirv_new/types.hpp
@@ -14,6 +14,8 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 #pragma once
 #include <CL/cl.h>
 
+#include "../../test_common/harness/kernelHelpers.h"
+
 #if defined(_MSC_VER) || defined(_WIN32)
 #define PACKED(__STRUCT__) __pragma(pack(push, 1)) __STRUCT__ __pragma(pack(pop))
 #elif defined(__GNUC__) || defined(__clang__)
@@ -182,3 +184,32 @@ Tv notOpVec(Tv in)
     }
     return out;
 }
+
+template <typename T>
+struct align_allocator {
+    typedef T value_type;
+    typedef T* pointer;
+    typedef const T* const_pointer;
+    typedef T& reference;
+    typedef const T& const_reference;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+
+    template <class U>
+    struct rebind {
+        typedef align_allocator<U> other;
+    };
+
+    template <class U>
+    align_allocator(const align_allocator<U> &) {}
+
+    align_allocator() {}
+
+    T* allocate(size_t count) {
+        return static_cast<T *>(align_malloc(sizeof(T) * count, alignof(T)));
+    };
+
+    void deallocate(T* ptr, size_t) {
+        align_free(ptr);
+    };
+};


### PR DESCRIPTION
On 32-bit Release builds assignment to `std::vector<cl_double2>` was
segfaulting due to the underlying storage having incorrect alignment, the
fix is to specialize `std::vector` with a custom allocator
`align_allocator` which uses `align_malloc` and `align_free` for
allocating the underlying storage.