### PR TITLE
cl21: Reuse test harness code in kernel_image_methods

### DIFF
--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -26,40 +26,39 @@
 
 #include "../testBase.h"
 
-bool            gDebugTrace = false, gTestSmallImages = false, gTestMaxImages = false, gTestRounding = false;
-int                gTypesToTest = 0;
+bool gDebugTrace;
+bool gTestSmallImages;
+bool gTestMaxImages;
+bool gTestRounding;
+int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
-static cl_device_id device;
 
-extern int test_image_set( cl_device_id device, cl_mem_object_type imageType );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 
 static void printUsage( const char *execName );
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
-clCommandQueueWrapper queue;
-clContextWrapper context;
-
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
 }
 
 test_definition test_list[] = {
@@ -74,11 +73,7 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id platform;
     cl_channel_type chanType;
-    bool randomize = false;
-
-  test_start();
 
     argc = parseCustomParam(argc, argv);
     if (argc == -1)
@@ -120,9 +115,6 @@ int main(int argc, const char *argv[])
         else if( strcmp( argv[i], "max_images" ) == 0 )
             gTestMaxImages = true;
 
-        else if( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
-
         else if( strcmp( argv[i], "--help" ) == 0 || strcmp( argv[i], "-h" ) == 0 )
         {
             printUsage( argv[ 0 ] );
@@ -137,104 +129,10 @@ int main(int argc, const char *argv[])
         }
     }
 
-    // Seed the random # generators
-  if( randomize )
-  {
-    gRandomSeed = (cl_uint) time( NULL );
-    log_info( "Random seed: %u.\n", gRandomSeed );
-    gReSeed = 1;
-  }
-
-    // Get our device
-    int error;
-
-    // Get our platform
-    error = clGetPlatformIDs(1, &platform, NULL);
-    if( error )
-    {
-        print_error( error, "Unable to get platform" );
-        test_finish();
-        return -1;
-    }
-
-  // Get our device
-  unsigned int num_devices;
-  error = clGetDeviceIDs(platform, gDeviceType, 0, NULL, &num_devices);
-  if( error )
-  {
-    print_error( error, "Unable to get number of devices" );
-    test_finish();
-    return -1;
-  }
-
-  uint32_t gDeviceIndex = 0;
-  const char* device_index_env = getenv("CL_DEVICE_INDEX");
-  if (device_index_env) {
-    if (device_index_env) {
-        gDeviceIndex = atoi(device_index_env);
-    }
-
-    if (gDeviceIndex >= num_devices) {
-      vlog("Specified CL_DEVICE_INDEX=%d out of range, using index 0.\n", gDeviceIndex);
-      gDeviceIndex = 0;
-    }
-  }
-
-  cl_device_id *gDeviceList = (cl_device_id *)malloc( num_devices * sizeof( cl_device_id ) );
-  error = clGetDeviceIDs(platform, gDeviceType, num_devices, gDeviceList, NULL);
-  if( error )
-  {
-    print_error( error, "Unable to get devices" );
-    free( gDeviceList );
-    test_finish();
-    return -1;
-  }
-
-  device = gDeviceList[gDeviceIndex];
-  free( gDeviceList );
-
-  log_info( "Using " );
-    if( printDeviceHeader( device ) != CL_SUCCESS )
-    {
-        test_finish();
-        return -1;
-    }
-
-  // Check for image support
-  if (checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED)
-  {
-    log_info("Device does not support images. Skipping test.\n");
-    test_finish();
-    return 0;
-  }
-
-  // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-  if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
-
-  // Clean up
-  error = clFinish(queue);
-  if (error)
-    print_error(error, "clFinish failed.");
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
   if (gTestFailure == 0) {
     if (gTestCount > 1)
@@ -249,8 +147,6 @@ int main(int argc, const char *argv[])
   }
 
   free(argList);
-  test_finish();
-
   return ret;
 }
 

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -20,9 +20,6 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern clCommandQueueWrapper queue;
-extern clContextWrapper context;
-
 typedef struct image_kernel_data
 {
     cl_int width;
@@ -50,7 +47,7 @@ static const char *methodTest1DImageKernelPattern =
 "   outData->expectedChannelOrder = %s;\n"
 "}";
 
-static int test_get_1Dimage_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+static int test_get_1Dimage_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error = 0;
 
@@ -147,7 +144,7 @@ static int test_get_1Dimage_info_single( cl_device_id device, image_descriptor *
     return error;
 }
 
-int test_get_image_info_1D( cl_device_id device, cl_image_format *format )
+int test_get_image_info_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -177,7 +174,7 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format )
             if( gDebugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int ret = test_get_1Dimage_info_single( device, &imageInfo, seed );
+            int ret = test_get_1Dimage_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }
@@ -198,7 +195,7 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ]);
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if( test_get_1Dimage_info_single( device, &imageInfo, seed ) )
+            if( test_get_1Dimage_info_single( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -227,7 +224,7 @@ int test_get_image_info_1D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret = test_get_1Dimage_info_single( device, &imageInfo, seed );
+            int ret = test_get_1Dimage_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -20,9 +20,6 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern clCommandQueueWrapper queue;
-extern clContextWrapper context;
-
 typedef struct image_kernel_data
 {
     cl_int width;
@@ -53,7 +50,7 @@ static const char *methodTestKernelPattern =
 "   outData->expectedChannelOrder = %s;\n"
 "}";
 
-int test_get_1Dimage_array_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_get_1Dimage_array_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error = 0;
 
@@ -155,7 +152,7 @@ int test_get_1Dimage_array_info_single( cl_device_id device, image_descriptor *i
     return error;
 }
 
-int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format )
+int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -189,7 +186,7 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_get_1Dimage_array_info_single( device, &imageInfo, seed );
+                int ret = test_get_1Dimage_array_info_single( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -213,7 +210,7 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ]);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if( test_get_1Dimage_array_info_single( device, &imageInfo, seed ) )
+            if( test_get_1Dimage_array_info_single( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -245,7 +242,7 @@ int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int ret = test_get_1Dimage_array_info_single( device, &imageInfo, seed );
+            int ret = test_get_1Dimage_array_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -20,9 +20,6 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern clCommandQueueWrapper queue;
-extern clContextWrapper context;
-
 typedef struct image_kernel_data
 {
     cl_int width;
@@ -69,7 +66,7 @@ static const char *methodTestKernelPattern =
 static const char *depthKernelLine = "   outData->depth = get_image_depth( input );\n";
 static const char *depthDimKernelLine = "   outData->depthDim = dim.z;\n";
 
-int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_get_image_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error = 0;
 
@@ -199,7 +196,7 @@ int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo
     return error;
 }
 
-int test_get_image_info_2D( cl_device_id device, cl_image_format *format )
+int test_get_image_info_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -232,7 +229,7 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format )
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_get_image_info_single( device, &imageInfo, seed );
+                int ret = test_get_image_info_single( context, queue, &imageInfo, seed );
                 if( ret )
                     return -1;
             }
@@ -255,7 +252,7 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if( test_get_image_info_single( device, &imageInfo, seed ) )
+            if( test_get_image_info_single( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -285,7 +282,7 @@ int test_get_image_info_2D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_get_image_info_single( device, &imageInfo, seed );
+            int ret = test_get_image_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -20,9 +20,6 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern clCommandQueueWrapper queue;
-extern clContextWrapper context;
-
 typedef struct image_kernel_data
 {
     cl_int width;
@@ -56,7 +53,7 @@ static const char *methodTestKernelPattern =
 "   outData->expectedChannelOrder = %s;\n"
 "}";
 
-int test_get_2Dimage_array_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d )
+int test_get_2Dimage_array_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     int error = 0;
 
@@ -164,7 +161,7 @@ int test_get_2Dimage_array_info_single( cl_device_id device, image_descriptor *i
     return error;
 }
 
-int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format )
+int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -200,7 +197,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format )
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_get_2Dimage_array_info_single( device, &imageInfo, seed );
+                    int ret = test_get_2Dimage_array_info_single( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -226,7 +223,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( test_get_2Dimage_array_info_single( device, &imageInfo, seed ) )
+            if( test_get_2Dimage_array_info_single( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -262,7 +259,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_get_2Dimage_array_info_single( device, &imageInfo, seed );
+            int ret = test_get_2Dimage_array_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -20,9 +20,9 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages;
 
-extern int test_get_image_info_single( cl_device_id device, image_descriptor *imageInfo, MTdata d );
+extern int test_get_image_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d );
 
-int test_get_image_info_3D( cl_device_id device, cl_image_format *format )
+int test_get_image_info_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -58,7 +58,7 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format )
                 {
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_get_image_info_single( device, &imageInfo, seed );
+                    int ret = test_get_image_info_single( context, queue, &imageInfo, seed );
                     if( ret )
                         return -1;
                 }
@@ -84,7 +84,7 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format )
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( test_get_image_info_single( device, &imageInfo, seed ) )
+            if( test_get_image_info_single( context, queue, &imageInfo, seed ) )
                 return -1;
         }
     }
