### PR TITLE
Generate kernel sources only mode

### DIFF
--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -30,6 +30,7 @@ using namespace std;
 CompilationMode      gCompilationMode = kOnline;
 CompilationCacheMode gCompilationCacheMode = kCacheModeCompileIfAbsent;
 std::string          gCompilationCachePath = ".";
+ExecutionMode        gExecutionMode = kExecute;
 
 void helpInfo ()
 {
@@ -47,6 +48,8 @@ void helpInfo ()
              "                                 force-read      Force reading from the cache\n"
              "                                 overwrite       Disable reading from the cache\n"
              "        --compilation-cache-path <path>   Path for offline compiler output and CL source\n"
+             "        --generate-sources-only Use this flag to dump the .cl and build options files used by the test.\n"
+             "                                This feature is still under development (Beta)"
              "\n");
 }
 
@@ -158,6 +161,12 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
                 return -1;
             }
         }
+        else if (!strcmp(argv[i], "--generate-sources-only"))
+        {
+            delArg++;
+            log_info("Generating sources only\n");
+            gExecutionMode = kGenerate;
+        }
 
         //cleaning parameters from argv tab
         for (int j = i; j < argc - delArg; j++)
@@ -172,6 +181,11 @@ int parseCustomParam (int argc, const char *argv[], const char *ignore)
         return -1;
     }
 
+    if (gExecutionMode == kGenerate && (gCompilationCacheMode != kCacheModeOverwrite || gCompilationMode == kOnline))
+    {
+        log_error("Compilation cache mode can only be overwrite when in generate sources only mode.\n");
+        return -1;
+    }
     return argc;
 }
 

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -19,6 +19,11 @@
 #include "compat.h"
 #include <string>
 
