### PR TITLE
Do not include sys/sysctl.h on Android

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -31,8 +31,11 @@
 
 #if !defined(_WIN32)
 #include <sys/utsname.h>
-#include <sys/sysctl.h>
 #include <unistd.h>
+#endif
+
+#if !defined(_WIN32) && !defined(__ANDROID__)
+#include <sys/sysctl.h>
 #endif
 
 #include <time.h>


### PR DESCRIPTION
Android has linux/sysctl.h, but the functions that need it are not
used when targeting Android at the moment.