### PR TITLE
cl21: Reuse test harness code in clCopyImage

### DIFF
--- a/test_conformance/images/clCopyImage/main.cpp
+++ b/test_conformance/images/clCopyImage/main.cpp
@@ -26,64 +26,67 @@
 #include "../testBase.h"
 #include "../../../test_common/harness/testHarness.h"
 
-bool            gDebugTrace = false, gTestSmallImages = false, gTestMaxImages = false, gUseRamp = false, gTestRounding = false, gEnablePitch = false, gTestMipmaps = false;
-int             gTypesToTest = 0;
+bool gDebugTrace;
+bool gTestSmallImages;
+bool gTestMaxImages;
+bool gUseRamp;
+bool gTestRounding;
+bool gEnablePitch;
+bool gTestMipmaps;
+int gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-cl_context context;
-cl_command_queue queue;
-static cl_device_id device;
 
-extern int test_image_set( cl_device_id device, MethodsToTest testMethod );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
 static void printUsage( const char *execName );
 
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k1D );
+    return test_image_set( device, context, queue, k1D );
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2D );
+    return test_image_set( device, context, queue, k2D );
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k3D );
+    return test_image_set( device, context, queue, k3D );
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k1DArray );
+    return test_image_set( device, context, queue, k1DArray );
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2DArray );
+    return test_image_set( device, context, queue, k2DArray );
 }
-int test_2Dto3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Dto3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2DTo3D );
+    return test_image_set( device, context, queue, k2DTo3D );
 }
-int test_3Dto2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3Dto2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k3DTo2D );
+    return test_image_set( device, context, queue, k3DTo2D );
 }
-int test_2Darrayto2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darrayto2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2DArrayTo2D );
+    return test_image_set( device, context, queue, k2DArrayTo2D );
 }
-int test_2Dto2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Dto2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2DTo2DArray );
+    return test_image_set( device, context, queue, k2DTo2DArray );
 }
-int test_2Darrayto3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darrayto3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k2DArrayTo3D );
+    return test_image_set( device, context, queue, k2DArrayTo3D );
 }
-int test_3Dto2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3Dto2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, k3DTo2DArray );
+    return test_image_set( device, context, queue, k3DTo2DArray );
 }
 
 test_definition test_list[] = {
@@ -104,12 +107,8 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id  platform;
     cl_channel_type chanType;
     cl_channel_order chanOrder;
-    bool            randomize = false;
-
-    test_start();
 
     checkDeviceTypeOverride( &gDeviceType );
 
@@ -155,9 +154,6 @@ int main(int argc, const char *argv[])
         else if( strcmp( argv[i], "use_pitches" ) == 0 )
             gEnablePitch = true;
 
-        else if( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
-
         else if( strcmp( argv[i], "--help" ) == 0 || strcmp( argv[i], "-h" ) == 0 )
         {
             printUsage( argv[ 0 ] );
@@ -176,78 +172,10 @@ int main(int argc, const char *argv[])
         }
     }
 
-    // Seed the random # generators
-    if( randomize )
-    {
-        gRandomSeed = (cl_uint) time( NULL );
-        log_info( "Random seed: %u.\n", gRandomSeed );
-        gReSeed = 1;
-    }
-
-    int error;
-    // Get our platform
-    error = clGetPlatformIDs(1, &platform, NULL);
-    if( error )
-    {
-        print_error( error, "Unable to get platform" );
-        test_finish();
-        return -1;
-    }
-
-    // Get our device
-    error = clGetDeviceIDs(platform,  gDeviceType, 1, &device, NULL );
-    if( error )
-    {
-        print_error( error, "Unable to get specified device" );
-        test_finish();
-        return -1;
-    }
-
-    char deviceName[ 128 ], deviceVendor[ 128 ], deviceVersion[ 128 ];
-    error = clGetDeviceInfo( device, CL_DEVICE_NAME, sizeof( deviceName ), deviceName, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_VENDOR, sizeof( deviceVendor ), deviceVendor, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_VERSION, sizeof( deviceVersion ), deviceVersion, NULL );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to get device information" );
-        test_finish();
-        return -1;
-    }
-    log_info("Using compute device: Name = %s, Vendor = %s, Version = %s\n", deviceName, deviceVendor, deviceVersion );
-
-    // Check for image support
-    if(checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED) {
-        log_info("Device does not support images. Skipping test.\n");
-        test_finish();
-        return 0;
-    }
-
-    // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
-
-    error = clFinish(queue);
-    if (error)
-        print_error(error, "clFinish failed.");
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
     if (gTestFailure == 0) {
         if (gTestCount > 1)
@@ -262,10 +190,7 @@ int main(int argc, const char *argv[])
     }
 
     // Clean up
