### PR TITLE
Failure in copy_images max_images

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -15,6 +15,7 @@
 //
 #include "imageHelpers.h"
 #include <limits.h>
+#include <assert.h>
 #if defined( __APPLE__ )
 #include <sys/mman.h>
 #endif
@@ -680,6 +681,16 @@ void get_max_sizes(size_t *numberOfSizes, const int maxNumberOfSizes,
       if(x0_dim == 0 && x0 < 16)
         x0 = 16;
       double x1 = fmin(fmin(A/M/x0,maximum_sizes[x1_dim]),other_sizes[(other_size++)%num_other_sizes]);
+
+      // Valid image sizes cannot be below 1. Due to the workaround for the xo_dim where x0 is overidden to 16
+      // there might not be enough space left for x1 dimension. This could be a fractional 0.x size that when cast to
+      // integer would result in a value 0. In these cases we clamp the size to a minimum of 1.
+      if ( x1 < 1 )
+        x1 = 1;
+
+      // M and x0 cannot be '0' as they derive from clDeviceInfo calls
+      assert(x0 > 0 && M > 0);
+
       // Store the size
       sizes[(*numberOfSizes)][fixed_dim] = (size_t)M;
       sizes[(*numberOfSizes)][x0_dim]    = (size_t)x0;


### PR DESCRIPTION
An existing workaround on the max_image size calulcation that disallows
the width of an image to be less than 16 can stress the calculcation of
the remainder dimension to be less than 1.0 in size. In three dimentional
objects (3d,2d array) where one dimention is set to max and the other is
set to 16 there might not be enough space left for the 3rd one.
This workaround clamps the third dimension to a minimum of 1.0

Signed-off-by: John Kesapides <john.kesapides@arm.com>