### PR TITLE
Conditionally test BGRA in Basic readimage3d (#623)

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -3811,6 +3811,26 @@ void build_required_image_formats(cl_mem_flags flags,
 	}
 }
 
+bool is_image_format_required(cl_image_format format,
+                              cl_mem_flags flags,
+                              cl_mem_object_type image_type,
+                              cl_device_id device)
+{
+	std::vector<cl_image_format> formatsToSupport;
+	build_required_image_formats(flags, image_type, device, formatsToSupport);
+
+	for (auto &formatItr: formatsToSupport)
+	{
+		if (formatItr.image_channel_order == format.image_channel_order &&
+		    formatItr.image_channel_data_type == format.image_channel_data_type)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool check_minimum_supported(cl_image_format *formatList,
                              unsigned int numFormats,
                              cl_mem_flags flags,

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -3664,15 +3664,14 @@ bool find_format( cl_image_format *formatList, unsigned int numFormats, cl_image
     return false;
 }
 
-bool check_minimum_supported(cl_image_format *formatList,
-                             unsigned int numFormats,
-                             cl_mem_flags flags,
-                             cl_mem_object_type image_type,
-                             cl_device_id device)
+void build_required_image_formats(cl_mem_flags flags,
+                                  cl_mem_object_type image_type,
+                                  cl_device_id device,
+                                  std::vector<cl_image_format>& formatsToSupport)
 {
-	bool passed = true;
-	std::vector<cl_image_format> formatsToSupport;
 	Version version = get_device_cl_version(device);
+
+	formatsToSupport.clear();
 
 	// Required embedded formats.
 	static std::vector<cl_image_format> embeddedProfReadOrWriteFormats
@@ -3810,18 +3809,30 @@ bool check_minimum_supported(cl_image_format *formatList,
 			}
 		}
 	}
+}
 
-    for (auto &format: formatsToSupport)
-    {
-        if( !find_format( formatList, numFormats, &format ) )
-        {
-            log_error( "ERROR: Format required by OpenCL %s is not supported: ", version.to_string().c_str() );
-            print_header( &format, true );
-            passed = false;
-        }
-    }
+bool check_minimum_supported(cl_image_format *formatList,
+                             unsigned int numFormats,
+                             cl_mem_flags flags,
+                             cl_mem_object_type image_type,
+                             cl_device_id device)
+{
+	bool passed = true;
+	Version version = get_device_cl_version(device);
+	std::vector<cl_image_format> formatsToSupport;
+	build_required_image_formats(flags, image_type, device, formatsToSupport);
 
-    return passed;
+	for (auto &format: formatsToSupport)
+	{
+		if( !find_format( formatList, numFormats, &format ) )
+		{
+			log_error( "ERROR: Format required by OpenCL %s is not supported: ", version.to_string().c_str() );
+			print_header( &format, true );
+			passed = false;
+		}
+	}
+
+	return passed;
 }
 
 cl_uint compute_max_mip_levels( size_t width, size_t height, size_t depth)

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -21,7 +21,6 @@
 #if !defined (_WIN32) && !defined(__APPLE__)
 #include <malloc.h>
 #endif
-#include <vector>
 #include <algorithm>
 #include <iterator>
 #if !defined (_WIN32)
@@ -3829,30 +3828,6 @@ bool is_image_format_required(cl_image_format format,
 	}
 
 	return false;
-}
-
-bool check_minimum_supported(cl_image_format *formatList,
-                             unsigned int numFormats,
-                             cl_mem_flags flags,
-                             cl_mem_object_type image_type,
-                             cl_device_id device)
-{
-	bool passed = true;
-	Version version = get_device_cl_version(device);
-	std::vector<cl_image_format> formatsToSupport;
-	build_required_image_formats(flags, image_type, device, formatsToSupport);
-
-	for (auto &format: formatsToSupport)
-	{
-		if( !find_format( formatList, numFormats, &format ) )
-		{
-			log_error( "ERROR: Format required by OpenCL %s is not supported: ", version.to_string().c_str() );
-			print_header( &format, true );
-			passed = false;
-		}
-	}
-
-	return passed;
 }
 
 cl_uint compute_max_mip_levels( size_t width, size_t height, size_t depth)

--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -76,6 +76,10 @@ extern bool check_minimum_supported(cl_image_format *formatList,
                                     cl_mem_flags flags,
                                     cl_mem_object_type image_type,
                                     cl_device_id device);
