### PR TITLE
cl21: Fix uninitialized test definition fields

### DIFF
--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -79,6 +79,8 @@ void spirvTestsRegistry::addTestClass(baseTestClass *test, const char *testName)
     test_definition testDef;
     testDef.func = test->getFunction();
     testDef.name = testName;
+    testDef.selected = false;
+    testDef.result = 0;
     testDefinitions.push_back(testDef);
 }
 


### PR DESCRIPTION
The `selected` field was not initialized, leading to intermittent
"Test X has already been selected" errors when passing a list of tests
on the test_spirv_new command line.

Initialize the selected and result fields with the same values as
ADD_TEST does in test_common/harness/testHarness.h .