### PR TITLE
cl12: Do not set -std=c99 on files that are set to be C++

### DIFF
--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -43,10 +43,6 @@ set_source_files_properties(
 endif()
 endif()
 
-set_source_files_properties(
-        Sleep.c test_conversions.c basic_test_conversions.c
-        COMPILE_FLAGS -std=c99)
-
 if(NOT MSVC)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 set_source_files_properties(


### PR DESCRIPTION
This eliminates some warnings for a few compiler configurations.  This change
is not required on master branch.