### PR TITLE
Simplify command line and globals for offline compilation

### DIFF
--- a/test_common/harness/errorHelpers.c
+++ b/test_common/harness/errorHelpers.c
@@ -20,7 +20,7 @@
 
 #include "errorHelpers.h"
 
-extern bool gOfflineCompiler;
+#include "parseParameters.h"
 
 const char    *IGetErrorString( int clErrorCode )
 {
@@ -800,7 +800,7 @@ int check_opencl_version(cl_device_id device, cl_uint requestedMajorVersion, cl_
 
 int check_functions_for_offline_compiler(const char *subtestname, cl_device_id device)
 {
-    if(gOfflineCompiler)
+    if (gCompilationMode != kOnline)
     {
         int nNotRequiredWithOfflineCompiler = sizeof(subtests_to_skip_with_offline_compiler)/sizeof(char *);
         size_t i;

--- a/test_common/harness/kernelHelpers.c
+++ b/test_common/harness/kernelHelpers.c
@@ -173,7 +173,7 @@ std::string add_build_options(const std::string &baseName, const char *options)
     do
     {
         i++;
-        std::string fileName = gSpirVPath + slash + get_file_name(baseName, i, ".options");
+        std::string fileName = gCompilationCachePath + slash + get_file_name(baseName, i, ".options");
         long fileSize = get_file_size(fileName);
         if (fileSize == 0)
             break;
@@ -187,7 +187,7 @@ std::string add_build_options(const std::string &baseName, const char *options)
     if (equal)
         return get_file_name(baseName, i, "");
 
-    std::string fileName = gSpirVPath + slash + get_file_name(baseName, i, ".options");
+    std::string fileName = gCompilationCachePath + slash + get_file_name(baseName, i, ".options");
     std::ofstream ofs(fileName.c_str(), std::ios::binary);
     if (!ofs.good())
     {
@@ -266,8 +266,8 @@ static int create_single_kernel_helper_create_program(cl_context context,
 
         kernelName = add_build_options(kernelName, buildOptions);
 
-        std::string sourceFilename = gSpirVPath + slash + kernelName + ".cl";
-        std::string outputFilename = gSpirVPath + slash + kernelName;
+        std::string sourceFilename = gCompilationCachePath + slash + kernelName + ".cl";
+        std::string outputFilename = gCompilationCachePath + slash + kernelName;
 
         // Get device CL_DEVICE_ADDRESS_BITS
         cl_uint device_address_space_size = 0;

--- a/test_common/harness/kernelHelpers.c
+++ b/test_common/harness/kernelHelpers.c
@@ -21,6 +21,7 @@
 #include "testHarness.h"
 #include "parseParameters.h"
 
+#include <cassert>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -200,6 +201,20 @@ std::string add_build_options(const std::string &baseName, const char *options)
     return get_file_name(baseName, i, "");
 }
 
+static std::string get_offline_compilation_file_type_str(const CompilationMode compilationMode)
+{
+    switch (compilationMode)
+    {
+        default:
+            assert(0 && "Invalid compilation mode for offline compilation");
+            abort();
+        case kBinary:
+            return "binary";
+        case kSpir_v:
+            return "SPIR-V";
+    }
+}
+
 static cl_int get_device_address_bits(cl_context context, cl_uint &device_address_space_size)
 {
     cl_uint numDevices = 0;
@@ -287,16 +302,20 @@ static int create_single_kernel_helper_create_program(cl_context context,
 
         if (gCompilationCacheMode == kCacheModeOverwrite || !ifs.good())
         {
+            std::string file_type = get_offline_compilation_file_type_str(compilationMode);
+
             if (gCompilationCacheMode == kCacheModeForceRead)
             {
-                log_info("OfflineCompiler: can't open cached SpirV file: %s\n", outputFilename.c_str());
+                log_info("OfflineCompiler: can't open cached %s file: %s\n",
+                         file_type.c_str(), outputFilename.c_str());
                 return -1;
             }
 
             ifs.close();
 
             if (gCompilationCacheMode != kCacheModeOverwrite)
-                log_info("OfflineCompiler: can't find cached SpirV file: %s\n", outputFilename.c_str());
+                log_info("OfflineCompiler: can't find cached %s file: %s\n",
+                         file_type.c_str(), outputFilename.c_str());
 
             std::ofstream ofs(sourceFilename.c_str(), std::ios::binary);
             if (!ofs.good())
@@ -361,7 +380,8 @@ static int create_single_kernel_helper_create_program(cl_context context,
             ifs.open(outputFilename.c_str(), std::ios::binary);
             if (!ifs.good())
             {
-                log_info("OfflineCompiler: can't read output file: %s\n", outputFilename.c_str());
+                log_info("OfflineCompiler: can't read generated %s file: %s\n",
+                         file_type.c_str(), outputFilename.c_str());
                 return -1;
             }
         }

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -27,11 +27,9 @@
 
 using namespace std;
 
-bool             gOfflineCompiler = false;
-bool             gForceSpirVCache = false;
-bool             gForceSpirVGenerate = false;
-std::string      gSpirVPath = ".";
-OfflineCompilerOutputType gOfflineCompilerOutputType;
+CompilationMode      gCompilationMode = kOnline;
+CompilationCacheMode gCompilationCacheMode = kCacheModeCompileIfAbsent;
+std::string          gSpirVPath = ".";
 
 void helpInfo ()
 {
@@ -70,29 +68,27 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
             delArg = 1;
             if ((i + 1) < argc)
             {
-                gOfflineCompiler = true;
-
                 if (!strcmp(argv[i + 1], "binary"))
                 {
-                    gOfflineCompilerOutputType = kBinary;
+                    gCompilationMode = kBinary;
                     delArg++;
                 }
                 else if (!strcmp(argv[i + 1], "spir_v"))
                 {
-                    gOfflineCompilerOutputType = kSpir_v;
+                    gCompilationMode = kSpir_v;
                     delArg++;
                     if ((i + 3) < argc)
                     {
                         if (!strcmp(argv[i + 2], "cache"))
                         {
-                            gForceSpirVCache = true;
+                            gCompilationCacheMode = kCacheModeForceRead;
                             gSpirVPath = argv[i + 3];
                             log_info(" SpirV reading from cache enabled.\n");
                             delArg += 2;
                         }
                         else if (!strcmp(argv[i + 2], "generate"))
                         {
-                            gForceSpirVGenerate = true;
+                            gCompilationCacheMode = kCacheModeOverwrite;
                             gSpirVPath = argv[i + 3];
                             log_info(" SpirV force generate binaries enabled.\n");
                             delArg += 2;

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 CompilationMode      gCompilationMode = kOnline;
 CompilationCacheMode gCompilationCacheMode = kCacheModeCompileIfAbsent;
-std::string          gSpirVPath = ".";
+std::string          gCompilationCachePath = ".";
 
 void helpInfo ()
 {
@@ -82,14 +82,14 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
                         if (!strcmp(argv[i + 2], "cache"))
                         {
                             gCompilationCacheMode = kCacheModeForceRead;
-                            gSpirVPath = argv[i + 3];
+                            gCompilationCachePath = argv[i + 3];
                             log_info(" SpirV reading from cache enabled.\n");
                             delArg += 2;
                         }
                         else if (!strcmp(argv[i + 2], "generate"))
                         {
                             gCompilationCacheMode = kCacheModeOverwrite;
-                            gSpirVPath = argv[i + 3];
+                            gCompilationCachePath = argv[i + 3];
                             log_info(" SpirV force generate binaries enabled.\n");
                             delArg += 2;
                         }

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -33,12 +33,21 @@ std::string          gCompilationCachePath = ".";
 
 void helpInfo ()
 {
-    log_info("  '-offlineCompiler <output_type:binary|spir_v>': use offline compiler\n");
-    log_info("  '                  output_type binary - \"../build_script_binary.py\" is invoked\n");
-    log_info("  '                  output_type spir_v <mode:generate|cache> - \"../cl_build_script_spir_v.py\" is invoked, optional modes: generate, cache\n");
-    log_info("  '                                     mode generate <path> - force binary generation\n");
-    log_info("  '                                     mode cache <path> - force reading binary files from cache\n");
-    log_info("\n");
+    log_info("Common options:\n"
+             "        -h, --help                  This help\n"
+             "        --compilation-mode <mode>   Specify a compilation mode.  Mode can be:\n"
+             "                           online     Use online compilation (default)\n"
+             "                           binary     Use binary offline compilation\n"
+             "                           spir-v     Use SPIR-V offline compilation\n"
+             "\n"
+             "    For offline compilation (binary and spir-v modes) only:\n"
+             "        --compilation-cache-mode <cache-mode>  Specify a compilation caching mode:\n"
+             "                                 compile-if-absent  Read from cache if already populated, or\n"
+             "                                                    else perform offline compilation (default)\n"
+             "                                 force-read      Force reading from the cache\n"
+             "                                 overwrite       Disable reading from the cache\n"
+             "        --compilation-cache-path <path>   Path for offline compiler output and CL source\n"
+             "\n");
 }
 
 int parseCustomParam (int argc, const char *argv[], const char *ignore)
@@ -57,64 +66,112 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
                (ptr[strlen(argv[i])] == 0 || ptr[strlen(argv[i])] == ' ')) // last on list or ' ' after
                 continue;
         }
-        if (i < 0) i = 0;
-        delArg = 0;
-        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
-            helpInfo ();
 
-        else if (!strcmp(argv[i], "-offlineCompiler"))
+        delArg = 0;
+
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
         {
-            log_info(" Offline Compiler enabled\n");
-            delArg = 1;
+            // Note: we don't increment delArg to delete this argument,
+            // to allow the caller's argument parsing routine to see the
+            // option and print its own help.
+            helpInfo ();
+        }
+        else if (!strcmp(argv[i], "--compilation-mode"))
+        {
+            delArg++;
             if ((i + 1) < argc)
             {
-                if (!strcmp(argv[i + 1], "binary"))
+                delArg++;
+                const char *mode = argv[i + 1];
+
+                if (!strcmp(mode, "online"))
+                {
+                    gCompilationMode = kOnline;
+                }
+                else if (!strcmp(mode, "binary"))
                 {
                     gCompilationMode = kBinary;
-                    delArg++;
                 }
-                else if (!strcmp(argv[i + 1], "spir_v"))
+                else if (!strcmp(mode, "spir-v"))
                 {
                     gCompilationMode = kSpir_v;
-                    delArg++;
-                    if ((i + 3) < argc)
-                    {
-                        if (!strcmp(argv[i + 2], "cache"))
-                        {
-                            gCompilationCacheMode = kCacheModeForceRead;
-                            gCompilationCachePath = argv[i + 3];
-                            log_info(" SpirV reading from cache enabled.\n");
-                            delArg += 2;
-                        }
-                        else if (!strcmp(argv[i + 2], "generate"))
-                        {
-                            gCompilationCacheMode = kCacheModeOverwrite;
-                            gCompilationCachePath = argv[i + 3];
-                            log_info(" SpirV force generate binaries enabled.\n");
-                            delArg += 2;
-                        }
-                    }
                 }
                 else
                 {
-                    log_error(" Offline Compiler output type not supported: %s\n", argv[i + 1]);
+                    log_error("Compilation mode not recognized: %s\n", mode);
                     return -1;
                 }
+                log_info("Compilation mode specified: %s\n", mode);
             }
             else
             {
-                log_error(" Offline Compiler parameters are incorrect. Usage:\n");
-                log_error("       -offlineCompiler <input> <output> <output_type:binary|spir_v>\n");
+                log_error("Compilation mode parameters are incorrect. Usage:\n"
+                          "  --compilation-mode <online|binary|spir-v>\n");
+                return -1;
+            }
+        }
+        else if (!strcmp(argv[i], "--compilation-cache-mode"))
+        {
+            delArg++;
+            if ((i + 1) < argc)
+            {
+                delArg++;
+                const char *mode = argv[i + 1];
+
+                if (!strcmp(mode, "compile-if-absent"))
+                {
+                    gCompilationCacheMode = kCacheModeCompileIfAbsent;
+                }
+                else if (!strcmp(mode, "force-read"))
+                {
+                    gCompilationCacheMode = kCacheModeForceRead;
+                }
+                else if (!strcmp(mode, "overwrite"))
+                {
+                    gCompilationCacheMode = kCacheModeOverwrite;
+                }
+                else
+                {
+                    log_error("Compilation cache mode not recognized: %s\n", mode);
+                    return -1;
+                }
+                log_info("Compilation cache mode specified: %s\n", mode);
+            }
+            else
+            {
+                log_error("Compilation cache mode parameters are incorrect. Usage:\n"
+                          "  --compilation-cache-mode <compile-if-absent|force-read|overwrite>\n");
+                return -1;
+            }
+        }
+        else if (!strcmp(argv[i], "--compilation-cache-path"))
+        {
+            delArg++;
+            if ((i + 1) < argc)
+            {
+                delArg++;
+                gCompilationCachePath = argv[i + 1];
+            }
+            else
+            {
+                log_error("Path argument for --compilation-cache-path was not specified.\n");
                 return -1;
             }
         }
 
         //cleaning parameters from argv tab
-        for (int j=i; j<argc-delArg; j++)
-            argv[j] = argv[j+delArg];
-        argc -= delArg ;
+        for (int j = i; j < argc - delArg; j++)
+            argv[j] = argv[j + delArg];
+        argc -= delArg;
         i -= delArg;
     }
+
+    if (gCompilationCacheMode != kCacheModeCompileIfAbsent && gCompilationMode == kOnline)
+    {
+        log_error("Compilation cache mode can only be specified when using an offline compilation mode.\n");
+        return -1;
+    }
+
     return argc;
 }
 

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -19,18 +19,23 @@
 #include "compat.h"
 #include <string>
 
-extern bool gOfflineCompiler;
-extern bool gForceSpirVCache;
-extern bool gForceSpirVGenerate;
-extern std::string gSpirVPath;
-
-enum OfflineCompilerOutputType
+enum CompilationMode
 {
-    kBinary = 0,
+    kOnline = 0,
+    kBinary,
     kSpir_v
 };
 
-extern OfflineCompilerOutputType gOfflineCompilerOutputType;
+enum CompilationCacheMode
+{
+    kCacheModeCompileIfAbsent = 0,
+    kCacheModeForceRead,
+    kCacheModeOverwrite
+};
+
+extern CompilationMode gCompilationMode;
+extern CompilationCacheMode gCompilationCacheMode;
+extern std::string gSpirVPath;
 
 extern int parseCustomParam (int argc, const char *argv[], const char *ignore = 0 );
 

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -35,7 +35,7 @@ enum CompilationCacheMode
 
 extern CompilationMode gCompilationMode;
 extern CompilationCacheMode gCompilationCacheMode;
-extern std::string gSpirVPath;
+extern std::string gCompilationCachePath;
 
 extern int parseCustomParam (int argc, const char *argv[], const char *ignore = 0 );
 

--- a/test_conformance/compiler/test_build_helpers.c
+++ b/test_conformance/compiler/test_build_helpers.c
@@ -423,7 +423,7 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try getting the length */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, NULL, NULL, &length );
     test_error( error, "Unable to get program source length" );
-    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && !gOfflineCompiler)
+    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length returned for program source is incorrect!\n" );
         return -1;
@@ -432,7 +432,7 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try normal source */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, sizeof( buffer ), buffer, NULL );
     test_error( error, "Unable to get program source" );
-    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && !gOfflineCompiler)
+    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length of program source is incorrect!\n" );
         return -1;
@@ -441,12 +441,12 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try both at once */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, sizeof( buffer ), buffer, &length );
     test_error( error, "Unable to get program source" );
-    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && !gOfflineCompiler)
+    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length of program source is incorrect!\n" );
         return -1;
     }
-    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && !gOfflineCompiler)
+    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Returned length of program source is incorrect!\n" );
         return -1;


### PR DESCRIPTION
These changes simplify the command line interface for controlling offline compilation, reduce the set of global variables that control offline compilation, and improve the naming of these variables.