### PR TITLE
Fix align_malloc on Linux

### DIFF
--- a/test_common/harness/alloc.h
+++ b/test_common/harness/alloc.h
@@ -40,6 +40,9 @@ static void * align_malloc(size_t size, size_t alignment)
     if ( ptr )
         return ptr;
 #else
+    if (alignment < sizeof(void*)) {
+        alignment = sizeof(void*);
+    }
     if (0 == posix_memalign(&ptr, alignment, size))
         return ptr;
 #endif


### PR DESCRIPTION
posix_memalign requires alignment to be a power of two and a multiple
of sizeof(void*). All powers of two greater than sizeof(void*) are
multiples of sizeof(void*) so we only need to make sure sizeof(void*)
is the minimum value passed to posix_memalign.

Fixes #644

Signed-off-by: Kevin Petit <kevin.petit@arm.com>