### PR TITLE
Remove -g flag from conformance build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,11 +127,11 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
     # to falsely fail. -ffloat-store also works, but WG suggested
     # that sse would be better.
     if(CMAKE_ARM_COMPILER OR ANDROID)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=gnu99 -Wno-narrowing")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=gnu++11 -Wno-narrowing")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wno-narrowing")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wno-narrowing")
     else(CMAKE_ARM_COMPILER OR ANDROID)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=gnu99 -msse -mfpmath=sse -Wno-narrowing")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -msse -mfpmath=sse -std=gnu++11 -Wno-narrowing")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -msse -mfpmath=sse -Wno-narrowing")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -mfpmath=sse -std=gnu++11 -Wno-narrowing")
     endif(CMAKE_ARM_COMPILER OR ANDROID)
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D__SSE__")


### PR DESCRIPTION
This reduces the size of binaries, and makes the tests finish tiny
bit faster. The debug symbols can be enabled by passing to cmake one of:
-DCMAKE_BUILD_TYPE=Debug
-DCMAKE_BUILD_TYPE=RelWithDebInfo

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>