-    clReleaseCommandQueue(queue);
-    clReleaseContext(context);
     free(argList);
-    test_finish();
 
     return ret;
 }

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -22,13 +22,11 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_1D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
   size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
   int ret = 0, retCode;
@@ -64,7 +62,7 @@ int test_copy_image_size_1D( cl_device_id device, image_descriptor *imageInfo, M
         regionSize[ 0 ] = width_lod;
     }
 
-    retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
       return retCode;
     else
@@ -93,7 +91,7 @@ int test_copy_image_size_1D( cl_device_id device, image_descriptor *imageInfo, M
 
 
       // Go for it!
-      retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+      retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
       if( retCode < 0 )
         return retCode;
       else
@@ -103,7 +101,7 @@ int test_copy_image_size_1D( cl_device_id device, image_descriptor *imageInfo, M
       return ret;
 }
 
-int test_copy_image_set_1D( cl_device_id device, cl_image_format *format )
+int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -146,7 +144,7 @@ int test_copy_image_set_1D( cl_device_id device, cl_image_format *format )
             if( gDebugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int ret = test_copy_image_size_1D( device, &imageInfo, seed );
+            int ret = test_copy_image_size_1D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }
@@ -179,7 +177,7 @@ int test_copy_image_set_1D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if( test_copy_image_size_1D( device, &imageInfo, seed ) )
+            if( test_copy_image_size_1D( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -225,7 +223,7 @@ int test_copy_image_set_1D( cl_device_id device, cl_image_format *format )
           log_info( "   and %llu mip levels\n", (size_t) imageInfo.num_mip_levels );
       }
 
-            int ret = test_copy_image_size_1D( device, &imageInfo, seed );
+            int ret = test_copy_image_size_1D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -22,13 +22,11 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_1D_array( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -64,7 +62,7 @@ int test_copy_image_size_1D_array( cl_device_id device, image_descriptor *imageI
         regionSize[ 0 ] = width_lod;
     }
 
-    retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
         return retCode;
     else
@@ -98,7 +96,7 @@ int test_copy_image_size_1D_array( cl_device_id device, image_descriptor *imageI
 
 
         // Go for it!
-        retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else
@@ -108,7 +106,7 @@ int test_copy_image_size_1D_array( cl_device_id device, image_descriptor *imageI
     return ret;
 }
 
-int test_copy_image_set_1D_array( cl_device_id device, cl_image_format *format )
+int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -155,7 +153,7 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_copy_image_size_1D_array( device, &imageInfo, seed );
+                int ret = test_copy_image_size_1D_array( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -192,7 +190,7 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if( test_copy_image_size_1D_array( device, &imageInfo, seed ) )
+            if( test_copy_image_size_1D_array( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -238,7 +236,7 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_image_format *format )
 
       if( gDebugTrace )
         log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-      int ret = test_copy_image_size_1D_array( device, &imageInfo, seed );
+      int ret = test_copy_image_size_1D_array( context, queue, &imageInfo, seed );
       if( ret )
         return -1;
     }

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -22,13 +22,11 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_2D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -70,7 +68,7 @@ int test_copy_image_size_2D( cl_device_id device, image_descriptor *imageInfo, M
         regionSize[ 1 ] = height_lod;
     }
 
-    retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
         return retCode;
     else
@@ -105,7 +103,7 @@ int test_copy_image_size_2D( cl_device_id device, image_descriptor *imageInfo, M
         destPos[ 1 ] = ( height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_copy_image_generic( device, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else
@@ -115,7 +113,7 @@ int test_copy_image_size_2D( cl_device_id device, image_descriptor *imageInfo, M
     return ret;
 }
 
-int test_copy_image_set_2D( cl_device_id device, cl_image_format *format )
+int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -161,7 +159,7 @@ int test_copy_image_set_2D( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_copy_image_size_2D( device, &imageInfo, seed );
+                int ret = test_copy_image_size_2D( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -197,7 +195,7 @@ int test_copy_image_set_2D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if( test_copy_image_size_2D( device, &imageInfo, seed ) )
+            if( test_copy_image_size_2D( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -238,7 +236,7 @@ int test_copy_image_set_2D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_copy_image_size_2D( device, &imageInfo, seed );
+            int ret = test_copy_image_size_2D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -22,10 +22,8 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
 
@@ -69,7 +67,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_2D_2D_array( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -144,7 +142,7 @@ int test_copy_image_size_2D_2D_array( cl_device_id device, image_descriptor *src
         }
     }
 
-    retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
         return retCode;
     else
@@ -210,7 +208,7 @@ int test_copy_image_size_2D_2D_array( cl_device_id device, image_descriptor *src
             }
 
         // Go for it!
-        retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else
@@ -221,7 +219,7 @@ int test_copy_image_size_2D_2D_array( cl_device_id device, image_descriptor *src
 }
 
 
-int test_copy_image_set_2D_2D_array( cl_device_id device, cl_image_format *format, bool reverse = false )
+int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse = false )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -277,9 +275,9 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_image_format *forma
                     }
                     int ret;
                     if( reverse )
-                        ret = test_copy_image_size_2D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                        ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
                     else
-                        ret = test_copy_image_size_2D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                        ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -339,9 +337,9 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_image_format *forma
               }
               int ret;
               if( reverse )
-                ret = test_copy_image_size_2D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
               else
-                ret = test_copy_image_size_2D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
               if( ret )
                 return -1;
             }
@@ -407,9 +405,9 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_image_format *forma
             }
             int ret;
             if( reverse )
-                ret = test_copy_image_size_2D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
             else
-                ret = test_copy_image_size_2D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -22,10 +22,8 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
 
@@ -65,7 +63,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_2D_3D( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -143,7 +141,7 @@ int test_copy_image_size_2D_3D( cl_device_id device, image_descriptor *srcImageI
         }
     }
 
-    retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
         return retCode;
     else
@@ -214,7 +212,7 @@ int test_copy_image_size_2D_3D( cl_device_id device, image_descriptor *srcImageI
             }
 
         // Go for it!
-        retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else
@@ -225,7 +223,7 @@ int test_copy_image_size_2D_3D( cl_device_id device, image_descriptor *srcImageI
 }
 
 
-int test_copy_image_set_2D_3D( cl_device_id device, cl_image_format *format, bool reverse = false )
+int test_copy_image_set_2D_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse = false )
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, max3DDepth;
     cl_ulong maxAllocSize, memSize;
@@ -279,9 +277,9 @@ int test_copy_image_set_2D_3D( cl_device_id device, cl_image_format *format, boo
 
                     int ret;
                     if( reverse )
-                        ret = test_copy_image_size_2D_3D( device, &dstImageInfo, &srcImageInfo, seed );
+                        ret = test_copy_image_size_2D_3D( context, queue, &dstImageInfo, &srcImageInfo, seed );
                     else
-                        ret = test_copy_image_size_2D_3D( device, &srcImageInfo, &dstImageInfo, seed );
+                        ret = test_copy_image_size_2D_3D( context, queue, &srcImageInfo, &dstImageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -330,9 +328,9 @@ int test_copy_image_set_2D_3D( cl_device_id device, cl_image_format *format, boo
                     log_info( "   at max size %d,%d to %d,%d,%d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.depth );
                 int ret;
                 if( reverse )
-                    ret = test_copy_image_size_2D_3D( device, &dstImageInfo, &srcImageInfo, seed );
+                    ret = test_copy_image_size_2D_3D( context, queue, &dstImageInfo, &srcImageInfo, seed );
                 else
-                    ret = test_copy_image_size_2D_3D( device, &srcImageInfo, &dstImageInfo, seed );
+                    ret = test_copy_image_size_2D_3D( context, queue, &srcImageInfo, &dstImageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -389,9 +387,9 @@ int test_copy_image_set_2D_3D( cl_device_id device, cl_image_format *format, boo
                 log_info( "   at size %d,%d to %d,%d,%d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.depth );
             int ret;
             if( reverse )
-                ret = test_copy_image_size_2D_3D( device, &dstImageInfo, &srcImageInfo, seed );
+                ret = test_copy_image_size_2D_3D( context, queue, &dstImageInfo, &srcImageInfo, seed );
             else
-                ret = test_copy_image_size_2D_3D( device, &srcImageInfo, &dstImageInfo, seed );
+                ret = test_copy_image_size_2D_3D( context, queue, &srcImageInfo, &dstImageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -21,14 +21,12 @@
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxImages, gEnablePitch, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
 // Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_2D_array( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t srcPos[] = { 0, 0, 0, 0}, dstPos[] = {0, 0, 0, 0};
     size_t region[] = { imageInfo->width, imageInfo->height, imageInfo->arraySize };
@@ -56,10 +54,10 @@ int test_copy_image_2D_array( cl_device_id device, image_descriptor *imageInfo, 
         srcPos[ 3 ] = src_lod;
         dstPos[ 3 ] = dst_lod;
 }
-    return test_copy_image_generic( device, imageInfo, imageInfo, srcPos, dstPos, region, d );
+    return test_copy_image_generic( context, queue, imageInfo, imageInfo, srcPos, dstPos, region, d );
 }
 
-int test_copy_image_set_2D_array( cl_device_id device, cl_image_format *format )
+int test_copy_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -110,7 +108,7 @@ int test_copy_image_set_2D_array( cl_device_id device, cl_image_format *format )
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_copy_image_2D_array( device, &imageInfo, seed );
+                    int ret = test_copy_image_2D_array( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -149,7 +147,7 @@ int test_copy_image_set_2D_array( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( test_copy_image_2D_array( device, &imageInfo, seed ) )
+            if( test_copy_image_2D_array( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -195,7 +193,7 @@ int test_copy_image_set_2D_array( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_copy_image_2D_array( device, &imageInfo,seed );
+            int ret = test_copy_image_2D_array( context, queue, &imageInfo,seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -21,14 +21,12 @@
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxImages, gEnablePitch, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
 // Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_3D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t origin[] = { 0, 0, 0, 0};
     size_t region[] = { imageInfo->width, imageInfo->height, imageInfo->depth };
@@ -42,10 +40,10 @@ int test_copy_image_3D( cl_device_id device, image_descriptor *imageInfo, MTdata
         region[ 2 ] = ( imageInfo->depth >> lod ) ? ( imageInfo->depth >> lod ) : 1;
     }
 
-    return test_copy_image_generic( device, imageInfo, imageInfo, origin, origin, region, d );
+    return test_copy_image_generic( context, queue, imageInfo, imageInfo, origin, origin, region, d );
 }
 
-int test_copy_image_set_3D( cl_device_id device, cl_image_format *format )
+int test_copy_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -95,7 +93,7 @@ int test_copy_image_set_3D( cl_device_id device, cl_image_format *format )
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_copy_image_3D( device, &imageInfo, seed );
+                    int ret = test_copy_image_3D( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -134,7 +132,7 @@ int test_copy_image_set_3D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( test_copy_image_3D( device, &imageInfo, seed ) )
+            if( test_copy_image_3D( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -182,7 +180,7 @@ int test_copy_image_set_3D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_copy_image_3D( device, &imageInfo,seed );
+            int ret = test_copy_image_3D( context, queue, &imageInfo,seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -22,10 +22,8 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
-extern int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
 
@@ -66,7 +64,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_3D_2D_array( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
 {
     size_t sourcePos[ 4 ], destPos[ 4 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -147,7 +145,7 @@ int test_copy_image_size_3D_2D_array( cl_device_id device, image_descriptor *src
         }
     }
 
-    retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
     if( retCode < 0 )
         return retCode;
     else
@@ -236,7 +234,7 @@ int test_copy_image_size_3D_2D_array( cl_device_id device, image_descriptor *src
 
 
         // Go for it!
-        retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else
@@ -247,7 +245,7 @@ int test_copy_image_size_3D_2D_array( cl_device_id device, image_descriptor *src
 }
 
 
-int test_copy_image_set_3D_2D_array( cl_device_id device, cl_image_format *format, bool reverse = false )
+int test_copy_image_set_3D_2D_array(cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse = false )
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, maxDepth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -305,9 +303,9 @@ int test_copy_image_set_3D_2D_array( cl_device_id device, cl_image_format *forma
                     }
                     int ret;
                     if( reverse )
-                        ret = test_copy_image_size_3D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                        ret = test_copy_image_size_3D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
                     else
-                        ret = test_copy_image_size_3D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                        ret = test_copy_image_size_3D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -364,9 +362,9 @@ int test_copy_image_set_3D_2D_array( cl_device_id device, cl_image_format *forma
                 }
                 int ret;
                 if( reverse )
-                    ret = test_copy_image_size_3D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                    ret = test_copy_image_size_3D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
                 else
-                    ret = test_copy_image_size_3D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                    ret = test_copy_image_size_3D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -430,9 +428,9 @@ int test_copy_image_set_3D_2D_array( cl_device_id device, cl_image_format *forma
             }
             int ret;
             if( reverse )
-                ret = test_copy_image_size_3D_2D_array( device, &dstImageInfo, &srcImageInfo, seed );
+                ret = test_copy_image_size_3D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
             else
-                ret = test_copy_image_size_3D_2D_array( device, &srcImageInfo, &dstImageInfo, seed );
+                ret = test_copy_image_size_3D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -22,8 +22,6 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
 size_t random_in_ranges( size_t minimum, size_t rangeA, size_t rangeB, MTdata d )
 {
@@ -39,7 +37,7 @@ static void CL_CALLBACK free_pitch_buffer( cl_mem image, void *buf )
     free( buf );
 }
 
-cl_mem create_image( cl_context context, BufferOwningPtr<char>& data, image_descriptor *imageInfo, int *error )
+cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr<char>& data, image_descriptor *imageInfo, int *error )
 {
     cl_mem img;
     cl_image_desc imageDesc;
@@ -292,7 +290,7 @@ BufferOwningPtr<char> dstData;
 BufferOwningPtr<char> srcHost;
 BufferOwningPtr<char> dstHost;
 
-int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
+int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                             const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d )
 {
     int error;
@@ -350,7 +348,7 @@ int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo
     if( gDebugTrace )
         log_info( " - Writing source image...\n" );
 
-    srcImage = create_image( context, srcData, srcImageInfo, &error );
+    srcImage = create_image( context, queue, srcData, srcImageInfo, &error );
     if( srcImage == NULL )
         return error;
 
@@ -406,7 +404,7 @@ int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo
     if( gDebugTrace )
         log_info( " - Writing destination image...\n" );
 
-    dstImage = create_image( context, dstData, dstImageInfo, &error );
+    dstImage = create_image( context, queue, dstData, dstImageInfo, &error );
     if( dstImage == NULL )
         return error;
 
@@ -654,7 +652,7 @@ int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo
     return 0;
 }
 
-int test_copy_image_size_generic( cl_device_id device, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -751,7 +749,7 @@ int test_copy_image_size_generic( cl_device_id device, image_descriptor *srcImag
         }
 
         // Go for it!
-        retCode = test_copy_image_generic( device, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
         if( retCode < 0 )
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -21,22 +21,20 @@ extern int                gTypesToTest;
 extern int                gNormalizedModeToUse;
 extern bool               gTestMipmaps;
 extern cl_channel_type      gChannelTypeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 extern cl_channel_type      gChannelTypeToUse;
 extern cl_channel_order      gChannelOrderToUse;
 
 
 extern bool gDebugTrace;
 
-extern int test_copy_image_set_1D( cl_device_id device, cl_image_format *format );
-extern int test_copy_image_set_2D( cl_device_id device, cl_image_format *format );
-extern int test_copy_image_set_3D( cl_device_id device, cl_image_format *format );
-extern int test_copy_image_set_1D_array( cl_device_id device, cl_image_format *format );
-extern int test_copy_image_set_2D_array( cl_device_id device, cl_image_format *format );
-extern int test_copy_image_set_2D_3D( cl_device_id device, cl_image_format *format, bool reverse );
-extern int test_copy_image_set_2D_2D_array( cl_device_id device, cl_image_format *format, bool reverse );
-extern int test_copy_image_set_3D_2D_array( cl_device_id device, cl_image_format *format, bool reverse );
+extern int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_copy_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_copy_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_copy_image_set_2D_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
+extern int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
+extern int test_copy_image_set_3D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
 
 
 int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
@@ -95,7 +93,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
+int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
 
@@ -111,7 +109,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image
     return 0;
 }
 
-int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags flags )
+int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {
     const char *name;
     cl_mem_object_type imageType;
@@ -195,7 +193,7 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
     bool *filterFlags;
     unsigned int numFormats;
 
-    if( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
 
     filterFlags = new bool[ numFormats ];
@@ -222,27 +220,27 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
         gTestCount++;
 
         if( testMethod == k1D )
-            test_return = test_copy_image_set_1D( device, &formatList[ i ] );
+            test_return = test_copy_image_set_1D( device, context, queue, &formatList[ i ] );
         else if( testMethod == k2D )
-            test_return = test_copy_image_set_2D( device, &formatList[ i ] );
+            test_return = test_copy_image_set_2D( device, context, queue, &formatList[ i ] );
         else if( testMethod == k3D )
-            test_return = test_copy_image_set_3D( device, &formatList[ i ] );
+            test_return = test_copy_image_set_3D( device, context, queue,&formatList[ i ] );
         else if( testMethod == k1DArray )
-            test_return = test_copy_image_set_1D_array( device, &formatList[ i ] );
+            test_return = test_copy_image_set_1D_array( device, context, queue, &formatList[ i ] );
         else if( testMethod == k2DArray )
-            test_return = test_copy_image_set_2D_array( device, &formatList[ i ] );
+            test_return = test_copy_image_set_2D_array( device, context, queue, &formatList[ i ] );
         else if( testMethod == k2DTo3D )
-            test_return = test_copy_image_set_2D_3D( device, &formatList[ i ], false );
+            test_return = test_copy_image_set_2D_3D( device, context, queue, &formatList[ i ], false );
         else if( testMethod == k3DTo2D )
-            test_return = test_copy_image_set_2D_3D( device, &formatList[ i ], true );
+            test_return = test_copy_image_set_2D_3D( device, context, queue, &formatList[ i ], true );
         else if( testMethod == k2DArrayTo2D)
-            test_return = test_copy_image_set_2D_2D_array( device, &formatList[ i ], true);
+            test_return = test_copy_image_set_2D_2D_array( device, context, queue, &formatList[ i ], true);
         else if( testMethod == k2DTo2DArray)
-            test_return = test_copy_image_set_2D_2D_array( device, &formatList[ i ], false);
+            test_return = test_copy_image_set_2D_2D_array( device, context, queue, &formatList[ i ], false);
         else if( testMethod == k2DArrayTo3D)
-            test_return = test_copy_image_set_3D_2D_array( device, &formatList[ i ], true);
+            test_return = test_copy_image_set_3D_2D_array( device, context, queue, &formatList[ i ], true);
         else if( testMethod == k3DTo2DArray)
-            test_return = test_copy_image_set_3D_2D_array( device, &formatList[ i ], false);
+            test_return = test_copy_image_set_3D_2D_array( device, context, queue, &formatList[ i ], false);
 
         if (test_return) {
             gTestFailure++;
@@ -260,11 +258,11 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
     return ret;
 }
 
-int test_image_set( cl_device_id device, MethodsToTest testMethod )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod )
 {
     int ret = 0;
 
-    ret += test_image_type( device, testMethod, CL_MEM_READ_ONLY );
+    ret += test_image_type( device, context, queue, testMethod, CL_MEM_READ_ONLY );
 
     return ret;
 }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>