+enum ExecutionMode
+{
+    kExecute = 0,
+    kGenerate ,
+};
 enum CompilationMode
 {
     kOnline = 0,
@@ -36,6 +41,7 @@ enum CompilationCacheMode
 extern CompilationMode gCompilationMode;
 extern CompilationCacheMode gCompilationCacheMode;
 extern std::string gCompilationCachePath;
+extern ExecutionMode gExecutionMode;
 
 extern int parseCustomParam (int argc, const char *argv[], const char *ignore = 0 );
 

--- a/test_conformance/buffers/test_buffer_fill.c
+++ b/test_conformance/buffers/test_buffer_fill.c
@@ -779,8 +779,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 buffers[0] = clCreateBuffer(context, flag_set[src_flag_id],  ptrSize * num_elements, NULL, &err);
             if ( err ){
                 print_error(err, " clCreateBuffer failed\n" );
-                clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -791,8 +789,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 err = clEnqueueWriteBuffer(queue, buffers[0], CL_FALSE, 0, ptrSize * num_elements, hostptr, 0, NULL, NULL);
                 if ( err != CL_SUCCESS ){
                     print_error(err, " clEnqueueWriteBuffer failed\n" );
-                    clReleaseEvent( event[0] );
-                    clReleaseEvent( event[1] );
                     free( (void *)pattern );
                     align_free( (void *)inptr );
                     align_free( (void *)hostptr );
@@ -807,8 +803,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 print_error(err, " clCreateBuffer failed\n" );
                 align_free( outptr );
                 clReleaseMemObject(buffers[0]);
-                clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -828,7 +822,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 clReleaseMemObject(buffers[0]);
                 clReleaseMemObject(buffers[1]);
                 clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -843,7 +836,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 clReleaseMemObject(buffers[0]);
                 clReleaseMemObject(buffers[1]);
                 clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -866,7 +858,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 clReleaseMemObject(buffers[0]);
                 clReleaseMemObject(buffers[1]);
                 clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -883,7 +874,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 clReleaseMemObject(buffers[0]);
                 clReleaseMemObject(buffers[1]);
                 clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
@@ -905,7 +895,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 clReleaseMemObject(buffers[0]);
                 clReleaseMemObject(buffers[1]);
                 clReleaseEvent( event[0] );
-                clReleaseEvent( event[1] );
                 free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );

--- a/test_conformance/buffers/test_buffer_read.c
+++ b/test_conformance/buffers/test_buffer_read.c
@@ -1242,7 +1242,6 @@ int test_buffer_read_struct(cl_device_id deviceID, cl_context context, cl_comman
 
     err = create_single_kernel_helper(  context, &program[0], &kernel[0], 1, &buffer_read_struct_kernel_code, "test_buffer_read_struct" );
     if ( err ){
-        clReleaseProgram( program[0] );
         align_free( output_ptr );
         return -1;
     }

--- a/test_conformance/commonfns/test_binary_fn.c
+++ b/test_conformance/commonfns/test_binary_fn.c
@@ -60,7 +60,7 @@ int test_binary_fn( cl_device_id device, cl_context context, cl_command_queue qu
     cl_kernel   *kernel;
     size_t threads[1];
     int num_elements;
-    int err;
+    int err, warnings = 0;
     int i, j;
     MTdata d;
 
@@ -141,7 +141,7 @@ int test_binary_fn( cl_device_id device, cl_context context, cl_command_queue qu
         }
         const char *ptr = programSrc;
         err = create_single_kernel_helper( context, &program[ i ], &kernel[ i ], 1, &ptr, "test_fn" );
-        test_error( err, "Unable to create kernel" );
+        test_failure_warning(CL_SUCCESS, err, "Unable to create kernel" );
 
         if (test_double)
         {
@@ -160,10 +160,14 @@ int test_binary_fn( cl_device_id device, cl_context context, cl_command_queue qu
         }
             ptr = programSrc;
             err = create_single_kernel_helper( context, &program[ kTotalVecCount + i ], &kernel[ kTotalVecCount + i ], 1, &ptr, "test_fn" );
-            test_error( err, "Unable to create kernel" );
+            test_failure_warning(CL_SUCCESS, err, "Unable to create kernel" );
         }
     }
 
+    if(warnings > 0) 
+    {
+        return -1;
+    }
     for( i = 0; i < kTotalVecCount; i++ )
     {
         for( j = 0; j < 3; j++ )

--- a/test_conformance/commonfns/test_clamp.c
+++ b/test_conformance/commonfns/test_clamp.c
@@ -123,7 +123,7 @@ test_clamp(cl_device_id device, cl_context context, cl_command_queue queue, int 
     cl_kernel   *kernel;
     size_t threads[1];
     int num_elements;
-    int err;
+    int err, warnings = 0;
     int i, j;
     MTdata d;
 
@@ -199,7 +199,7 @@ test_clamp(cl_device_id device, cl_context context, cl_command_queue queue, int 
     for( i = 0; i < kTotalVecCount; i++ )
     {
         err = create_single_kernel_helper( context, &program[ i ], &kernel[ i ], 1, &clamp_float_codes[ i ], "test_clamp" );
-        test_error( err, "Unable to create kernel" );
+        test_failure_warning(CL_SUCCESS, err, "Unable to create kernel" );
 
         log_info("Just made a program for float, i=%d, size=%d, in slot %d\n", i, g_arrVecSizes[i], i);
         fflush(stdout);
@@ -208,8 +208,12 @@ test_clamp(cl_device_id device, cl_context context, cl_command_queue queue, int 
         err = create_single_kernel_helper( context, &program[ kTotalVecCount + i ], &kernel[ kTotalVecCount + i ], 1, &clamp_double_codes[ i ], "test_clamp" );
         log_info("Just made a program for double, i=%d, size=%d, in slot %d\n", i, g_arrVecSizes[i], kTotalVecCount+i);
         fflush(stdout);
-        test_error( err, "Unable to create kernel" );
+        test_failure_warning(CL_SUCCESS, err, "Unable to create kernel" );
         }
+    }
+    if(warnings > 0) 
+    {
+        return -1;
     }
 
     for( i = 0; i < kTotalVecCount; i++ )

--- a/test_conformance/commonfns/test_degrees.c
+++ b/test_conformance/commonfns/test_degrees.c
@@ -27,7 +27,7 @@
 #endif
 
 static int test_degrees_double(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems);
-
+static int test_degrees_float(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems);
 
 const char *degrees_kernel_code =
 "__kernel void test_degrees(__global float *src, __global float *dst)\n"
@@ -79,6 +79,19 @@ const char *degrees3_kernel_code =
 
 
 #define MAX_ERR  2.0f
+int
+test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems) 
+{
+    int err;
+    err = test_degrees_float(device, context, queue, n_elems);
+    if( ! is_extension_available( device, "cl_khr_fp64" ) )
+    {
+        log_info( "Skipping double -- cl_khr_fp64 is not supported by this device.\n" );
+    } else {
+        err |= test_degrees_double(device, context, queue, n_elems);
+    }
+    return err;
+}
 
 static int
 verify_degrees(float *inptr, float *outptr, int n)
@@ -109,8 +122,8 @@ verify_degrees(float *inptr, float *outptr, int n)
     return 0;
 }
 
-int
-test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
+static int
+test_degrees_float(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
     cl_mem       streams[2];
     cl_float     *input_ptr[1], *output_ptr, *p;
@@ -119,7 +132,7 @@ test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, in
     void        *values[2];
     size_t threads[1];
     int          num_elements;
-    int          err;
+    int          err = 0;
     int          i;
     MTdata        d;
 
@@ -160,21 +173,11 @@ test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, in
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &degrees_kernel_code, "test_degrees" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &degrees2_kernel_code, "test_degrees2" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &degrees4_kernel_code, "test_degrees4" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &degrees8_kernel_code, "test_degrees8" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &degrees16_kernel_code, "test_degrees16" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &degrees3_kernel_code, "test_degrees3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &degrees2_kernel_code, "test_degrees2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &degrees4_kernel_code, "test_degrees4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &degrees8_kernel_code, "test_degrees8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &degrees16_kernel_code, "test_degrees16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &degrees3_kernel_code, "test_degrees3" );
     if (err)
         return -1;
 
@@ -237,16 +240,9 @@ test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, in
     free(input_ptr[0]);
     free(output_ptr);
 
-    if( err )
         return err;
 
-    if( ! is_extension_available( device, "cl_khr_fp64" ) )
-    {
-        log_info( "Skipping double -- cl_khr_fp64 is not supported by this device.\n" );
-        return 0;
-    }
 
-    return test_degrees_double( device, context, queue, n_elems);
 }
 
 #pragma mark -
@@ -388,21 +384,11 @@ test_degrees_double(cl_device_id device, cl_context context, cl_command_queue qu
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &degrees_kernel_code_double, "test_degrees_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &degrees2_kernel_code_double, "test_degrees2_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &degrees4_kernel_code_double, "test_degrees4_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &degrees8_kernel_code_double, "test_degrees8_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &degrees16_kernel_code_double, "test_degrees16_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &degrees3_kernel_code_double, "test_degrees3_double" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &degrees2_kernel_code_double, "test_degrees2_double" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &degrees4_kernel_code_double, "test_degrees4_double" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &degrees8_kernel_code_double, "test_degrees8_double" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &degrees16_kernel_code_double, "test_degrees16_double" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &degrees3_kernel_code_double, "test_degrees3_double" );
     if (err)
         return -1;
 

--- a/test_conformance/commonfns/test_fmax.c
+++ b/test_conformance/commonfns/test_fmax.c
@@ -149,21 +149,11 @@ test_fmax(cl_device_id device, cl_context context, cl_command_queue queue, int n
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &fmax_kernel_code, "test_fmax" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmax2_kernel_code, "test_fmax2" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmax4_kernel_code, "test_fmax4" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmax8_kernel_code, "test_fmax8" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmax16_kernel_code, "test_fmax16" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmax3_kernel_code, "test_fmax3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmax2_kernel_code, "test_fmax2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmax4_kernel_code, "test_fmax4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmax8_kernel_code, "test_fmax8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmax16_kernel_code, "test_fmax16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmax3_kernel_code, "test_fmax3" );
     if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_fmaxf.c
+++ b/test_conformance/commonfns/test_fmaxf.c
@@ -157,21 +157,11 @@ test_fmaxf(cl_device_id device, cl_context context, cl_command_queue queue, int 
         }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &fmax_kernel_code, "test_fmax" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmax2_kernel_code, "test_fmax2" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmax4_kernel_code, "test_fmax4" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmax8_kernel_code, "test_fmax8" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmax16_kernel_code, "test_fmax16" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmax3_kernel_code, "test_fmax3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmax2_kernel_code, "test_fmax2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmax4_kernel_code, "test_fmax4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmax8_kernel_code, "test_fmax8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmax16_kernel_code, "test_fmax16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmax3_kernel_code, "test_fmax3" );
     if (err)
         return -1;
 

--- a/test_conformance/commonfns/test_fmin.c
+++ b/test_conformance/commonfns/test_fmin.c
@@ -157,21 +157,11 @@ test_fmin(cl_device_id device, cl_context context, cl_command_queue queue, int n
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &fmin_kernel_code, "test_fmin" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmin2_kernel_code, "test_fmin2" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmin4_kernel_code, "test_fmin4" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmin8_kernel_code, "test_fmin8" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmin16_kernel_code, "test_fmin16" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmin3_kernel_code, "test_fmin3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmin2_kernel_code, "test_fmin2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmin4_kernel_code, "test_fmin4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmin8_kernel_code, "test_fmin8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmin16_kernel_code, "test_fmin16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmin3_kernel_code, "test_fmin3" );
     if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_fminf.c
+++ b/test_conformance/commonfns/test_fminf.c
@@ -152,21 +152,11 @@ test_fminf(cl_device_id device, cl_context context, cl_command_queue queue, int 
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &fmin_kernel_code, "test_fmin" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmin2_kernel_code, "test_fmin2" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmin4_kernel_code, "test_fmin4" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmin8_kernel_code, "test_fmin8" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmin16_kernel_code, "test_fmin16" );
-    if (err)
-    return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmin3_kernel_code, "test_fmin3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &fmin2_kernel_code, "test_fmin2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &fmin4_kernel_code, "test_fmin4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &fmin8_kernel_code, "test_fmin8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &fmin16_kernel_code, "test_fmin16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &fmin3_kernel_code, "test_fmin3" );
     if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_radians.c
+++ b/test_conformance/commonfns/test_radians.c
@@ -161,21 +161,11 @@ test_radians(cl_device_id device, cl_context context, cl_command_queue queue, in
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &radians_kernel_code, "test_radians" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &radians2_kernel_code, "test_radians2" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &radians4_kernel_code, "test_radians4" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &radians8_kernel_code, "test_radians8" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &radians16_kernel_code, "test_radians16" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &radians3_kernel_code, "test_radians3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &radians2_kernel_code, "test_radians2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &radians4_kernel_code, "test_radians4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &radians8_kernel_code, "test_radians8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &radians16_kernel_code, "test_radians16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &radians3_kernel_code, "test_radians3" );
     if (err)
         return -1;
 
@@ -390,21 +380,11 @@ test_radians_double(cl_device_id device, cl_context context, cl_command_queue qu
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &radians_kernel_code_double, "test_radians_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &radians2_kernel_code_double, "test_radians2_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &radians4_kernel_code_double, "test_radians4_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &radians8_kernel_code_double, "test_radians8_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &radians16_kernel_code_double, "test_radians16_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &radians3_kernel_code_double, "test_radians3_double" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &radians2_kernel_code_double, "test_radians2_double" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &radians4_kernel_code_double, "test_radians4_double" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &radians8_kernel_code_double, "test_radians8_double" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &radians16_kernel_code_double, "test_radians16_double" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &radians3_kernel_code_double, "test_radians3_double" );
     if (err)
         return -1;
 

--- a/test_conformance/commonfns/test_sign.c
+++ b/test_conformance/commonfns/test_sign.c
@@ -148,21 +148,11 @@ test_sign(cl_device_id device, cl_context context, cl_command_queue queue, int n
   }
 
   err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &sign_kernel_code, "test_sign" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &sign2_kernel_code, "test_sign2" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &sign4_kernel_code, "test_sign4" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &sign8_kernel_code, "test_sign8" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &sign16_kernel_code, "test_sign16" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &sign3_kernel_code, "test_sign3" );
+  err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &sign2_kernel_code, "test_sign2" );
+  err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &sign4_kernel_code, "test_sign4" );
+  err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &sign8_kernel_code, "test_sign8" );
+  err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &sign16_kernel_code, "test_sign16" );
+  err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &sign3_kernel_code, "test_sign3" );
   if (err)
     return -1;
 
@@ -361,21 +351,11 @@ test_sign_double(cl_device_id device, cl_context context, cl_command_queue queue
   }
 
   err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &sign_kernel_code_double, "test_sign_double" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &sign2_kernel_code_double, "test_sign2_double" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &sign4_kernel_code_double, "test_sign4_double" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &sign8_kernel_code_double, "test_sign8_double" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &sign16_kernel_code_double, "test_sign16_double" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &sign3_kernel_code_double, "test_sign3_double" );
+  err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &sign2_kernel_code_double, "test_sign2_double" );
+  err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &sign4_kernel_code_double, "test_sign4_double" );
+  err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &sign8_kernel_code_double, "test_sign8_double" );
+  err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &sign16_kernel_code_double, "test_sign16_double" );
+  err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &sign3_kernel_code_double, "test_sign3_double" );
   if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_smoothstep.c
