### PR TITLE
cl22: Reuse test harness code in clReadWriteImage

### DIFF
--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -25,40 +25,42 @@
 
 #include "../testBase.h"
 
-bool            gDebugTrace = false, gTestSmallImages = false, gTestMaxImages = false, gUseRamp = false, gTestRounding = false, gTestMipmaps = false;
-int                gTypesToTest = 0;
+bool gDebugTrace;
+bool gTestSmallImages;
+bool gTestMaxImages;
+bool gUseRamp;
+bool gTestRounding;
+bool gTestMipmaps;
+int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 bool            gEnablePitch = false;
 cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-cl_command_queue queue;
-cl_context context;
-static cl_device_id device;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
 static void printUsage( const char *execName );
 
-extern int test_image_set( cl_device_id device, cl_mem_object_type image_type );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type image_type );
 
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
 }
 
 test_definition test_list[] = {
@@ -73,11 +75,7 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id platform;
     cl_channel_type chanType;
-    bool randomize = false;
-
-  test_start();
 
     checkDeviceTypeOverride( &gDeviceType );
 
@@ -120,8 +118,6 @@ int main(int argc, const char *argv[])
             // Don't test pitches with mipmaps right now.
             gEnablePitch = false;
         }
-        else if( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
 
         else if( strcmp( argv[i], "--help" ) == 0 || strcmp( argv[i], "-h" ) == 0 )
         {
@@ -137,100 +133,10 @@ int main(int argc, const char *argv[])
         }
     }
 
-    // Seed the random # generators
-  if( randomize )
-  {
-    gRandomSeed = (cl_uint) time( NULL );
-    log_info( "Random seed: %u.\n", gRandomSeed );
-    gReSeed = 1;
-  }
-
-  int error;
-  // Get our platform
-  error = clGetPlatformIDs(1, &platform, NULL);
-  if( error )
-  {
-    print_error( error, "Unable to get platform" );
-    test_finish();
-    return -1;
-  }
-
-  // Get our device
-  unsigned int num_devices;
-  error = clGetDeviceIDs(platform, gDeviceType, 0, NULL, &num_devices);
-  if( error )
-  {
-    print_error( error, "Unable to get number of devices" );
-    test_finish();
-    return -1;
-  }
-
-  uint32_t gDeviceIndex = 0;
-  const char* device_index_env = getenv("CL_DEVICE_INDEX");
-  if (device_index_env) {
-    if (device_index_env) {
-      gDeviceIndex = atoi(device_index_env);
-    }
-
-    if (gDeviceIndex >= num_devices) {
-      vlog("Specified CL_DEVICE_INDEX=%d out of range, using index 0.\n", gDeviceIndex);
-      gDeviceIndex = 0;
-    }
-  }
-
-  cl_device_id *gDeviceList = (cl_device_id *)malloc( num_devices * sizeof( cl_device_id ) );
-  error = clGetDeviceIDs(platform, gDeviceType, num_devices, gDeviceList, NULL);
-  if( error )
-  {
-    print_error( error, "Unable to get devices" );
-    free( gDeviceList );
-    test_finish();
-    return -1;
-  }
-
-  device = gDeviceList[gDeviceIndex];
-  free( gDeviceList );
-
-  log_info( "Using " );
-  if( printDeviceHeader( device ) != CL_SUCCESS )
-  {
-    test_finish();
-    return -1;
-  }
-
-  // Check for image support
-  if(checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED) {
-    log_info("Device does not support images. Skipping test.\n");
-    test_finish();
-    return 0;
-  }
-
-    // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-  if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
-
-  error = clFinish(queue);
-  if (error)
-    print_error(error, "clFinish failed.");
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
   if (gTestFailure == 0) {
     if (gTestCount > 1)
@@ -244,12 +150,7 @@ int main(int argc, const char *argv[])
       log_error("FAILED sub-test.\n");
   }
 
-    // Clean up
-  clReleaseCommandQueue(queue);
-  clReleaseContext(context);
-  free(argList);
-    test_finish();
-
+    free(argList);
     return ret;
 }
 

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -20,18 +20,16 @@ extern cl_addressing_mode gAddressModeToUse;
 extern int                gTypesToTest;
 extern int                gNormalizedModeToUse;
 extern cl_channel_type      gChannelTypeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
 extern bool gDebugTrace;
 extern bool gTestMipmaps;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_image_format *format );
-extern int test_read_image_set_2D( cl_device_id device, cl_image_format *format );
-extern int test_read_image_set_3D( cl_device_id device, cl_image_format *format );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format );
+extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 
 static const char *str_1d_image = "1D";
 static const char *str_2d_image = "2D";
@@ -113,7 +111,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
+int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
 
@@ -129,7 +127,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image
     return 0;
 }
 
-int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_flags flags )
+int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
 {
   log_info( "Running %s %s %s-only tests...\n", gTestMipmaps?"mipmapped":"",convert_image_type_to_string(imageType), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -151,7 +149,7 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
     }
   }
 
