### PR TITLE
Moved all instances of gDeviceType to imageHelper.cpp

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -27,6 +27,8 @@ RoundingMode gFloatToHalfRoundingMode = kDefaultRoundingMode;
 static cl_ushort float2half_rte( float f );
 static cl_ushort float2half_rtz( float f );
 
+cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
+
 double
 sRGBmap(float fc)
 {

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -775,7 +775,6 @@ float get_max_relative_error( cl_image_format *format, image_sampler_data *sampl
     {
         if( sampler->filter_mode != CL_FILTER_NEAREST )
         {
-            extern cl_device_type   gDeviceType;
             // The maximum
             if( gDeviceType == CL_DEVICE_TYPE_GPU )
                 maxError += MAKE_HEX_FLOAT(0x1.0p-4f, 0x1L, -4);              // Some GPUs ain't so accurate

--- a/test_conformance/api/main.c
+++ b/test_conformance/api/main.c
@@ -28,7 +28,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {

--- a/test_conformance/basic/main.c
+++ b/test_conformance/basic/main.c
@@ -28,7 +28,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {

--- a/test_conformance/clcpp/images/main.cpp
+++ b/test_conformance/clcpp/images/main.cpp
@@ -22,7 +22,6 @@
 // FIXME: To use certain functions in test_common/harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variable (hangover from code specific to Apple's implementation):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 int main(int argc, const char *argv[])
 {

--- a/test_conformance/images/clCopyImage/main.cpp
+++ b/test_conformance/images/clCopyImage/main.cpp
@@ -36,7 +36,6 @@ bool gTestMipmaps;
 int gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 

--- a/test_conformance/images/clFillImage/main.cpp
+++ b/test_conformance/images/clFillImage/main.cpp
@@ -34,7 +34,6 @@ bool gEnablePitch;
 int  gTypesToTest;
 cl_channel_type  gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-cl_device_type   gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
 static void printUsage( const char *execName );

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -31,7 +31,6 @@ bool gTestMaxImages;
 bool gTestRounding;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_mem_object_type image_type );
 static void printUsage( const char *execName );

--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -34,7 +34,6 @@ bool gTestMipmaps;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 bool            gEnablePitch = false;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 

--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -34,7 +34,6 @@ int  gTypesToTest;
 bool gDeviceLt20 = false;
 
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -55,7 +55,6 @@ int             gNormalizedModeToUse = 7;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 bool            gEnablePitch = false;
-cl_device_type    gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 
 int             gtestTypesToRun = 0;
 static int testTypesToRun;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestImage2DFromBuffer, gTestMipmaps;
-extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
-extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
-extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -20,7 +20,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool         gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
-extern cl_device_type   gDeviceType;
 extern bool         gUseKernelSamplers;
 extern cl_filter_mode   gFilterModeToUse;
 extern cl_addressing_mode   gAddressModeToUse;

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -20,7 +20,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool            gDebugTrace, gExtraValidateInfo, gDisableOffsets, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gTestMipmaps;
-extern cl_device_type    gDeviceType;
 extern bool            gUseKernelSamplers;
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;

--- a/test_conformance/images/samplerlessReads/main.cpp
+++ b/test_conformance/images/samplerlessReads/main.cpp
@@ -43,7 +43,6 @@ int                 gTypesToTest;
 cl_channel_type     gChannelTypeToUse = (cl_channel_type)-1;
 cl_channel_order    gChannelOrderToUse = (cl_channel_order)-1;
 bool                gEnablePitch = false;
-cl_device_type      gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool                gDeviceLt20 = false;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
 
 #define MAX_TRIES   1

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
 
 #define MAX_TRIES   1

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool                 gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type       gDeviceType;
 extern bool                 gTestReadWrite;
 
 #define MAX_TRIES   1

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -26,7 +26,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool                 gDebugTrace, gTestSmallImages, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type       gDeviceType;
 
 #define MAX_TRIES   1
 #define MAX_CLAMPED 1

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -20,7 +20,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool             gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type   gDeviceType;
 extern bool             gTestReadWrite;
 
 const char *read2DArrayKernelSourcePattern =

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -20,7 +20,6 @@
 #define MAX_HALF_LINEAR_ERR 0.3f
 
 extern bool             gDebugTrace, gTestSmallImages, gEnablePitch, gTestMaxImages, gTestRounding, gDeviceLt20;
-extern cl_device_type   gDeviceType;
 extern bool             gTestReadWrite;
 
 const char *read3DKernelSourcePattern =

--- a/test_conformance/profiling/main.c
+++ b/test_conformance/profiling/main.c
@@ -23,7 +23,6 @@
 // FIXME: To use certain functions in harness/imageHelpers.h
 // (for example, generate_random_image_data()), the tests are required to declare
 // the following variables (<rdar://problem/11111245>):
-cl_device_type gDeviceType = CL_DEVICE_TYPE_DEFAULT;
 bool gTestRounding = false;
 
 test_definition test_list[] = {


### PR DESCRIPTION
This is the first step in trying to refactor gDeviceType, from comments in this Closed PR: https://github.com/KhronosGroup/OpenCL-CTS/pull/560

gDeviceType is now moved to imageHelper.cpp, and only in imageHelper.cpp/.h are they declared and defined. 

