### PR TITLE
Remove unused parameter

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -60,12 +60,12 @@ int     gHasLong = 1;
 int runTestHarness( int argc, const char *argv[], int testNum, test_definition testList[],
                     int imageSupportRequired, int forceNoContextCreation, cl_command_queue_properties queueProps )
 {
-    return runTestHarnessWithCheck( argc, argv, testNum, testList, imageSupportRequired, forceNoContextCreation, queueProps,
+    return runTestHarnessWithCheck( argc, argv, testNum, testList, forceNoContextCreation, queueProps,
                           ( imageSupportRequired ) ? verifyImageSupport : NULL );
 }
 
 int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_definition testList[],
-                             int imageSupportRequired, int forceNoContextCreation, cl_command_queue_properties queueProps,
+                             int forceNoContextCreation, cl_command_queue_properties queueProps,
                              DeviceCheckFn deviceCheckFn )
 {
     test_start();

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -88,8 +88,8 @@ typedef test_status (*DeviceCheckFn)( cl_device_id device );
 // Returns EXIT_SUCCESS iff all tests succeeded or the tests were listed,
 // otherwise return EXIT_FAILURE.
 extern int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_definition testList[],
-                                    int imageSupportRequired, int forceNoContextCreation,
-                                    cl_command_queue_properties queueProps, DeviceCheckFn deviceCheckFn );
+                                    int forceNoContextCreation, cl_command_queue_properties queueProps,
+                                    DeviceCheckFn deviceCheckFn );
 
 // The command line parser used by runTestHarness to break up parameters into calls to callTestFunctions
 extern int parseAndCallCommandLineTests( int argc, const char *argv[], cl_device_id device, int testNum,

--- a/test_conformance/SVM/main.cpp
+++ b/test_conformance/SVM/main.cpp
@@ -304,6 +304,6 @@ test_status InitCL(cl_device_id device) {
 
 int main(int argc, const char *argv[])
 {
-  return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, true, 0, InitCL);
+  return runTestHarnessWithCheck(argc, argv, test_num, test_list, true, 0, InitCL);
 }
 

--- a/test_conformance/allocations/main.cpp
+++ b/test_conformance/allocations/main.cpp
@@ -335,7 +335,7 @@ int main(int argc, const char *argv[])
         }
     }
 
-    int ret = runTestHarnessWithCheck( argCount, argList, test_num, test_list, false, false, 0, init_cl );
+    int ret = runTestHarnessWithCheck( argCount, argList, test_num, test_list, false, 0, init_cl );
 
     free(argList);
     return ret;

--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -331,7 +331,7 @@ int main( int argc, const char **argv )
 
     if( !error )
     {
-        error = runTestHarnessWithCheck( gArgCount, gArgList, test_num, test_list, false, true, 0, InitCL );
+        error = runTestHarnessWithCheck( gArgCount, gArgList, test_num, test_list, true, 0, InitCL );
     }
 
     if( gQueue )

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -316,7 +316,7 @@ int main (int argc, const char **argv )
     gMTdata = init_genrand( seed );
 
     const char* arg[] = {argv[0]};
-    int ret = runTestHarnessWithCheck( 1, arg, test_num, test_list, false, true, 0, InitCL );
+    int ret = runTestHarnessWithCheck( 1, arg, test_num, test_list, true, 0, InitCL );
 
     free_mtdata( gMTdata );
 

--- a/test_conformance/device_execution/main.cpp
+++ b/test_conformance/device_execution/main.cpp
@@ -96,5 +96,5 @@ int main(int argc, const char *argv[])
       }
     }
 
-    return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, false, 0, InitCL);
+    return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, 0, InitCL);
 }

--- a/test_conformance/half/main.cpp
+++ b/test_conformance/half/main.cpp
@@ -110,7 +110,7 @@ int main (int argc, const char **argv )
     }
 
     fflush( stdout );
-    error = runTestHarnessWithCheck( argCount, argList, test_num, test_list, false, true, 0, InitCL );
+    error = runTestHarnessWithCheck( argCount, argList, test_num, test_list, true, 0, InitCL );
 
 exit:
     if(gQueue)

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -869,7 +869,7 @@ int main (int argc, const char * argv[])
     FPU_mode_type oldMode;
     DisableFTZ( &oldMode );
 
-    int ret = runTestHarnessWithCheck( gTestNameCount, gTestNames, test_num, test_list, false, true, 0, InitCL );
+    int ret = runTestHarnessWithCheck( gTestNameCount, gTestNames, test_num, test_list, true, 0, InitCL );
 
     RestoreFPState( &oldMode );
 

--- a/test_conformance/pipes/main.cpp
+++ b/test_conformance/pipes/main.cpp
@@ -103,6 +103,6 @@ test_definition test_list[] = {
 const int test_num = ARRAY_SIZE(test_list);
 
 int main(int argc, const char *argv[]) {
-  return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, false,
+  return runTestHarnessWithCheck(argc, argv, test_num, test_list, false,
                                  0, InitCL);
 }

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -966,7 +966,7 @@ int main(int argc, const char* argv[])
         return -1;
     }
 
-    int err = runTestHarnessWithCheck( argCount, argList, test_num, test_list, false, true, 0, InitCL );
+    int err = runTestHarnessWithCheck( argCount, argList, test_num, test_list, true, 0, InitCL );
 
     if(gQueue)
     {

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -213,5 +213,5 @@ int main(int argc, const char *argv[])
     return runTestHarnessWithCheck(argc, argv,
                           spirvTestsRegistry::getInstance().getNumTests(),
                           spirvTestsRegistry::getInstance().getTestDefinitions(),
-                          false, false, 0, checkAddressWidth);
+                          false, 0, checkAddressWidth);
 }

--- a/test_conformance/subgroups/main.cpp
+++ b/test_conformance/subgroups/main.cpp
@@ -59,6 +59,6 @@ static test_status checkSubGroupsExtension(cl_device_id device)
 int main(int argc, const char *argv[])
 {
     gMTdata = init_genrand(0);
-    return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, false, 0, checkSubGroupsExtension);
+    return runTestHarnessWithCheck(argc, argv, test_num, test_list, false, 0, checkSubGroupsExtension);
 }
 


### PR DESCRIPTION
The imageSupportRequired param is not needed in runTestHarnessWithCheck,
so just remove it.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>