### PR TITLE
cl22: Reuse test harness code in clFillImage

### DIFF
--- a/test_conformance/images/clFillImage/main.cpp
+++ b/test_conformance/images/clFillImage/main.cpp
@@ -26,39 +26,40 @@
 #include "../testBase.h"
 #include "../../../test_common/harness/testHarness.h"
 
-bool             gDebugTrace = false, gTestSmallImages = false, gTestMaxImages = false, gTestRounding = false, gEnablePitch = false;
-int              gTypesToTest = 0;
+bool gDebugTrace;
+bool gTestSmallImages;
+bool gTestMaxImages;
+bool gTestRounding;
+bool gEnablePitch;
+int  gTypesToTest;
 cl_channel_type  gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 cl_device_type   gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-cl_context       context;
-cl_command_queue queue;
-static cl_device_id device;
 
-extern int test_image_set( cl_device_id device, MethodsToTest testMethod );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 static void printUsage( const char *execName );
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set(device, k1D);
+    return test_image_set(device, context, queue, k1D);
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set(device, k2D);
+    return test_image_set(device, context, queue, k2D);
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set(device, k3D);
+    return test_image_set(device, context, queue, k3D);
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set(device, k1DArray);
+    return test_image_set(device, context, queue, k1DArray);
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set(device, k2DArray);
+    return test_image_set(device, context, queue, k2DArray);
 }
 
 test_definition test_list[] = {
@@ -73,12 +74,8 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id   platform;
     cl_channel_type  chanType;
     cl_channel_order chanOrder;
-    bool             randomize = false;
-
-    test_start();
 
     checkDeviceTypeOverride( &gDeviceType );
 
@@ -116,9 +113,6 @@ int main(int argc, const char *argv[])
         else if ( strcmp( argv[i], "use_pitches" ) == 0 )
             gEnablePitch = true;
 
-        else if ( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
-
         else if( strcmp( argv[i], "int" ) == 0 )
             gTypesToTest |= kTestInt;
         else if( strcmp( argv[i], "uint" ) == 0 )
@@ -147,78 +141,10 @@ int main(int argc, const char *argv[])
     if ( gTypesToTest == 0 )
         gTypesToTest = kTestAllTypes;
 
-    // Seed the random # generators
-    if ( randomize )
-    {
-        gRandomSeed = (cl_uint) time( NULL );
-        log_info( "Random seed: %u.\n", gRandomSeed );
-        gReSeed = 1;
-    }
-
-    int error;
-    // Get our platform
-    error = clGetPlatformIDs(1, &platform, NULL);
-    if ( error )
-    {
-        print_error( error, "Unable to get platform" );
-        test_finish();
-        return -1;
-    }
-
-    // Get our device
-    error = clGetDeviceIDs(platform,  gDeviceType, 1, &device, NULL );
-    if ( error )
-    {
-        print_error( error, "Unable to get specified device" );
-        test_finish();
-        return -1;
-    }
-
-    char deviceName[ 128 ], deviceVendor[ 128 ], deviceVersion[ 128 ];
-    error = clGetDeviceInfo( device, CL_DEVICE_NAME, sizeof( deviceName ), deviceName, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_VENDOR, sizeof( deviceVendor ), deviceVendor, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_VERSION, sizeof( deviceVersion ), deviceVersion, NULL );
-    if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to get device information" );
-        test_finish();
-        return -1;
-    }
-    log_info("Using compute device: Name = %s, Vendor = %s, Version = %s\n", deviceName, deviceVendor, deviceVersion );
-
-    // Check for image support
-    if (checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED) {
-        log_info("Device does not support images. Skipping test.\n");
-        test_finish();
-        return 0;
-    }
-
-    // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-    if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if ( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
-
-    error = clFinish(queue);
-    if (error)
-        print_error(error, "clFinish failed.");
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
     if (gTestFailure == 0) {
         if (gTestCount > 1)
@@ -233,12 +159,7 @@ int main(int argc, const char *argv[])
             log_error("FAILED sub-test.\n");
     }
 
-    // Clean up
-    clReleaseCommandQueue(queue);
-    clReleaseContext(context);
     free(argList);
-    test_finish();
-
     return ret;
 }
 

