### PR TITLE
Fix inconsistent dll linking warnings for VS 2015/17 (#466)

### DIFF
--- a/test_common/harness/compat.h
+++ b/test_common/harness/compat.h
@@ -151,83 +151,83 @@ typedef long long           int64_t;
         #define     isinf( _x)      ((_x) == INFINITY || (_x) == -INFINITY)
     #endif
         
-#if ! defined( __INTEL_COMPILER )
+    #if _MSC_VER < 1900 && ! defined( __INTEL_COMPILER )
 
-double rint( double x);
-float  rintf( float x);
-long double rintl( long double x);
+        double rint( double x);
+        float  rintf( float x);
+        long double rintl( long double x);
 
-float cbrtf( float );
-double cbrt( double );
+        float cbrtf( float );
+        double cbrt( double );
 
-int    ilogb( double x);
-int    ilogbf (float x);
-int    ilogbl(long double x);
+        int    ilogb( double x);
+        int    ilogbf (float x);
+        int    ilogbl(long double x);
 
-double fmax(double x, double y);
-double fmin(double x, double y);
-float  fmaxf( float x, float y );
-float  fminf(float x, float y);
+        double fmax(double x, double y);
+        double fmin(double x, double y);
+        float  fmaxf( float x, float y );
+        float  fminf(float x, float y);
 
-double      log2(double x);
-long double log2l(long double x);
+        double      log2(double x);
+        long double log2l(long double x);
 
-double      exp2(double x);
-long double exp2l(long double x);
+        double      exp2(double x);
+        long double exp2l(long double x);
 
-double      fdim(double x, double y);
-float       fdimf(float x, float y);
-long double fdiml(long double x, long double y);
+        double      fdim(double x, double y);
+        float       fdimf(float x, float y);
+        long double fdiml(long double x, long double y);
 
-double      remquo( double x, double y, int *quo);
-float       remquof( float x, float y, int *quo);
-long double remquol( long double x, long double y, int *quo);
+        double      remquo( double x, double y, int *quo);
+        float       remquof( float x, float y, int *quo);
+        long double remquol( long double x, long double y, int *quo);
 
-long double scalblnl(long double x, long n);
+        long double scalblnl(long double x, long n);
 
-float hypotf(float x, float y);
-long double hypotl(long double x, long double y) ;
-double lgamma(double x);
-float  lgammaf(float x);
+        float hypotf(float x, float y);
+        long double hypotl(long double x, long double y) ;
+        double lgamma(double x);
+        float  lgammaf(float x);
 
-double trunc(double x);
-float  truncf(float x);
+        double trunc(double x);
+        float  truncf(float x);
 
-double log1p(double x);
-float  log1pf(float x);
-long double log1pl(long double x);
+        double log1p(double x);
+        float  log1pf(float x);
+        long double log1pl(long double x);
 
-double copysign(double x, double y);
-float  copysignf(float x, float y);
-long double copysignl(long double x, long double y);
+        double copysign(double x, double y);
+        float  copysignf(float x, float y);
+        long double copysignl(long double x, long double y);
 
-long lround(double x);
-long lroundf(float x);
-//long lroundl(long double x)
+        long lround(double x);
+        long lroundf(float x);
+        //long lroundl(long double x)
 
-double round(double x);
-float  roundf(float x);
-long double roundl(long double x);
+        double round(double x);
+        float  roundf(float x);
+        long double roundl(long double x);
 
         int cf_signbit(double x);
         int cf_signbitf(float x);
 
-// Added in _MSC_VER == 1800 (Visual Studio 2013)
-#if _MSC_VER < 1800
-        static int signbit(double x) { return  cf_signbit(x); }
-#endif
+        // Added in _MSC_VER == 1800 (Visual Studio 2013)
+        #if _MSC_VER < 1800
+                static int signbit(double x) { return  cf_signbit(x); }
+        #endif
         static int signbitf(float x) { return cf_signbitf(x); }
 
-long int lrint (double flt);
-long int lrintf (float flt);
+        long int lrint (double flt);
+        long int lrintf (float flt);
 
-float   int2float (int32_t ix);
-int32_t float2int (float   fx);
+        float   int2float (int32_t ix);
+        int32_t float2int (float   fx);
 
-    #endif
+    #endif // _MSC_VER < 1900 && ! defined( __INTEL_COMPILER )
 
-    #if ! defined( __INTEL_COMPILER ) || __INTEL_COMPILER < 1300
-        // These functions appeared in Intel C v13.
+    #if _MSC_VER < 1900 && ( ! defined( __INTEL_COMPILER ) || __INTEL_COMPILER < 1300 )
+        // These functions appeared in Intel C v13 and Visual Studio 2015
         float  nanf( const char* str);
         double nan( const char* str);
         long double nanl( const char* str);

--- a/test_common/harness/msvc9.c
+++ b/test_common/harness/msvc9.c
@@ -24,7 +24,7 @@
 
 #include <windows.h>
 
-#if ! defined( __INTEL_COMPILER )
+#if _MSC_VER < 1900 && ! defined( __INTEL_COMPILER )
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -275,6 +275,8 @@ int SIGNBIT_DP64(double x )
     return((hx>>31));
 }
 #endif
+
+#if _MSC_VER < 1900
 
 /* fmax(x, y) returns the larger (more positive) of x and y.
    NaNs are treated as missing values: if one argument is NaN,
@@ -560,6 +562,7 @@ long int lrintf (float x)
     return (long int) x;
 }
 
+#endif // _MSC_VER < 1900
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -589,20 +592,7 @@ int feclearexcept(int excepts)
 
 #endif // __INTEL_COMPILER
 
-#if ! defined( __INTEL_COMPILER ) || __INTEL_COMPILER < 1300
-
-float make_nan()
-{
-/* This is the IEEE 754 single-precision format:
-    unsigned int mantissa:  22;
-    unsigned int quiet_nan:  1;
-    unsigned int exponent:   8;
-    unsigned int negative:   1;
-*/
-     //const static unsigned
-     static const int32_t _nan = 0x7fc00000;
-     return *(const float*)(&_nan);
-}
+#if _MSC_VER < 1900 && ( ! defined( __INTEL_COMPILER ) || __INTEL_COMPILER < 1300 )
 
 float nanf( const char* str)
 {


### PR DESCRIPTION
-- #ifdef out duplicate definitions
-- remove make_nan() dead code

Fixes #466