### PR TITLE
cl22: Reuse test harness code in samplerlessReads

### DIFF
--- a/test_conformance/images/samplerlessReads/main.cpp
+++ b/test_conformance/images/samplerlessReads/main.cpp
@@ -34,45 +34,43 @@
 __thread fpu_control_t fpu_control = 0;
 #endif
 
-bool                gTestReadWrite = false;
-bool                gDebugTrace = false;
-bool                gTestMaxImages = false, gTestSmallImages = false, gTestRounding = false;
-int                 gTypesToTest = 0;
+bool                gTestReadWrite;
+bool                gDebugTrace;
+bool                gTestMaxImages;
+bool                gTestSmallImages;
+bool                gTestRounding;
+int                 gTypesToTest;
 cl_channel_type     gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order    gChannelOrderToUse = (cl_channel_order)-1;
 bool                gEnablePitch = false;
 cl_device_type      gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
-cl_command_queue    queue;
-cl_context          context;
-static cl_device_id device;
-
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
 static void printUsage( const char *execName );
 
-extern int test_image_set( cl_device_id device, cl_mem_object_type imageType );
+extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 
-int test_1D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D ) +
-           test_image_set( device, CL_MEM_OBJECT_IMAGE1D_BUFFER );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D ) +
+           test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER );
 }
-int test_2D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
 }
-int test_3D(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_3D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
 }
-int test_1Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_1Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
 }
