### PR TITLE
Fix overflow in OpenCL 2.x CTS allocations tests

### DIFF
--- a/test_conformance/allocations/allocation_functions.cpp
+++ b/test_conformance/allocations/allocation_functions.cpp
@@ -48,7 +48,10 @@ int find_good_image_size(cl_device_id device_id, size_t size_to_allocate, size_t
 
   num_pixels = size_to_allocate / (sizeof(cl_uint)*4);
 
-  if (num_pixels > (max_width*max_height)) {
+  // Use a 64-bit variable to avoid overflow in 32-bit architectures
+  long long unsigned max_pixels = (long long unsigned)max_width * max_height;
+
+  if (num_pixels > max_pixels) {
     if(NULL != max_size) {
       *max_size = max_width * max_height * sizeof(cl_uint) * 4;
     }


### PR DESCRIPTION
Add size_t overflow contingency code for 32-bit platforms where
max_width,max_height are 64k each. The code is modified to avoid
the overflowing multiplication.

Signed-off-by: John Kesapides <john.kesapides@arm.com>