+extern bool is_image_format_required(cl_image_format format,
+                                     cl_mem_flags flags,
+                                     cl_mem_object_type image_type,
+                                     cl_device_id device);
 
 extern size_t get_format_type_size( const cl_image_format *format );
 extern size_t get_channel_data_type_size( cl_channel_type channelType );

--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <vector>
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -71,15 +72,14 @@ extern void print_read_header( cl_image_format *format, image_sampler_data *samp
 extern void print_write_header( cl_image_format *format, bool err);
 extern void print_header( cl_image_format *format, bool err );
 extern bool find_format( cl_image_format *formatList, unsigned int numFormats, cl_image_format *formatToFind );
-extern bool check_minimum_supported(cl_image_format *formatList,
-                                    unsigned int numFormats,
-                                    cl_mem_flags flags,
-                                    cl_mem_object_type image_type,
-                                    cl_device_id device);
 extern bool is_image_format_required(cl_image_format format,
                                      cl_mem_flags flags,
                                      cl_mem_object_type image_type,
                                      cl_device_id device);
+extern void build_required_image_formats(cl_mem_flags flags,
+                                         cl_mem_object_type image_type,
+                                         cl_device_id device,
+                                         std::vector<cl_image_format>& formatsToSupport);
 
 extern size_t get_format_type_size( const cl_image_format *format );
 extern size_t get_channel_data_type_size( cl_channel_type channelType );

--- a/test_conformance/basic/test_readimage3d.cpp
+++ b/test_conformance/basic/test_readimage3d.cpp
@@ -193,25 +193,9 @@ int test_readimage3d(cl_device_id device, cl_context context, cl_command_queue q
 		err = verify_3d_image8(ref_ptr, output_ptr, img_width, img_height, img_depth);
 		if ( err == 0 )
 		{
-			switch (i)
-			{
-				case 0:
-				{
-					log_info("READ_IMAGE3D_BGRA_UNORM_INT8 test passed\n");
-					break;
-				}
-				case 1:
-				{
-					log_info("READ_IMAGE3D_RGBA_UNORM_INT8 test passed\n");
-					break;
-				}
-				default:
-				{
-					err = CL_OUT_OF_RESOURCES;
-					test_error(err, "Unhandled case");
-					break;
-				}
-			}
+			log_info("READ_IMAGE3D_%s_%s test passed\n",
+			         GetChannelTypeName(formatsToTest[i].img_format.image_channel_data_type),
+			         GetChannelOrderName(formatsToTest[i].img_format.image_channel_order));
 		}
 
 		clReleaseSampler(sampler);

--- a/test_conformance/basic/test_readimage3d.cpp
+++ b/test_conformance/basic/test_readimage3d.cpp
@@ -108,19 +108,18 @@ prepare_reference(unsigned char * input_ptr, int w, int h, int d)
     return ptr;
 }
 
-struct testFormat
-{
-	const char* kernelName;
-	const char* kernelSourceString;
-	const cl_image_format img_format;
-};
-
 int test_readimage3d(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
 	cl_mem streams[2];
 	cl_program program;
 	cl_kernel kernel;
 	cl_sampler sampler;
+	struct testFormat
+	{
+		const char* kernelName;
+		const char* kernelSourceString;
+		const cl_image_format img_format;
+	};
 
 	static testFormat formatsToTest[] =
 	{

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -14,6 +14,9 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "harness/imageHelpers.h"
+#include <algorithm>
+#include <iterator>
 
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
@@ -35,6 +38,30 @@ static const char *str_2d_image = "2D";
 static const char *str_3d_image = "3D";
 static const char *str_1d_image_array = "1D array";
 static const char *str_2d_image_array = "2D array";
+
+static bool check_minimum_supported(cl_image_format *formatList,
+                                    unsigned int numFormats,
+                                    cl_mem_flags flags,
+                                    cl_mem_object_type image_type,
+                                    cl_device_id device)
+{
+	bool passed = true;
+	Version version = get_device_cl_version(device);
+	std::vector<cl_image_format> formatsToSupport;
+	build_required_image_formats(flags, image_type, device, formatsToSupport);
+
+	for (auto &format: formatsToSupport)
+	{
+		if( !find_format( formatList, numFormats, &format ) )
+		{
+			log_error( "ERROR: Format required by OpenCL %s is not supported: ", version.to_string().c_str() );
+			print_header( &format, true );
+			passed = false;
+		}
+	}
+
+	return passed;
+}
 
 static const char *convert_image_type_to_string(cl_mem_object_type image_type)
 {


### PR DESCRIPTION
This change adds checks to see if testing against an embedded implementation and if so, queries whether BGRA is supported or not.