### PR TITLE
Improved PrintArch functions (#595)

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -28,6 +28,8 @@
 #include "typeWrappers.h"
 #include "imageHelpers.h"
 #include "parseParameters.h"
+#include <sys/utsname.h>
+#include <sys/sysctl.h>
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -944,4 +946,53 @@ Version get_device_cl_version(cl_device_id device)
         return Version(2, 2);
 
     throw std::runtime_error(std::string("Unknown OpenCL version: ") + str.data());
+}
+
+void PrintArch( void )
+{
+    vlog( "sizeof( void*) = %ld\n", sizeof( void *) );
+#if defined( __ppc__ )
+    vlog( "ARCH:\tppc\n" );
+#elif defined( __ppc64__ )   
+    vlog( "ARCH:\tppc64\n" );
+#elif defined( __PPC__ )   
+    vlog( "ARCH:\tppc\n" );
+#elif defined( __i386__ )   
+    vlog( "ARCH:\ti386\n" );
+#elif defined( __x86_64__ )   
+    vlog( "ARCH:\tx86_64\n" );
+#elif defined( __arm__ )   
+    vlog( "ARCH:\tarm\n" );
+#elif defined(__aarch64__)
+    vlog( "ARCH:\taarch64\n" );
+#elif defined (_WIN32)
+    vlog( "ARCH:\tWindows\n" );
+#else
+#error unknown arch
+#endif
+
+#if defined( __APPLE__ )
+
+    int type = 0;
+    size_t typeSize = sizeof( type );
+    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
+    vlog( "cpu type:\t%d\n", type );
+    typeSize = sizeof( type );
+    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
+    vlog( "cpu subtype:\t%d\n", type );
+
+#elif defined( __linux__ )
+    struct utsname buffer;
+ 
+    if (uname(&buffer) != 0) {
+       vlog("uname error");
+    }
+    else {
+       vlog("system name = %s\n", buffer.sysname);
+       vlog("node name   = %s\n", buffer.nodename);
+       vlog("release     = %s\n", buffer.release);
+       vlog("version     = %s\n", buffer.version);
+       vlog("machine     = %s\n", buffer.machine);
+    }
+#endif
 }

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -146,6 +146,8 @@ extern int      gIsOpenCL_C_1_0_Device; // This is set to 1 if the device suppor
 #ifdef __cplusplus
 }
 #endif
+extern void PrintArch(void);
+
 
 #endif // _testHarness_h
 

--- a/test_conformance/contractions/contractions.c
+++ b/test_conformance/contractions/contractions.c
@@ -99,7 +99,6 @@ static size_t       gArgCount;
 
 
 static int ParseArgs( int argc, const char **argv );
-static void PrintArch( void );
 static void PrintUsage( void );
 test_status InitCL( cl_device_id device );
 static void ReleaseCL( void );
@@ -440,63 +439,6 @@ static int ParseArgs( int argc, const char **argv )
     PrintArch();
 
     return 0;
-}
-
-static void PrintArch( void )
-{
-    vlog( "\nHost info:\n" );
-    vlog( "\tsizeof( void*) = %ld\n", sizeof( void *) );
-#if defined( __ppc__ )
-    vlog( "\tARCH:\tppc\n" );
-#elif defined( __ppc64__ )
-    vlog( "\tARCH:\tppc64\n" );
-#elif defined( __PPC__ )
-    vlog( "ARCH:\tppc\n" );
-#elif defined( __i386__ )
-    vlog( "\tARCH:\ti386\n" );
-#elif defined( __x86_64__ )
-    vlog( "\tARCH:\tx86_64\n" );
-#elif defined( __arm__ )
-    vlog( "\tARCH:\tarm\n" );
-#elif defined( __aarch64__ )
-    vlog( "\tARCH:\taarch64\n" );
-#else
-    vlog( "\tARCH:\tunknown\n" );
-#endif
-
-#if defined( __APPLE__ )
-    int type = 0;
-    size_t typeSize = sizeof( type );
-    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
-    vlog( "\tcpu type:\t%d\n", type );
-    typeSize = sizeof( type );
-    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
-    vlog( "\tcpu subtype:\t%d\n", type );
-
-#elif defined( __linux__ ) && !defined(__aarch64__)
-    int _sysctl(struct __sysctl_args *args );
-#define OSNAMESZ 100
-
-    struct __sysctl_args args;
-    char osname[OSNAMESZ];
-    size_t osnamelth;
-    int name[] = { CTL_KERN, KERN_OSTYPE };
-    memset(&args, 0, sizeof(struct __sysctl_args));
-    args.name = name;
-    args.nlen = sizeof(name)/sizeof(name[0]);
-    args.oldval = osname;
-    args.oldlenp = &osnamelth;
-
-    osnamelth = sizeof(osname);
-
-    if (syscall(SYS__sysctl, &args) == -1) {
-        vlog( "_sysctl error\n" );
-    }
-    else {
-        vlog("this machine is running %*s\n", osnamelth, osname);
-    }
-
-#endif
 }
 
 static void PrintUsage( void )

