### PR TITLE
Moved common code to testHarness.c and replaced sysctl with uname

### DIFF
--- a/test_common/harness/testHarness.c
+++ b/test_common/harness/testHarness.c
@@ -16,6 +16,10 @@
 #include "testHarness.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/utsname.h>
+
 
 #if !defined(_WIN32)
 #include <stdbool.h>
@@ -809,4 +813,52 @@ cl_device_id GetOpposingDevice( cl_device_id device )
     return NULL;
 }
 
+
+void PrintArch( void )
+{
+    vlog( "\nHost info:\n" );
+    vlog( "\tsizeof( void*) = %ld\n", sizeof( void *) );
+#if defined( __ppc__ )
+    vlog( "\tARCH:\tppc\n" );
+#elif defined( __ppc64__ )
+    vlog( "\tARCH:\tppc64\n" );
+#elif defined( __PPC__ )
+    vlog( "ARCH:\tppc\n" );
+#elif defined( __i386__ )
+    vlog( "\tARCH:\ti386\n" );
+#elif defined( __x86_64__ )
+    vlog( "\tARCH:\tx86_64\n" );
+#elif defined( __arm__ )
+    vlog( "\tARCH:\tarm\n" );
+#elif defined( __aarch64__ )
+    vlog( "\tARCH:\taarch64\n" );
+#else
+    vlog( "\tARCH:\tunknown\n" );
+#endif
+
+#if defined( __APPLE__ )
+    int type = 0;
+    size_t typeSize = sizeof( type );
+    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
+    vlog( "\tcpu type:\t%d\n", type );
+    typeSize = sizeof( type );
+    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
+    vlog( "\tcpu subtype:\t%d\n", type );
+
+#elif defined( __linux__ ) // && !defined(__aarch64__)
+   struct utsname buffer;
+
+   if (uname(&buffer) != 0) {
+      vlog("uname");
+   }
+   else {
+      vlog("system name = %s\n", buffer.sysname);
+      vlog("node name   = %s\n", buffer.nodename);
+      vlog("release     = %s\n", buffer.release);
+      vlog("version     = %s\n", buffer.version);
+      vlog("machine     = %s\n", buffer.machine);
+   }
+
+#endif
+}
 

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -99,6 +99,9 @@ extern int      gIsOpenCL_C_1_0_Device; // This is set to 1 if the device suppor
 }
 #endif
 
+extern void PrintArch( void );
+
+
 #endif // _testHarness_h
 
 

--- a/test_conformance/computeinfo/main.c
+++ b/test_conformance/computeinfo/main.c
@@ -349,11 +349,11 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
             log_info("\t%s == %d\n", info->opcode_name, info->config.uint);
             break;
         case type_size_t_arr:
-            log_info("\t%s == %d %d %d\n", info->opcode_name, info->config.sizet_arr[0],
+            log_info("\t%s == %zu %zu %zu\n", info->opcode_name, info->config.sizet_arr[0],
                      info->config.sizet_arr[1], info->config.sizet_arr[2]);
             break;
         case type_size_t:
-            log_info("\t%s == %ld\n", info->opcode_name, info->config.sizet);
+            log_info("\t%s == %zu\n", info->opcode_name, info->config.sizet);
             break;
         case type_cl_ulong:
             log_info("\t%s == %lld\n", info->opcode_name, info->config.ull);
@@ -386,7 +386,7 @@ void print_platform_string_selector( cl_platform_id platform, const char *select
     value = (char*) malloc( size );
     if( NULL == value )
     {
-        log_error( "Internal test failure:  Unable to allocate %ld bytes\n", size );
+        log_error( "Internal test failure:  Unable to allocate %zu bytes\n", size );
         exit(-1);
     }
 

--- a/test_conformance/contractions/CMakeLists.txt
+++ b/test_conformance/contractions/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(test_contractions
         ../../test_common/harness/errorHelpers.c
         ../../test_common/harness/rounding_mode.c
         ../../test_common/harness/kernelHelpers.c
+        ../../test_common/harness/testHarness.c
 )
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)" AND NOT MSVC)
@@ -23,6 +24,7 @@ set_source_files_properties(
         ../../test_common/harness/errorHelpers.c
         ../../test_common/harness/rounding_mode.c
         ../../test_common/harness/kernelHelpers.c
+        ../../test_common/harness/testHarness.c
         PROPERTIES LANGUAGE CXX)
 endif(WIN32)
 

--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(conformance_test_conversions
         ../../test_common/harness/mingw_compat.c
         ../../test_common/harness/errorHelpers.c
         ../../test_common/harness/parseParameters.cpp
+        ../../test_common/harness/testHarness.c
+        ../../test_common/harness/kernelHelpers.c
 )
 
 set_source_files_properties(
@@ -26,6 +28,8 @@ set_source_files_properties(
         ../../test_common/harness/mingw_compat.c
         ../../test_common/harness/msvc9.c
         ../../test_common/harness/errorHelpers.c
+        ../../test_common/harness/testHarness.c
+        ../../test_common/harness/kernelHelpers.c
         PROPERTIES LANGUAGE CXX)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86$)|(X86$)")
@@ -39,6 +43,8 @@ set_source_files_properties(
         ../../test_common/harness/mingw_compat.c
         ../../test_common/harness/msvc9.c
         ../../test_common/harness/errorHelpers.c
+        ../../test_common/harness/testHarness.c
+        ../../test_common/harness/kernelHelpers.c
         COMPILE_FLAGS -march=i686)
 endif()
 endif()

--- a/test_conformance/math_brute_force/CMakeLists.txt
+++ b/test_conformance/math_brute_force/CMakeLists.txt
@@ -14,6 +14,9 @@ add_executable(test_bruteforce
     ../../test_common/harness/ThreadPool.c
     ../../test_common/harness/mt19937.c
     ../../test_common/harness/msvc9.c
+    ../../test_common/harness/testHarness.c
+    ../../test_common/harness/kernelHelpers.c
+    ../../test_common/harness/errorHelpers.c
 )
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)" AND NOT MSVC)
@@ -47,6 +50,9 @@ set_source_files_properties(
     ../../test_common/harness/ThreadPool.c
     ../../test_common/harness/msvc9.c
     ../../test_common/harness/mt19937.c
+    ../../test_common/harness/testHarness.c
+    ../../test_common/harness/kernelHelpers.c
+    ../../test_common/harness/errorHelpers.c
 	PROPERTIES LANGUAGE CXX)
 endif(MSVC)
 
@@ -66,6 +72,9 @@ set_source_files_properties(
     ../../test_common/harness/rounding_mode.c
     ../../test_common/harness/ThreadPool.c
     ../../test_common/harness/msvc9.c
+    ../../test_common/harness/testHarness.c
+    ../../test_common/harness/kernelHelpers.c
+    ../../test_common/harness/errorHelpers.c
 	COMPILE_FLAGS -march=i686)
 endif()
 endif(NOT CMAKE_CL_64 AND NOT MSVC)


### PR DESCRIPTION
Moved the common function 'PrintArch' used math_brute_force, contractions, and conversion to testHarness.c.
Some other functions are also removed from the above mentioned test suites since those are already present in testHarness.c
Also 'sysctl' system call used in  'PrintArch' function is replaced with 'uname' system call to make the code portable across various platforms.

@kpet please review the changes you asked for in my earlier PR. Somehow I deleted the commits in my forked repo so the PR also got removed.