### PR TITLE
use strtok_s in place of strtok_r on Windows

### DIFF
--- a/test_common/harness/compat.h
+++ b/test_common/harness/compat.h
@@ -259,6 +259,16 @@ typedef long long           int64_t;
 
 
 //
+// string.h
+//
+
+#if defined(_MSC_VER)
+    #define strtok_r strtok_s
+#endif
+
+
+
+//
 // unistd.h
 //
 


### PR DESCRIPTION
Fixes #605.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>