### PR TITLE
cl20: Reuse test harness code in clGetInfo

### DIFF
--- a/test_conformance/images/clGetInfo/test_1D.cpp
+++ b/test_conformance/images/clGetInfo/test_1D.cpp
@@ -20,10 +20,10 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
 
 
-int test_get_image_info_1D( cl_device_id device, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -62,10 +62,10 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at size %d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }
@@ -88,10 +88,10 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at max size %d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }
@@ -124,10 +124,10 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at size %d (flags[%u] 0x%x pitch %d) out of %d\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -20,9 +20,9 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
 
-int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -63,10 +63,10 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, 
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                         return -1;
                     if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                        if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                             return -1;
                     }
                 }
@@ -94,10 +94,10 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, 
             {
               if( gDebugTrace )
                 log_info( "   at max size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-              if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+              if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                 return -1;
               if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                   return -1;
               }
             }
@@ -129,10 +129,10 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, 
             {
                 if( gDebugTrace )
                     log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }
@@ -143,7 +143,7 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, 
 }
 
 
-int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -190,10 +190,10 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format, 
                     {
                         if( gDebugTrace )
                             log_info( "   at size %d,%d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                        if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                             return -1;
                         if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                            if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                            if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                                 return -1;
                         }
                     }
@@ -222,10 +222,10 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format, 
             {
               if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-              if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+              if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                 return -1;
               if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                   return -1;
               }
             }
@@ -265,10 +265,10 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format, 
             {
                 if( gDebugTrace )
                     log_info( "   at size %d,%d,%d (flags[%u] 0x%x pitch %d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_2D.cpp
+++ b/test_conformance/images/clGetInfo/test_2D.cpp
@@ -19,11 +19,9 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
-int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch )
+int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch )
 {
     int error;
     clMemWrapper image;
@@ -264,7 +262,7 @@ int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo
     return 0;
 }
 
-int test_get_image_info_2D( cl_device_id device, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -306,10 +304,10 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format, cl_mem
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                         return -1;
                     if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                        if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                             return -1;
                     }
                 }
@@ -334,10 +332,10 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at max size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
         }
             }
@@ -371,10 +369,10 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_3D.cpp
+++ b/test_conformance/images/clGetInfo/test_3D.cpp
@@ -20,9 +20,9 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
 
-int test_get_image_info_3D( cl_device_id device, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -69,10 +69,10 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format, cl_mem
                     {
                         if( gDebugTrace )
                             log_info( "   at size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, j, (unsigned long)all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch );
-                        if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                             return -1;
                         if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                            if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                            if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
                                 return -1;
                         }
                     }
@@ -101,10 +101,10 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at max size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d)\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ], j, (unsigned long)all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch );
-                if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
                         return -1;
                 }
             }
@@ -144,10 +144,10 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format, cl_mem
             {
                 if( gDebugTrace )
                     log_info( "   at size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, j, (unsigned long) all_host_ptr_flags[i], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-                if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( device, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -20,17 +20,15 @@ extern cl_addressing_mode gAddressModeToUse;
 extern int                gTypesToTest;
 extern int                gNormalizedModeToUse;
 extern cl_channel_type      gChannelTypeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
 extern bool gDebugTrace;
 
-extern int test_get_image_info_1D( cl_device_id device, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_2D( cl_device_id device, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_3D( cl_device_id device, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
 
 static const char *str_1d_image = "1D";
 static const char *str_2d_image = "2D";
@@ -112,7 +110,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type image_type, cl_image_format * &outFormatList,
+int get_format_list( cl_context context, cl_mem_object_type image_type, cl_image_format * &outFormatList,
                                                          unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
@@ -129,7 +127,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type image_type, cl_imag
     return 0;
 }
 
-int test_image_type( cl_device_id device, cl_mem_object_type image_type, cl_mem_flags flags )
+int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type image_type, cl_mem_flags flags )
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(image_type), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -140,7 +138,7 @@ int test_image_type( cl_device_id device, cl_mem_object_type image_type, cl_mem_
     bool *filterFlags;
     unsigned int numFormats;
 
-    if ( get_format_list( device, image_type, formatList, numFormats, flags ) )
+    if ( get_format_list( context, image_type, formatList, numFormats, flags ) )
         return -1;
 
     BufferOwningPtr<cl_image_format> formatListBuf(formatList);
@@ -184,19 +182,19 @@ int test_image_type( cl_device_id device, cl_mem_object_type image_type, cl_mem_
 
         switch (image_type) {
           case CL_MEM_OBJECT_IMAGE1D:
-            test_return = test_get_image_info_1D( device, &formatList[ i ], flags );
+            test_return = test_get_image_info_1D( device, context, &formatList[ i ], flags );
             break;
           case CL_MEM_OBJECT_IMAGE2D:
-            test_return = test_get_image_info_2D( device, &formatList[ i ], flags );
+            test_return = test_get_image_info_2D( device, context,&formatList[ i ], flags );
             break;
           case CL_MEM_OBJECT_IMAGE3D:
-            test_return = test_get_image_info_3D( device, &formatList[ i ], flags );
+            test_return = test_get_image_info_3D( device, context, &formatList[ i ], flags );
             break;
           case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            test_return = test_get_image_info_1D_array( device, &formatList[ i ], flags );
+            test_return = test_get_image_info_1D_array( device, context, &formatList[ i ], flags );
             break;
           case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            test_return = test_get_image_info_2D_array( device, &formatList[ i ], flags );
+            test_return = test_get_image_info_2D_array( device, context, &formatList[ i ], flags );
             break;
         }
 
@@ -213,12 +211,12 @@ int test_image_type( cl_device_id device, cl_mem_object_type image_type, cl_mem_
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_mem_object_type image_type )
+int test_image_set( cl_device_id device, cl_context context, cl_mem_object_type image_type )
 {
     int ret = 0;
 
-    ret += test_image_type( device, image_type, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, image_type, CL_MEM_WRITE_ONLY );
+    ret += test_image_type( device, context, image_type, CL_MEM_READ_ONLY );
+    ret += test_image_type( device, context, image_type, CL_MEM_WRITE_ONLY );
 
     return ret;
 }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>