### PR TITLE
checkDeviceTypeOverride will now detect a cl device if not given one

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -27,6 +27,8 @@ RoundingMode gFloatToHalfRoundingMode = kDefaultRoundingMode;
 static cl_ushort float2half_rte( float f );
 static cl_ushort float2half_rtz( float f );
 
+cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
+
 double
 sRGBmap(float fc)
 {

--- a/test_conformance/api/main.c
+++ b/test_conformance/api/main.c
@@ -28,7 +28,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {

--- a/test_conformance/basic/main.c
+++ b/test_conformance/basic/main.c
@@ -28,7 +28,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {

--- a/test_conformance/clcpp/images/main.cpp
+++ b/test_conformance/clcpp/images/main.cpp
@@ -22,7 +22,6 @@
 // FIXME: To use certain functions in test_common/harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variable (hangover from code specific to Apple's implementation):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 int main(int argc, const char *argv[])
 {

--- a/test_conformance/images/clCopyImage/main.cpp
+++ b/test_conformance/images/clCopyImage/main.cpp
@@ -36,7 +36,6 @@ bool gTestMipmaps;
 int gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 

--- a/test_conformance/images/clFillImage/main.cpp
+++ b/test_conformance/images/clFillImage/main.cpp
@@ -34,7 +34,6 @@ bool gEnablePitch;
 int  gTypesToTest;
 cl_channel_type  gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-cl_device_type   gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 static void printUsage( const char *execName );

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -31,7 +31,6 @@ bool gTestMaxImages;
 bool gTestRounding;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_mem_object_type image_type );
 static void printUsage( const char *execName );

--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -34,7 +34,6 @@ bool gTestMipmaps;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 bool            gEnablePitch = false;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 

--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -34,7 +34,6 @@ int  gTypesToTest;
 bool gDeviceLt20 = false;
 
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -55,7 +55,6 @@ int             gNormalizedModeToUse = 7;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 bool            gEnablePitch = false;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 int             gtestTypesToRun = 0;
 static int testTypesToRun;

--- a/test_conformance/images/samplerlessReads/main.cpp
+++ b/test_conformance/images/samplerlessReads/main.cpp
@@ -43,7 +43,6 @@ int                 gTypesToTest;
 cl_channel_type     gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order    gChannelOrderToUse = (cl_channel_order)-1;
 bool                gEnablePitch = false;
-cl_device_type      gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool                gDeviceLt20 = false;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0

--- a/test_conformance/profiling/main.c
+++ b/test_conformance/profiling/main.c
@@ -23,7 +23,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {


### PR DESCRIPTION
Previously multiple test_image_stream.exe tests were failing because the test would not use the right device type if not given one. Now, when the test uses checkDeviceTypeOverride to check for device types, it now detects the device type in addition to previously checking for environmental variables. 

All image tests passed when ran.