### PR TITLE
[QC] cl20: bruteforce: Fix domains used in fast math mode.

### DIFF
--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -491,13 +491,13 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
         if ( strcmp(fname,"sin")==0 || strcmp(fname,"cos")==0 )  //the domain of the function is [-pi,pi]
         {
           if( fabs(p_j) > M_PI )
-            p[j] = NAN;
+            ((float*)p)[j] = NAN;
         }
 
         if ( strcmp( fname, "reciprocal" ) == 0 )
         {
           if( fabs(p_j) > 0x7E800000 ) //the domain of the function is [2^-126,2^126]
-            p[j] = NAN;
+            ((float*)p)[j] = NAN;
         }
       }
     }

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -242,7 +242,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             {
               float pj = *(float *)&p[j];
               if(fabs(pj) > M_PI)
-                p[j] = NAN;
+                ((float*)p)[j] = NAN;
             }
           }
         }
@@ -255,7 +255,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             {
               float pj = *(float *)&p[j];
               if(fabs(pj) > M_PI)
-                p[j] = NAN;
+                ((float*)p)[j] = NAN;
             }
           }
         }


### PR DESCRIPTION
Cast input array to floats before setting NANs which are also floats to
prevent large nonsensical numbers outside of the valid domains of
several math functions from being tested.

Khronos Bug: https://github.com/KhronosGroup/OpenCL-CTS/issues/491
Test Suite Affected: bruteforce Subtests: sin, cos, sincos, reciprocal