### PR TITLE
cl12: Do not mistake x86_64 platforms as x86

### DIFF
--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -29,7 +29,7 @@ set_source_files_properties(
         ../../test_common/harness/errorHelpers.c
         PROPERTIES LANGUAGE CXX)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86$)|(X86$)")
 if(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
 # -march is needed for CPU atomics, default arch on gcc is i386 
 # that does not support atomics. 

--- a/test_conformance/integer_ops/CMakeLists.txt
+++ b/test_conformance/integer_ops/CMakeLists.txt
@@ -41,7 +41,7 @@ set_source_files_properties(
         PROPERTIES LANGUAGE CXX)
         
 if (NOT CMAKE_CL_64 AND NOT MSVC)                   
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)" AND NOT MSVC)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86$)|(X86$)" AND NOT MSVC)
 set_source_files_properties(
 	main.c
 	test_popcount.c

--- a/test_conformance/math_brute_force/CMakeLists.txt
+++ b/test_conformance/math_brute_force/CMakeLists.txt
@@ -50,7 +50,7 @@ set_source_files_properties(
 endif(MSVC)
 
 if (NOT CMAKE_CL_64 AND NOT MSVC)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)" AND NOT MSVC)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86$)|(X86$)" AND NOT MSVC)
 set_source_files_properties(
     FunctionList.c
     Sleep.c


### PR DESCRIPTION
This resulted in “unknown target CPU 'i686'” error messages on my laptop, as `CMAKE_SYSTEM_PROCESSOR` was `x86_64` which matches the `x86` string.