+++ b/test_conformance/commonfns/test_smoothstep.c
@@ -191,21 +191,11 @@ test_smoothstep(cl_device_id device, cl_context context, cl_command_queue queue,
   }
 
   err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &smoothstep_kernel_code, "test_smoothstep" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &smoothstep2_kernel_code, "test_smoothstep2" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &smoothstep4_kernel_code, "test_smoothstep4" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &smoothstep8_kernel_code, "test_smoothstep8" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &smoothstep16_kernel_code, "test_smoothstep16" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &smoothstep3_kernel_code, "test_smoothstep3" );
+  err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &smoothstep2_kernel_code, "test_smoothstep2" );
+  err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &smoothstep4_kernel_code, "test_smoothstep4" );
+  err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &smoothstep8_kernel_code, "test_smoothstep8" );
+  err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &smoothstep16_kernel_code, "test_smoothstep16" );
+  err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &smoothstep3_kernel_code, "test_smoothstep3" );
   if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_smoothstepf.c
+++ b/test_conformance/commonfns/test_smoothstepf.c
@@ -168,12 +168,8 @@ test_smoothstepf(cl_device_id device, cl_context context, cl_command_queue queue
   }
 
   err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &smoothstep_kernel_code, "test_smoothstep" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &smoothstep2_kernel_code, "test_smoothstep2f" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &smoothstep4_kernel_code, "test_smoothstep4f" );
+  err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &smoothstep2_kernel_code, "test_smoothstep2f" );
+  err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &smoothstep4_kernel_code, "test_smoothstep4f" );
   if (err)
     return -1;
 

--- a/test_conformance/commonfns/test_step.c
+++ b/test_conformance/commonfns/test_step.c
@@ -155,21 +155,11 @@ test_step(cl_device_id device, cl_context context, cl_command_queue queue, int n
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &step_kernel_code, "test_step" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code, "test_step2" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code, "test_step4" );
-    if (err)
-        return -1;
-  err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code, "test_step8" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code, "test_step16" );
-  if (err)
-    return -1;
-  err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code, "test_step3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code, "test_step2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code, "test_step4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code, "test_step8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code, "test_step16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code, "test_step3" );
   if (err)
     return -1;
 
