### PR TITLE
cl21: Fix SVM if 64-bit atomic extensions are supported

### DIFF
--- a/test_conformance/SVM/common.h
+++ b/test_conformance/SVM/common.h
@@ -44,7 +44,8 @@ bool AtomicCompareExchangeStrongExplicit(volatile T *a, T *expected, T desired,
 {
     T tmp;
 #if defined( _MSC_VER ) || (defined( __INTEL_COMPILER ) && defined(WIN32))
-    tmp = (T)InterlockedCompareExchange((volatile LONG *)a, (LONG)desired, *(LONG *)expected);
+    tmp = (sizeof(void*) == 8) ? (T)InterlockedCompareExchange64((volatile LONG64 *)a, (LONG64)desired, *(LONG64 *)expected) :
+      (T)InterlockedCompareExchange((volatile LONG*)a, (LONG)desired, *(LONG*)expected);
 #elif defined(__GNUC__)
     tmp = (T)__sync_val_compare_and_swap((volatile intptr_t*)a, (intptr_t)(*expected), (intptr_t)desired);
 #else


### PR DESCRIPTION
Need to enable 64-bit atomic extensions in kernel source.
Use InterlockedCompareExchange64 for 64-bit type. See issue #381

This patch modifies test_fine_grain_memory_consistency.cpp to be the same as in cl20_branch.