### PR TITLE
cl21: Remove redundant releaseOutputStream call in printf

### DIFF
--- a/test_conformance/printf/test_printf.c
+++ b/test_conformance/printf/test_printf.c
@@ -993,8 +993,6 @@ int main(int argc, const char* argv[])
     if(clReleaseContext(gContext)!= CL_SUCCESS)
         log_error("clReleaseContext\n");
 
-    releaseOutputStream(gFd);
-
 
     free(argList);
     return err;


### PR DESCRIPTION
Fix #212