### PR TITLE
Fix test_host_queue_order not to rely on bit accurate float ops

### DIFF
--- a/test_conformance/device_execution/host_queue_order.cpp
+++ b/test_conformance/device_execution/host_queue_order.cpp
@@ -37,7 +37,7 @@ static const char* enqueue_block_first_kernel[] =
     NL, "    for(int i = 1 ; i < tid ; i++)"
     NL, "    {"
     NL, "      for(int j = 0 ; j < num ; j++)"
-    NL, "        atomic_add(res+tid, convert_int_rte(sqrt((float)i*i) / i));"
+    NL, "        atomic_add(res+tid, 1);"
     NL, "    }"
     NL, "}"
     NL, ""


### PR DESCRIPTION
Currently, test_host_queue_order relies on bit accurate float ops.
It expects expects that sqrt((float)i * i) == i.
This is not always true due to floating point precision limitations.
The test does not really need the sqrt operation and it can be removed
instead of trying to correct the floating point check.

Replace problematic float operation with constant value of 1.