### PR TITLE
CL20: Use slice pitch instead of row pitch for 1D arrays.

### DIFF
--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -194,12 +194,26 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
     }
     else {
         // Else copy one scan line at a time.
+        size_t dstPitch2D = 0;
+        switch (imageInfo->type)
+        {
+            case CL_MEM_OBJECT_IMAGE3D:
+            case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+            case CL_MEM_OBJECT_IMAGE2D:
+                dstPitch2D = mappedRow;
+                break;
+            case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+            case CL_MEM_OBJECT_IMAGE1D:
+                dstPitch2D = mappedSlice;
+                break;
+        }
+
         for ( size_t z = 0; z < depth; z++ )
         {
             for ( size_t y = 0; y < height; y++ )
             {
                 memcpy( dst, src, imageInfo->width * get_pixel_size(imageInfo->format) );
-                dst += mappedRow;
+                dst += dstPitch2D;
                 src += scanlineSize;
             }
 
@@ -531,6 +545,9 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
 
             total_matched += scanlineSize;
             sourcePtr += imageInfo->rowPitch;
+            if((imageInfo->type == CL_MEM_OBJECT_IMAGE1D_ARRAY || imageInfo->type == CL_MEM_OBJECT_IMAGE1D))
+            destPtr += mappedSlice;
+            else
             destPtr += mappedRow;
         }
 


### PR DESCRIPTION
The copy_image (for OpenCL 1.2) and fill_image (for 1.2 and 2.x) conformance tests incorrectly use the row pitch instead of the slice pitch when mapping the image.

See #312 