### PR TITLE
remove check for extension for writeable sRGB images

### DIFF
--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -828,19 +828,6 @@ int test_write_image_formats( cl_device_id device, cl_context context, cl_comman
         if( filterFlags[ i ] )
             continue;
 
-        if (is_sRGBA_order(imageFormat.image_channel_order))
-        {
-            if( !is_extension_available( device, "cl_khr_srgb_image_writes" ))
-            {
-                log_missing_feature( "-----------------------------------------------------\n" );
-                log_missing_feature( "WARNING!!! sRGB formats are shown in the supported write-format list.\n");
-                log_missing_feature( "However the extension cl_khr_srgb_image_writes is not available.\n");
-                log_missing_feature( "Please make sure the extension is officially supported by the device .\n");
-                log_missing_feature( "-----------------------------------------------------\n\n" );
-                continue;
-            }
-        }
-
         gTestCount++;
 
         print_write_header( &imageFormat, false );


### PR DESCRIPTION
This change removes the check for the `cl_khr_srgb_image_writes` extension when testing writes to sRGB image channel orders.  Writes to sRGB image channel orders will be tested so long as they are in the list of image formats supported for writing, regardless whether the device supports the `cl_khr_srgb_image_writes` extension.

See discussion in: https://github.com/KhronosGroup/OpenCL-Docs/pull/119