@@ -419,21 +409,11 @@ test_step_double(cl_device_id device, cl_context context, cl_command_queue queue
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &step_kernel_code_double, "test_step_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code_double, "test_step2_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code_double, "test_step4_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code_double, "test_step8_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code_double, "test_step16_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code_double, "test_step3_double" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code_double, "test_step2_double" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code_double, "test_step4_double" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code_double, "test_step8_double" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code_double, "test_step16_double" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code_double, "test_step3_double" );
     if (err)
         return -1;
 

--- a/test_conformance/commonfns/test_stepf.c
+++ b/test_conformance/commonfns/test_stepf.c
@@ -157,21 +157,11 @@ int test_stepf(cl_device_id device, cl_context context, cl_command_queue queue, 
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &step_kernel_code, "test_step" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code, "test_step2" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code, "test_step4" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code, "test_step8" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code, "test_step16" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code, "test_step3" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code, "test_step2" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code, "test_step4" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code, "test_step8" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code, "test_step16" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code, "test_step3" );
     if (err)
         return -1;
 
@@ -421,21 +411,11 @@ int test_stepf_double(cl_device_id device, cl_context context, cl_command_queue 
     }
 
     err = create_single_kernel_helper( context, &program[0], &kernel[0], 1, &step_kernel_code_double, "test_step_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code_double, "test_step2_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code_double, "test_step4_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code_double, "test_step8_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code_double, "test_step16_double" );
-    if (err)
-        return -1;
-    err = create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code_double, "test_step3_double" );
+    err |= create_single_kernel_helper( context, &program[1], &kernel[1], 1, &step2_kernel_code_double, "test_step2_double" );
+    err |= create_single_kernel_helper( context, &program[2], &kernel[2], 1, &step4_kernel_code_double, "test_step4_double" );
+    err |= create_single_kernel_helper( context, &program[3], &kernel[3], 1, &step8_kernel_code_double, "test_step8_double" );
+    err |= create_single_kernel_helper( context, &program[4], &kernel[4], 1, &step16_kernel_code_double, "test_step16_double" );
+    err |= create_single_kernel_helper( context, &program[5], &kernel[5], 1, &step3_kernel_code_double, "test_step3_double" );
     if (err)
         return -1;
 

--- a/test_conformance/geometrics/test_geometrics.cpp
+++ b/test_conformance/geometrics/test_geometrics.cpp
@@ -154,7 +154,7 @@ int test_geom_cross(cl_device_id deviceID, cl_context context, cl_command_queue 
 {
     int vecsize;
     RandomSeed seed(gRandomSeed);
-
+    int error = 0;
     /* Get the default rounding mode */
     cl_device_fp_config defaultRoundingMode = get_default_rounding_mode(deviceID);
     if( 0 == defaultRoundingMode )
@@ -178,7 +178,10 @@ int test_geom_cross(cl_device_id deviceID, cl_context context, cl_command_queue 
 
         /* Create kernels */
         if( create_single_kernel_helper( context, &program, &kernel, 1, vecsize == 3 ? &crossKernelSourceV3 : &crossKernelSource, "sample_test" ) )
-            return -1;
+        {
+            error = -1;
+            continue;
+        }
 
         /* Generate some streams. Note: deliberately do some random data in w to verify that it gets ignored */
         for( i = 0; i < TEST_SIZE * vecsize; i++ )
@@ -265,10 +268,11 @@ int test_geom_cross(cl_device_id deviceID, cl_context context, cl_command_queue 
 
     if(!is_extension_available(deviceID, "cl_khr_fp64")) {
         log_info("Extension cl_khr_fp64 not supported; skipping double tests.\n");
-        return 0;
+        return error;
     } else {
         log_info("Testing doubles...\n");
-        return test_geom_cross_double( deviceID,  context,  queue,  num_elements, seed);
+        error |= test_geom_cross_double( deviceID,  context,  queue,  num_elements, seed);
+        return error;
     }
 }
 
@@ -502,17 +506,16 @@ int test_geom_dot(cl_device_id deviceID, cl_context context, cl_command_queue qu
         }
     }
 
-    if (retVal)
-        return retVal;
 
     if(!is_extension_available(deviceID, "cl_khr_fp64"))
     {
         log_info("Extension cl_khr_fp64 not supported; skipping double tests.\n");
-        return 0;
+        return retVal;
     }
 
     log_info("Testing doubles...\n");
-    return test_geom_dot_double( deviceID,  context,  queue,  num_elements, seed);
+    retVal |= test_geom_dot_double( deviceID,  context,  queue,  num_elements, seed);
+    return retVal;
 }
 
 double verifyFastDistance( float *srcA, float *srcB, size_t vecSize )
@@ -602,16 +605,15 @@ int test_geom_distance(cl_device_id deviceID, cl_context context, cl_command_que
             log_info( "   distance vector size %d passed\n", (int)sizes[ size ] );
         }
     }
-    if (retVal)
-        return retVal;
 
     if(!is_extension_available(deviceID, "cl_khr_fp64"))
     {
         log_info("Extension cl_khr_fp64 not supported; skipping double tests.\n");
-        return 0;
+        return retVal;
     } else {
         log_info("Testing doubles...\n");
-        return test_geom_distance_double( deviceID,  context,  queue,  num_elements, seed);
+        retVal |= test_geom_distance_double( deviceID,  context,  queue,  num_elements, seed);
+        return retVal;
     }
 }
 
@@ -766,18 +768,17 @@ int test_geom_length(cl_device_id deviceID, cl_context context, cl_command_queue
             log_info( "   length vector vector size %d passed\n", (int)sizes[ size ] );
         }
     }
-    if (retVal)
-        return retVal;
 
     if(!is_extension_available(deviceID, "cl_khr_fp64"))
     {
         log_info("Extension cl_khr_fp64 not supported; skipping double tests.\n");
-        return 0;
+        return retVal;
     }
     else
     {
         log_info("Testing doubles...\n");
-        return test_geom_length_double( deviceID,  context,  queue,  num_elements, seed);
+        retVal |= test_geom_length_double( deviceID,  context,  queue,  num_elements, seed);
+        return retVal;
     }
 }
 
@@ -1048,6 +1049,7 @@ int test_geom_normalize(cl_device_id deviceID, cl_context context, cl_command_qu
     size_t sizes[] = { 1, 2, 3, 4, 0 };
     unsigned int size;
     int retVal = 0;
+    int warnings = 0;
     RandomSeed seed(gRandomSeed);
 
     for( size = 0; sizes[ size ] != 0 ; size++ )
@@ -1065,16 +1067,15 @@ int test_geom_normalize(cl_device_id deviceID, cl_context context, cl_command_qu
             log_info( "   normalized vector size %d passed\n", (int)sizes[ size ] );
         }
     }
-    if (retVal)
-        return retVal;
 
     if(!is_extension_available(deviceID, "cl_khr_fp64"))
     {
         log_info("Extension cl_khr_fp64 not supported; skipping double tests.\n");
-        return 0;
+        return retVal;
     } else {
         log_info("Testing doubles...\n");
-        return test_geom_normalize_double( deviceID,  context,  queue,  num_elements, seed);
+        retVal |= test_geom_normalize_double( deviceID,  context,  queue,  num_elements, seed);
+        return retVal;
     }
 }
 

