### PR TITLE
Put "run_conformance.py" and all test runner files ".csv" in build directory

### DIFF
--- a/test_conformance/CMakeLists.txt
+++ b/test_conformance/CMakeLists.txt
@@ -89,3 +89,13 @@ add_subdirectory(vec_step)
 
 # Add any extension folders
 add_subdirectory(spir)
+
+# Copy all csv files
+FILE(GLOB CSV_FILES
+ 	 "${CMAKE_CURRENT_SOURCE_DIR}/*.csv"
+)
+FILE(COPY ${CSV_FILES} DESTINATION "${CMAKE_BINARY_DIR}")
+
+# Copy test runner
+FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/run_conformance.py" DESTINATION "${CMAKE_BINARY_DIR}")
+

--- a/test_conformance/allocations/CMakeLists.txt
+++ b/test_conformance/allocations/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_allocations
+add_executable(test_allocations
         main.cpp
         allocation_execute.cpp
         allocation_fill.cpp
@@ -26,10 +26,10 @@ set_source_files_properties(
         ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_allocations
+TARGET_LINK_LIBRARIES(test_allocations
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_allocations)
-install(TARGETS conformance_test_allocations
+add_dependencies(OpenCLCTS test_allocations)
+install(TARGETS test_allocations
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_api
+add_executable(test_api
    main.c
    test_retain_program.c
    test_queries.cpp
@@ -62,10 +62,10 @@ set_source_files_properties(
    ../../test_common/harness/conversions.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_api
+TARGET_LINK_LIBRARIES(test_api
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_api)
-install(TARGETS conformance_test_api
+add_dependencies(OpenCLCTS test_api)
+install(TARGETS test_api
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/atomics/CMakeLists.txt
+++ b/test_conformance/atomics/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_atomics
+add_executable(test_atomics
         main.c
         test_atomics.cpp
         test_indexed_cases.c
@@ -24,10 +24,10 @@ set_source_files_properties(
         ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_atomics
+TARGET_LINK_LIBRARIES(test_atomics
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_atomics)
-install(TARGETS conformance_test_atomics
+add_dependencies(OpenCLCTS test_atomics)
+install(TARGETS test_atomics
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/basic/CMakeLists.txt
+++ b/test_conformance/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_basic
+add_executable(test_basic
         main.c
 	test_fpmath_float.c test_fpmath_float2.c test_fpmath_float4.c
 	test_intmath_int.c test_intmath_int2.c test_intmath_int4.c
@@ -117,10 +117,10 @@ set_source_files_properties(
   	../../test_common/harness/rounding_mode.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_basic
+TARGET_LINK_LIBRARIES(test_basic
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_basic)
-install(TARGETS conformance_test_basic
+add_dependencies(OpenCLCTS test_basic)
+install(TARGETS test_basic
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/buffers/CMakeLists.txt
+++ b/test_conformance/buffers/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_buffers
+add_executable(test_buffers
 	main.c test_buffer_copy.c test_buffer_read.c test_buffer_write.c
 	test_buffer_mem.c array_info.c test_buffer_map.c
 	test_sub_buffers.cpp test_buffer_fill.c
@@ -27,10 +27,10 @@ set_source_files_properties(
 	../../test_common/harness/typeWrappers.cpp
     PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_buffers
+TARGET_LINK_LIBRARIES(test_buffers
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_buffers)
-install(TARGETS conformance_test_buffers
+add_dependencies(OpenCLCTS test_buffers)
+install(TARGETS test_buffers
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/commonfns/CMakeLists.txt
+++ b/test_conformance/commonfns/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_commonfns
+add_executable(test_commonfns
         main.c test_clamp.c test_degrees.c
 	test_max.c test_maxf.c test_min.c test_minf.c
         test_mix.c test_radians.c test_step.c test_stepf.c
@@ -28,10 +28,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c    
     PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_commonfns
+TARGET_LINK_LIBRARIES(test_commonfns
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_commonfns)
-install(TARGETS conformance_test_commonfns
+add_dependencies(OpenCLCTS test_commonfns)
+install(TARGETS test_commonfns
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/compiler/CMakeLists.txt
+++ b/test_conformance/compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_compiler    
+add_executable(test_compiler    
 	main.c
 	test_build_helpers.c
 	test_compile.c
@@ -36,20 +36,20 @@ set_source_files_properties(
 	../../test_common/harness/conversions.c
     PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_compiler
+TARGET_LINK_LIBRARIES(test_compiler
         ${CLConform_LIBRARIES})
 
 # Need to copy the test include folders to sit beside the executable
-add_custom_command(TARGET conformance_test_compiler POST_BUILD
+add_custom_command(TARGET test_compiler POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_CURRENT_SOURCE_DIR}/includeTestDirectory"
-		"$<TARGET_FILE_DIR:conformance_test_compiler>/includeTestDirectory"
+		"$<TARGET_FILE_DIR:test_compiler>/includeTestDirectory"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_CURRENT_SOURCE_DIR}/secondIncludeTestDirectory"
-		"$<TARGET_FILE_DIR:conformance_test_compiler>/secondIncludeTestDirectory")
+		"$<TARGET_FILE_DIR:test_compiler>/secondIncludeTestDirectory")
 
-add_dependencies(OpenCLCTS conformance_test_compiler)
-install(TARGETS conformance_test_compiler
+add_dependencies(OpenCLCTS test_compiler)
+install(TARGETS test_compiler
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)
 

--- a/test_conformance/computeinfo/CMakeLists.txt
+++ b/test_conformance/computeinfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_computeinfo
+add_executable(test_computeinfo
         main.c
         ../../test_common/harness/errorHelpers.c
         ../../test_common/harness/msvc9.c
@@ -10,10 +10,10 @@ set_source_files_properties(
         ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
         
-TARGET_LINK_LIBRARIES(conformance_test_computeinfo
+TARGET_LINK_LIBRARIES(test_computeinfo
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_computeinfo)
-install(TARGETS conformance_test_computeinfo
+add_dependencies(OpenCLCTS test_computeinfo)
+install(TARGETS test_computeinfo
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/contractions/CMakeLists.txt
+++ b/test_conformance/contractions/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_contractions
+add_executable(test_contractions
         contractions.c
         ../../test_common/harness/mt19937.c
         ../../test_common/harness/msvc9.c
@@ -26,10 +26,10 @@ set_source_files_properties(
         PROPERTIES LANGUAGE CXX)
 endif(WIN32)
 
-TARGET_LINK_LIBRARIES(conformance_test_contractions
+TARGET_LINK_LIBRARIES(test_contractions
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_contractions)
-install(TARGETS conformance_test_contractions
+add_dependencies(OpenCLCTS test_contractions)
+install(TARGETS test_contractions
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/d3d10/CMakeLists.txt
+++ b/test_conformance/d3d10/CMakeLists.txt
@@ -32,18 +32,18 @@ set(D3D10_SOURCES
     ../../test_common/harness/conversions.c
     ../../test_common/harness/msvc9.c)
 
-add_executable(conformance_test_d3d10
+add_executable(test_d3d10
     ${D3D10_SOURCES})
 
 set_source_files_properties(
     ${D3D10_SOURCES}
     PROPERTIES LANGUAGE CXX)
         
-TARGET_LINK_LIBRARIES(conformance_test_d3d10
+TARGET_LINK_LIBRARIES(test_d3d10
     ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_d3d10)
-install(TARGETS conformance_test_d3d10
+add_dependencies(OpenCLCTS test_d3d10)
+install(TARGETS test_d3d10
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)
 

--- a/test_conformance/d3d11/CMakeLists.txt
+++ b/test_conformance/d3d11/CMakeLists.txt
@@ -32,18 +32,18 @@ set(D3D11_SOURCES
     ../../test_common/harness/conversions.c
     ../../test_common/harness/msvc9.c)
 
-add_executable(conformance_test_d3d11
+add_executable(test_d3d11
     ${D3D11_SOURCES})
 
 set_source_files_properties(
     ${D3D11_SOURCES}
     PROPERTIES LANGUAGE CXX)
         
-TARGET_LINK_LIBRARIES(conformance_test_d3d11
+TARGET_LINK_LIBRARIES(test_d3d11
     ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_d3d11)
-install(TARGETS conformance_test_d3d11
+add_dependencies(OpenCLCTS test_d3d11)
+install(TARGETS test_d3d11
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)
 

--- a/test_conformance/device_partition/CMakeLists.txt
+++ b/test_conformance/device_partition/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_device_partition
+add_executable(test_device_partition
 	main.c
 	test_device_partition.cpp
 	../../test_common/harness/errorHelpers.c
@@ -26,10 +26,10 @@ set_source_files_properties(
 	../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-target_link_libraries(conformance_test_device_partition
+target_link_libraries(test_device_partition
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_device_partition)
-install(TARGETS conformance_test_device_partition
+add_dependencies(OpenCLCTS test_device_partition)
+install(TARGETS test_device_partition
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/events/CMakeLists.txt
+++ b/test_conformance/events/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_events
+add_executable(test_events
 	main.c
 	test_events.cpp
 	test_event_dependencies.cpp
@@ -40,10 +40,10 @@ set_source_files_properties(
 	../../test_common/harness/ThreadPool.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_events
+TARGET_LINK_LIBRARIES(test_events
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_events)
-install(TARGETS conformance_test_events
+add_dependencies(OpenCLCTS test_events)
+install(TARGETS test_events
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/geometrics/CMakeLists.txt
+++ b/test_conformance/geometrics/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_C_FLAGS_RELEASE "/Od /Ob0")
 set(CMAKE_CXX_FLAGS_RELEASE "/Od /Ob0")
 endif(MSVC)
 
-add_executable(conformance_test_geometrics
+add_executable(test_geometrics
         main.c
 	test_geometrics_double.cpp
 	test_geometrics.cpp
@@ -28,10 +28,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c    
     PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_geometrics
+TARGET_LINK_LIBRARIES(test_geometrics
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_geometrics)
-install(TARGETS conformance_test_geometrics
+add_dependencies(OpenCLCTS test_geometrics)
+install(TARGETS test_geometrics
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/gl/CMakeLists.txt
+++ b/test_conformance/gl/CMakeLists.txt
@@ -57,7 +57,7 @@ if (MSVC)
     endif(CMAKE_CL_64)
 endif(MSVC)
 
-add_executable(conformance_test_gl
+add_executable(test_gl
         ${GL_SOURCES} ${GLUT_SOURCES})
 
 set_source_files_properties(
@@ -67,13 +67,13 @@ set_source_files_properties(
 # Add the current folder to the include path, so that
 # test_common/gl/setup_x11.cpp can find testBase.h which is located in this
 # folder.
-target_include_directories(conformance_test_gl
+target_include_directories(test_gl
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-TARGET_LINK_LIBRARIES(conformance_test_gl
+TARGET_LINK_LIBRARIES(test_gl
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_gl)
-install(TARGETS conformance_test_gl
+add_dependencies(OpenCLCTS test_gl)
+install(TARGETS test_gl
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/half/CMakeLists.txt
+++ b/test_conformance/half/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_half
+add_executable(test_half
         cl_utils.c Test_vLoadHalf.c Test_roundTrip.c
         Test_vStoreHalf.c main.c
         ../../test_common/harness/msvc9.c
@@ -13,10 +13,10 @@ set_source_files_properties(
         ../../test_common/harness/mingw_compat.c  
         ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
-TARGET_LINK_LIBRARIES(conformance_test_half
+TARGET_LINK_LIBRARIES(test_half
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_half)
-install(TARGETS conformance_test_half
+add_dependencies(OpenCLCTS test_half)
+install(TARGETS test_half
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/headers/CMakeLists.txt
+++ b/test_conformance/headers/CMakeLists.txt
@@ -1,82 +1,82 @@
-add_executable(conformance_test_headers 
+add_executable(test_headers 
     test_headers.c
 )
 
-add_executable(conformance_test_cl_h
+add_executable(test_cl_h
     test_cl.h.c
 )
 
-add_executable(conformance_test_cl_platform_h
+add_executable(test_cl_platform_h
     test_cl_platform.h.c
 )
 
-add_executable(conformance_test_cl_gl_h
+add_executable(test_cl_gl_h
     test_cl_gl.h.c
 )
 
-add_executable(conformance_test_opencl_h
+add_executable(test_opencl_h
     test_opencl.h.c
 )
 
-add_executable(conformance_test_cl_h_c99
+add_executable(test_cl_h_c99
     test_cl.h.c
 )
 
-add_executable(conformance_test_cl_platform_h_c99
+add_executable(test_cl_platform_h_c99
     test_cl_platform.h.c
 )
 
-add_executable(conformance_test_cl_gl_h_c99
+add_executable(test_cl_gl_h_c99
     test_cl_gl.h.c
 )
 
-add_executable(conformance_test_opencl_h_c99
+add_executable(test_opencl_h_c99
     test_opencl.h.c
 )
 
-set_target_properties(conformance_test_cl_h_c99
-    conformance_test_cl_platform_h_c99
-    conformance_test_cl_gl_h_c99
-    conformance_test_opencl_h_c99
+set_target_properties(test_cl_h_c99
+    test_cl_platform_h_c99
+    test_cl_gl_h_c99
+    test_opencl_h_c99
     PROPERTIES COMPILE_FLAGS "-std=c99"
 )
 
-TARGET_LINK_LIBRARIES(conformance_test_headers
+TARGET_LINK_LIBRARIES(test_headers
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_h
+TARGET_LINK_LIBRARIES(test_cl_h
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_platform_h
+TARGET_LINK_LIBRARIES(test_cl_platform_h
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_gl_h
+TARGET_LINK_LIBRARIES(test_cl_gl_h
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_opencl_h
+TARGET_LINK_LIBRARIES(test_opencl_h
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_h_c99
+TARGET_LINK_LIBRARIES(test_cl_h_c99
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_platform_h_c99
+TARGET_LINK_LIBRARIES(test_cl_platform_h_c99
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_gl_h_c99
+TARGET_LINK_LIBRARIES(test_cl_gl_h_c99
         ${CLConform_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(conformance_test_opencl_h_c99
+TARGET_LINK_LIBRARIES(test_opencl_h_c99
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_headers conformance_test_cl_h
-    conformance_test_cl_platform_h conformance_test_cl_gl_h
-    conformance_test_opencl_h conformance_test_cl_h_c99
-    conformance_test_cl_platform_h_c99 conformance_test_cl_gl_h_c99
-    conformance_test_opencl_h_c99)
-install(TARGETS conformance_test_headers conformance_test_cl_h
-    conformance_test_cl_platform_h conformance_test_cl_gl_h
-    conformance_test_opencl_h conformance_test_cl_h_c99
-    conformance_test_cl_platform_h_c99 conformance_test_cl_gl_h_c99
-    conformance_test_opencl_h_c99
+add_dependencies(OpenCLCTS test_headers test_cl_h
+    test_cl_platform_h test_cl_gl_h
+    test_opencl_h test_cl_h_c99
+    test_cl_platform_h_c99 test_cl_gl_h_c99
+    test_opencl_h_c99)
+install(TARGETS test_headers test_cl_h
+    test_cl_platform_h test_cl_gl_h
+    test_opencl_h test_cl_h_c99
+    test_cl_platform_h_c99 test_cl_gl_h_c99
+    test_opencl_h_c99
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/clCopyImage/CMakeLists.txt
+++ b/test_conformance/images/clCopyImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_cl_copy_images
+add_executable(test_cl_copy_images
 	main.cpp
 	test_copy_generic.cpp
 	test_copy_1D.cpp
@@ -45,10 +45,10 @@ set_source_files_properties(
 	../../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_copy_images
+TARGET_LINK_LIBRARIES(test_cl_copy_images
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_cl_copy_images)
-install(TARGETS conformance_test_cl_copy_images
+add_dependencies(OpenCLCTS test_cl_copy_images)
+install(TARGETS test_cl_copy_images
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/clFillImage/CMakeLists.txt
+++ b/test_conformance/images/clFillImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_cl_fill_images
+add_executable(test_cl_fill_images
 	main.cpp
 	test_fill_generic.cpp
 	test_fill_1D.cpp
@@ -39,10 +39,10 @@ set_source_files_properties(
 	../../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_fill_images
+TARGET_LINK_LIBRARIES(test_cl_fill_images
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_cl_fill_images)
-install(TARGETS conformance_test_cl_fill_images
+add_dependencies(OpenCLCTS test_cl_fill_images)
+install(TARGETS test_cl_fill_images
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/clGetInfo/CMakeLists.txt
+++ b/test_conformance/images/clGetInfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_cl_get_info
+add_executable(test_cl_get_info
 	main.cpp
 	test_1D.cpp
 	test_2D.cpp
@@ -36,10 +36,10 @@ set_source_files_properties(
 	../../../test_common/harness/typeWrappers.cpp
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_get_info
+TARGET_LINK_LIBRARIES(test_cl_get_info
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_cl_get_info)
-install(TARGETS conformance_test_cl_get_info
+add_dependencies(OpenCLCTS test_cl_get_info)
+install(TARGETS test_cl_get_info
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/clReadWriteImage/CMakeLists.txt
+++ b/test_conformance/images/clReadWriteImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_cl_read_write_images
+add_executable(test_cl_read_write_images
   main.cpp
   test_read_1D.cpp
   test_read_1D_array.cpp
@@ -38,10 +38,10 @@ set_source_files_properties(
   ../../../test_common/harness/typeWrappers.cpp
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_cl_read_write_images
+TARGET_LINK_LIBRARIES(test_cl_read_write_images
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_cl_read_write_images)
-install(TARGETS conformance_test_cl_read_write_images
+add_dependencies(OpenCLCTS test_cl_read_write_images)
+install(TARGETS test_cl_read_write_images
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/kernel_image_methods/CMakeLists.txt
+++ b/test_conformance/images/kernel_image_methods/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_kernel_image_methods
+add_executable(test_kernel_image_methods
 	main.cpp
 	test_1D.cpp
 	test_1D_array.cpp
@@ -38,10 +38,10 @@ set_source_files_properties(
 	../../../test_common/harness/typeWrappers.cpp
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_kernel_image_methods
+TARGET_LINK_LIBRARIES(test_kernel_image_methods
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_kernel_image_methods)
-install(TARGETS conformance_test_kernel_image_methods
+add_dependencies(OpenCLCTS test_kernel_image_methods)
+install(TARGETS test_kernel_image_methods
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_image_streams
+add_executable(test_image_streams
 	main.cpp
 	test_iterations.cpp
 	../image_helpers.cpp 
@@ -48,10 +48,10 @@ set_source_files_properties(
 	../../../test_common/harness/typeWrappers.cpp
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_image_streams
+TARGET_LINK_LIBRARIES(test_image_streams
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_image_streams)
-install(TARGETS conformance_test_image_streams
+add_dependencies(OpenCLCTS test_image_streams)
+install(TARGETS test_image_streams
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/images/samplerlessReads/CMakeLists.txt
+++ b/test_conformance/images/samplerlessReads/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_samplerless_reads
+add_executable(test_samplerless_reads
 	main.cpp
 	test_iterations.cpp
 	test_loops.cpp
@@ -40,10 +40,10 @@ set_source_files_properties(
 	../../../test_common/harness/typeWrappers.cpp 
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_samplerless_reads
+TARGET_LINK_LIBRARIES(test_samplerless_reads
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_samplerless_reads)
-install(TARGETS conformance_test_samplerless_reads
+add_dependencies(OpenCLCTS test_samplerless_reads)
+install(TARGETS test_samplerless_reads
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/integer_ops/CMakeLists.txt
+++ b/test_conformance/integer_ops/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_integer_ops
+add_executable(test_integer_ops
 	main.c
 	test_popcount.c
 	test_int_basic_ops.c
@@ -64,10 +64,10 @@ set_source_files_properties(
 endif()
 endif (NOT CMAKE_CL_64 AND NOT MSVC)
 
-TARGET_LINK_LIBRARIES(conformance_test_integer_ops
+TARGET_LINK_LIBRARIES(test_integer_ops
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_integer_ops)
-install(TARGETS conformance_test_integer_ops
+add_dependencies(OpenCLCTS test_integer_ops)
+install(TARGETS test_integer_ops
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/math_brute_force/CMakeLists.txt
+++ b/test_conformance/math_brute_force/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_bruteforce
+add_executable(test_bruteforce
     FunctionList.c
     Sleep.c
     binary.c
@@ -70,10 +70,10 @@ set_source_files_properties(
 endif()
 endif(NOT CMAKE_CL_64 AND NOT MSVC)
 
-TARGET_LINK_LIBRARIES(conformance_test_bruteforce
+TARGET_LINK_LIBRARIES(test_bruteforce
     ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_bruteforce)
-install(TARGETS conformance_test_bruteforce
+add_dependencies(OpenCLCTS test_bruteforce)
+install(TARGETS test_bruteforce
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/mem_host_flags/CMakeLists.txt
+++ b/test_conformance/mem_host_flags/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_mem_host_flags
+add_executable(test_mem_host_flags
 	main.cpp
 	mem_host_buffer.cpp
 	mem_host_image.cpp
@@ -30,10 +30,10 @@ set_source_files_properties(
 	../../test_common/harness/ThreadPool.c
         PROPERTIES LANGUAGE CXX)
 
-target_link_libraries(conformance_test_mem_host_flags
+target_link_libraries(test_mem_host_flags
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_mem_host_flags)
-install(TARGETS conformance_test_mem_host_flags
+add_dependencies(OpenCLCTS test_mem_host_flags)
+install(TARGETS test_mem_host_flags
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/multiple_device_context/CMakeLists.txt
+++ b/test_conformance/multiple_device_context/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_multiples
+add_executable(test_multiples
         main.c
 	test_multiple_contexts.c
 	test_multiple_devices.cpp
@@ -30,10 +30,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_multiples
+TARGET_LINK_LIBRARIES(test_multiples
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_multiples)
-install(TARGETS conformance_test_multiples
+add_dependencies(OpenCLCTS test_multiples)
+install(TARGETS test_multiples
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/opencl_conformance_tests_full.csv
+++ b/test_conformance/opencl_conformance_tests_full.csv
@@ -5,7 +5,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -89,7 +89,7 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 Conversions,conversions/test_conversions
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce
 Integer Ops,integer_ops/test_integer_ops
-Half Ops,half/Test_half
+Half Ops,half/test_half

--- a/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
+++ b/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
@@ -5,7 +5,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -86,7 +86,7 @@ OpenCL-GL Sharing,gl/test_gl
 # Thorough math and conversions tests
 # #########################################
 Select,select/test_select
-Contractions,contractions/contractions
+Contractions,contractions/test_contractions
 Integer Ops,integer_ops/test_integer_ops
-Half Ops,half/Test_half
+Half Ops,half/test_half
 

--- a/test_conformance/opencl_conformance_tests_math.csv
+++ b/test_conformance/opencl_conformance_tests_math.csv
@@ -1,4 +1,4 @@
 #
 # OpenCL Conformance Test Suite (math only)
 #
-Math,math_brute_force/bruteforce 
+Math,math_brute_force/test_bruteforce 

--- a/test_conformance/opencl_conformance_tests_quick.csv
+++ b/test_conformance/opencl_conformance_tests_quick.csv
@@ -7,7 +7,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -89,6 +89,6 @@ OpenCL-GL Sharing,gl/test_gl
 Select,select/test_select
 #Conversions,conversions/test_conversions
 Contractions,contractions/contractions
-Math,math_brute_force/bruteforce -w
+Math,math_brute_force/test_bruteforce -w
 Integer Ops,integer_ops/test_integer_ops integer_* quick_*
-Half Ops,half/Test_half -w
+Half Ops,half/test_half -w

--- a/test_conformance/printf/CMakeLists.txt
+++ b/test_conformance/printf/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_compile_options(-std=c++11)
 
-add_executable(conformance_test_printf
+add_executable(test_printf
 	test_printf.c
 	util_printf.c
 	../../test_common/harness/mt19937.c
@@ -18,10 +18,10 @@ set_source_files_properties(
 	../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-target_link_libraries(conformance_test_printf
+target_link_libraries(test_printf
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_printf)
-install(TARGETS conformance_test_printf
+add_dependencies(OpenCLCTS test_printf)
+install(TARGETS test_printf
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/profiling/CMakeLists.txt
+++ b/test_conformance/profiling/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_profiling
+add_executable(test_profiling
         main.c readArray.c writeArray.c readImage.c writeImage.c copy.c
         execute.c execute_multipass.c
         ../../test_common/harness/testHarness.c
@@ -27,10 +27,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_profiling
+TARGET_LINK_LIBRARIES(test_profiling
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_profiling)
-install(TARGETS conformance_test_profiling
+add_dependencies(OpenCLCTS test_profiling)
+install(TARGETS test_profiling
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/relationals/CMakeLists.txt
+++ b/test_conformance/relationals/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_relationals 
+add_executable(test_relationals 
         main.c
 	test_relationals.cpp
     test_comparisons_float.cpp
@@ -33,10 +33,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_relationals
+TARGET_LINK_LIBRARIES(test_relationals
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_relationals)
-install(TARGETS conformance_test_relationals
+add_dependencies(OpenCLCTS test_relationals)
+install(TARGETS test_relationals
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/select/CMakeLists.txt
+++ b/test_conformance/select/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_select
+add_executable(test_select
         test_select.c
         util_select.c
         ../../test_common/harness/mt19937.c
@@ -24,10 +24,10 @@ set_source_files_properties(
         ../../test_common/harness/testHarness.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_select
+TARGET_LINK_LIBRARIES(test_select
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_select)
-install(TARGETS conformance_test_select
+add_dependencies(OpenCLCTS test_select)
+install(TARGETS test_select
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/spir/CMakeLists.txt
+++ b/test_conformance/spir/CMakeLists.txt
@@ -5,7 +5,7 @@ endfunction()
 
 # Import function list from math_brute_force
 add_definitions(-DFUNCTION_LIST_ULPS_ONLY)
-set(SPIR_OUT conformance_test_spir)
+set(SPIR_OUT test_spir)
     
 set (SPIR_SOURCES
     main.cpp
@@ -34,45 +34,45 @@ endif()
 set_source_files_properties(${SPIR_SOURCES} PROPERTIES LANGUAGE CXX)
 
 if(UNIX)
-    set_target_properties(conformance_test_spir PROPERTIES
+    set_target_properties(test_spir PROPERTIES
 	   COMPILE_FLAGS "-fexceptions -frtti")
 elseif(MSVC)
-    set_target_properties(conformance_test_spir PROPERTIES
+    set_target_properties(test_spir PROPERTIES
        COMPILE_FLAGS "/GR /EHs /EHc")
 endif()
 
-TARGET_LINK_LIBRARIES(conformance_test_spir
+TARGET_LINK_LIBRARIES(test_spir
 	${CLConform_LIBRARIES})
 
 # Need to copy the spir zips to sit beside the executable
-add_custom_command(TARGET conformance_test_spir POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/khr.csv" "$<TARGET_FILE_DIR:conformance_test_spir>/khr.csv"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/api.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/api.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/atomics.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/atomics.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/basic.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/basic.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/compile_and_link.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/compile_and_link.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/commonfns.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/commonfns.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/conversions.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/conversions.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/geometrics.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/geometrics.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/enum_values.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/enum_values.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/half.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/half.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/kernel_attributes.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/kernel_attributes.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/kernel_image_methods.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/kernel_image_methods.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/images_kernel_read_write.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/images_kernel_read_write.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/images_samplerlessRead.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/images_samplerlessRead.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/integer_ops.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/integer_ops.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/math_brute_force.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/math_brute_force.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/printf.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/printf.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/profiling.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/profiling.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/relationals.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/relationals.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/select.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/select.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/sampler_enumeration.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/sampler_enumeration.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/vec_align.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/vec_align.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/vec_step.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/vec_step.zip"
-	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/binary_type.zip" "$<TARGET_FILE_DIR:conformance_test_spir>/binary_type.zip")
+add_custom_command(TARGET test_spir POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/khr.csv" "$<TARGET_FILE_DIR:test_spir>/khr.csv"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/api.zip" "$<TARGET_FILE_DIR:test_spir>/api.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/atomics.zip" "$<TARGET_FILE_DIR:test_spir>/atomics.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/basic.zip" "$<TARGET_FILE_DIR:test_spir>/basic.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/compile_and_link.zip" "$<TARGET_FILE_DIR:test_spir>/compile_and_link.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/commonfns.zip" "$<TARGET_FILE_DIR:test_spir>/commonfns.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/conversions.zip" "$<TARGET_FILE_DIR:test_spir>/conversions.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/geometrics.zip" "$<TARGET_FILE_DIR:test_spir>/geometrics.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/enum_values.zip" "$<TARGET_FILE_DIR:test_spir>/enum_values.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/half.zip" "$<TARGET_FILE_DIR:test_spir>/half.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/kernel_attributes.zip" "$<TARGET_FILE_DIR:test_spir>/kernel_attributes.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/kernel_image_methods.zip" "$<TARGET_FILE_DIR:test_spir>/kernel_image_methods.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/images_kernel_read_write.zip" "$<TARGET_FILE_DIR:test_spir>/images_kernel_read_write.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/images_samplerlessRead.zip" "$<TARGET_FILE_DIR:test_spir>/images_samplerlessRead.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/integer_ops.zip" "$<TARGET_FILE_DIR:test_spir>/integer_ops.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/math_brute_force.zip" "$<TARGET_FILE_DIR:test_spir>/math_brute_force.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/printf.zip" "$<TARGET_FILE_DIR:test_spir>/printf.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/profiling.zip" "$<TARGET_FILE_DIR:test_spir>/profiling.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/relationals.zip" "$<TARGET_FILE_DIR:test_spir>/relationals.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/select.zip" "$<TARGET_FILE_DIR:test_spir>/select.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/sampler_enumeration.zip" "$<TARGET_FILE_DIR:test_spir>/sampler_enumeration.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/vec_align.zip" "$<TARGET_FILE_DIR:test_spir>/vec_align.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/vec_step.zip" "$<TARGET_FILE_DIR:test_spir>/vec_step.zip"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/binary_type.zip" "$<TARGET_FILE_DIR:test_spir>/binary_type.zip")
 
-add_dependencies(OpenCLCTS conformance_test_spir)
-install(TARGETS conformance_test_spir
+add_dependencies(OpenCLCTS test_spir)
+install(TARGETS test_spir
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)
 

--- a/test_conformance/thread_dimensions/CMakeLists.txt
+++ b/test_conformance/thread_dimensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_thread_dimensions
+add_executable(test_thread_dimensions
         main.c
 	test_thread_dimensions.c
 	../../test_common/harness/errorHelpers.c
@@ -28,10 +28,10 @@ set_source_files_properties(
     ../../test_common/harness/msvc9.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_thread_dimensions
+TARGET_LINK_LIBRARIES(test_thread_dimensions
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_thread_dimensions)
-install(TARGETS conformance_test_thread_dimensions
+add_dependencies(OpenCLCTS test_thread_dimensions)
+install(TARGETS test_thread_dimensions
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/vec_align/CMakeLists.txt
+++ b/test_conformance/vec_align/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_vecalign
+add_executable(test_vecalign
 	globals.c
         main.c
         structs.c
@@ -31,10 +31,10 @@ set_source_files_properties(
         ../../test_common/harness/conversions.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_vecalign
+TARGET_LINK_LIBRARIES(test_vecalign
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_vecalign)
-install(TARGETS conformance_test_vecalign
+add_dependencies(OpenCLCTS test_vecalign)
+install(TARGETS test_vecalign
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)

--- a/test_conformance/vec_step/CMakeLists.txt
+++ b/test_conformance/vec_step/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(conformance_test_vecstep
+add_executable(test_vecstep
 	globals.c
         test_step.c
         main.c
@@ -29,10 +29,10 @@ set_source_files_properties(
         ../../test_common/harness/errorHelpers.c
         PROPERTIES LANGUAGE CXX)
 
-TARGET_LINK_LIBRARIES(conformance_test_vecstep
+TARGET_LINK_LIBRARIES(test_vecstep
         ${CLConform_LIBRARIES})
 
-add_dependencies(OpenCLCTS conformance_test_vecstep)
-install(TARGETS conformance_test_vecstep
+add_dependencies(OpenCLCTS test_vecstep)
+install(TARGETS test_vecstep
     DESTINATION "${CLConf_OUT_DIR}"
     COMPONENT OpenCLCTS)


### PR DESCRIPTION
Put "run_conformance.py" and all test runner files ".csv" in build directory
Added steps in CMakeLists.txt to copy the ".csv" files and "run_conformance.py" from 'test_conformance' directory

Signed-off-by: bhargavthriler <bhargavthriler@gmail.com>