-    if( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
 
     filterFlags = new bool[ numFormats ];
@@ -180,19 +178,19 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
 
         switch (imageType) {
             case CL_MEM_OBJECT_IMAGE1D:
-                test_return = test_read_image_set_1D( device, &formatList[ i ] );
+                test_return = test_read_image_set_1D( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                test_return = test_read_image_set_2D( device, &formatList[ i ] );
+                test_return = test_read_image_set_2D( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                test_return = test_read_image_set_3D( device, &formatList[ i ] );
+                test_return = test_read_image_set_3D( device,context, queue,  &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                test_return = test_read_image_set_1D_array( device, &formatList[ i ] );
+                test_return = test_read_image_set_1D_array( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                test_return = test_read_image_set_2D_array( device, &formatList[ i ] );
+                test_return = test_read_image_set_2D_array( device, context, queue, &formatList[ i ] );
                 break;
         }
 
@@ -212,12 +210,12 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_mem_object_type imageType )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
 {
     int ret = 0;
 
-    ret += test_image_type( device, imageType, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, imageType, CL_MEM_WRITE_ONLY );
+    ret += test_image_type( device, context, queue, imageType, CL_MEM_READ_ONLY );
+    ret += test_image_type( device, context, queue, imageType, CL_MEM_WRITE_ONLY );
 
     return ret;
 }

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -22,11 +22,9 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
-int test_read_image_1D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_read_image_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error;
 
@@ -169,7 +167,7 @@ int test_read_image_1D( cl_device_id device, image_descriptor *imageInfo, MTdata
     return 0;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_image_format *format )
+int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -203,7 +201,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format )
             if( gDebugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int ret = test_read_image_1D( device, &imageInfo, seed );
+            int ret = test_read_image_1D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }
@@ -227,7 +225,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format )
             log_info("Testing %d\n", (int)imageInfo.width);
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)maxWidth );
-            if( test_read_image_1D( device, &imageInfo, seed ) )
+            if( test_read_image_1D( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -263,7 +261,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret = test_read_image_1D( device, &imageInfo, seed );
+            int ret = test_read_image_1D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -22,11 +22,9 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
-int test_read_image_1D_array( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_read_image_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error;
 
@@ -175,7 +173,7 @@ int test_read_image_1D_array( cl_device_id device, image_descriptor *imageInfo, 
     return 0;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format )
+int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -212,7 +210,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_read_image_1D_array( device, &imageInfo, seed );
+                int ret = test_read_image_1D_array( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -239,7 +237,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format )
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.arraySize);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxArraySize );
-            if( test_read_image_1D_array( device, &imageInfo, seed ) )
+            if( test_read_image_1D_array( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -277,7 +275,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int ret = test_read_image_1D_array( device, &imageInfo, seed );
+            int ret = test_read_image_1D_array( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D.cpp
@@ -22,11 +22,9 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePi
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
-extern cl_command_queue queue;
-extern cl_context context;
 
 
-int test_read_image_2D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_read_image_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error;
 
@@ -178,7 +176,7 @@ int test_read_image_2D( cl_device_id device, image_descriptor *imageInfo, MTdata
     return 0;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_image_format *format )
+int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -214,7 +212,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_read_image_2D( device, &imageInfo, seed );
+                int ret = test_read_image_2D( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -240,7 +238,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format )
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.height);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxHeight );
-            if( test_read_image_2D( device, &imageInfo, seed ) )
+            if( test_read_image_2D( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -276,7 +274,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_read_image_2D( device, &imageInfo, seed );
+            int ret = test_read_image_2D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -21,10 +21,8 @@
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
-int test_read_image_2D_array( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_read_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error;
 
@@ -151,7 +149,7 @@ int test_read_image_2D_array( cl_device_id device, image_descriptor *imageInfo, 
     return 0;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format )
+int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -190,7 +188,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format )
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_read_image_2D_array( device, &imageInfo, seed );
+                    int ret = test_read_image_2D_array( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -218,7 +216,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format )
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
             log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize);
-            if( test_read_image_2D_array( device, &imageInfo, seed ) )
+            if( test_read_image_2D_array( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -262,7 +260,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_read_image_2D_array( device, &imageInfo, seed );
+            int ret = test_read_image_2D_array( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -21,10 +21,8 @@
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
-extern cl_command_queue queue;
-extern cl_context context;
 
-int test_read_image_3D( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_read_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error;
 
@@ -156,7 +154,7 @@ int test_read_image_3D( cl_device_id device, image_descriptor *imageInfo, MTdata
     return 0;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_image_format *format )
+int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -195,7 +193,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format )
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_read_image_3D( device, &imageInfo, seed );
+                    int ret = test_read_image_3D( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -223,7 +221,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format )
         imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
 
       log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth);
-      if( test_read_image_3D( device, &imageInfo, seed ) )
+      if( test_read_image_3D( context, queue, &imageInfo, seed ) )
         return -1;
     }
   }
@@ -266,7 +264,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_read_image_3D( device, &imageInfo, seed );
+            int ret = test_read_image_3D( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>