### PR TITLE
Fix coarse-grain SVM memory sync between devices

### DIFF
--- a/test_conformance/SVM/common.h
+++ b/test_conformance/SVM/common.h
@@ -80,6 +80,8 @@ extern cl_int        verify_linked_lists_on_device(int qi, cl_command_queue q, c
 extern cl_int create_linked_lists_on_device_no_map(int qi, cl_command_queue q, size_t *pAllocator,   cl_kernel k, size_t numLists  );
 extern cl_int verify_linked_lists_on_device_no_map(int qi, cl_command_queue q, cl_int *pNum_correct, cl_kernel k, cl_int ListLength, size_t numLists  );
 
+extern cl_int sync_coarse_grain_buffer_on_devices(cl_command_queue qc, cl_command_queue qv, cl_mem nodes, Node *pNodes, cl_mem nodes2, cl_int ListLength, size_t numLists);
+
 extern int    test_svm_byte_granularity(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_set_kernel_exec_info_svm_ptrs(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_fine_grain_memory_consistency(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);

--- a/test_conformance/SVM/test_cross_buffer_pointers.cpp
+++ b/test_conformance/SVM/test_cross_buffer_pointers.cpp
@@ -196,6 +196,13 @@ int test_svm_cross_buffer_pointers_coarse_grain(cl_device_id deviceID, cl_contex
         {
           error = create_linked_lists_on_device(ci, queues[ci], allocator, kernel_create_lists, numLists);
           if(error) return -1;
+          // If ci and vi is the same device, sync is unnecessary.
+          // If vi is host, sync is done in verify_linked_lists_on_host.
+          if (ci != vi && vi != num_devices)
+          {
+            error = sync_coarse_grain_buffer_on_devices(queues[ci], queues[vi], nodes, pNodes, nodes2, ListLength, numLists);
+            if(error) return -1;
+          }
         }
 
         if(vi == num_devices)

--- a/test_conformance/SVM/test_shared_sub_buffers.cpp
+++ b/test_conformance/SVM/test_shared_sub_buffers.cpp
@@ -219,6 +219,13 @@ int test_svm_shared_sub_buffers(cl_device_id deviceID, cl_context context2, cl_c
         {
           error = create_linked_lists_on_device(ci, queues[ci], allocator, kernel_create_lists, numLists);
           if(error) return -1;
+          // If ci and vi is the same device, sync is unnecessary.
+          // If vi is host, sync is done in verify_linked_lists_on_host_sb.
+          if (ci != vi && vi != num_devices)
+          {
+            error = sync_coarse_grain_buffer_on_devices(queues[ci], queues[vi], nodes, pNodes, nodes2, ListLength, numLists);
+            if(error) return -1;
+          }
         }
 
         if(vi == num_devices)


### PR DESCRIPTION
Coarse-grain SVM memory consistency model is similar to the global
memory consistency model. Map/unmap commands are required to drive
updates between host and device.
This patch fixes sync between two devices: first sync data from
commit device to host and then sync data from host to verify device.

See #450 