--- a/test_conformance/geometrics/test_geometrics_double.cpp
+++ b/test_conformance/geometrics/test_geometrics_double.cpp
@@ -189,7 +189,7 @@ int test_geom_cross_double(cl_device_id deviceID, cl_context context, cl_command
         clKernelWrapper kernel;
         clMemWrapper streams[3];
         cl_double testVector[4];
-        int error, i;
+        int i;
         size_t threads[1], localThreads[1];
         BufferOwningPtr<cl_double> A(malloc(bufSize));
         BufferOwningPtr<cl_double> B(malloc(bufSize));
@@ -200,7 +200,10 @@ int test_geom_cross_double(cl_device_id deviceID, cl_context context, cl_command
 
         /* Create kernels */
         if( create_single_kernel_helper( context, &program, &kernel, 1, vecsize == 3 ? &crossKernelSource_doubleV3 : &crossKernelSource_double, "sample_test" ) )
-            return -1;
+        {
+            error = -1;
+            continue;
+        }
 
         /* Generate some streams. Note: deliberately do some random data in w to verify that it gets ignored */
         for( i = 0; i < size * vecsize; i++ )
@@ -275,7 +278,7 @@ int test_geom_cross_double(cl_device_id deviceID, cl_context context, cl_command
             }
         }
     }
-    return 0;
+    return error;
 }
 
 double getMaxValue_double( double vecA[], double vecB[], size_t vecSize )

--- a/test_conformance/integer_ops/test_absdiff.c
+++ b/test_conformance/integer_ops/test_absdiff.c
@@ -186,7 +186,7 @@ static void printSrc(const char *src[], int nSrcStrings) {
 int test_integer_abs_diff(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
     cl_int *input_ptr[2], *output_ptr, *p;
-    int err;
+    int err, compile_count = 0;
     int i;
     cl_uint vectorSize;
     cl_uint type;
@@ -286,7 +286,9 @@ int test_integer_abs_diff(cl_device_id device, cl_context context, cl_command_qu
             err = create_single_kernel_helper(context, &program, &kernel, sizeof( source ) / sizeof( source[0] ), source, kernelName );
 
             if (err) {
-                return -1;
+                compile_count++;
+                log_error("Failed to compile %s", kernelName);
+                continue;
             }
 
 #if 0
@@ -362,6 +364,10 @@ int test_integer_abs_diff(cl_device_id device, cl_context context, cl_command_qu
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }    
     log_info("ABS_DIFF test passed\n");
 
     free(input_ptr[0]);

--- a/test_conformance/integer_ops/test_add_sat.c
+++ b/test_conformance/integer_ops/test_add_sat.c
@@ -184,7 +184,7 @@ static const size_t  kSizes[8] = { 1, 1, 2, 2, 4, 4, 8, 8 };
 int test_integer_add_sat(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
     cl_int *input_ptr[2], *output_ptr, *p;
-    int err;
+    int err, compile_count = 0;;
     int i;
     cl_uint vectorSize;
     cl_uint type;
@@ -299,9 +299,11 @@ int test_integer_add_sat(cl_device_id device, cl_context context, cl_command_que
             {
                 err = create_single_kernel_helper(context, &program, &kernel, sizeof( sourceV3 ) / sizeof( sourceV3[0] ), sourceV3, kernelName );
             }
-            if (err)
-                return -1;
-
+            if (err) {
+                compile_count++;
+                log_error("Failed to compile %s", kernelName);
+                continue;
+            }
             err  = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0]);
             err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1]);
             err |= clSetKernelArg(kernel, 2, sizeof streams[2], &streams[2]);
@@ -365,7 +367,10 @@ int test_integer_add_sat(cl_device_id device, cl_context context, cl_command_que
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
-
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }
     log_info("ADD_SAT test passed\n");
 
     free(input_ptr[0]);

--- a/test_conformance/integer_ops/test_int_basic_ops.c
+++ b/test_conformance/integer_ops/test_int_basic_ops.c
@@ -207,7 +207,7 @@ cl_int perThreadDataInit(perThreadData * pThis, ExplicitType type,
                          cl_context context, int start_test_ID,
                          int end_test_ID, int testID)
 {
-    int i;
+    int i, compile_count = 0;
     const char * sizeNames[] = { "", "", "2", "3", "4", "", "", "", "8", "", "", "", "", "", "", "", "16" };
 
     const char *type_name = get_explicit_type_name(type);
@@ -319,7 +319,11 @@ cl_int perThreadDataInit(perThreadData * pThis, ExplicitType type,
                                           &(pThis->m_program[ i ]),
                                           &(pThis->m_kernel[ i ]), 1,
                                           &ptr, "test" );
-        test_error( err, "Unable to create test kernel" );
+        if(err) {
+            log_error("Unable to compile kernel");
+            compile_count++;
+            continue;
+        }
         err = clSetKernelArg(pThis->m_kernel[i], 0,
                              sizeof pThis->m_streams[0],
                              &(pThis->m_streams[0]) );
@@ -331,7 +335,9 @@ cl_int perThreadDataInit(perThreadData * pThis, ExplicitType type,
                               &(pThis->m_streams[2]) );
         test_error(err, "clSetKernelArgs failed");
     }
-
+    if(compile_count) {
+        return -1;
+    }
     return CL_SUCCESS;
 }
 

--- a/test_conformance/integer_ops/test_intmad24.c
+++ b/test_conformance/integer_ops/test_intmad24.c
@@ -234,40 +234,18 @@ int test_integer_mad24(cl_device_id device, cl_context context, cl_command_queue
       test_error(err, "clEnqueueWriteBuffer failed");
 
     err = create_single_kernel_helper(context, &program[0], &kernel[0], 1, &int_mad24_kernel_code, "test_int_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[1], &kernel[1], 1, &int2_mad24_kernel_code, "test_int2_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[2], &kernel[2], 1, &int3_mad24_kernel_code, "test_int3_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[3], &kernel[3], 1, &int4_mad24_kernel_code, "test_int4_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[4], &kernel[4], 1, &int8_mad24_kernel_code, "test_int8_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[5], &kernel[5], 1, &int16_mad24_kernel_code, "test_int16_mad24");
-    if (err)
-        return -1;
+    err |= create_single_kernel_helper(context, &program[1], &kernel[1], 1, &int2_mad24_kernel_code, "test_int2_mad24");
+    err |= create_single_kernel_helper(context, &program[2], &kernel[2], 1, &int3_mad24_kernel_code, "test_int3_mad24");
+    err |= create_single_kernel_helper(context, &program[3], &kernel[3], 1, &int4_mad24_kernel_code, "test_int4_mad24");
+    err |= create_single_kernel_helper(context, &program[4], &kernel[4], 1, &int8_mad24_kernel_code, "test_int8_mad24");
+    err |= create_single_kernel_helper(context, &program[5], &kernel[5], 1, &int16_mad24_kernel_code, "test_int16_mad24");
 
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS], &kernel[NUM_PROGRAMS], 1, &uint_mad24_kernel_code, "test_uint_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+1], &kernel[NUM_PROGRAMS+1], 1, &uint2_mad24_kernel_code, "test_uint2_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+2], &kernel[NUM_PROGRAMS+2], 1, &uint3_mad24_kernel_code, "test_uint3_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+3], &kernel[NUM_PROGRAMS+3], 1, &uint4_mad24_kernel_code, "test_uint4_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+4], &kernel[NUM_PROGRAMS+4], 1, &uint8_mad24_kernel_code, "test_uint8_mad24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+5], &kernel[NUM_PROGRAMS+5], 1, &uint16_mad24_kernel_code, "test_uint16_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS], &kernel[NUM_PROGRAMS], 1, &uint_mad24_kernel_code, "test_uint_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+1], &kernel[NUM_PROGRAMS+1], 1, &uint2_mad24_kernel_code, "test_uint2_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+2], &kernel[NUM_PROGRAMS+2], 1, &uint3_mad24_kernel_code, "test_uint3_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+3], &kernel[NUM_PROGRAMS+3], 1, &uint4_mad24_kernel_code, "test_uint4_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+4], &kernel[NUM_PROGRAMS+4], 1, &uint8_mad24_kernel_code, "test_uint8_mad24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+5], &kernel[NUM_PROGRAMS+5], 1, &uint16_mad24_kernel_code, "test_uint16_mad24");
     if (err)
         return -1;
 