@@ -120,7 +120,7 @@ int test_get_image_info_3D( cl_device_id device, cl_image_format *format )
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_get_image_info_single( device, &imageInfo, seed );
+            int ret = test_get_image_info_single( context, queue, &imageInfo, seed );
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -24,11 +24,11 @@ extern cl_channel_type      gChannelTypeToUse;
 
 extern bool gDebugTrace;
 
-extern int test_get_image_info_1D( cl_device_id device, cl_image_format *format );
-extern int test_get_image_info_2D( cl_device_id device, cl_image_format *format );
-extern int test_get_image_info_3D( cl_device_id device, cl_image_format *format );
-extern int test_get_image_info_1D_array( cl_device_id device, cl_image_format *format );
-extern int test_get_image_info_2D_array( cl_device_id device, cl_image_format *format );
+extern int test_get_image_info_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 
 static const char *str_1d_image = "1D";
 static const char *str_2d_image = "2D";
@@ -110,9 +110,8 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
+int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
 {
-    extern clContextWrapper context;
     int error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
                                        imageType, 0, NULL, &outFormatCount );
     test_error( error, "Unable to get count of supported image formats" );
@@ -125,7 +124,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image
 }
 
 
-int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_flags flags )
+int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(imageType), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -136,7 +135,7 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
     bool *filterFlags;
     unsigned int numFormats;
 
