### PR TITLE
cl20: Reuse test harness code in half

### DIFF
--- a/test_conformance/half/Test_roundTrip.c
+++ b/test_conformance/half/Test_roundTrip.c
@@ -18,7 +18,7 @@
 #include "tests.h"
 #include "../../test_common/harness/testHarness.h"
 
-int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
+int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue queue, int num_elements )
 {
     int vectorSize, error;
     uint64_t i, j;
@@ -107,7 +107,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
 */
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize] = MakeProgram( sourceV3, sizeof( sourceV3) / sizeof( sourceV3[0])  );
+            programs[vectorSize] = MakeProgram( device, sourceV3, sizeof( sourceV3) / sizeof( sourceV3[0])  );
             if( NULL == programs[ vectorSize ] )
             {
                 gFailCount++;
@@ -115,7 +115,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
                 return -1;
             }
         } else {
-            programs[vectorSize] = MakeProgram( source, sizeof( source) / sizeof( source[0])  );
+            programs[vectorSize] = MakeProgram( device, source, sizeof( source) / sizeof( source[0])  );
             if( NULL == programs[ vectorSize ] )
             {
                 gFailCount++;
@@ -134,14 +134,14 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
         if( gTestDouble )
         {
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize] = MakeProgram( doubleSourceV3, sizeof( doubleSourceV3) / sizeof( doubleSourceV3[0])  );
+                doublePrograms[vectorSize] = MakeProgram( device, doubleSourceV3, sizeof( doubleSourceV3) / sizeof( doubleSourceV3[0])  );
                 if( NULL == doublePrograms[ vectorSize ] )
                 {
                     gFailCount++;
                     return -1;
                 }
             } else {
-                doublePrograms[vectorSize] = MakeProgram( doubleSource, sizeof( doubleSource) / sizeof( doubleSource[0])  );
+                doublePrograms[vectorSize] = MakeProgram( device, doubleSource, sizeof( doubleSource) / sizeof( doubleSource[0])  );
                 if( NULL == doublePrograms[ vectorSize ] )
                 {
                     gFailCount++;
@@ -161,7 +161,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
 
     // Figure out how many elements are in a work block
     size_t elementSize = MAX( sizeof(cl_half), sizeof(cl_float));
-    size_t blockCount = (size_t)gBufferSize / elementSize; //elementSize is a power of two
+    size_t blockCount = (size_t)getBufferSize(device) / elementSize; //elementSize is a power of two
     uint64_t lastCase = 1ULL << (8*sizeof(cl_half)); // number of cl_half
     size_t stride = blockCount;
 
@@ -201,7 +201,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
 
 
             // here is where "3" starts to cause problems.
-            error = RunKernel( kernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
+            error = RunKernel(device, kernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
                               runsOverBy(count, vectorSize, false) );
             if(error)
             {
@@ -252,7 +252,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
                 }
 
 
-                if( (error = RunKernel( doubleKernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
+                if( (error = RunKernel(device, doubleKernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
                                        runsOverBy(count, vectorSize, false) ) ) )
                 {
                     gFailCount++;
@@ -313,7 +313,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
             for( j = 0; j < loopCount; j++ )
             {
                 uint64_t startTime = ReadTime();
-                if( (error = RunKernel( kernels[vectorSize], gInBuffer_half, gOutBuffer_half,numVecs(count, vectorSize, false) ,
+                if( (error = RunKernel(device, kernels[vectorSize], gInBuffer_half, gOutBuffer_half,numVecs(count, vectorSize, false) ,
                                        runsOverBy(count, vectorSize, false)) ) )
                 {
                     gFailCount++;
@@ -340,7 +340,7 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
                 for( j = 0; j < loopCount; j++ )
                 {
                     uint64_t startTime = ReadTime();
-                    if( (error = RunKernel( doubleKernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
+                    if( (error = RunKernel(device, doubleKernels[vectorSize], gInBuffer_half, gOutBuffer_half, numVecs(count, vectorSize, false) ,
                                            runsOverBy(count, vectorSize, false)) ) )
                     {
                         gFailCount++;

--- a/test_conformance/half/Test_vStoreHalf.c
+++ b/test_conformance/half/Test_vStoreHalf.c
@@ -614,73 +614,73 @@ double2half_rtn( double f )
 
 int test_vstore_half( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    switch (get_default_rounding_mode(gDevice))
+    switch (get_default_rounding_mode(deviceID))
     {
         case CL_FP_ROUND_TO_ZERO:
-            return Test_vStoreHalf_private(float2half_rtz, double2half_rte, "");
+            return Test_vStoreHalf_private(deviceID, float2half_rtz, double2half_rte, "");
         case 0:
             return -1;
         default:
-            return Test_vStoreHalf_private(float2half_rte, double2half_rte, "");
+            return Test_vStoreHalf_private(deviceID, float2half_rte, double2half_rte, "");
     }
 }
 
 int test_vstore_half_rte( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreHalf_private(float2half_rte, double2half_rte, "_rte");
+    return Test_vStoreHalf_private(deviceID, float2half_rte, double2half_rte, "_rte");
 }
 
 int test_vstore_half_rtz( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreHalf_private(float2half_rtz, double2half_rtz, "_rtz");
+    return Test_vStoreHalf_private(deviceID, float2half_rtz, double2half_rtz, "_rtz");
 }
 
 int test_vstore_half_rtp( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreHalf_private(float2half_rtp, double2half_rtp, "_rtp");
+    return Test_vStoreHalf_private(deviceID, float2half_rtp, double2half_rtp, "_rtp");
 }
 
 int test_vstore_half_rtn( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreHalf_private(float2half_rtn, double2half_rtn, "_rtn");
+    return Test_vStoreHalf_private(deviceID, float2half_rtn, double2half_rtn, "_rtn");
 }
 
 int test_vstorea_half( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    switch (get_default_rounding_mode(gDevice))
+    switch (get_default_rounding_mode(deviceID))
     {
         case CL_FP_ROUND_TO_ZERO:
-            return Test_vStoreaHalf_private(float2half_rtz, double2half_rte, "");
+            return Test_vStoreaHalf_private(deviceID,float2half_rtz, double2half_rte, "");
         case 0:
             return -1;
         default:
-            return Test_vStoreaHalf_private(float2half_rte, double2half_rte, "");
+            return Test_vStoreaHalf_private(deviceID, float2half_rte, double2half_rte, "");
     }
 }
 
 int test_vstorea_half_rte( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreaHalf_private(float2half_rte, double2half_rte, "_rte");
+    return Test_vStoreaHalf_private(deviceID, float2half_rte, double2half_rte, "_rte");
 }
 
 int test_vstorea_half_rtz( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreaHalf_private(float2half_rtz, double2half_rtz, "_rtz");
+    return Test_vStoreaHalf_private(deviceID, float2half_rtz, double2half_rtz, "_rtz");
 }
 
 int test_vstorea_half_rtp( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreaHalf_private(float2half_rtp, double2half_rtp, "_rtp");
+    return Test_vStoreaHalf_private(deviceID, float2half_rtp, double2half_rtp, "_rtp");
 }
 
 int test_vstorea_half_rtn( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    return Test_vStoreaHalf_private(float2half_rtn, double2half_rtn, "_rtn");
+    return Test_vStoreaHalf_private(deviceID, float2half_rtn, double2half_rtn, "_rtn");
 }
 
 #pragma mark -
 
-int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
+int Test_vStoreHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
 {
     int vectorSize, error;
     cl_program  programs[kVectorSizeCount+kStrangeVectorSizeCount][3];
@@ -906,9 +906,9 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
 
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][0] = MakeProgram( source_v3, sizeof(source_v3) / sizeof( source_v3[0]) );
+            programs[vectorSize][0] = MakeProgram( device, source_v3, sizeof(source_v3) / sizeof( source_v3[0]) );
         } else {
-            programs[vectorSize][0] = MakeProgram( source, sizeof(source) / sizeof( source[0]) );
+            programs[vectorSize][0] = MakeProgram( device, source, sizeof(source) / sizeof( source[0]) );
         }
         if( NULL == programs[ vectorSize ][0] )
         {
@@ -925,9 +925,9 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
         }
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][1] = MakeProgram( source_private_store_v3, sizeof(source_private_store_v3) / sizeof( source_private_store_v3[0]) );
+            programs[vectorSize][1] = MakeProgram( device, source_private_store_v3, sizeof(source_private_store_v3) / sizeof( source_private_store_v3[0]) );
         } else {
-            programs[vectorSize][1] = MakeProgram( source_private_store, sizeof(source_private_store) / sizeof( source_private_store[0]) );
+            programs[vectorSize][1] = MakeProgram( device, source_private_store, sizeof(source_private_store) / sizeof( source_private_store[0]) );
         }
         if( NULL == programs[ vectorSize ][1] )
         {
@@ -944,7 +944,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
         }
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][2] = MakeProgram( source_local_store_v3, sizeof(source_local_store_v3) / sizeof( source_local_store_v3[0]) );
+            programs[vectorSize][2] = MakeProgram( device, source_local_store_v3, sizeof(source_local_store_v3) / sizeof( source_local_store_v3[0]) );
             if(  NULL == programs[ vectorSize ][2] )
             {
                 unsigned q;
@@ -956,7 +956,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
 
             }
         } else {
-            programs[vectorSize][2] = MakeProgram( source_local_store, sizeof(source_local_store) / sizeof( source_local_store[0]) );
+            programs[vectorSize][2] = MakeProgram( device, source_local_store, sizeof(source_local_store) / sizeof( source_local_store[0]) );
             if( NULL == programs[ vectorSize ][2] )
             {
                 unsigned q;
@@ -980,9 +980,9 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
         if( gTestDouble )
         {
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize][0] = MakeProgram( double_source_v3, sizeof(double_source_v3) / sizeof( double_source_v3[0]) );
+                doublePrograms[vectorSize][0] = MakeProgram( device, double_source_v3, sizeof(double_source_v3) / sizeof( double_source_v3[0]) );
             } else {
-                doublePrograms[vectorSize][0] = MakeProgram( double_source, sizeof(double_source) / sizeof( double_source[0]) );
+                doublePrograms[vectorSize][0] = MakeProgram( device, double_source, sizeof(double_source) / sizeof( double_source[0]) );
             }
             if( NULL == doublePrograms[ vectorSize ][0] )
             {
@@ -999,9 +999,9 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
             }
 
             if(g_arrVecSizes[vectorSize] == 3)
-                doublePrograms[vectorSize][1] = MakeProgram( double_source_private_store_v3, sizeof(double_source_private_store_v3) / sizeof( double_source_private_store_v3[0]) );
+                doublePrograms[vectorSize][1] = MakeProgram( device, double_source_private_store_v3, sizeof(double_source_private_store_v3) / sizeof( double_source_private_store_v3[0]) );
             else
-                doublePrograms[vectorSize][1] = MakeProgram( double_source_private_store, sizeof(double_source_private_store) / sizeof( double_source_private_store[0]) );
+                doublePrograms[vectorSize][1] = MakeProgram( device, double_source_private_store, sizeof(double_source_private_store) / sizeof( double_source_private_store[0]) );
 
             if( NULL == doublePrograms[ vectorSize ][1] )
             {
@@ -1018,9 +1018,9 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
             }
 
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize][2] = MakeProgram( double_source_local_store_v3, sizeof(double_source_local_store_v3) / sizeof( double_source_local_store_v3[0]) );
+                doublePrograms[vectorSize][2] = MakeProgram( device, double_source_local_store_v3, sizeof(double_source_local_store_v3) / sizeof( double_source_local_store_v3[0]) );
             } else {
-                doublePrograms[vectorSize][2] = MakeProgram( double_source_local_store, sizeof(double_source_local_store) / sizeof( double_source_local_store[0]) );
+                doublePrograms[vectorSize][2] = MakeProgram( device, double_source_local_store, sizeof(double_source_local_store) / sizeof( double_source_local_store[0]) );
             }
             if( NULL == doublePrograms[ vectorSize ][2] )
             {
@@ -1136,7 +1136,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
                     goto exit;
                 }
 
-                error = RunKernel(kernels[vectorSize][addressSpace], gInBuffer_single, gOutBuffer_half,
+                error = RunKernel(device, kernels[vectorSize][addressSpace], gInBuffer_single, gOutBuffer_half,
                                        numVecs(count, vectorSize, aligned) ,
                                   runsOverBy(count, vectorSize, aligned));
                 if (error) {
@@ -1167,7 +1167,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
                         goto exit;
                     }
 
-                    error = RunKernel(doubleKernels[vectorSize][addressSpace], gInBuffer_double, gOutBuffer_half,
+                    error = RunKernel(device, doubleKernels[vectorSize][addressSpace], gInBuffer_double, gOutBuffer_half,
                                       numVecs(count, vectorSize, aligned),
                                       runsOverBy(count, vectorSize, aligned));
                     if (error) {
@@ -1237,7 +1237,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
                 uint64_t startTime = ReadTime();
 
 
-                if( (error = RunKernel( kernels[vectorSize][0], gInBuffer_single, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
+                if( (error = RunKernel(device, kernels[vectorSize][0], gInBuffer_single, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
                                        runsOverBy(count, vectorSize, aligned)) ) )
                 {
                     gFailCount++;
@@ -1264,7 +1264,7 @@ int Test_vStoreHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const c
                 for( j = 0; j < loopCount; j++ )
                 {
                     uint64_t startTime = ReadTime();
-                    if( (error = RunKernel( doubleKernels[vectorSize][0], gInBuffer_double, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
+                    if( (error = RunKernel(device, doubleKernels[vectorSize][0], gInBuffer_double, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
                                            runsOverBy(count, vectorSize, aligned)) ) )
                     {
                         gFailCount++;
@@ -1341,7 +1341,7 @@ exit:
     return error;
 }
 
-int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
+int Test_vStoreaHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
 {
     int vectorSize, error;
     cl_program  programs[kVectorSizeCount+kStrangeVectorSizeCount][3];
@@ -1500,14 +1500,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
         };
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][0] = MakeProgram( source_v3, sizeof(source_v3) / sizeof( source_v3[0]) );
+            programs[vectorSize][0] = MakeProgram( device, source_v3, sizeof(source_v3) / sizeof( source_v3[0]) );
             if( NULL == programs[ vectorSize ][0] )
             {
                 gFailCount++;
                 return -1;
             }
         } else {
-            programs[vectorSize][0] = MakeProgram( source, sizeof(source) / sizeof( source[0]) );
+            programs[vectorSize][0] = MakeProgram( device, source, sizeof(source) / sizeof( source[0]) );
             if( NULL == programs[ vectorSize ][0] )
             {
                 gFailCount++;
@@ -1524,14 +1524,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
         }
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][1] = MakeProgram( source_private_v3, sizeof(source_private_v3) / sizeof( source_private_v3[0]) );
+            programs[vectorSize][1] = MakeProgram( device, source_private_v3, sizeof(source_private_v3) / sizeof( source_private_v3[0]) );
             if( NULL == programs[ vectorSize ][1] )
             {
                 gFailCount++;
                 return -1;
             }
         } else {
-            programs[vectorSize][1] = MakeProgram( source_private, sizeof(source_private) / sizeof( source_private[0]) );
+            programs[vectorSize][1] = MakeProgram( device, source_private, sizeof(source_private) / sizeof( source_private[0]) );
             if( NULL == programs[ vectorSize ][1] )
             {
                 gFailCount++;
@@ -1548,14 +1548,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
         }
 
         if(g_arrVecSizes[vectorSize] == 3) {
-            programs[vectorSize][2] = MakeProgram( source_local_v3, sizeof(source_local_v3) / sizeof( source_local_v3[0]) );
+            programs[vectorSize][2] = MakeProgram( device, source_local_v3, sizeof(source_local_v3) / sizeof( source_local_v3[0]) );
             if( NULL == programs[ vectorSize ][2] )
             {
                 gFailCount++;
                 return -1;
             }
         } else {
-            programs[vectorSize][2] = MakeProgram( source_local, sizeof(source_local) / sizeof( source_local[0]) );
+            programs[vectorSize][2] = MakeProgram( device, source_local, sizeof(source_local) / sizeof( source_local[0]) );
             if( NULL == programs[ vectorSize ][2] )
             {
                 gFailCount++;
@@ -1574,14 +1574,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
         if( gTestDouble )
         {
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize][0] = MakeProgram( double_source_v3, sizeof(double_source_v3) / sizeof( double_source_v3[0]) );
+                doublePrograms[vectorSize][0] = MakeProgram( device, double_source_v3, sizeof(double_source_v3) / sizeof( double_source_v3[0]) );
                 if( NULL == doublePrograms[ vectorSize ][0] )
                 {
                     gFailCount++;
                     return -1;
                 }
             } else {
-                doublePrograms[vectorSize][0] = MakeProgram( double_source, sizeof(double_source) / sizeof( double_source[0]) );
+                doublePrograms[vectorSize][0] = MakeProgram( device, double_source, sizeof(double_source) / sizeof( double_source[0]) );
                 if( NULL == doublePrograms[ vectorSize ][0] )
                 {
                     gFailCount++;
@@ -1598,14 +1598,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
             }
 
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize][1] = MakeProgram( double_source_private_v3, sizeof(double_source_private_v3) / sizeof( double_source_private_v3[0]) );
+                doublePrograms[vectorSize][1] = MakeProgram( device, double_source_private_v3, sizeof(double_source_private_v3) / sizeof( double_source_private_v3[0]) );
                 if( NULL == doublePrograms[ vectorSize ][1] )
                 {
                     gFailCount++;
                     return -1;
                 }
             } else {
-                doublePrograms[vectorSize][1] = MakeProgram( double_source_private, sizeof(double_source_private) / sizeof( double_source_private[0]) );
+                doublePrograms[vectorSize][1] = MakeProgram( device, double_source_private, sizeof(double_source_private) / sizeof( double_source_private[0]) );
                 if( NULL == doublePrograms[ vectorSize ][1] )
                 {
                     gFailCount++;
@@ -1622,14 +1622,14 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
             }
 
             if(g_arrVecSizes[vectorSize] == 3) {
-                doublePrograms[vectorSize][2] = MakeProgram( double_source_local_v3, sizeof(double_source_local_v3) / sizeof( double_source_local_v3[0]) );
+                doublePrograms[vectorSize][2] = MakeProgram( device, double_source_local_v3, sizeof(double_source_local_v3) / sizeof( double_source_local_v3[0]) );
                 if( NULL == doublePrograms[ vectorSize ][2] )
                 {
                     gFailCount++;
                     return -1;
                 }
             } else {
-                doublePrograms[vectorSize][2] = MakeProgram( double_source_local, sizeof(double_source_local) / sizeof( double_source_local[0]) );
+                doublePrograms[vectorSize][2] = MakeProgram( device, double_source_local, sizeof(double_source_local) / sizeof( double_source_local[0]) );
                 if( NULL == doublePrograms[ vectorSize ][2] )
                 {
                     gFailCount++;
@@ -1744,7 +1744,7 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
                     goto exit;
                 }
 
-                error = RunKernel(kernels[vectorSize][addressSpace], gInBuffer_single, gOutBuffer_half,
+                error = RunKernel(device, kernels[vectorSize][addressSpace], gInBuffer_single, gOutBuffer_half,
                                   numVecs(count, vectorSize, aligned),
                                   runsOverBy(count, vectorSize, aligned));
                 if (error) {
@@ -1775,7 +1775,7 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
                         goto exit;
                     }
 
-                    error = RunKernel(doubleKernels[vectorSize][addressSpace], gInBuffer_double, gOutBuffer_half,
+                    error = RunKernel(device, doubleKernels[vectorSize][addressSpace], gInBuffer_double, gOutBuffer_half,
                                       numVecs(count, vectorSize, aligned),
                                       runsOverBy(count, vectorSize, aligned));
                     if (error) {
@@ -1842,7 +1842,7 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
             for( j = 0; j < loopCount; j++ )
             {
                 uint64_t startTime = ReadTime();
-                if( (error = RunKernel( kernels[vectorSize][0], gInBuffer_single, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
+                if( (error = RunKernel(device, kernels[vectorSize][0], gInBuffer_single, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
                                        runsOverBy(count, vectorSize, aligned)) ) )
                 {
                     gFailCount++;
@@ -1869,7 +1869,7 @@ int Test_vStoreaHalf_private( f2h referenceFunc, d2h doubleReferenceFunc, const 
                 for( j = 0; j < loopCount; j++ )
                 {
                     uint64_t startTime = ReadTime();
-                    if( (error = RunKernel( doubleKernels[vectorSize][0], gInBuffer_double, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
+                    if( (error = RunKernel(device, doubleKernels[vectorSize][0], gInBuffer_double, gOutBuffer_half, numVecs(count, vectorSize, aligned) ,
                                            runsOverBy(count, vectorSize, aligned)) ) )
                     {
                         gFailCount++;

--- a/test_conformance/half/cl_utils.c
+++ b/test_conformance/half/cl_utils.c
@@ -51,8 +51,6 @@ cl_mem          gOutBuffer_single = NULL;
 cl_mem          gInBuffer_double = NULL;
 // cl_mem          gOutBuffer_double = NULL;
 
-cl_device_type  gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-cl_device_id    gDevice = NULL;
 cl_context       gContext = NULL;
 cl_command_queue gQueue = NULL;
 uint32_t        gDeviceFrequency = 0;
@@ -63,8 +61,6 @@ int             gFailCount = 0;
 bool            gWimpyMode = false;
 int             gWimpyReductionFactor = 512;
 int             gTestDouble = 0;
-uint32_t        gDeviceIndex = 0;
-size_t          gBufferSize = 0;
 
 #if defined( __APPLE__ )
 int             gReportTimes = 1;
@@ -74,43 +70,18 @@ int             gReportTimes = 0;
 
 #pragma mark -
 
-int InitCL( void )
+test_status InitCL( cl_device_id device )
 {
-    cl_platform_id platform = NULL;
     size_t configSize = sizeof( gComputeDevices );
     int error;
 
-    if( (error = clGetPlatformIDs(1, &platform, NULL) ) )
-        return error;
-
-    // gDeviceType & gDeviceIndex are globals set in ParseArgs
-
-    cl_uint ndevices;
-    if ( (error = clGetDeviceIDs(platform, gDeviceType, 0, NULL, &ndevices)) )
-        return error;
-
-    cl_device_id *gDeviceList = (cl_device_id *)malloc(ndevices*sizeof( cl_device_id ));
-    if ( gDeviceList == 0 )
-    {
-        log_error("Unable to allocate memory for devices\n");
-        return -1;
-    }
-    if( (error = clGetDeviceIDs(platform,  gDeviceType, ndevices, gDeviceList, NULL )) )
-    {
-        free( gDeviceList );
-        return error;
-    }
-
-    gDevice = gDeviceList[gDeviceIndex];
-    free( gDeviceList );
-
 #if MULTITHREAD
-    if( (error = clGetDeviceInfo( gDevice, CL_DEVICE_MAX_COMPUTE_UNITS,  configSize, &gComputeDevices, NULL )) )
+    if( (error = clGetDeviceInfo( device, CL_DEVICE_MAX_COMPUTE_UNITS,  configSize, &gComputeDevices, NULL )) )
 #endif
     gComputeDevices = 1;
 
     configSize = sizeof( gMaxThreadGroupSize );
-    if( (error = clGetDeviceInfo( gDevice, CL_DEVICE_MAX_WORK_GROUP_SIZE, configSize, &gMaxThreadGroupSize,  NULL )) )
+    if( (error = clGetDeviceInfo( device, CL_DEVICE_MAX_WORK_GROUP_SIZE, configSize, &gMaxThreadGroupSize,  NULL )) )
         gMaxThreadGroupSize = 1;
 
     // Use only one-eighth the work group size
@@ -120,13 +91,13 @@ int InitCL( void )
         gWorkGroupSize = gMaxThreadGroupSize;
 
     configSize = sizeof( gDeviceFrequency );
-    if( (error = clGetDeviceInfo( gDevice, CL_DEVICE_MAX_CLOCK_FREQUENCY, configSize, &gDeviceFrequency,  NULL )) )
+    if( (error = clGetDeviceInfo( device, CL_DEVICE_MAX_CLOCK_FREQUENCY, configSize, &gDeviceFrequency,  NULL )) )
         gDeviceFrequency = 1;
 
     // Check extensions
     size_t extSize = 0;
     int hasDouble = 0;
-    if((error = clGetDeviceInfo( gDevice, CL_DEVICE_EXTENSIONS, 0, NULL, &extSize)))
+    if((error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, 0, NULL, &extSize)))
     {   vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
     else
     {
@@ -135,7 +106,7 @@ int InitCL( void )
         { vlog_error( "malloc failed at %s:%d\nUnable to determine if double present.\n", __FILE__, __LINE__ ); }
         else
         {
-            if((error = clGetDeviceInfo( gDevice, CL_DEVICE_EXTENSIONS, extSize, ext, NULL)))
+            if((error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, extSize, ext, NULL)))
             {    vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
             else
             {
@@ -151,7 +122,7 @@ int InitCL( void )
 
     //detect whether profile of the device is embedded
     char profile[64] = "";
-    if( (error = clGetDeviceInfo( gDevice, CL_DEVICE_PROFILE, sizeof(profile), profile, NULL ) ) )
+    if( (error = clGetDeviceInfo( device, CL_DEVICE_PROFILE, sizeof(profile), profile, NULL ) ) )
     {
         vlog_error( "Unable to get device CL DEVICE PROFILE string. (%d) \n", error );
     }
@@ -163,36 +134,34 @@ int InitCL( void )
     vlog( "%d compute devices at %f GHz\n", gComputeDevices, (double) gDeviceFrequency / 1000. );
     vlog( "Max thread group size is %lld.\n", (uint64_t) gMaxThreadGroupSize );
 
-    gContext = clCreateContext( NULL, 1, &gDevice, notify_callback, NULL, &error );
+    gContext = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
     if( NULL == gContext )
     {
         vlog_error( "clCreateDeviceGroup failed. (%d)\n", error );
-        return -1;
+        return TEST_FAIL;
     }
 
-    gQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+    gQueue = clCreateCommandQueueWithProperties(gContext, device, 0, &error);
     if( NULL == gQueue )
     {
         vlog_error( "clCreateContext failed. (%d)\n", error );
-        return -2;
+        return TEST_FAIL;
     }
 
 #if defined( __APPLE__ )
     // FIXME: use clProtectedArray
 #endif
-    gBufferSize = getBufferSize(gDevice);
-
     //Allocate buffers
-    gIn_half   = malloc( gBufferSize/2  );
+    gIn_half   = malloc( getBufferSize(device)/2  );
     gOut_half = malloc( BUFFER_SIZE/2  );
     gOut_half_reference = malloc( BUFFER_SIZE/2  );
     gOut_half_reference_double = malloc( BUFFER_SIZE/2  );
     gIn_single   = malloc( BUFFER_SIZE );
-    gOut_single = malloc( gBufferSize  );
-    gOut_single_reference = malloc( gBufferSize  );
+    gOut_single = malloc( getBufferSize(device)  );
+    gOut_single_reference = malloc( getBufferSize(device)  );
     gIn_double   = malloc( 2*BUFFER_SIZE  );
-    // gOut_double = malloc( (2*gBufferSize)  );
-    // gOut_double_reference = malloc( (2*gBufferSize)  );
+    // gOut_double = malloc( (2*getBufferSize(device))  );
+    // gOut_double_reference = malloc( (2*getBufferSize(device))  );
 
     if ( NULL == gIn_half ||
      NULL == gOut_half ||
@@ -203,73 +172,73 @@ int InitCL( void )
      NULL == gOut_single_reference ||
          NULL == gIn_double // || NULL == gOut_double || NULL == gOut_double_reference
          )
-        return -3;
+        return TEST_FAIL;
 
-    gInBuffer_half = clCreateBuffer(gContext, CL_MEM_READ_ONLY, gBufferSize / 2, NULL, &error);
+    gInBuffer_half = clCreateBuffer(gContext, CL_MEM_READ_ONLY, getBufferSize(device) / 2, NULL, &error);
     if( gInBuffer_half == NULL )
     {
         vlog_error( "clCreateArray failed for input (%d)\n", error );
-        return -4;
+        return TEST_FAIL;
     }
 
     gInBuffer_single = clCreateBuffer(gContext, CL_MEM_READ_ONLY, BUFFER_SIZE, NULL, &error );
     if( gInBuffer_single == NULL )
     {
         vlog_error( "clCreateArray failed for input (%d)\n", error );
-        return -4;
+        return TEST_FAIL;
     }
 
     gInBuffer_double = clCreateBuffer(gContext, CL_MEM_READ_ONLY, BUFFER_SIZE*2, NULL, &error );
     if( gInBuffer_double == NULL )
     {
         vlog_error( "clCreateArray failed for input (%d)\n", error );
-        return -4;
+        return TEST_FAIL;
     }
 
     gOutBuffer_half = clCreateBuffer(gContext, CL_MEM_WRITE_ONLY, BUFFER_SIZE/2, NULL, &error );
     if( gOutBuffer_half == NULL )
     {
         vlog_error( "clCreateArray failed for output (%d)\n", error );
-        return -5;
+        return TEST_FAIL;
     }
 
-    gOutBuffer_single = clCreateBuffer(gContext, CL_MEM_WRITE_ONLY, gBufferSize, NULL, &error );
+    gOutBuffer_single = clCreateBuffer(gContext, CL_MEM_WRITE_ONLY, getBufferSize(device), NULL, &error );
     if( gOutBuffer_single == NULL )
     {
         vlog_error( "clCreateArray failed for output (%d)\n", error );
-        return -5;
+        return TEST_FAIL;
     }
 
 #if 0
-    gOutBuffer_double = clCreateBuffer(gContext, CL_MEM_WRITE_ONLY, (size_t)(2*gBufferSize), NULL, &error );
+    gOutBuffer_double = clCreateBuffer(gContext, CL_MEM_WRITE_ONLY, (size_t)(2*getBufferSize(device)), NULL, &error );
     if( gOutBuffer_double == NULL )
     {
         vlog_error( "clCreateArray failed for output (%d)\n", error );
-        return -5;
+        return TEST_FAIL;
     }
 #endif
 
     char string[16384];
     vlog( "\nCompute Device info:\n" );
-    error = clGetDeviceInfo(gDevice, CL_DEVICE_NAME, sizeof(string), string, NULL);
+    error = clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(string), string, NULL);
     vlog( "\tDevice Name: %s\n", string );
-    error = clGetDeviceInfo(gDevice, CL_DEVICE_VENDOR, sizeof(string), string, NULL);
+    error = clGetDeviceInfo(device, CL_DEVICE_VENDOR, sizeof(string), string, NULL);
     vlog( "\tVendor: %s\n", string );
-    error = clGetDeviceInfo(gDevice, CL_DEVICE_VERSION, sizeof(string), string, NULL);
+    error = clGetDeviceInfo(device, CL_DEVICE_VERSION, sizeof(string), string, NULL);
     vlog( "\tDevice Version: %s\n", string );
-    error = clGetDeviceInfo(gDevice, CL_DEVICE_OPENCL_C_VERSION, sizeof(string), string, NULL);
+    error = clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, sizeof(string), string, NULL);
     vlog( "\tOpenCL C Version: %s\n", string );
-    error = clGetDeviceInfo(gDevice, CL_DRIVER_VERSION, sizeof(string), string, NULL);
+    error = clGetDeviceInfo(device, CL_DRIVER_VERSION, sizeof(string), string, NULL);
     vlog( "\tDriver Version: %s\n", string );
     vlog( "\tProcessing with %d devices\n", gComputeDevices );
     vlog( "\tDevice Frequency: %d MHz\n", gDeviceFrequency );
     vlog( "\tHas double? %s\n", hasDouble ? "YES" : "NO" );
     vlog( "\tTest double? %s\n", gTestDouble ? "YES" : "NO" );
 
-    return 0;
+    return TEST_PASS;
 }
 
-cl_program   MakeProgram( const char *source[], int count )
+cl_program MakeProgram( cl_device_id device, const char *source[], int count )
 {
     int error;
     int i;
@@ -283,13 +252,13 @@ cl_program   MakeProgram( const char *source[], int count )
     }
 
     // build it
-    if( (error = clBuildProgram( program, 1, &gDevice, NULL, NULL, NULL )) )
+    if( (error = clBuildProgram( program, 1, &device, NULL, NULL, NULL )) )
     {
         size_t  len;
         char    buffer[16384];
 
         vlog_error("\t\tFAILED -- clBuildProgramExecutable() failed:\n");
-        clGetProgramBuildInfo(program, gDevice, CL_PROGRAM_BUILD_LOG, sizeof(buffer), buffer, &len);
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, sizeof(buffer), buffer, &len);
         vlog_error("Log: %s\n", buffer);
         vlog_error("Source :\n");
         for(i = 0; i < count; ++i) {
@@ -345,7 +314,7 @@ void printSource(const char * src[], int len) {
     }
 }
 
-int RunKernel( cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount , int extraArg)
+int RunKernel( cl_device_id device, cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount , int extraArg)
 {
     size_t localCount = blockCount;
     size_t wg_size;
@@ -364,7 +333,7 @@ int RunKernel( cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount 
         return -3;
     }
 
-    error = clGetKernelWorkGroupInfo(kernel, gDevice, CL_KERNEL_WORK_GROUP_SIZE, sizeof( wg_size ), &wg_size, NULL);
+    error = clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE, sizeof( wg_size ), &wg_size, NULL);
     if (error)
     {
         vlog_error( "FAILED -- could not get kernel work group info\n" );

--- a/test_conformance/half/cl_utils.h
+++ b/test_conformance/half/cl_utils.h
@@ -16,6 +16,7 @@
 #ifndef CL_UTILS_H
 #define  CL_UTILS_H
 
+#include "../../test_common/harness/testHarness.h"
 #include "../../test_common/harness/compat.h"
 
 #include <stdio.h>
@@ -59,9 +60,6 @@ extern cl_mem          gOutBuffer_single;
 extern cl_mem          gInBuffer_double;
 // extern cl_mem          gOutBuffer_double;
 
-extern uint32_t           gDeviceIndex;
-extern cl_device_type  gDeviceType;
-extern cl_device_id    gDevice;
 extern cl_context      gContext;
 extern cl_command_queue gQueue;
 extern uint32_t        gDeviceFrequency;
@@ -71,7 +69,6 @@ extern size_t          gWorkGroupSize;
 extern int             gFailCount;
 extern int             gTestDouble;
 extern int             gReportTimes;
-extern size_t          gBufferSize;
 
 // gWimpyMode indicates if we run the test in wimpy mode where we limit the
 // size of 32 bit ranges to a much smaller set.  This is meant to be used
@@ -92,10 +89,10 @@ extern const char *vector_size_strings[kVectorSizeCount+kStrangeVectorSizeCount]
 extern const char *align_divisors[kVectorSizeCount+kStrangeVectorSizeCount];
 extern const char *align_types[kVectorSizeCount+kStrangeVectorSizeCount];
 
-int InitCL( void );
+test_status InitCL( cl_device_id device );
 void ReleaseCL( void );
-int RunKernel( cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount , int extraArg);
-cl_program   MakeProgram( const char *source[], int count );
+int RunKernel( cl_device_id device, cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount , int extraArg);
+cl_program MakeProgram( cl_device_id device, const char *source[], int count );
 
 #define STRING( _x )    STRINGIFY( _x )
 #define STRINGIFY(x)    #x

--- a/test_conformance/half/main.c
+++ b/test_conformance/half/main.c
@@ -48,7 +48,6 @@ const char *addressSpaceNames[] = {"global", "private", "local", "constant"};
 static int ParseArgs( int argc, const char **argv );
 static void PrintUsage( void );
 static void PrintArch(void);
-static void PrintDevice(void);
 
 
 int g_arrVecSizes[kVectorSizeCount+kStrangeVectorSizeCount];
@@ -94,12 +93,7 @@ int main (int argc, const char **argv )
         g_arrVecAligns[i] = alignbound;
     }
 
-    test_start();
-
     if( (error = ParseArgs( argc, argv )) )
-        goto exit;
-
-    if( (error = InitCL()) )
         goto exit;
 
     if (gIsEmbedded) {
@@ -110,7 +104,7 @@ int main (int argc, const char **argv )
     }
 
     fflush( stdout );
-    error = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
+    error = runTestHarnessWithCheck( argCount, argList, test_num, test_list, false, true, 0, InitCL );
 
 exit:
     if(gQueue)
@@ -128,8 +122,6 @@ exit:
     }
 
     ReleaseCL();
-    test_finish();
-
     return error;
 }
 
@@ -176,43 +168,6 @@ static int ParseArgs( int argc, const char **argv )
     }
 #endif
 
-    /* Check for environment variable to set device type */
-    char *env_mode = getenv( "CL_DEVICE_TYPE" );
-    if( env_mode != NULL )
-    {
-        if( strcmp( env_mode, "gpu" ) == 0 || strcmp( env_mode, "CL_DEVICE_TYPE_GPU" ) == 0 )
-            gDeviceType = CL_DEVICE_TYPE_GPU;
-        else if( strcmp( env_mode, "cpu" ) == 0 || strcmp( env_mode, "CL_DEVICE_TYPE_CPU" ) == 0 )
-            gDeviceType = CL_DEVICE_TYPE_CPU;
-        else if( strcmp( env_mode, "accelerator" ) == 0 || strcmp( env_mode, "CL_DEVICE_TYPE_ACCELERATOR" ) == 0 )
-            gDeviceType = CL_DEVICE_TYPE_ACCELERATOR;
-        else if( strcmp( env_mode, "default" ) == 0 || strcmp( env_mode, "CL_DEVICE_TYPE_DEFAULT" ) == 0 )
-            gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-        else
-        {
-            vlog_error( "Unknown CL_DEVICE_TYPE env variable setting: %s.\nAborting...\n", env_mode );
-            abort();
-        }
-    }
-
-    unsigned int num_devices;
-    cl_platform_id platform = NULL;
-    clGetPlatformIDs(1, &platform, NULL);
-    clGetDeviceIDs(platform, gDeviceType, 0, NULL, &num_devices);
-
-    const char* device_index_env = getenv("CL_DEVICE_INDEX");
-    if (device_index_env) {
-        if (device_index_env) {
-            gDeviceIndex = atoi(device_index_env);
-        }
-
-        if (gDeviceIndex >= num_devices) {
-            vlog("Specified CL_DEVICE_INDEX=%d out of range, using index 0.\n",
-                gDeviceIndex);
-            gDeviceIndex = 0;
-        }
-    }
-
     vlog( "\n%s", appName );
     for( i = 1; i < argc; i++ )
     {
@@ -256,19 +211,8 @@ static int ParseArgs( int argc, const char **argv )
         }
         else
         {
-            if( 0 == strcmp( arg, "CL_DEVICE_TYPE_CPU" ) )
-                gDeviceType = CL_DEVICE_TYPE_CPU;
-            else if( 0 == strcmp( arg, "CL_DEVICE_TYPE_GPU" ) )
-                gDeviceType = CL_DEVICE_TYPE_GPU;
-            else if( 0 == strcmp( arg, "CL_DEVICE_TYPE_ACCELERATOR" ) )
-                gDeviceType = CL_DEVICE_TYPE_ACCELERATOR;
-            else if( 0 == strcmp( arg, "CL_DEVICE_TYPE_DEFAULT" ) )
-                gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-            else
-            {
-                argList[ argCount ] = arg;
-                argCount++;
-            }
+            argList[ argCount ] = arg;
+            argCount++;
         }
     }
 
@@ -280,7 +224,6 @@ static int ParseArgs( int argc, const char **argv )
 
     vlog( "Test binary built %s %s\n", __DATE__, __TIME__ );
     PrintArch();
-    PrintDevice();
     if( gWimpyMode )
     {
         vlog( "\n" );
@@ -335,22 +278,4 @@ static void PrintArch( void )
     sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
     vlog( "cpu subtype:\t%d\n", type );
 #endif
-}
-
-static void PrintDevice( void)
-{
-    switch(gDeviceType) {
-        case CL_DEVICE_TYPE_CPU:
-            vlog( "DEVICE:\tcpu\n" );
-            break;
-        case CL_DEVICE_TYPE_GPU:
-            vlog( "DEVICE:\tgpu\n" );
-            break;
-        case CL_DEVICE_TYPE_ACCELERATOR:
-            vlog( "DEVICE:\taccelerator\n" );
-            break;
-        default:
-            vlog_error( "DEVICE:\tunknown\n" );
-            break;
-    }
 }

--- a/test_conformance/half/tests.h
+++ b/test_conformance/half/tests.h
@@ -33,8 +33,8 @@ int test_roundTrip( cl_device_id deviceID, cl_context context, cl_command_queue 
 
 typedef cl_ushort (*f2h)( float );
 typedef cl_ushort (*d2h)( double );
-int Test_vStoreHalf_private( f2h referenceFunc, d2h referenceDoubleFunc, const char *roundName );
-int Test_vStoreaHalf_private( f2h referenceFunc, d2h referenceDoubleFunc, const char *roundName );
+int Test_vStoreHalf_private( cl_device_id device, f2h referenceFunc, d2h referenceDoubleFunc, const char *roundName );
+int Test_vStoreaHalf_private( cl_device_id device, f2h referenceFunc, d2h referenceDoubleFunc, const char *roundName );
 
 #endif /* TESTS_H */
 


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>