### PR TITLE
Add missing cl_khr_subgroups pragma enable

### DIFF
--- a/test_conformance/api/test_sub_group_dispatch.cpp
+++ b/test_conformance/api/test_sub_group_dispatch.cpp
@@ -18,6 +18,7 @@
 #include "harness/conversions.h"
 
 const char *subgroup_dispatch_kernel[] = {
+"#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n"
 "__kernel void subgroup_dispatch_kernel(__global int *output)\n"
 "{\n"
 "    size_t size = get_num_sub_groups ();\n"


### PR DESCRIPTION
In the kernel source code for test_api sub_group_dispatch. Although subgroups
is a core feature there is no separate 2.1 language spec
so we use the 2.0 with the pragma.

Signed-off-by: John Kesapides <john.kesapides@arm.com>