### PR TITLE
enable Appveyor Windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,6 @@ os:
 
 shallow_clone: true
 
-branches:
-  except:
-    - gh-pages
-
 platform:
   - Win32
   - x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,51 @@
+os:
+  - Visual Studio 2017
+
+# do not build on tags
+#skip_tags: true
+
+# clone only the top level commit
+shallow_clone: true
+
+# branches to build: all but pages
+branches:
+  except:
+    - gh-pages
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+  #- Debug
+  - Release
+
+before_build:
+  # Setup environment:
+  - ps: $env:TOP = $env:APPVEYOR_BUILD_FOLDER
+  - ps: $env:TOP
+  - echo %TOP%
+  # Get the OpenCL Headers:
+  - git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers OpenCL-Headers
+  # Get and build the OpenCL ICD Loader:
+  - git clone --depth=1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+  - ps: cd OpenCL-ICD-Loader
+  - ps: mkdir build
+  - ps: cd build
+  - cmake -A%PLATFORM% -DOPENCL_ICD_LOADER_HEADERS_DIR=%TOP%/OpenCL-Headers/ ..
+  - cmake --build . --config %CONFIGURATION%
+  - ps: cd $env:TOP
+  # Get the libclcxx standard library:
+  - git clone --depth=1 https://github.com/KhronosGroup/libclcxx.git libclcxx
+  # Generate the CTS solution file:
+  - cmake -DCL_INCLUDE_DIR=%TOP%/OpenCL-Headers
+          -DCL_LIB_DIR=%TOP%/OpenCL-ICD-Loader/build
+          -DCL_LIBCLCXX_DIR=%TOP%/libclcxx
+          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=./bin
+          -DOPENCL_LIBRARIES="OpenCL"
+          -H. -Bbuild_win -A%PLATFORM%
+
+build:
+  project: build_win\CLConform.sln
+  parallel: true
+  verbosity: normal

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,8 @@
 os:
   - Visual Studio 2017
 
-# do not build on tags
-#skip_tags: true
-
-# clone only the top level commit
 shallow_clone: true
 
-# branches to build: all but pages
 branches:
   except:
     - gh-pages
@@ -17,7 +12,6 @@ platform:
   - x64
 
 configuration:
-  #- Debug
   - Release
 
 before_build:


### PR DESCRIPTION
Enables AppVeyor Windows builds, using similar build steps as for Travis Linux and OSX builds.  This will help to prevent, or at least identify, future Windows build breaks.

Example build output:

* https://ci.appveyor.com/project/bashbaug/opencl-cts

I've enabled builds for Visual Studio 2017, for 32-bit and 64-bit builds, for Release builds only, for now at least.  It's reasonably straightforward to add support for other builds if we so desire.

Fixes #11 (I think).
