### PR TITLE
cl12: Reintroduce M_PI compatibility

### DIFF
--- a/test_common/harness/compat.h
+++ b/test_common/harness/compat.h
@@ -117,15 +117,15 @@ typedef long long           int64_t;
     #include <math.h>
 #endif
 
+#ifndef M_PI
+    #define M_PI    3.14159265358979323846264338327950288
+#endif
+
 #if defined( _MSC_VER )
 
     #ifdef __cplusplus
         extern "C" {
     #endif
-
-#ifndef M_PI
-    #define M_PI    3.14159265358979323846264338327950288
-#endif
 
         #ifndef NAN
             #define NAN  (INFINITY - INFINITY)


### PR DESCRIPTION
M_PI is not part of C99 or C++ and thus aren't provided in all configurations.
This used to be handled in reference_math.c directly but was recently removed.
Just tweak the M_PI handling in the compatibility headers to restore builds.