### PR TITLE
cl20: Reuse test harness code in math_brute_force

### DIFF
--- a/test_conformance/math_brute_force/Utility.h
+++ b/test_conformance/math_brute_force/Utility.h
@@ -43,7 +43,6 @@ extern int gWimpyReductionFactor;
 extern const char *sizeNames[VECTOR_SIZE_COUNT];
 extern const int   sizeValues[VECTOR_SIZE_COUNT];
 
-extern cl_device_type   gDeviceType;
 extern cl_device_id     gDevice;
 extern cl_context       gContext;
 extern cl_command_queue gQueue;


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>