--- a/test_conformance/integer_ops/test_intmul24.c
+++ b/test_conformance/integer_ops/test_intmul24.c
@@ -233,40 +233,18 @@ int test_integer_mul24(cl_device_id device, cl_context context, cl_command_queue
         return -1;
     }
     err = create_single_kernel_helper(context, &program[0], &kernel[0], 1, &int_mul24_kernel_code, "test_int_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[1], &kernel[1], 1, &int2_mul24_kernel_code, "test_int2_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[2], &kernel[2], 1, &int3_mul24_kernel_code, "test_int3_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[3], &kernel[3], 1, &int4_mul24_kernel_code, "test_int4_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[4], &kernel[4], 1, &int8_mul24_kernel_code, "test_int8_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[5], &kernel[5], 1, &int16_mul24_kernel_code, "test_int16_mul24");
-    if (err)
-        return -1;
+    err |= create_single_kernel_helper(context, &program[1], &kernel[1], 1, &int2_mul24_kernel_code, "test_int2_mul24");
+    err |= create_single_kernel_helper(context, &program[2], &kernel[2], 1, &int3_mul24_kernel_code, "test_int3_mul24");
+    err |= create_single_kernel_helper(context, &program[3], &kernel[3], 1, &int4_mul24_kernel_code, "test_int4_mul24");
+    err |= create_single_kernel_helper(context, &program[4], &kernel[4], 1, &int8_mul24_kernel_code, "test_int8_mul24");
+    err |= create_single_kernel_helper(context, &program[5], &kernel[5], 1, &int16_mul24_kernel_code, "test_int16_mul24");
 
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS], &kernel[NUM_PROGRAMS], 1, &uint_mul24_kernel_code, "test_int_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+1], &kernel[NUM_PROGRAMS+1], 1, &uint2_mul24_kernel_code, "test_int2_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+2], &kernel[NUM_PROGRAMS+2], 1, &uint3_mul24_kernel_code, "test_int3_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+3], &kernel[NUM_PROGRAMS+3], 1, &uint4_mul24_kernel_code, "test_int4_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+4], &kernel[NUM_PROGRAMS+4], 1, &uint8_mul24_kernel_code, "test_int8_mul24");
-    if (err)
-        return -1;
-    err = create_single_kernel_helper(context, &program[NUM_PROGRAMS+5], &kernel[NUM_PROGRAMS+5], 1, &uint16_mul24_kernel_code, "test_int16_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS], &kernel[NUM_PROGRAMS], 1, &uint_mul24_kernel_code, "test_int_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+1], &kernel[NUM_PROGRAMS+1], 1, &uint2_mul24_kernel_code, "test_int2_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+2], &kernel[NUM_PROGRAMS+2], 1, &uint3_mul24_kernel_code, "test_int3_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+3], &kernel[NUM_PROGRAMS+3], 1, &uint4_mul24_kernel_code, "test_int4_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+4], &kernel[NUM_PROGRAMS+4], 1, &uint8_mul24_kernel_code, "test_int8_mul24");
+    err |= create_single_kernel_helper(context, &program[NUM_PROGRAMS+5], &kernel[NUM_PROGRAMS+5], 1, &uint16_mul24_kernel_code, "test_int16_mul24");
     if (err)
         return -1;
 

--- a/test_conformance/integer_ops/test_popcount.c
+++ b/test_conformance/integer_ops/test_popcount.c
@@ -90,7 +90,7 @@ static void printSrc(const char *src[], int nSrcStrings) {
 int test_popcount(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
     cl_int *input_ptr[1], *output_ptr, *p;
-    int err;
+    int err, compile_count = 0;;
     int i;
     cl_uint vectorSize;
     cl_uint type;
@@ -172,7 +172,9 @@ int test_popcount(cl_device_id device, cl_context context, cl_command_queue queu
             err = create_single_kernel_helper(context, &program, &kernel, sizeof( source ) / sizeof( source[0] ), source, kernelName );
 
             if (err) {
-                return -1;
+                compile_count++;
+                log_error("Failed to compile %s", kernelName);
+                continue;
             }
 
             err  = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0]);
@@ -237,6 +239,10 @@ int test_popcount(cl_device_id device, cl_context context, cl_command_queue queu
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }        
     log_info("popcount test passed\n");
 
     free(input_ptr[0]);

--- a/test_conformance/integer_ops/test_sub_sat.c
+++ b/test_conformance/integer_ops/test_sub_sat.c
@@ -184,7 +184,7 @@ static const size_t  kSizes[8] = { 1, 1, 2, 2, 4, 4, 8, 8 };
 int test_integer_sub_sat(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
     int *input_ptr[2], *output_ptr, *p;
-    int err;
+    int err, compile_count = 0;;
     cl_uint i;
     cl_uint vectorSize;
     cl_uint type;
@@ -298,8 +298,11 @@ int test_integer_sub_sat(cl_device_id device, cl_context context, cl_command_que
             } else {
                 err = create_single_kernel_helper(context, &program, &kernel, sizeof( sourceV3 ) / sizeof( sourceV3[0] ), sourceV3, kernelName );
             }
-            if (err)
-                return -1;
+            if (err) {
+                compile_count++;
+                log_error("Failed to compile %s", kernelName);
+                continue;
+            }
 
             err  = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0]);
             err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1]);
@@ -364,6 +367,10 @@ int test_integer_sub_sat(cl_device_id device, cl_context context, cl_command_que
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }    
     log_info("SUB_SAT test passed\n");
 
     free(input_ptr[0]);

