### PR TITLE
Use clCreateCommandQueue when possible (in a few tests)

### DIFF
--- a/test_conformance/contractions/contractions.c
+++ b/test_conformance/contractions/contractions.c
@@ -570,7 +570,7 @@ test_status InitCL( cl_device_id device )
         return TEST_FAIL;
     }
 
-    gQueue = clCreateCommandQueueWithProperties( gContext, device, 0, &error );
+    gQueue = clCreateCommandQueue( gContext, device, 0, &error );
     if( NULL == gQueue || error )
     {
         vlog_error( "clCreateContext failed. %d\n", error );

--- a/test_conformance/conversions/test_conversions.c
+++ b/test_conformance/conversions/test_conversions.c
@@ -719,7 +719,7 @@ test_status InitCL( cl_device_id device )
         return TEST_FAIL;
     }
 
-    gQueue = clCreateCommandQueueWithProperties(gContext, device, 0, &error);
+    gQueue = clCreateCommandQueue(gContext, device, 0, &error);
     if( NULL == gQueue || error )
     {
         vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/binary.c
+++ b/test_conformance/math_brute_force/binary.c
@@ -332,7 +332,7 @@ int TestFunc_Float_Float_Float_common(const Func *f, MTdata d, int isNextafter)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -1065,7 +1065,7 @@ int TestFunc_Double_Double_Double_common(const Func *f, MTdata d, int isNextafte
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/binaryOperator.c
+++ b/test_conformance/math_brute_force/binaryOperator.c
@@ -321,7 +321,7 @@ int TestFunc_Float_Float_Float_Operator(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -1009,7 +1009,7 @@ int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/binary_i.c
+++ b/test_conformance/math_brute_force/binary_i.c
@@ -324,7 +324,7 @@ int TestFunc_Float_Float_Int(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -832,7 +832,7 @@ int TestFunc_Double_Double_Int(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/macro_binary.c
+++ b/test_conformance/math_brute_force/macro_binary.c
@@ -309,7 +309,7 @@ int TestMacro_Int_Float_Float(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -821,7 +821,7 @@ int TestMacro_Int_Double_Double(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/macro_unary.c
+++ b/test_conformance/math_brute_force/macro_unary.c
@@ -273,7 +273,7 @@ int TestMacro_Int_Float(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -673,7 +673,7 @@ int TestMacro_Int_Double(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/main.c
+++ b/test_conformance/math_brute_force/main.c
@@ -1371,7 +1371,7 @@ test_status InitCL( cl_device_id device )
         return TEST_FAIL;
     }
 
-    gQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+    gQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
     if( NULL == gQueue || error )
     {
         vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/math_brute_force/unary.c
+++ b/test_conformance/math_brute_force/unary.c
@@ -288,7 +288,7 @@ int TestFunc_Float_Float(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );
@@ -1065,7 +1065,7 @@ int TestFunc_Double_Double(const Func *f, MTdata d)
                 goto exit;
             }
         }
-        test_info.tinfo[i].tQueue = clCreateCommandQueueWithProperties(gContext, gDevice, 0, &error);
+        test_info.tinfo[i].tQueue = clCreateCommandQueue(gContext, gDevice, 0, &error);
         if( NULL == test_info.tinfo[i].tQueue || error )
         {
             vlog_error( "clCreateCommandQueue failed. (%d)\n", error );

--- a/test_conformance/multiple_device_context/test_multiple_contexts.c
+++ b/test_conformance/multiple_device_context/test_multiple_contexts.c
@@ -118,7 +118,7 @@ TestItem *CreateTestItem( cl_device_id deviceID, cl_int *err )
     }
 
     // Create a queue
-    item->q = clCreateCommandQueueWithProperties( item->c, deviceID, 0, &error);
+    item->q = clCreateCommandQueue( item->c, deviceID, 0, &error);
     if( item->q == NULL || error != CL_SUCCESS)
     {
         if (err) {

--- a/test_conformance/multiple_device_context/test_multiple_devices.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_devices.cpp
@@ -119,7 +119,7 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     /* Create work queues */
     for( i = 0; i < queueCount; i++ )
     {
-        queues[i] = clCreateCommandQueueWithProperties( context, devices[ i % deviceCount ], 0, &error );
+        queues[i] = clCreateCommandQueue( context, devices[ i % deviceCount ], 0, &error );
     if (error != CL_SUCCESS || queues[i] == NULL) {
       log_info("Could not create queue[%d].\n", (int)i);
       queueCount = i;

--- a/test_conformance/printf/test_printf.c
+++ b/test_conformance/printf/test_printf.c
@@ -1093,7 +1093,7 @@ test_status InitCL( cl_device_id device )
     gContext = clCreateContext(props, 1, &device, notify_callback, NULL, NULL);
     checkNull(gContext, "clCreateContext");
 
-    gQueue = clCreateCommandQueueWithProperties(gContext, device, 0, NULL);
+    gQueue = clCreateCommandQueue(gContext, device, 0, NULL);
     checkNull(gQueue, "clCreateCommandQueue");
 
     releaseOutputStream(gFd);


### PR DESCRIPTION
In all these cases, the new entrypoint is not necessary. These
changes enable the tests to work or are a necessary step to get
the tests to work on an OpenCL 1.2 implementation.

While this may not be the final approach we want to solve this
specific compatibility issue, it also has the nice property of
reducing the diff with cl12_trunk until we merge.

Signed-off-by: Kévin Petit <kpet@free.fr>