-int test_2Darray(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_2Darray(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return test_image_set( device, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
 }
 
 test_definition test_list[] = {
@@ -87,17 +85,12 @@ const int test_num = ARRAY_SIZE( test_list );
 
 int main(int argc, const char *argv[])
 {
-    cl_platform_id  platform;
     cl_channel_type chanType;
     cl_channel_order chanOrder;
-    bool            randomize = false;
 
-    test_start();
-    
     argc = parseCustomParam(argc, argv);
     if (argc == -1)
     {
-        test_finish();
         return -1;
     }
 
@@ -145,9 +138,6 @@ int main(int argc, const char *argv[])
         else if ( strcmp( argv[i], "float" ) == 0 )
             gTypesToTest |= kTestFloat;
 
-        else if ( strcmp( argv[i], "randomize" ) == 0 )
-            randomize = true;
-
         else if ( strcmp( argv[i], "--help" ) == 0 || strcmp( argv[i], "-h" ) == 0 )
         {
             printUsage( argv[ 0 ] );
@@ -169,74 +159,6 @@ int main(int argc, const char *argv[])
     if ( gTypesToTest == 0 )
         gTypesToTest = kTestAllTypes;
 
-    // Seed the random # generators
-    if ( randomize )
-    {
-        gRandomSeed = (cl_uint) time( NULL );
-        gReSeed = 1;
-        log_info( "Random seed: %u.\n", gRandomSeed );
-    }
-
-    int error;
-    // Get our platform
-    error = clGetPlatformIDs(1, &platform, NULL);
-    if ( error )
-    {
-        print_error( error, "Unable to get platform" );
-        test_finish();
-        return -1;
-    }
-
-    // Get our device
-    error = clGetDeviceIDs(platform,  gDeviceType, 1, &device, NULL );
-    if ( error )
-    {
-        print_error( error, "Unable to get specified device" );
-        test_finish();
-        return -1;
-    }
-
-    // Get the device type so we know if it is a GPU even if default is passed in.
-    error = clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(gDeviceType), &gDeviceType, NULL);
-    if ( error )
-    {
-        print_error( error, "Unable to get device type" );
-        test_finish();
-        return -1;
-    }
-
-
-    if ( printDeviceHeader( device ) != CL_SUCCESS )
-    {
-        test_finish();
-        return -1;
-    }
-
-    // Check for image support
-    if (checkForImageSupport( device ) == CL_IMAGE_FORMAT_NOT_SUPPORTED) {
-        log_info("Device does not support images. Skipping test.\n");
-        test_finish();
-        return 0;
-    }
-
-    // Create a context to test with
-    context = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
-    if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing context" );
-        test_finish();
-        return -1;
-    }
-
-    // Create a queue against the context
-    queue = clCreateCommandQueueWithProperties( context, device, 0, &error );
-    if ( error != CL_SUCCESS )
-    {
-        print_error( error, "Unable to create testing command queue" );
-        test_finish();
-        return -1;
-    }
-
     if ( gTestSmallImages )
         log_info( "Note: Using small test images\n" );
 
@@ -251,17 +173,10 @@ int main(int argc, const char *argv[])
     FPU_mode_type oldMode;
     DisableFTZ(&oldMode);
 
-    int ret = parseAndCallCommandLineTests( argCount, argList, NULL, test_num, test_list, true, 0, 0 );
+    int ret = runTestHarness( argCount, argList, test_num, test_list, true, false, 0 );
 
     // Restore FP state before leaving
     RestoreFPState(&oldMode);
-
-    error = clFinish(queue);
-    if (error)
-        print_error(error, "clFinish failed.");
-
-    clReleaseContext(context);
-    clReleaseCommandQueue(queue);
 
     if (gTestFailure == 0) {
         if (gTestCount > 1)
@@ -276,10 +191,7 @@ int main(int argc, const char *argv[])
             log_error("FAILED sub-test.\n");
     }
 
-    // Clean up
     free(argList);
-    test_finish();
-
     return ret;
 }
 

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue     queue;
-extern cl_context           context;
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding;
 extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
@@ -64,7 +62,7 @@ const char *read_write2DKernelSourcePattern =
 "   else\n"
 "      results[offset] = 0;\n"
 "}";
-int test_read_image_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -191,7 +189,7 @@ int test_read_image_2D( cl_device_id device, cl_context context, cl_command_queu
     return 0;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];
@@ -276,7 +274,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
                 if ( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                 if ( retCode )
                     return retCode;
             }
@@ -298,7 +296,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
             log_info("Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -327,7 +325,7 @@ int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int retCode = test_read_image_2D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -15,7 +15,6 @@
 //
 #include "../testBase.h"
 
-extern cl_context           context;
 extern int                  gTypesToTest;
 extern cl_channel_type      gChannelTypeToUse;
 extern cl_channel_order     gChannelOrderToUse;
@@ -24,12 +23,12 @@ extern bool                 gDebugTrace;
 
 extern bool                 gTestReadWrite;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_buffer( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
 
 static const char *str_1d_image = "1D";
 static const char *str_2d_image = "2D";
@@ -121,7 +120,7 @@ int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int
     return numSupported;
 }
 
-int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
+int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
 {
     int error;
 
@@ -138,7 +137,7 @@ int get_format_list( cl_device_id device, cl_mem_object_type imageType, cl_image
     return 0;
 }
 
-int test_read_image_type( cl_device_id device, cl_image_format *format,
+int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
                           image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -151,22 +150,22 @@ int test_read_image_type( cl_device_id device, cl_image_format *format,
     switch (imageType)
     {
         case CL_MEM_OBJECT_IMAGE1D:
-            ret = test_read_image_set_1D( device, format, imageSampler, outputType );
+            ret = test_read_image_set_1D( device, context, queue, format, imageSampler, outputType );
             break;
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-            ret += test_read_image_set_1D_buffer( device, format, imageSampler, outputType );
+            ret += test_read_image_set_1D_buffer( device, context, queue, format, imageSampler, outputType );
             break;
         case CL_MEM_OBJECT_IMAGE2D:
-            ret = test_read_image_set_2D( device, format, imageSampler, outputType );
+            ret = test_read_image_set_2D( device, context, queue, format, imageSampler, outputType );
             break;
         case CL_MEM_OBJECT_IMAGE3D:
-            ret = test_read_image_set_3D( device, format, imageSampler, outputType );
+            ret = test_read_image_set_3D( device, context, queue, format, imageSampler, outputType );
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            ret = test_read_image_set_1D_array( device, format, imageSampler, outputType );
+            ret = test_read_image_set_1D_array( device, context, queue, format, imageSampler, outputType );
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            ret = test_read_image_set_2D_array( device, format, imageSampler, outputType );
+            ret = test_read_image_set_2D_array( device, context, queue, format, imageSampler, outputType );
             break;
     }
 
@@ -180,7 +179,7 @@ int test_read_image_type( cl_device_id device, cl_image_format *format,
     return ret;
 }
 
-int test_read_image_formats( cl_device_id device, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
                              image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -195,13 +194,13 @@ int test_read_image_formats( cl_device_id device, cl_image_format *formatList, b
 
         cl_image_format &imageFormat = formatList[ i ];
 
-        ret |= test_read_image_type( device, &imageFormat, imageSampler, outputType, imageType );
+        ret |= test_read_image_type( device, context, queue, &imageFormat, imageSampler, outputType, imageType );
     }
     return ret;
 }
 
 
-int test_image_set( cl_device_id device, cl_mem_object_type imageType )
+int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
 {
     int ret = 0;
     static int printedFormatList = -1;
@@ -215,7 +214,7 @@ int test_image_set( cl_device_id device, cl_mem_object_type imageType )
     // The flag for creating image will be set explicitly in test functions
     cl_mem_flags flags = (gTestReadWrite)? CL_MEM_KERNEL_READ_AND_WRITE : CL_MEM_READ_ONLY;
 
-    if ( get_format_list( device, imageType, formatList, numFormats, flags ) )
+    if ( get_format_list( context, imageType, formatList, numFormats, flags ) )
         return -1;
 
     filterFlags = new bool[ numFormats ];
@@ -260,7 +259,7 @@ int test_image_set( cl_device_id device, cl_mem_object_type imageType )
         else
         {
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
+            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
         }
     }
 
@@ -276,7 +275,7 @@ int test_image_set( cl_device_id device, cl_mem_object_type imageType )
         {
             // Only filter mode we support on int is nearest
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
+            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
         }
     }
 
@@ -293,7 +292,7 @@ int test_image_set( cl_device_id device, cl_mem_object_type imageType )
         {
             // Only filter mode we support on uint is nearest
             imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
+            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
         }
     }
 

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue     queue;
-extern cl_context           context;
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding;
 extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
@@ -62,7 +60,7 @@ const char *read_write1DKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -192,7 +190,7 @@ int test_read_image_1D( cl_device_id device, cl_context context, cl_command_queu
     return 0;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];
@@ -273,7 +271,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
                 if ( gDebugTrace )
                     log_info( "   at size %d\n", (int)imageInfo.width );
 
-                int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                 if ( retCode )
                     return retCode;
             }
@@ -294,7 +292,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
             log_info("Testing %d\n", (int)sizes[ idx ][ 0 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -322,7 +320,7 @@ int test_read_image_set_1D( cl_device_id device, cl_image_format *format, image_
 
             if ( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode = test_read_image_1D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue     queue;
-extern cl_context           context;
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding;
 extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
@@ -64,7 +62,7 @@ const char *read_write1DArrayKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -188,7 +186,7 @@ int test_read_image_1D_array( cl_device_id device, cl_context context, cl_comman
     return 0;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];
@@ -272,7 +270,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
                 if ( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                 if ( retCode )
                     return retCode;
             }
@@ -295,7 +293,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
             log_info("Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -326,7 +324,7 @@ int test_read_image_set_1D_array( cl_device_id device, cl_image_format *format, 
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int retCode = test_read_image_1D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -25,8 +25,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue     queue;
-extern cl_context           context;
 extern bool                 gDebugTrace, gTestSmallImages, gTestMaxImages, gTestRounding;
 extern cl_device_type       gDeviceType;
 
@@ -47,7 +45,7 @@ const char *read1DBufferKernelSourcePattern =
 "}";
 
 
-int test_read_image_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -175,7 +173,7 @@ int test_read_image_1D_buffer( cl_device_id device, cl_context context, cl_comma
     return 0;
 }
 
-int test_read_image_set_1D_buffer( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];
@@ -270,7 +268,7 @@ int test_read_image_set_1D_buffer( cl_device_id device, cl_image_format *format,
                 if ( gDebugTrace )
                     log_info( "   at size %d\n", (int)imageInfo.width );
 
-                int retCode = test_read_image_1D_buffer( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                 if ( retCode )
                     return retCode;
             }
@@ -291,7 +289,7 @@ int test_read_image_set_1D_buffer( cl_device_id device, cl_image_format *format,
             log_info("Testing %d\n", (int)sizes[ idx ][ 0 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode = test_read_image_1D_buffer( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -312,7 +310,7 @@ int test_read_image_set_1D_buffer( cl_device_id device, cl_image_format *format,
 
             if ( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode = test_read_image_1D_buffer( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -19,8 +19,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context       context;
 extern bool             gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding;
 extern cl_device_type   gDeviceType;
 extern bool             gTestReadWrite;
@@ -55,7 +53,7 @@ const char *read_write2DArrayKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -173,7 +171,8 @@ int test_read_image_2D_array( cl_device_id device, cl_context context, cl_comman
     return 0;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType )
+int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
+                                  image_sampler_data *imageSampler, ExplicitType outputType )
 {
     char programSrc[10240];
     const char *ptr;
@@ -264,7 +263,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
                 {
                     if ( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                    int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                     if ( retCode )
                         return retCode;
                 }
@@ -289,7 +288,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -324,7 +323,7 @@ int test_read_image_set_2D_array( cl_device_id device, cl_image_format *format, 
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int retCode = test_read_image_2D_array( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -19,8 +19,6 @@
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
 
-extern cl_command_queue queue;
-extern cl_context       context;
 extern bool             gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding;
 extern cl_device_type   gDeviceType;
 extern bool             gTestReadWrite;
@@ -54,7 +52,7 @@ const char *read_write3DKernelSourcePattern =
 "   else\n"
 "      results[offset] = 0;\n"
 "}";
-int test_read_image_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
+int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, image_sampler_data *imageSampler,
                         ExplicitType outputType, MTdata d )
 {
@@ -176,7 +174,8 @@ int test_read_image_3D( cl_device_id device, cl_context context, cl_command_queu
     return 0;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType )
+int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
+                            image_sampler_data *imageSampler, ExplicitType outputType )
 {
     char programSrc[10240];
     const char *ptr;
@@ -267,7 +266,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
                 {
                     if ( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                    int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
                     if ( retCode )
                         return retCode;
                 }
@@ -292,7 +291,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
             if ( gDebugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }
@@ -327,7 +326,7 @@ int test_read_image_set_3D( cl_device_id device, cl_image_format *format, image_
 
             if ( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int retCode = test_read_image_3D( device, context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
             if ( retCode )
                 return retCode;
         }


### PR DESCRIPTION
Some of the setup functionality is already there in the test harness, so
use that and remove the duplicated code from within the suite.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>