### PR TITLE
cl21: Simplify command line and globals for offline compilation

### DIFF
--- a/test_common/harness/errorHelpers.c
+++ b/test_common/harness/errorHelpers.c
@@ -20,7 +20,7 @@
 
 #include "errorHelpers.h"
 
-extern bool gOfflineCompiler;
+#include "parseParameters.h"
 
 const char    *IGetErrorString( int clErrorCode )
 {
@@ -800,7 +800,7 @@ int check_opencl_version(cl_device_id device, cl_uint requestedMajorVersion, cl_
 
 int check_functions_for_offline_compiler(const char *subtestname, cl_device_id device)
 {
-    if(gOfflineCompiler)
+    if (gCompilationMode != kOnline)
     {
         int nNotRequiredWithOfflineCompiler = sizeof(subtests_to_skip_with_offline_compiler)/sizeof(char *);
         size_t i;

--- a/test_common/harness/kernelHelpers.c
+++ b/test_common/harness/kernelHelpers.c
@@ -173,7 +173,7 @@ std::string add_build_options(const std::string &baseName, const char *options)
     do
     {
         i++;
-        std::string fileName = gSpirVPath + slash + get_file_name(baseName, i, ".options");
+        std::string fileName = gCompilationCachePath + slash + get_file_name(baseName, i, ".options");
         long fileSize = get_file_size(fileName);
         if (fileSize == 0)
             break;
@@ -186,7 +186,8 @@ std::string add_build_options(const std::string &baseName, const char *options)
     } while (!equal);
     if (equal)
         return get_file_name(baseName, i, "");
-    std::string fileName = gSpirVPath + slash + get_file_name(baseName, i, ".options");
+
+    std::string fileName = gCompilationCachePath + slash + get_file_name(baseName, i, ".options");
     std::ofstream ofs(fileName.c_str(), std::ios::binary);
     if (!ofs.good())
     {
@@ -260,8 +261,8 @@ static int create_single_kernel_helper_create_program(cl_context context,
 
         kernelName = add_build_options(kernelName, buildOptions);
 
-        std::string sourceFilename = gSpirVPath + slash + kernelName + ".cl";
-        std::string outputFilename = gSpirVPath + slash + kernelName;
+        std::string sourceFilename = gCompilationCachePath + slash + kernelName + ".cl";
+        std::string outputFilename = gCompilationCachePath + slash + kernelName;
 
         std::string size_t_width_str;
 

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -27,11 +27,9 @@
 
 using namespace std;
 
-bool             gOfflineCompiler = false;
-bool             gForceSpirVCache = false;
-bool             gForceSpirVGenerate = false;
-std::string      gSpirVPath = ".";
-OfflineCompilerOutputType gOfflineCompilerOutputType;
+CompilationMode      gCompilationMode = kOnline;
+CompilationCacheMode gCompilationCacheMode = kCacheModeCompileIfAbsent;
+std::string          gSpirVPath = ".";
 
 void helpInfo ()
 {
@@ -78,29 +76,27 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
             delArg = 1;
             if ((i + 1) < argc)
             {
-                gOfflineCompiler = true;
-
                 if (!strcmp(argv[i + 1], "binary"))
                 {
-                    gOfflineCompilerOutputType = kBinary;
+                    gCompilationMode = kBinary;
                     delArg++;
                 }
                 else if (!strcmp(argv[i + 1], "spir_v"))
                 {
-                    gOfflineCompilerOutputType = kSpir_v;
+                    gCompilationMode = kSpir_v;
                     delArg++;
                     if ((i + 3) < argc)
                     {
                         if (!strcmp(argv[i + 2], "cache"))
                         {
-                            gForceSpirVCache = true;
+                            gCompilationCacheMode = kCacheModeForceRead;
                             gSpirVPath = argv[i + 3];
                             log_info(" SpirV reading from cache enabled.\n");
                             delArg += 2;
                         }
                         else if (!strcmp(argv[i + 2], "generate"))
                         {
-                            gForceSpirVGenerate = true;
+                            gCompilationCacheMode = kCacheModeOverwrite;
                             gSpirVPath = argv[i + 3];
                             log_info(" SpirV force generate binaries enabled.\n");
                             delArg += 2;

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 CompilationMode      gCompilationMode = kOnline;
 CompilationCacheMode gCompilationCacheMode = kCacheModeCompileIfAbsent;
-std::string          gSpirVPath = ".";
+std::string          gCompilationCachePath = ".";
 
 void helpInfo ()
 {
@@ -67,7 +67,7 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
         }
         else if (!strcmp(argv[i], "-ILPath"))
         {
-            gSpirVPath = argv[i + 1];
+            gCompilationCachePath = argv[i + 1];
             delArg = 2;
         }
         else if (!strcmp(argv[i], "-offlineCompiler"))
@@ -90,14 +90,14 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
                         if (!strcmp(argv[i + 2], "cache"))
                         {
                             gCompilationCacheMode = kCacheModeForceRead;
-                            gSpirVPath = argv[i + 3];
+                            gCompilationCachePath = argv[i + 3];
                             log_info(" SpirV reading from cache enabled.\n");
                             delArg += 2;
                         }
                         else if (!strcmp(argv[i + 2], "generate"))
                         {
                             gCompilationCacheMode = kCacheModeOverwrite;
-                            gSpirVPath = argv[i + 3];
+                            gCompilationCachePath = argv[i + 3];
                             log_info(" SpirV force generate binaries enabled.\n");
                             delArg += 2;
                         }

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -19,18 +19,23 @@
 #include "compat.h"
 #include <string>
 
-extern bool gOfflineCompiler;
-extern bool gForceSpirVCache;
-extern bool gForceSpirVGenerate;
-extern std::string gSpirVPath;
-
-enum OfflineCompilerOutputType
+enum CompilationMode
 {
-    kBinary = 0,
+    kOnline = 0,
+    kBinary,
     kSpir_v
 };
 
-extern OfflineCompilerOutputType gOfflineCompilerOutputType;
+enum CompilationCacheMode
+{
+    kCacheModeCompileIfAbsent = 0,
+    kCacheModeForceRead,
+    kCacheModeOverwrite
+};
+
+extern CompilationMode gCompilationMode;
+extern CompilationCacheMode gCompilationCacheMode;
+extern std::string gSpirVPath;
 
 extern int parseCustomParam (int argc, const char *argv[], const char *ignore = 0 );
 

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -35,7 +35,7 @@ enum CompilationCacheMode
 
 extern CompilationMode gCompilationMode;
 extern CompilationCacheMode gCompilationCacheMode;
-extern std::string gSpirVPath;
+extern std::string gCompilationCachePath;
 
 extern int parseCustomParam (int argc, const char *argv[], const char *ignore = 0 );
 

--- a/test_conformance/compiler/test_build_helpers.c
+++ b/test_conformance/compiler/test_build_helpers.c
@@ -423,7 +423,7 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try getting the length */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, NULL, NULL, &length );
     test_error( error, "Unable to get program source length" );
-    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && !gOfflineCompiler)
+    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length returned for program source is incorrect!\n" );
         return -1;
@@ -432,7 +432,7 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try normal source */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, sizeof( buffer ), buffer, NULL );
     test_error( error, "Unable to get program source" );
-    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && !gOfflineCompiler)
+    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length of program source is incorrect!\n" );
         return -1;
@@ -441,12 +441,12 @@ int test_get_program_source(cl_device_id deviceID, cl_context context, cl_comman
     /* Try both at once */
     error = clGetProgramInfo( program, CL_PROGRAM_SOURCE, sizeof( buffer ), buffer, &length );
     test_error( error, "Unable to get program source" );
-    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && !gOfflineCompiler)
+    if (strlen(buffer) != strlen(sample_kernel_code_single_line[0]) && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Length of program source is incorrect!\n" );
         return -1;
     }
-    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && !gOfflineCompiler)
+    if (length != strlen(sample_kernel_code_single_line[0]) + 1 && gCompilationMode == kOnline)
     {
         log_error( "ERROR: Returned length of program source is incorrect!\n" );
         return -1;

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -139,7 +139,7 @@ int get_program_with_il(clProgramWrapper &prog,
                         const char *prog_name)
 {
     cl_int err = 0;
-    if (gOfflineCompiler && gOfflineCompilerOutputType == kBinary) {
+    if (gCompilationMode == kBinary) {
         return offline_get_program_with_il(prog, deviceID, context, prog_name);
     }
 

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -58,7 +58,7 @@ std::vector<unsigned char> readBinary(const char *file_name)
 
 std::vector<unsigned char> readSPIRV(const char *file_name)
 {
-    std::string full_name_str = gSpirVPath + slash + file_name + spvExt + gAddrWidth;
+    std::string full_name_str = gCompilationCachePath + slash + file_name + spvExt + gAddrWidth;
     return readBinary(full_name_str.c_str());
 }
 
@@ -97,7 +97,7 @@ static int offline_get_program_with_il(clProgramWrapper &prog,
     cl_int err = 0;
     std::string outputTypeStr = "binary";
     std::string defaultScript = std::string("..") + slash + std::string("spv_to_binary.py");
-    std::string outputFilename = gSpirVPath + slash + std::string(prog_name);
+    std::string outputFilename = gCompilationCachePath + slash + std::string(prog_name);
     std::string sourceFilename = outputFilename +  spvExt;
 
     std::string scriptArgs =


### PR DESCRIPTION
These changes simplify the command line interface for controlling offline compilation, reduce the set of global variables that control offline compilation, and improve the naming of these variables.