--- a/test_conformance/conversions/test_conversions.c
+++ b/test_conformance/conversions/test_conversions.c
@@ -114,7 +114,6 @@ static MTdata   gMTdata;
 
 static int ParseArgs( int argc, const char **argv );
 static void PrintUsage( void );
-static void PrintArch(void);
 test_status InitCL( cl_device_id device );
 static int GetTestCase( const char *name, Type *outType, Type *inType, SaturationMode *sat, RoundingMode *round );
 static int DoTest( cl_device_id device, Type outType, Type inType, SaturationMode sat, RoundingMode round, MTdata d );
@@ -526,69 +525,6 @@ static void PrintUsage( void )
     vlog( "\n" );
     vlog( "You may also pass the number of the test on which to start.\nA second number can be then passed to indicate how many tests to run\n\n" );
 }
-
-static void PrintArch( void )
-{
-    vlog( "sizeof( void*) = %ld\n", sizeof( void *) );
-#if defined( __ppc__ )
-    vlog( "ARCH:\tppc\n" );
-#elif defined( __ppc64__ )
-    vlog( "ARCH:\tppc64\n" );
-#elif defined( __PPC__ )
-    vlog( "ARCH:\tppc\n" );
-#elif defined( __i386__ )
-    vlog( "ARCH:\ti386\n" );
-#elif defined( __x86_64__ )
-    vlog( "ARCH:\tx86_64\n" );
-#elif defined( __arm__ )
-    vlog( "ARCH:\tarm\n" );
-// Add 64 bit support
-#elif defined(__aarch64__)
-    vlog( "ARCH:\taarch64\n" );
-#elif defined (_WIN32)
-    vlog( "ARCH:\tWindows\n" );
-#else
-#error unknown arch
-#endif
-
-#if defined( __APPLE__ )
-
-    int type = 0;
-    size_t typeSize = sizeof( type );
-    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
-    vlog( "cpu type:\t%d\n", type );
-    typeSize = sizeof( type );
-    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
-    vlog( "cpu subtype:\t%d\n", type );
-
-#elif defined( __linux__ ) && !defined(__aarch64__)
-#define OSNAMESZ 100
-    int _sysctl(struct __sysctl_args *args );
-
-    struct __sysctl_args args;
-    char osname[OSNAMESZ];
-    size_t osnamelth;
-    int name[] = { CTL_KERN, KERN_OSTYPE };
-    memset(&args, 0, sizeof(struct __sysctl_args));
-    args.name = name;
-    args.nlen = sizeof(name)/sizeof(name[0]);
-    args.oldval = osname;
-    args.oldlenp = &osnamelth;
-
-    osnamelth = sizeof(osname);
-
-    if (syscall(SYS__sysctl, &args) == -1) {
-        vlog( "_sysctl error\n" );
-    }
-    else {
-        vlog("this machine is running %*s\n", osnamelth, osname);
-    }
-
-#endif
-}
-
-
-
 
 
 static int GetTestCase( const char *name, Type *outType, Type *inType, SaturationMode *sat, RoundingMode *round )

--- a/test_conformance/half/main.c
+++ b/test_conformance/half/main.c
@@ -47,7 +47,6 @@ const char *addressSpaceNames[AS_NumAddressSpaces] = {"global", "private", "loca
 
 static int ParseArgs( int argc, const char **argv );
 static void PrintUsage( void );
-static void PrintArch(void);
 
 
 int g_arrVecSizes[kVectorSizeCount+kStrangeVectorSizeCount];
@@ -251,33 +250,3 @@ static void PrintUsage( void )
     }
 }
 
-static void PrintArch( void )
-{
-    vlog( "sizeof( void*) = %ld\n", sizeof( void *) );
-
-#if defined( __APPLE__ )
-#if defined( __ppc__ )
-    vlog( "ARCH:\tppc\n" );
-#elif defined( __ppc64__ )
-    vlog( "ARCH:\tppc64\n" );
-#elif defined( __i386__ )
-    vlog( "ARCH:\ti386\n" );
-#elif defined( __x86_64__ )
-    vlog( "ARCH:\tx86_64\n" );
-#elif defined( __arm__ )
-    vlog( "ARCH:\tarm\n" );
-#elif defined( __aarch64__ )
-    vlog( "\tARCH:\taarch64\n" );
-#else
-#error unknown arch
-#endif
-
-    int type = 0;
-    size_t typeSize = sizeof( type );
-    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
-    vlog( "cpu type:\t%d\n", type );
-    typeSize = sizeof( type );
-    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
-    vlog( "cpu subtype:\t%d\n", type );
-#endif
-}

