### PR TITLE
cl21: Fix ilogbl crash and fetestexcept build if _MSC_VER>=1800

### DIFF
--- a/test_common/harness/msvc9.c
+++ b/test_common/harness/msvc9.c
@@ -117,6 +117,7 @@ long double rintl(long double x)
     return x;
 }
 
+#if _MSC_VER < 1800
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -221,7 +222,7 @@ int ilogbl (long double x)
     return exp - 0x3fff;
 }
 
-
+#endif // _MSC_VER < 1800
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -566,7 +567,7 @@ long int lrintf (float x)
 //
 ///////////////////////////////////////////////////////////////////
 
-#if _MSC_VER < 1900
+#if _MSC_VER < 1800
 int fetestexcept(int excepts)
 {
     unsigned int status = _statusfp();


### PR DESCRIPTION
FP_ILOGB0, FP_ILOGBNAN, ilogbm, ilogbf, ilogbl, fetestexcept and
feclearexcept are supported in Visual Studio 2013. See #183