--- a/test_conformance/multiple_device_context/test_multiple_contexts.c
+++ b/test_conformance/multiple_device_context/test_multiple_contexts.c
@@ -402,7 +402,7 @@ int test_context_multiple_contexts_same_device(cl_device_id deviceID, size_t max
 {
     size_t i, j;
     cl_int err = CL_SUCCESS;
-
+    int test_item_failures = 0;
     //Figure out how many of these we can make before the first failure
     TestItem *list = NULL;
 
@@ -410,8 +410,10 @@ int test_context_multiple_contexts_same_device(cl_device_id deviceID, size_t max
     {
         // create a context and accompanying objects
         TestItem *current = CreateTestItem( deviceID, NULL /*no error reporting*/ );
-        if( NULL == current )
-            break;
+        if( NULL == current ) {
+            test_item_failures++;
+            continue;
+        }
 
         // Attempt to use it
         cl_int failed = UseTestItem( current, NULL );
@@ -425,6 +427,11 @@ int test_context_multiple_contexts_same_device(cl_device_id deviceID, size_t max
         // Add the successful test item to the list
         current->next = list;
         list = current;
+    }
+    if(test_item_failures) {
+        log_error( "FAILURE: could not compile %ld of programs!\n", test_item_failures );
+        err = -1;
+        goto exit;
     }
 
     // Check to make sure we made the minimum amount

--- a/test_conformance/pipes/test_pipe_read_write.c
+++ b/test_conformance/pipes/test_pipe_read_write.c
@@ -434,7 +434,7 @@ int test_pipe_readwrite( cl_device_id deviceID, cl_context context, cl_command_q
     cl_int      err;
     int         i, ii;
     size_t      ptrSizes[5];
-    int         total_errors = 0;
+    int         total_errors = 0, compilation_count = 0;
     cl_event    producer_sync_event[5];
     cl_event    consumer_sync_event[5];
     char        *sourceCode[5];
@@ -513,12 +513,13 @@ int test_pipe_readwrite( cl_device_id deviceID, cl_context context, cl_command_q
         // Create producer kernel
         err = create_single_kernel_helper_with_build_options(context, &program[i], &kernel[ii], 1, (const char**)&sourceCode[i], kernelName[ii], "-cl-std=CL2.0");
         if(err){
+            compilation_count++;
             clReleaseMemObject(buffers[ii]);
             clReleaseMemObject(buffers[ii+1]);
             clReleaseMemObject(pipes[i]);
             align_free( outptr[i] );
             print_error(err, "Error creating program\n");
-            return -1;
+            continue;
         }
         //Create consumer kernel
         kernel[ii + 1] = clCreateKernel(program[i], kernelName[ii + 1], &err);
@@ -662,7 +663,9 @@ int test_pipe_readwrite( cl_device_id deviceID, cl_context context, cl_command_q
         align_free(outptr[i]);
 
     }
-
+    if(compilation_count) {
+        return -1;
+    }
     return total_errors;
 }
 

--- a/test_conformance/profiling/readArray.c
+++ b/test_conformance/profiling/readArray.c
@@ -625,7 +625,7 @@ int test_stream_read( cl_device_id device, cl_context context, cl_command_queue 
 #ifdef USE_LOCAL_THREADS
     size_t            localThreads[1];
 #endif
-    int                err, err_count = 0;
+    int                err, err_count = 0, compile_count = 0;
     int                i;
     size_t            ptrSizes[5];
 
@@ -660,10 +660,11 @@ int test_stream_read( cl_device_id device, cl_context context, cl_command_queue 
         }
         err = create_single_kernel_helper( context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i] );
         if( err ){
+            compile_count++;
             log_error( " Error creating program for %s\n", type );
             clReleaseMemObject(streams[i]);
             free( outptr[i] );
-            return -1;
+            continue;
         }
 
         err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&streams[i] );
@@ -768,6 +769,9 @@ int test_stream_read( cl_device_id device, cl_context context, cl_command_queue 
         free( outptr[i] );
     }
 
+    if(compile_count) {
+        return -1;
+    }
     return err_count;
 
 }    // end test_stream_read()

--- a/test_conformance/profiling/writeArray.c
+++ b/test_conformance/profiling/writeArray.c
@@ -624,7 +624,7 @@ int test_stream_write( cl_device_id device, cl_context context, cl_command_queue
 #ifdef USE_LOCAL_THREADS
     size_t            localThreads[1];
 #endif
-    int                err, err_count = 0;
+    int                err, err_count = 0, compile_count = 0;;
     int                i, ii;
 
     threads[0] = (size_t)num_elements;
@@ -743,12 +743,13 @@ int test_stream_write( cl_device_id device, cl_context context, cl_command_queue
 
         err = create_single_kernel_helper( context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i] );
         if( err ){
+            compile_count++;
             clReleaseEvent(writeEvent);
             clReleaseMemObject(streams[ii]);
             clReleaseMemObject(streams[ii+1]);
             free( outptr[i] );
             log_error( " Error creating program for %s\n", type );
-            return -1;
+            continue;
         }
 
         err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&streams[ii] );
@@ -828,7 +829,9 @@ int test_stream_write( cl_device_id device, cl_context context, cl_command_queue
         clReleaseMemObject( streams[ii+1] );
         free( outptr[i] );
     }
-
+    if(compile_count) {
+        return -1;
+    }
     return err_count;
 
 }    // end test_stream_write()

--- a/test_conformance/select/test_select.c
+++ b/test_conformance/select/test_select.c
@@ -335,13 +335,18 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
        }
     }
 
+    int compilation_count = 0;
     for (vecsize = 0; vecsize < VECTOR_SIZE_COUNT; ++vecsize)
     {
         programs[vecsize] = makeSelectProgram(&kernels[vecsize], context, stype, cmptype, element_count[vecsize] );
         if (!programs[vecsize] || !kernels[vecsize]) {
             ++s_test_fail;
-            return -1;
+            compilation_count++;
+            continue;
         }
+    }
+    if(compilation_count) {
+        return -1;
     }
 
     ref = malloc( BUFFER_SIZE );