-    if( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
 
     filterFlags = new bool[ numFormats ];
@@ -165,19 +164,19 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
 
         switch (imageType) {
             case CL_MEM_OBJECT_IMAGE1D:
-                test_return = test_get_image_info_1D( device, &formatList[ i ] );
+                test_return = test_get_image_info_1D( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                test_return = test_get_image_info_2D( device, &formatList[ i ] );
+                test_return = test_get_image_info_2D( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                test_return = test_get_image_info_3D( device, &formatList[ i ] );
+                test_return = test_get_image_info_3D( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                test_return = test_get_image_info_1D_array( device, &formatList[ i ] );
+                test_return = test_get_image_info_1D_array( device, context, queue, &formatList[ i ] );
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                test_return = test_get_image_info_2D_array( device, &formatList[ i ] );
+                test_return = test_get_image_info_2D_array( device, context, queue, &formatList[ i ] );
                 break;
         }
 
@@ -197,7 +196,7 @@ int test_image_type( cl_device_id device, cl_mem_object_type imageType, cl_mem_f
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_mem_object_type imageType )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
 {
     int version_check;
   if ((version_check = check_opencl_version(device,1,2))) {
@@ -212,8 +211,8 @@ int test_image_set( cl_device_id device, cl_mem_object_type imageType )
   }
 
   int ret = 0;
-    ret += test_image_type( device, imageType, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, imageType, CL_MEM_WRITE_ONLY );
+    ret += test_image_type( device, context, queue, imageType, CL_MEM_READ_ONLY );
+    ret += test_image_type( device, context, queue, imageType, CL_MEM_WRITE_ONLY );
 
     return ret;
 }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>