--- a/test_conformance/images/clFillImage/test_fill_1D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D.cpp
@@ -22,15 +22,13 @@ extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gEnabl
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
 extern uint64_t           gRoundingStartValue;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                                     const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
 
 
-int test_fill_image_size_1D( cl_device_id device, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -41,7 +39,7 @@ int test_fill_image_size_1D( cl_device_id device, image_descriptor *imageInfo, E
     region[ 1 ] = 1;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
     if ( retCode < 0 )
         return retCode;
     else
@@ -57,7 +55,7 @@ int test_fill_image_size_1D( cl_device_id device, image_descriptor *imageInfo, E
         origin[ 0 ] = ( imageInfo->width > region[ 0 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->width - region[ 0 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
         if ( retCode < 0 )
             return retCode;
         else
@@ -68,7 +66,7 @@ int test_fill_image_size_1D( cl_device_id device, image_descriptor *imageInfo, E
 }
 
 
-int test_fill_image_set_1D( cl_device_id device, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -110,7 +108,7 @@ int test_fill_image_set_1D( cl_device_id device, cl_image_format *format, Explic
             if ( gDebugTrace )
                 log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-            int ret = test_fill_image_size_1D( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }
@@ -140,7 +138,7 @@ int test_fill_image_set_1D( cl_device_id device, cl_image_format *format, Explic
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
             if ( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if ( test_fill_image_size_1D( device, &imageInfo, outputType, seed ) )
+            if ( test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed ) )
                 return -1;
         }
     }
@@ -171,7 +169,7 @@ int test_fill_image_set_1D( cl_device_id device, cl_image_format *format, Explic
 
             if ( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret = test_fill_image_size_1D( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_1D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_array.cpp
@@ -22,15 +22,13 @@ extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gEnabl
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
 extern uint64_t           gRoundingStartValue;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                                     const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
 
 
-int test_fill_image_size_1D_array( cl_device_id device, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -41,7 +39,7 @@ int test_fill_image_size_1D_array( cl_device_id device, image_descriptor *imageI
     region[ 1 ] = imageInfo->arraySize;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
     if ( retCode < 0 )
         return retCode;
     else
@@ -59,7 +57,7 @@ int test_fill_image_size_1D_array( cl_device_id device, image_descriptor *imageI
         origin[ 1 ] = ( imageInfo->arraySize > region[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - region[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
         if ( retCode < 0 )
             return retCode;
         else
@@ -70,7 +68,7 @@ int test_fill_image_size_1D_array( cl_device_id device, image_descriptor *imageI
 }
 
 
-int test_fill_image_set_1D_array( cl_device_id device, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -116,7 +114,7 @@ int test_fill_image_set_1D_array( cl_device_id device, cl_image_format *format, 
                 if ( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_fill_image_size_1D_array( device, &imageInfo, outputType, seed );
+                int ret = test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed );
                 if ( ret )
                     return -1;
             }
@@ -149,7 +147,7 @@ int test_fill_image_set_1D_array( cl_device_id device, cl_image_format *format, 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if ( test_fill_image_size_1D_array( device, &imageInfo, outputType, seed ) )
+            if ( test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed ) )
                 return -1;
         }
     }
@@ -183,7 +181,7 @@ int test_fill_image_set_1D_array( cl_device_id device, cl_image_format *format, 
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int ret = test_fill_image_size_1D_array( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_2D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D.cpp
@@ -22,15 +22,13 @@ extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gEnabl
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
 extern uint64_t           gRoundingStartValue;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                                     const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
 
 
-int test_fill_image_size_2D( cl_device_id device, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -41,7 +39,7 @@ int test_fill_image_size_2D( cl_device_id device, image_descriptor *imageInfo, E
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
     if ( retCode < 0 )
         return retCode;
     else
@@ -59,7 +57,7 @@ int test_fill_image_size_2D( cl_device_id device, image_descriptor *imageInfo, E
         origin[ 1 ] = ( imageInfo->height > region[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->height - region[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
         if ( retCode < 0 )
             return retCode;
         else
@@ -70,7 +68,7 @@ int test_fill_image_size_2D( cl_device_id device, image_descriptor *imageInfo, E
 }
 
 
-int test_fill_image_set_2D( cl_device_id device, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -115,7 +113,7 @@ int test_fill_image_set_2D( cl_device_id device, cl_image_format *format, Explic
                 if ( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_fill_image_size_2D( device, &imageInfo, outputType, seed );
+                int ret = test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed );
                 if ( ret )
                     return -1;
             }
@@ -147,7 +145,7 @@ int test_fill_image_set_2D( cl_device_id device, cl_image_format *format, Explic
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if ( test_fill_image_size_2D( device, &imageInfo, outputType, seed ) )
+            if ( test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed ) )
                 return -1;
         }
     }
@@ -179,7 +177,7 @@ int test_fill_image_set_2D( cl_device_id device, cl_image_format *format, Explic
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_fill_image_size_2D( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_2D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D_array.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,15 +21,13 @@
 extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxImages, gEnablePitch, gTestRounding;
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
 
 
-static int test_fill_image_2D_array( cl_device_id device, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+static int test_fill_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -40,7 +38,7 @@ static int test_fill_image_2D_array( cl_device_id device, image_descriptor *imag
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = imageInfo->arraySize;
 
-    retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
     if ( retCode < 0 )
         return retCode;
     else
@@ -60,7 +58,7 @@ static int test_fill_image_2D_array( cl_device_id device, image_descriptor *imag
         origin[ 2 ] = ( imageInfo->arraySize > region[ 2 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - region[ 2 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
         if ( retCode < 0 )
             return retCode;
         else
@@ -71,7 +69,7 @@ static int test_fill_image_2D_array( cl_device_id device, image_descriptor *imag
 }
 
 
-int test_fill_image_set_2D_array( cl_device_id device, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -120,7 +118,7 @@ int test_fill_image_set_2D_array( cl_device_id device, cl_image_format *format, 
                 {
                     if ( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_fill_image_2D_array( device, &imageInfo, outputType, seed );
+                    int ret = test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed );
                     if ( ret )
                         return -1;
                 }
@@ -155,7 +153,7 @@ int test_fill_image_set_2D_array( cl_device_id device, cl_image_format *format, 
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if ( test_fill_image_2D_array( device, &imageInfo, outputType, seed ) )
+            if ( test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed ) )
                 return -1;
         }
     }
@@ -190,7 +188,7 @@ int test_fill_image_set_2D_array( cl_device_id device, cl_image_format *format, 
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_fill_image_2D_array( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_3D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_3D.cpp
@@ -21,15 +21,13 @@
 extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxImages, gEnablePitch, gTestRounding;
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
 
 
-int test_fill_image_3D( cl_device_id device, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -40,7 +38,7 @@ int test_fill_image_3D( cl_device_id device, image_descriptor *imageInfo, Explic
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = imageInfo->depth;
 
-    retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
     if ( retCode < 0 )
         return retCode;
     else
@@ -60,7 +58,7 @@ int test_fill_image_3D( cl_device_id device, image_descriptor *imageInfo, Explic
         origin[ 2 ] = ( imageInfo->depth > region[ 2 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->depth - region[ 2 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( device, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
         if ( retCode < 0 )
             return retCode;
         else
@@ -71,7 +69,7 @@ int test_fill_image_3D( cl_device_id device, image_descriptor *imageInfo, Explic
 }
 
 
-int test_fill_image_set_3D( cl_device_id device, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -120,7 +118,7 @@ int test_fill_image_set_3D( cl_device_id device, cl_image_format *format, Explic
                 {
                     if ( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_fill_image_3D( device, &imageInfo, outputType, seed );
+                    int ret = test_fill_image_3D( context, queue, &imageInfo, outputType, seed );
                     if ( ret )
                         return -1;
                 }
@@ -155,7 +153,7 @@ int test_fill_image_set_3D( cl_device_id device, cl_image_format *format, Explic
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if ( test_fill_image_3D( device, &imageInfo, outputType, seed ) )
+            if ( test_fill_image_3D( context, queue, &imageInfo, outputType, seed ) )
                 return -1;
         }
     }
@@ -190,7 +188,7 @@ int test_fill_image_set_3D( cl_device_id device, cl_image_format *format, Explic
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_fill_image_3D( device, &imageInfo, outputType, seed );
+            int ret = test_fill_image_3D( context, queue, &imageInfo, outputType, seed );
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -22,8 +22,6 @@ extern bool               gDebugTrace, gDisableOffsets, gTestSmallImages, gTestM
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
 extern uint64_t           gRoundingStartValue;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo, int x, int y, int z, float *outData );
 
@@ -34,7 +32,7 @@ static void CL_CALLBACK free_pitch_buffer( cl_mem image, void *buf )
 }
 
 
-cl_mem create_image( cl_context context, BufferOwningPtr<char>& data, image_descriptor *imageInfo, int *error )
+cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr<char>& data, image_descriptor *imageInfo, int *error )
 {
     cl_mem img;
     cl_image_desc imageDesc;
@@ -252,7 +250,7 @@ static void fill_region_with_value( image_descriptor *imageInfo, void *imageValu
     free(fillColor);
 }
 
-int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
+int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
                              const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d )
 {
     BufferOwningPtr<char> imgData;
@@ -309,7 +307,7 @@ int test_fill_image_generic( cl_device_id device, image_descriptor *imageInfo,
     if ( gDebugTrace )
         log_info( " - Creating image...\n" );
 
-    image = create_image( context, imgData, imageInfo, &error );
+    image = create_image( context, queue, imgData, imageInfo, &error );
     if ( image == NULL )
         return error;
 

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -22,15 +22,13 @@ extern int                gTypesToTest;
 extern int                gNormalizedModeToUse;
 extern cl_channel_type    gChannelTypeToUse;
 extern cl_channel_order   gChannelOrderToUse;
-extern cl_command_queue   queue;
-extern cl_context         context;
 
 
-extern int test_fill_image_set_1D( cl_device_id device, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_2D( cl_device_id device, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_3D( cl_device_id device, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_1D_array( cl_device_id device, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_2D_array( cl_device_id device, cl_image_format *format, ExplicitType outputType );
+extern int test_fill_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
+extern int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
+extern int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
+extern int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
+extern int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
 
 
 int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
@@ -92,7 +90,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
 }
 
 
-int get_format_list( cl_device_id device, cl_mem_object_type image_type, cl_image_format * &outFormatList,
+int get_format_list( cl_context context, cl_mem_object_type image_type, cl_image_format * &outFormatList,
                     unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
@@ -110,7 +108,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type image_type, cl_imag
 }
 
 
-int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags flags )
+int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {
     const char *name;
     cl_mem_object_type imageType;
@@ -150,7 +148,7 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
     bool *filterFlags;
     unsigned int numFormats;
 
-    if ( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if ( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
 
     filterFlags = new bool[ numFormats ];
@@ -194,15 +192,15 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
                 gTestCount++;
 
                 if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, &formatList[ i ], kFloat );
+                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kFloat );
                 else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, &formatList[ i ], kFloat );
+                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kFloat );
                 else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, &formatList[ i ], kFloat );
+                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kFloat );
                 else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, &formatList[ i ], kFloat );
+                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kFloat );
                 else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, &formatList[ i ], kFloat );
+                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kFloat );
 
                 if (test_return)
                 {
@@ -241,15 +239,15 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
                 gTestCount++;
 
                 if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, &formatList[ i ], kInt );
+                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kInt );
                 else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, &formatList[ i ], kInt );
+                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kInt );
                 else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, &formatList[ i ], kInt );
+                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kInt );
                 else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, &formatList[ i ], kInt );
+                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kInt );
                 else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, &formatList[ i ], kInt );
+                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kInt );
 
                 if (test_return) {
                     gTestFailure++;
@@ -288,15 +286,15 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
                 gTestCount++;
 
                 if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, &formatList[ i ], kUInt );
+                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kUInt );
                 else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, &formatList[ i ], kUInt );
+                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kUInt );
                 else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, &formatList[ i ], kUInt );
+                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kUInt );
                 else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, &formatList[ i ], kUInt );
+                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kUInt );
                 else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, &formatList[ i ], kUInt );
+                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kUInt );
 
                 if (test_return) {
                     gTestFailure++;
@@ -317,11 +315,11 @@ int test_image_type( cl_device_id device, MethodsToTest testMethod, cl_mem_flags
 }
 
 
-int test_image_set( cl_device_id device, MethodsToTest testMethod )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod )
 {
     int ret = 0;
 
-    ret += test_image_type( device, testMethod, CL_MEM_READ_ONLY );
+    ret += test_image_type( device, context, queue, testMethod, CL_MEM_READ_ONLY );
 
     return ret;
 }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>