### PR TITLE
Remove redundant prints from half

### DIFF
--- a/test_conformance/half/Test_roundTrip.c
+++ b/test_conformance/half/Test_roundTrip.c
@@ -33,10 +33,6 @@ int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue qu
     memset( min_time, -1, sizeof( min_time ) );
     memset( min_double_time, -1, sizeof( min_double_time ) );
 
-    vlog( "Testing roundTrip\n" );
-    fflush( stdout );
-
-
     for( vectorSize = kMinVectorSize; vectorSize < kLastVectorSizeToTest; vectorSize++)
     {
         const char *source[] = {
@@ -300,7 +296,7 @@ int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue qu
         }
     }
 
-    vlog( "\tPassed\n" );
+    vlog( "\n" );
 
     loopCount = 100;
     if( gReportTimes )

--- a/test_conformance/half/Test_vLoadHalf.c
+++ b/test_conformance/half/Test_vLoadHalf.c
@@ -73,8 +73,6 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
 
     memset( min_time, -1, sizeof( min_time ) );
 
-    vlog( "Testing vload%s_half\n", aligned ? "a" : "" );
-    fflush( stdout );
     const char *vector_size_names[]   = {"1", "2", "4", "8", "16", "3"};
 
     int minVectorSize = kMinVectorSize;
@@ -590,7 +588,7 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
         }
     }
 
-    vlog( "\tPassed\n" );
+    vlog( "\n" );
 
     if( gReportTimes )
     {

--- a/test_conformance/half/Test_vStoreHalf.c
+++ b/test_conformance/half/Test_vStoreHalf.c
@@ -695,9 +695,6 @@ int Test_vStoreHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleR
     uint64_t min_double_time[kVectorSizeCount+kStrangeVectorSizeCount] = {0};
     memset( min_double_time, -1, sizeof( min_double_time ) );
 
-    vlog( "Testing vstore_half%s\n", roundName );
-    fflush( stdout );
-
     bool aligned= false;
 
     for( vectorSize = kMinVectorSize; vectorSize < kLastVectorSizeToTest; vectorSize++)
@@ -1288,22 +1285,6 @@ int Test_vStoreHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleR
         }
     }
 
-    if( 0 == gFailCount )
-    {
-        if( gWimpyMode )
-        {
-            vlog( "\tfloat: Wimp Passed\n" );
-            if( gTestDouble )
-                vlog( "\tdouble: Wimp Passed\n" );
-        }
-        else
-        {
-            vlog( "\tfloat Passed\n" );
-            if( gTestDouble )
-                vlog( "\tdouble Passed\n" );
-        }
-    }
-
     if( gReportTimes )
     {
         for( vectorSize = kMinVectorSize; vectorSize < kLastVectorSizeToTest; vectorSize++)
@@ -1357,9 +1338,6 @@ int Test_vStoreaHalf_private( cl_device_id device, f2h referenceFunc, d2h double
     memset( min_double_time, -1, sizeof( min_double_time ) );
 
     bool aligned = true;
-
-    vlog( "Testing vstorea_half%s\n", roundName );
-    fflush( stdout );
 
     int minVectorSize = kMinVectorSize;
     // There is no aligned scalar vstorea_half
@@ -1891,20 +1869,6 @@ int Test_vStoreaHalf_private( cl_device_id device, f2h referenceFunc, d2h double
                     min_double_time[ vectorSize ] = bestTime;
             }
         }
-    }
-
-    if( gWimpyMode )
-    {
-        vlog( "\tfloat: Wimp Passed\n" );
-
-        if( gTestDouble )
-            vlog( "\tdouble: Wimp Passed\n" );
-    }
-    else
-    {
-        vlog( "\tfloat Passed\n" );
-        if( gTestDouble )
-            vlog( "\tdouble Passed\n" );
     }
 
     if( gReportTimes )


### PR DESCRIPTION
The test harness already prints if the test passed, no need to duplicate
this information.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>