### PR TITLE
Remove redundant prints from integer_ops

### DIFF
--- a/test_conformance/integer_ops/test_abs.c
+++ b/test_conformance/integer_ops/test_abs.c
@@ -324,7 +324,6 @@ int test_integer_abs(cl_device_id device, cl_context context, cl_command_queue q
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
-    log_info("ABS test passed\n");
 
     free(input_ptr);
     free(output_ptr);

--- a/test_conformance/integer_ops/test_absdiff.c
+++ b/test_conformance/integer_ops/test_absdiff.c
@@ -362,7 +362,6 @@ int test_integer_abs_diff(cl_device_id device, cl_context context, cl_command_qu
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
-    log_info("ABS_DIFF test passed\n");
 
     free(input_ptr[0]);
     free(input_ptr[1]);

--- a/test_conformance/integer_ops/test_add_sat.c
+++ b/test_conformance/integer_ops/test_add_sat.c
@@ -366,8 +366,6 @@ int test_integer_add_sat(cl_device_id device, cl_context context, cl_command_que
         return -1;
     }
 
-    log_info("ADD_SAT test passed\n");
-
     free(input_ptr[0]);
     free(input_ptr[1]);
     free(output_ptr);

--- a/test_conformance/integer_ops/test_popcount.c
+++ b/test_conformance/integer_ops/test_popcount.c
@@ -237,7 +237,6 @@ int test_popcount(cl_device_id device, cl_context context, cl_command_queue queu
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
-    log_info("popcount test passed\n");
 
     free(input_ptr[0]);
     free(output_ptr);

--- a/test_conformance/integer_ops/test_sub_sat.c
+++ b/test_conformance/integer_ops/test_sub_sat.c
@@ -364,7 +364,6 @@ int test_integer_sub_sat(cl_device_id device, cl_context context, cl_command_que
         log_info("Failed on %d types\n", fail_count);
         return -1;
     }
-    log_info("SUB_SAT test passed\n");
 
     free(input_ptr[0]);
     free(input_ptr[1]);


### PR DESCRIPTION
The test harness already prints if the test passed, no need to duplicate
this information.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>