### PR TITLE
cl20: Remove redundant releaseOutputStream call in printf

### DIFF
--- a/test_conformance/printf/test_printf.c
+++ b/test_conformance/printf/test_printf.c
@@ -1032,8 +1032,6 @@ int main(int argc, char* argv[])
     if(clReleaseContext(gContext)!= CL_SUCCESS)
         log_error("clReleaseContext\n");
 
-    releaseOutputStream(gFd);
-
 
     free(argList);
     return err;


### PR DESCRIPTION
Fix #212