--- a/test_conformance/math_brute_force/main.c
+++ b/test_conformance/math_brute_force/main.c
@@ -126,7 +126,6 @@ size_t          gNumBasicDoubleFuncs = sizeof(gBasicDoubleFuncs)/sizeof(char*);
 
 
 static int ParseArgs( int argc, const char **argv );
-static void PrintArch( void );
 static void PrintUsage( void );
 static void PrintFunctions( void );
 test_status InitCL( cl_device_id device );
@@ -1137,63 +1136,6 @@ static int ParseArgs( int argc, const char **argv )
     return 0;
 }
 
-static void PrintArch( void )
-{
-    vlog( "\nHost info:\n" );
-    vlog( "\tsizeof( void*) = %zd\n", sizeof( void *) );
-    #if defined( __ppc__ )
-        vlog( "\tARCH:\tppc\n" );
-    #elif defined( __ppc64__ )
-        vlog( "\tARCH:\tppc64\n" );
-    #elif defined( __PPC__ )
-                vlog( "ARCH:\tppc\n" );
-    #elif defined( __i386__ )
-        vlog( "\tARCH:\ti386\n" );
-    #elif defined( __x86_64__ )
-        vlog( "\tARCH:\tx86_64\n" );
-    #elif defined( __arm__ )
-        vlog( "\tARCH:\tarm\n" );
-    #elif defined( __aarch64__ )
-        vlog( "\tARCH:\taarch64\n");
-    #else
-        vlog( "\tARCH:\tunknown\n" );
-    #endif
-
-#if defined( __APPLE__ )
-    int type = 0;
-    size_t typeSize = sizeof( type );
-    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
-    vlog( "\tcpu type:\t%d\n", type );
-    typeSize = sizeof( type );
-    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
-    vlog( "\tcpu subtype:\t%d\n", type );
-
-#elif defined( __linux__ ) && !defined(__aarch64__)
-        int _sysctl(struct __sysctl_args *args );
-        #define OSNAMESZ 100
-
-        struct __sysctl_args args;
-        char osname[OSNAMESZ];
-        size_t osnamelth;
-        int name[] = { CTL_KERN, KERN_OSTYPE };
-        memset(&args, 0, sizeof(struct __sysctl_args));
-        args.name = name;
-        args.nlen = sizeof(name)/sizeof(name[0]);
-        args.oldval = osname;
-        args.oldlenp = &osnamelth;
-
-        osnamelth = sizeof(osname);
-
-        if (syscall(SYS__sysctl, &args) == -1) {
-           vlog( "_sysctl error\n" );
-        }
-        else {
-           vlog("this machine is running %*s\n", osnamelth, osname);
-        }
-
-
-#endif
-}
 
 static void PrintFunctions ( void )
 {

--- a/test_conformance/printf/test_printf.c
+++ b/test_conformance/printf/test_printf.c
@@ -594,42 +594,6 @@ exit:
     return err;
 }
 
-//-----------------------------------------
-// printArch
-//-----------------------------------------
-static void printArch( void )
-{
-    log_info( "sizeof( void*) = %d\n", (int) sizeof( void *) );
-
-#if defined( __APPLE__ )
-
-#if defined( __ppc__ )
-    log_info( "ARCH:\tppc\n" );
-#elif defined( __ppc64__ )
-    log_info( "ARCH:\tppc64\n" );
-#elif defined( __i386__ )
-    log_info( "ARCH:\ti386\n" );
-#elif defined( __x86_64__ )
-    log_info( "ARCH:\tx86_64\n" );
-#elif defined( __arm__ )
-    log_info( "ARCH:\tarm\n" );
-#elif defined( __aarch64__ )
-    log_info( "ARCH:\taarch64\n" );
-#else
-#error unknown arch
-#endif
-
-    int type = 0;
-    size_t typeSize = sizeof( type );
-    sysctlbyname( "hw.cputype", &type, &typeSize, NULL, 0 );
-    log_info( "cpu type:\t%d\n", type );
-    typeSize = sizeof( type );
-    sysctlbyname( "hw.cpusubtype", &type, &typeSize, NULL, 0 );
-    log_info( "cpu subtype:\t%d\n", type );
-
-#endif
-}
-
 
 int test_int_0(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
@@ -1063,7 +1027,8 @@ test_status InitCL( cl_device_id device )
 
     printDeviceHeader( device );
 
-    printArch();
+    PrintArch();
+
 
     err = check_opencl_version(device,1,2);
     if( err != CL_SUCCESS ) {


### PR DESCRIPTION
Moved all duplicate 'PrintArch' functions to testHarness.c
Replaced sysctl system call used in 'PrintArch' function with uname
system call

Signed-off-by: bhargavdas <bhargav_das@mentor.com>