### PR TITLE
select: don't forget to count tests when failing to create programs

### DIFF
--- a/test_conformance/select/test_select.c
+++ b/test_conformance/select/test_select.c
@@ -385,6 +385,7 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
         programs[vecsize] = makeSelectProgram(&kernels[vecsize], context, stype, cmptype, element_count[vecsize] );
         if (!programs[vecsize] || !kernels[vecsize]) {
             ++s_test_fail;
+            ++s_test_cnt;
             return -1;
         }
     }


### PR DESCRIPTION
A test writer really shouldn't have to think about this...

Signed-off-by: Kévin Petit <kpet@free.fr>