@@ -573,13 +578,18 @@ test_definition test_list[] = {
 
 const int test_num = ARRAY_SIZE( test_list );
 
-int main(int argc, char* argv[])
+int main(int argc, const char* argv[])
 {
     const char ** argList = (const char **)calloc( argc, sizeof( char*) );
 
     if( NULL == argList )
     {
         log_error( "Failed to allocate memory for argList array.\n" );
+        return 1;
+    }
+    argc = parseCustomParam(argc, argv);
+    if (argc == -1)
+    {
         return 1;
     }
 

--- a/test_conformance/vec_align/test_vec_align.c
+++ b/test_conformance/vec_align/test_vec_align.c
@@ -78,7 +78,7 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
                       size_t preSize, size_t typeMultiplePreSize,
                       size_t postSize, size_t typeMultiplePostSize)
 {
-    int err;
+    int err, compile_count = 0;
     int typeIdx, vecSizeIdx;
 
     char tmpBuffer[2048];
@@ -149,11 +149,10 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
 
             err = clStateMakeProgram(pClState, srcBuffer, testName );
             if (err) {
+                compile_count++;
                 vlog_error("%s: Error compiling \"\n%s\n\"",
                            testName, srcBuffer);
-                destroyBufferStruct(pBuffers, pClState);
-                destroyClState(pClState);
-                return -1;
+                continue;
             }
 
             err = pushArgs(pBuffers, pClState);
@@ -230,6 +229,10 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
 
     destroyClState(pClState);
 
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }
 
     // vlog_error("%s : implementation incomplete : FAIL\n", testName);
     return 0; // -1; // fails on account of not being written.

--- a/test_conformance/vec_step/test_step.c
+++ b/test_conformance/vec_step/test_step.c
@@ -38,7 +38,7 @@
 
 int test_step_internal(cl_device_id deviceID, cl_context context, cl_command_queue queue, const char * pattern, const char * testName)
 {
-    int err;
+    int err, compile_count = 0;
     int typeIdx, vecSizeIdx;
 
     char tempBuffer[2048];
@@ -112,11 +112,10 @@ int test_step_internal(cl_device_id deviceID, cl_context context, cl_command_que
             err = clStateMakeProgram(pClState, srcBuffer, testName );
             if (err)
             {
+                compile_count++;
                 vlog_error("%s: Error compiling \"\n%s\n\"",
                            testName, srcBuffer);
-                destroyBufferStruct(pBuffers, pClState);
-                destroyClState(pClState);
-                return -1;
+                continue;
             }
 
             err = pushArgs(pBuffers, pClState);
@@ -180,7 +179,10 @@ int test_step_internal(cl_device_id deviceID, cl_context context, cl_command_que
 
     destroyClState(pClState);
 
-
+    if(compile_count) {
+        log_info("Failed to compile %d kernels\n", compile_count);
+        return -1;
+    }
     // vlog_error("%s : implementation incomplete : FAIL\n", testName);
     return 0; // -1; // fails on account of not being written.
 }

--- a/test_conformance/workgroups/test_wg_broadcast.c
+++ b/test_conformance/workgroups/test_wg_broadcast.c
@@ -514,9 +514,7 @@ test_work_group_broadcast(cl_device_id device, cl_context context, cl_command_qu
     int err;
 
     err = test_work_group_broadcast_1D(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_broadcast_2D(device, context, queue, n_elems);
-    if (err) return err;
+    err |= test_work_group_broadcast_2D(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_reduce.c
+++ b/test_conformance/workgroups/test_wg_reduce.c
@@ -569,12 +569,9 @@ test_work_group_reduce_add(cl_device_id device, cl_context context, cl_command_q
     int err;
 
     err = test_work_group_reduce_add_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_add_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_add_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_add_ulong(device, context, queue, n_elems);
+    err |= test_work_group_reduce_add_uint(device, context, queue, n_elems);
+    err |= test_work_group_reduce_add_long(device, context, queue, n_elems);
+    err |= test_work_group_reduce_add_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_reduce_max.c
+++ b/test_conformance/workgroups/test_wg_reduce_max.c
@@ -569,12 +569,9 @@ test_work_group_reduce_max(cl_device_id device, cl_context context, cl_command_q
     int err;
 
     err = test_work_group_reduce_max_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_max_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_max_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_max_ulong(device, context, queue, n_elems);
+    err |= test_work_group_reduce_max_uint(device, context, queue, n_elems);
+    err |= test_work_group_reduce_max_long(device, context, queue, n_elems);
+    err |= test_work_group_reduce_max_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_reduce_min.c
+++ b/test_conformance/workgroups/test_wg_reduce_min.c
@@ -569,12 +569,9 @@ test_work_group_reduce_min(cl_device_id device, cl_context context, cl_command_q
     int err;
 
     err = test_work_group_reduce_min_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_min_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_min_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_reduce_min_ulong(device, context, queue, n_elems);
+    err |= test_work_group_reduce_min_uint(device, context, queue, n_elems);
+    err |= test_work_group_reduce_min_long(device, context, queue, n_elems);
+    err |= test_work_group_reduce_min_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_exclusive_add.c
+++ b/test_conformance/workgroups/test_wg_scan_exclusive_add.c
@@ -577,12 +577,9 @@ test_work_group_scan_exclusive_add(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_exclusive_add_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_add_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_add_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_add_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_add_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_add_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_add_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_exclusive_max.c
+++ b/test_conformance/workgroups/test_wg_scan_exclusive_max.c
@@ -568,12 +568,9 @@ test_work_group_scan_exclusive_max(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_exclusive_max_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_max_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_max_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_max_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_max_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_max_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_max_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_exclusive_min.c
+++ b/test_conformance/workgroups/test_wg_scan_exclusive_min.c
@@ -569,12 +569,9 @@ test_work_group_scan_exclusive_min(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_exclusive_min_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_min_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_min_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_exclusive_min_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_min_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_min_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_exclusive_min_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_inclusive_add.c
+++ b/test_conformance/workgroups/test_wg_scan_inclusive_add.c
@@ -566,12 +566,9 @@ test_work_group_scan_inclusive_add(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_inclusive_add_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_add_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_add_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_add_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_add_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_add_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_add_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_inclusive_max.c
+++ b/test_conformance/workgroups/test_wg_scan_inclusive_max.c
@@ -568,12 +568,9 @@ test_work_group_scan_inclusive_max(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_inclusive_max_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_max_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_max_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_max_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_max_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_max_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_max_ulong(device, context, queue, n_elems);
     return err;
 }
 

--- a/test_conformance/workgroups/test_wg_scan_inclusive_min.c
+++ b/test_conformance/workgroups/test_wg_scan_inclusive_min.c
@@ -568,12 +568,9 @@ test_work_group_scan_inclusive_min(cl_device_id device, cl_context context, cl_c
     int err;
 
     err = test_work_group_scan_inclusive_min_int(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_min_uint(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_min_long(device, context, queue, n_elems);
-    if (err) return err;
-    err = test_work_group_scan_inclusive_min_ulong(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_min_uint(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_min_long(device, context, queue, n_elems);
+    err |= test_work_group_scan_inclusive_min_ulong(device, context, queue, n_elems);
     return err;
 }
 


### PR DESCRIPTION
This introduces a new generate kernel sources mode. In this mode the conformance dumps the .cl files into a folder but does not attempt to run the full conformance. The change is comprised from the introduction of the new flag and forcing the individual conformance tests to continue running all tests even if compilation fails. A few suites still need to be modified to support this change.