### PR TITLE
Global variable gDeviceType correctly set

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -235,7 +235,7 @@ int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_def
         }
     }
 
- 	gDeviceType = device_type;
+
 
 	switch (device_type)
 	{
@@ -332,6 +332,13 @@ int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_def
 
     device = devices[choosen_device_index];
 
+    err = clGetDeviceInfo( device, CL_DEVICE_TYPE, sizeof(gDeviceType), &gDeviceType, NULL );
+    if( err )
+    {
+        print_error( err, "Unable to get device type" );
+        return TEST_FAIL;
+    }
+    
     if( printDeviceHeader( device ) != CL_SUCCESS )
     {
         test_finish();


### PR DESCRIPTION
Add function to set gDeviceType  on kernel_read_write tests(image_streams)
as the device type affects the way validation is performed in the test.

Signed-off-by: John Kesapides <john.kesapides@arm.com>