### PR TITLE
Copy all csv files during build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,6 @@ add_subdirectory(test_common)
 add_subdirectory(test_conformance)
 add_subdirectory(test_extensions)
 
-set (PY_PATH   "${CLConform_SOURCE_DIR}/test_conformance/*.py")
-set (CSV_PATH  "${CLConform_SOURCE_DIR}/test_conformance/*.csv")
 # Support both VS2008 and VS2012.
 set (DLL_FILES "${VS_BUILD_DIR}/Debug/*.dll")
 set (DST_DIR   "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/")
@@ -194,8 +192,6 @@ set_property(TARGET COPY_DLL${CONFORMANCE_SUFFIX} PROPERTY FOLDER "CONFORMANCE${
 
 if(WIN32)
   add_custom_target( COPY_FILES${CONFORMANCE_SUFFIX} ALL
-                     COMMAND ${COPY} ${PY_PATH} ${DST_DIR}
-                     COMMAND ${COPY} ${CSV_PATH} ${DST_DIR}
                      COMMAND ${COPY} ${DLL_FILES} ${DST_DIR}
                      COMMENT "Copying other files to output folder..." )
 else(WIN32)

--- a/test_conformance/CMakeLists.txt
+++ b/test_conformance/CMakeLists.txt
@@ -54,28 +54,14 @@ add_subdirectory( clcpp )
 add_subdirectory( spirv_new )
 add_subdirectory( spir )
 
-set(CSV_FILES
-    opencl_conformance_tests_21_full_spirv.csv
-    opencl_conformance_tests_21_legacy_wimpy.csv
-    opencl_conformance_tests_22.csv
-    opencl_conformance_tests_generate_spirv.csv
-    opencl_conformance_tests_conversions.csv
-    opencl_conformance_tests_d3d.csv
-    opencl_conformance_tests_full.csv
-    opencl_conformance_tests_full_no_math_or_conversions.csv
-    opencl_conformance_tests_math.csv
-    opencl_conformance_tests_quick.csv
-    opencl_conformance_tests_20_full.csv
-    opencl_conformance_tests_20_full_no_math_or_conversions.csv
-    opencl_conformance_tests_20_quick.csv
-)
-set(PY_FILES
-    run_conformance.py
-)
+file(GLOB CSV_FILES "opencl_conformance_tests_*.csv")
+
+set(PY_FILES run_conformance.py)
 
 # Copy .csv files
 foreach(FILE ${CSV_FILES})
-    configure_file(${FILE} ${FILE} COPYONLY)
+    get_filename_component(strippedName ${FILE} NAME)
+    configure_file(${strippedName} ${strippedName} COPYONLY)
 endforeach()
 
 # Copy test run script


### PR DESCRIPTION
This commit introduces a generic method of copying the opencl_conformance_tests_*.csv files during the build.

Fixes any unspecified files from being omitted during the copy process.