### PR TITLE
Fix for https://github.com/KhronosGroup/OpenCL-CTS/issues/346 - causi…

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -3287,6 +3287,7 @@ char *create_random_image_data( ExplicitType dataType, image_descriptor *imageIn
                     }
                     break;
             }
+            break;
         }
 
         case kInt:


### PR DESCRIPTION
Fix for https://github.com/KhronosGroup/OpenCL-CTS/issues/346 - causing special float number generation to be skipped

Co-Contributor jlewis-austin