### PR TITLE
CL12: Use slice pitch instead of row pitch for 1D arrays.

### DIFF
--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -195,12 +195,26 @@ cl_mem create_image( cl_context context, BufferOwningPtr<char>& data, image_desc
     }
     else {
         // Else copy one scan line at a time.
+        size_t dstPitch2D = 0;
+        switch (imageInfo->type)
+        {
+            case CL_MEM_OBJECT_IMAGE3D:
+            case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+            case CL_MEM_OBJECT_IMAGE2D:
+                dstPitch2D = mappedRow;
+                break;
+            case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+            case CL_MEM_OBJECT_IMAGE1D:
+                dstPitch2D = mappedSlice;
+                break;
+        }
+
         for ( size_t z = 0; z < depth; z++ )
         {
             for ( size_t y = 0; y < height; y++ )
             {
                 memcpy( dst, src, scanlineSize );
-                dst += mappedRow;
+                dst += dstPitch2D;
                 src += scanlineSize;
             }
 
@@ -478,6 +492,9 @@ int test_copy_image_generic( cl_device_id device, image_descriptor *srcImageInfo
                 return -1;
             }
             sourcePtr += dstImageInfo->rowPitch;
+            if((dstImageInfo->type == CL_MEM_OBJECT_IMAGE1D_ARRAY || dstImageInfo->type == CL_MEM_OBJECT_IMAGE1D))
+            destPtr += mappedSlice;
+            else
             destPtr += mappedRow;
         }
         sourcePtr += dstImageInfo->slicePitch - dstImageInfo->rowPitch * dstImageInfo->height;


### PR DESCRIPTION
The copy_image (for OpenCL 1.2) and fill_image (for 1.2 and 2.x) conformance tests incorrectly use the row pitch instead of the slice pitch when mapping the image.

See #312