### PR TITLE
Fix Issue #53: required buffer size exceed the available size in non_…

### DIFF
--- a/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.h
+++ b/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.h
@@ -117,6 +117,7 @@ private:
   void calculateExpectedValues ();
   void showTestInfo ();
   size_t adjustLocalArraySize(size_t localArraySize);
+  size_t adjustGlobalBufferSize(size_t globalBufferSize);
 };
 
 // Class responsible for running subtest scenarios in test function
@@ -145,3 +146,4 @@ private:
 };
 
 #endif // _TESTNONUNIFORMWORKGROUP_H
+


### PR DESCRIPTION
in non_uniform_work_group the required buffer size may exceed the available device memory size.