### PR TITLE
cl21: Reuse test harness code in kernel_read_write

### DIFF
--- a/test_common/harness/testHarness.c
+++ b/test_common/harness/testHarness.c
@@ -819,7 +819,7 @@ void memset_pattern4(void *dest, const void *src_pattern, size_t bytes )
 }
 #endif
 
-extern cl_device_type GetDeviceType( cl_device_id d )
+cl_device_type GetDeviceType( cl_device_id d )
 {
     cl_device_type result = -1;
     cl_int err = clGetDeviceInfo( d, CL_DEVICE_TYPE, sizeof( result ), &result, NULL );

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -36,7 +36,14 @@
 __thread fpu_control_t fpu_control = 0;
 #endif
 
-bool            gDebugTrace = false, gExtraValidateInfo = false, gDisableOffsets = false, gTestSmallImages = false, gTestMaxImages = false, gTestRounding = false, gTestImage2DFromBuffer = 0, gTestMipmaps = false;
+bool gDebugTrace;
+bool gExtraValidateInfo;
+bool gDisableOffsets;
+bool gTestSmallImages;
+bool gTestMaxImages;
+bool gTestRounding;
+bool gTestImage2DFromBuffer;
+bool gTestMipmaps;
 cl_filter_mode    gFilterModeToUse = (cl_filter_mode)-1;
 // Default is CL_MEM_USE_HOST_PTR for the test
 cl_mem_flags    gMemFlagsToUse = CL_MEM_USE_HOST_PTR;
@@ -51,15 +58,12 @@ cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 int             gtestTypesToRun = 0;
 static int testTypesToRun;
-cl_command_queue queue;
-cl_context context;
-static cl_device_id device;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
 static void printUsage( const char *execName );
 
-extern int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem_object_type imageType );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, test_format_set_fn formatTestFn, cl_mem_object_type imageType );
 
 /** read_write images only support sampler-less read buildt-ins which require special settings
   * for some global parameters. This pair of functions temporarily overwrite those global parameters
@@ -106,7 +110,7 @@ static void recover_global_params_from_read_write_test(bool            tTestMipm
     gFilterModeToUse        = tFilterModeToUse;
 }
 
-static int doTest( cl_mem_object_type imageType )
+static int doTest( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
 {
     int ret = 0;
     bool is_2d_image = imageType == CL_MEM_OBJECT_IMAGE2D;
@@ -118,7 +122,7 @@ static int doTest( cl_mem_object_type imageType )
     if( testTypesToRun & kReadTests )
     {
         gtestTypesToRun = kReadTests;
-        ret += test_image_set( device, test_read_image_formats, imageType );
+        ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
@@ -133,7 +137,7 @@ static int doTest( cl_mem_object_type imageType )
                 // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
                 gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
 
-                ret += test_image_set( device, test_read_image_formats, imageType );
+                ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
 
                 gTestImage2DFromBuffer = false;
                 gMemFlagsToUse = saved_gMemFlagsToUse;
@@ -144,7 +148,7 @@ static int doTest( cl_mem_object_type imageType )
     if( testTypesToRun & kWriteTests )
     {
         gtestTypesToRun = kWriteTests;
-        ret += test_image_set( device, test_write_image_formats, imageType );
+        ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
@@ -161,7 +165,7 @@ static int doTest( cl_mem_object_type imageType )
                 gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
                 gTestImage2DFromBuffer = true;
 
-                ret += test_image_set( device, test_write_image_formats, imageType );
+                ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
 
                 gTestImage2DFromBuffer = false;
                 gMemFlagsToUse = saved_gMemFlagsToUse;
@@ -174,7 +178,7 @@ static int doTest( cl_mem_object_type imageType )
     {
         gtestTypesToRun = kReadWriteTests;
         overwrite_global_params_for_read_write_test(&tTestMipMaps, &tDisableOffsets, &tNormalizedModeToUse, &tFilterModeToUse);
-        ret += test_image_set( device, test_read_image_formats, imageType );
+        ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
@@ -189,14 +193,14 @@ static int doTest( cl_mem_object_type imageType )
                 // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
                 gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
 
-                ret += test_image_set( device, test_read_image_formats, imageType );
+                ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
 
                 gTestImage2DFromBuffer = false;
                 gMemFlagsToUse = saved_gMemFlagsToUse;
             }
         }
 
-        ret += test_image_set( device, test_write_image_formats, imageType );
+        ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
@@ -213,7 +217,7 @@ static int doTest( cl_mem_object_type imageType )
                 gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
                 gTestImage2DFromBuffer = true;
 
-                ret += test_image_set( device, test_write_image_formats, imageType );
+                ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
 
                 gTestImage2DFromBuffer = false;
                 gMemFlagsToUse = saved_gMemFlagsToUse;
@@ -227,25 +231,25 @@ static int doTest( cl_mem_object_type imageType )
     return ret;
 }
 
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest( CL_MEM_OBJECT_IMAGE1D );
+    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest( CL_MEM_OBJECT_IMAGE2D );
+    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest( CL_MEM_OBJECT_IMAGE3D );
+    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest( CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest( CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
 }
 
 test_definition test_list[] = {
@@ -260,12 +264,8 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id  platform;
     cl_channel_type chanType;
     cl_channel_order chanOrder;
-    bool            randomize = false;
-
-    test_start();
 
     argc = parseCustomParam(argc, argv);
     if (argc == -1)
@@ -363,9 +363,6 @@ int main(int argc, const char *argv[])
         else if( strcmp( argv[i], "float" ) == 0 )
             gTypesToTest |= kTestFloat;
 
-        else if( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
-
         else if( strcmp( argv[i], "CL_MEM_COPY_HOST_PTR" ) == 0 || strcmp( argv[i], "COPY_HOST_PTR" ) == 0 )
             gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
         else if( strcmp( argv[i], "CL_MEM_USE_HOST_PTR" ) == 0 || strcmp( argv[i], "USE_HOST_PTR" ) == 0 )
@@ -427,93 +424,6 @@ int main(int argc, const char *argv[])
 #endif
 #endif
 
-    // Seed the random # generators
-    if( randomize )
-    {
-        gRandomSeed = (cl_uint) time( NULL );
-        gReSeed = 1;
-        log_info( "Random seed: %u\n", gRandomSeed );
-    }
-
-    int error;
-    // Get our platform
-    error = clGetPlatformIDs(1, &platform, NULL);
-    if( error )
-    {
-        print_error( error, "Unable to get platform" );
-        test_finish();
-        return -1;
-    }
-
-    // Get our device
-    cl_uint num_devices = 0;
-    error = clGetDeviceIDs(platform, gDeviceType, 0, NULL, &num_devices );
-    if( error )
-    {
-        print_error( error, "Unable to get the number of devices" );
-        test_finish();
-        return -1;
-    }
-
-    std::vector<cl_device_id> devices(num_devices);
-    error = clGetDeviceIDs(platform, gDeviceType, num_devices, &devices[0], NULL );
-    if( error )
-    {
-        print_error( error, "Unable to get specified device type" );
-        test_finish();
-        return -1;
-    }
-
-    int device_index = 0;
-    char* device_index_str = getenv("CL_DEVICE_INDEX");
-    if (device_index_str && ((device_index = atoi(device_index_str))) >= num_devices) {
-        log_error("CL_DEVICE_INDEX=%d is greater than the number of devices %d\n",device_index,num_devices);
-        test_finish();
-        return -1;
-    }
-
-    device = devices[device_index];
-
-    // Get the device type so we know if it is a GPU even if default is passed in.
-    error = clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(gDeviceType), &gDeviceType, NULL);
-    if( error )
-    {
-        print_error( error, "Unable to get device type" );
-        test_finish();
-        return -1;
-    }
-
-      if( printDeviceHeader( device ) != CL_SUCCESS )
-    {
-        test_finish();
-        return -1;
-    }
-
-    // Check for image support
-    if(checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED) {
-        log_info("Device does not support images. Skipping test.\n");
-        test_finish();
-        return 0;
-    }
-
-    // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-    if( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
@@ -528,17 +438,10 @@ int main(int argc, const char *argv[])
     FPU_mode_type oldMode;
     DisableFTZ(&oldMode);
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
     // Restore FP state before leaving
     RestoreFPState(&oldMode);
-
-    error = clFinish(queue);
-    if (error)
-        print_error(error, "clFinish failed.");
-
-    clReleaseContext(context);
-    clReleaseCommandQueue(queue);
 
     if (gTestFailure == 0) {
         if (gTestCount > 1)
@@ -552,10 +455,7 @@ int main(int argc, const char *argv[])
             log_error("FAILED sub-test.\n");
     }
 
-    // Clean up
     free(argList);
-    test_finish();
-
     return ret;
 }
 

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestImage2DFromBuffer, gTestMipmaps;
 extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
@@ -1153,7 +1151,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
     return 0;
 }
 
-int test_read_image_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                        bool useFloatCoords, ExplicitType outputType, MTdata d )
 {
@@ -1524,7 +1522,7 @@ int test_read_image_2D( cl_device_id device, cl_context context, cl_command_queu
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                         bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];
@@ -1641,7 +1639,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
                 if( retCode )
                     return retCode;
             }
@@ -1667,7 +1665,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
 
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1693,7 +1691,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
         {
             if( gDebugTrace )
                 log_info( "   at size %d,%d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, (int)imageInfo.height, gRoundingStartValue, typeRange );
-            int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
 
@@ -1755,7 +1753,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -15,7 +15,6 @@
 //
 #include "../testBase.h"
 
-extern cl_context context;
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
 extern int                gTypesToTest;
@@ -28,15 +27,15 @@ extern bool gTestMipmaps;
 
 extern int  gtestTypesToRun;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue,  cl_image_format *format, image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                                         bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                                         bool floatCoords, ExplicitType outputType );
 
 static const char *str_1d_image = "1D";
@@ -132,7 +131,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
+int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
 
@@ -149,7 +148,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image
     return 0;
 }
 
-int test_read_image_type( cl_device_id device, cl_image_format *format, bool floatCoords,
+int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool floatCoords,
                          image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -210,19 +209,19 @@ int test_read_image_type( cl_device_id device, cl_image_format *format, bool flo
         switch (imageType)
         {
             case CL_MEM_OBJECT_IMAGE1D:
-                retCode = test_read_image_set_1D( device, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_1D( device, context, queue, format, imageSampler, floatCoords, outputType );
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                retCode = test_read_image_set_1D_array( device, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_1D_array( device, context, queue, format, imageSampler, floatCoords, outputType );
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                retCode = test_read_image_set_2D( device, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_2D( device, context, queue, format, imageSampler, floatCoords, outputType );
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                retCode = test_read_image_set_2D_array( device, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_2D_array( device, context, queue, format, imageSampler, floatCoords, outputType );
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                retCode = test_read_image_set_3D( device, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_3D( device, context, queue, format, imageSampler, floatCoords, outputType );
                 break;
         }
         if( retCode != 0 )
@@ -238,7 +237,7 @@ int test_read_image_type( cl_device_id device, cl_image_format *format, bool flo
     return ret;
 }
 
-int test_read_image_formats( cl_device_id device, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
                             image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -281,7 +280,7 @@ int test_read_image_formats( cl_device_id device, cl_image_format *formatList, b
 
                 cl_image_format &imageFormat = formatList[ i ];
 
-                ret |= test_read_image_type( device, &imageFormat, flipFlop[ floatCoordIdx ], imageSampler, outputType, imageType );
+                ret |= test_read_image_type( device, context, queue, &imageFormat, flipFlop[ floatCoordIdx ], imageSampler, outputType, imageType );
             }
         }
     }
@@ -289,7 +288,7 @@ int test_read_image_formats( cl_device_id device, cl_image_format *formatList, b
 }
 
 
-int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem_object_type imageType )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, test_format_set_fn formatTestFn, cl_mem_object_type imageType )
 {
     int ret = 0;
     static int printedFormatList = -1;
@@ -371,7 +370,7 @@ int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem
         }
     }
 
-    if( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
     BufferOwningPtr<cl_image_format> formatListBuf(formatList);
 
@@ -423,10 +422,10 @@ int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem
         else
         {
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
+            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
 
             imageSampler.filter_mode = CL_FILTER_LINEAR;
-            ret += formatTestFn( device, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
+            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
         }
     }
 
@@ -442,7 +441,7 @@ int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem
         {
             // Only filter mode we support on int is nearest
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
+            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
         }
     }
 
@@ -459,7 +458,7 @@ int test_image_set( cl_device_id device, test_format_set_fn formatTestFn, cl_mem
         {
             // Only filter mode we support on uint is nearest
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
+            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
         }
     }
     return ret;

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
@@ -236,7 +234,7 @@ static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *im
 #endif
 
 
-int test_read_image_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                        bool useFloatCoords, ExplicitType outputType, MTdata d )
 {
@@ -988,7 +986,7 @@ int test_read_image_1D( cl_device_id device, cl_context context, cl_command_queu
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                         bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];
@@ -1078,7 +1076,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
             if( gDebugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1100,7 +1098,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1120,7 +1118,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
         {
             if( gDebugTrace )
                 log_info( "   at size %d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, gRoundingStartValue, typeRange );
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
 
@@ -1159,7 +1157,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
 
             if( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
@@ -286,7 +284,7 @@ static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *im
 #endif
 
 
-int test_read_image_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
                              image_descriptor *imageInfo, image_sampler_data *imageSampler,
                              bool useFloatCoords, ExplicitType outputType, MTdata d )
 {
@@ -1097,7 +1095,7 @@ int test_read_image_1D_array( cl_device_id device, cl_context context, cl_comman
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                                  bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];
@@ -1183,7 +1181,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
                 if( retCode )
                     return retCode;
             }
@@ -1207,7 +1205,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1233,7 +1231,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
         {
             if( gDebugTrace )
                 log_info( "   at size %d,%d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, (int)imageInfo.arraySize, gRoundingStartValue, typeRange );
-            int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
 
@@ -1274,7 +1272,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -19,8 +19,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool         gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_device_type   gDeviceType;
 extern bool         gUseKernelSamplers;
@@ -316,7 +314,7 @@ static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *im
 #define MAX(_a, _b)             ((_a) > (_b) ? (_a) : (_b))
 #endif
 
-int test_read_image_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
                        bool useFloatCoords, ExplicitType outputType, MTdata d )
 {
@@ -1269,7 +1267,7 @@ int test_read_image_2D_array( cl_device_id device, cl_context context, cl_comman
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                            bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];
@@ -1380,7 +1378,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                    int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
                     if( retCode )
                         return retCode;
                 }
@@ -1427,7 +1425,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1441,7 +1439,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
 
         imageInfo.rowPitch = imageInfo.width * pixelSize;
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-        int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+        int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
         if( retCode )
             return retCode;
     }
@@ -1492,7 +1490,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
                 if ( gTestMipmaps )
                     log_info("  and %d mip levels\n", (int) imageInfo.num_mip_levels);
             }
-            int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -19,8 +19,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
@@ -317,7 +315,7 @@ static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *im
 #define MAX(_a, _b)             ((_a) > (_b) ? (_a) : (_b))
 #endif
 
-int test_read_image_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
                        bool useFloatCoords, ExplicitType outputType, MTdata d )
 {
@@ -1132,7 +1130,7 @@ int test_read_image_3D( cl_device_id device, cl_context context, cl_command_queu
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                            bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];
@@ -1223,7 +1221,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                    int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
                     if( retCode )
                         return retCode;
                 }
@@ -1250,7 +1248,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }
@@ -1264,7 +1262,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
 
         imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-        int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+        int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
         if( retCode )
             return retCode;
     }
@@ -1314,7 +1312,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
                 if ( gTestMipmaps )
                     log_info( "   and number of mip levels :%d\n", (int)imageInfo.num_mip_levels );
             }
-            int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -21,8 +21,6 @@
 
 #define MAX_ERR 0.005f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToSkip;
 extern cl_mem_flags gMemFlagsToUse;
@@ -79,13 +77,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
 
 #if defined( __APPLE__ )
         // Require Apple's CPU implementation to be correctly rounded, not just within 0.6
-        cl_device_type type = 0;
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof( type), &type, NULL )))
-        {
-            log_error("Error: Could not get device type for Apple device! (%d) \n", error );
-            return 1;
-        }
-        if( type == CL_DEVICE_TYPE_CPU )
+        if( GetDeviceType(device) == CL_DEVICE_TYPE_CPU )
             forceCorrectlyRoundedWrites = 1;
 #endif
 
@@ -542,7 +534,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
 }
 
 
-int test_write_image_1D_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -21,8 +21,6 @@
 
 #define MAX_ERR 0.005f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToSkip;
 extern cl_mem_flags gMemFlagsToUse;
@@ -88,13 +86,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 
 #if defined( __APPLE__ )
         // Require Apple's CPU implementation to be correctly rounded, not just within 0.6
-        cl_device_type type = 0;
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof( type), &type, NULL )))
-        {
-            log_error("Error: Could not get device type for Apple device! (%d) \n", error );
-            return 1;
-        }
-        if( type == CL_DEVICE_TYPE_CPU )
+        if( GetDeviceType(device) == CL_DEVICE_TYPE_CPU )
             forceCorrectlyRoundedWrites = 1;
 #endif
 
@@ -562,7 +554,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_1D_array_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -21,8 +21,6 @@
 
 #define MAX_ERR 0.005f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToSkip;
 extern cl_mem_flags gMemFlagsToUse;
@@ -115,13 +113,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 
 #if defined( __APPLE__ )
         // Require Apple's CPU implementation to be correctly rounded, not just within 0.6
-        cl_device_type type = 0;
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof( type), &type, NULL )))
-        {
-            log_error("Error: Could not get device type for Apple device! (%d) \n", error );
-            return 1;
-        }
-        if( type == CL_DEVICE_TYPE_CPU )
+        if( GetDeviceType(device) == CL_DEVICE_TYPE_CPU )
             forceCorrectlyRoundedWrites = 1;
 #endif
 
@@ -588,7 +580,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_2D_array_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -21,8 +21,6 @@
 
 #define MAX_ERR 0.005f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToSkip;
 extern cl_mem_flags gMemFlagsToUse;
@@ -118,13 +116,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 
 #if defined( __APPLE__ )
         // Require Apple's CPU implementation to be correctly rounded, not just within 0.6
-        cl_device_type type = 0;
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof( type), &type, NULL )))
-        {
-            log_error("Error: Could not get device type for Apple device! (%d) \n", error );
-            return 1;
-        }
-        if( type == CL_DEVICE_TYPE_CPU )
+        if( GetDeviceType(device) == CL_DEVICE_TYPE_CPU )
             forceCorrectlyRoundedWrites = 1;
 #endif
 
@@ -596,7 +588,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 }
 
 
-int test_write_image_3D_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -21,17 +21,15 @@
 
 #define MAX_ERR 0.005f
 
-extern cl_command_queue queue;
-extern cl_context context;
 extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestImage2DFromBuffer, gTestMipmaps;
 extern cl_filter_mode    gFilterModeToSkip;
 extern cl_mem_flags gMemFlagsToUse;
 extern int gtestTypesToRun;
 
-extern int test_write_image_1D_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_3D_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_1D_array_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_2D_array_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
 
 
 const char *writeKernelSourcePattern =
@@ -95,13 +93,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 
 #if defined( __APPLE__ )
         // Require Apple's CPU implementation to be correctly rounded, not just within 0.6
-        cl_device_type type = 0;
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof( type), &type, NULL )))
-        {
-            log_error("Error: Could not get device type for Apple device! (%d) \n", error );
-            return 1;
-        }
-        if( type == CL_DEVICE_TYPE_CPU )
+        if( GetDeviceType(device) == CL_DEVICE_TYPE_CPU )
             forceCorrectlyRoundedWrites = 1;
 #endif
 
@@ -614,7 +606,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 }
 
 
-int test_write_image_set( cl_device_id device, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;
@@ -815,7 +807,7 @@ int test_write_image_set( cl_device_id device, cl_image_format *format, Explicit
     return 0;
 }
 
-int test_write_image_formats( cl_device_id device, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
                              image_sampler_data *imageSampler, ExplicitType inputType, cl_mem_object_type imageType )
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
@@ -856,19 +848,19 @@ int test_write_image_formats( cl_device_id device, cl_image_format *formatList, 
         switch (imageType)
         {
             case CL_MEM_OBJECT_IMAGE1D:
-                retCode = test_write_image_1D_set( device, &imageFormat, inputType, seed );
+                retCode = test_write_image_1D_set( device, context, queue, &imageFormat, inputType, seed );
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                retCode = test_write_image_set( device, &imageFormat, inputType, seed );
+                retCode = test_write_image_set( device, context, queue, &imageFormat, inputType, seed );
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                retCode = test_write_image_3D_set( device, &imageFormat, inputType, seed );
+                retCode = test_write_image_3D_set( device, context, queue, &imageFormat, inputType, seed );
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                retCode = test_write_image_1D_array_set( device, &imageFormat, inputType, seed );
+                retCode = test_write_image_1D_array_set( device, context, queue, &imageFormat, inputType, seed );
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                retCode = test_write_image_2D_array_set( device, &imageFormat, inputType, seed );
+                retCode = test_write_image_2D_array_set( device, context, queue, &imageFormat, inputType, seed );
                 break;
         }
 

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -58,16 +58,16 @@ enum TestTypes
     kAllTests = ( kReadTests | kWriteTests | kReadWriteTests )
 };
 
-typedef int (*test_format_set_fn)( cl_device_id device,
+typedef int (*test_format_set_fn)( cl_device_id device, cl_context context, cl_command_queue queue,
   cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
 
-extern int test_read_image_formats( cl_device_id device,
+extern int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
   cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
-extern int test_write_image_formats( cl_device_id device,
+extern int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
   cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>