### PR TITLE
Bugfix for Khronos Bug 16242.

### DIFF
--- a/test_conformance/device_execution/host_queue_order.cpp
+++ b/test_conformance/device_execution/host_queue_order.cpp
@@ -37,7 +37,7 @@ static const char* enqueue_block_first_kernel[] =
     NL, "    for(int i = 1 ; i < tid ; i++)"
     NL, "    {"
     NL, "      for(int j = 0 ; j < num ; j++)"
-    NL, "        atomic_add(res+tid, (int)sqrt((float)i*i) / i);"
+    NL, "        atomic_add(res+tid, convert_int_rte(sqrt((float)i*i) / i));"
     NL, "    }"
     NL, "}"
     NL, ""


### PR DESCRIPTION
Use convert_int_rte for the result of the sqrt instead of casting to int.

Fixes possible rounding issues.