### PR TITLE
Add a test that clSetKernelArg does not retain the arg

### DIFF
--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -105,6 +105,7 @@ test_definition test_list[] = {
     ADD_TEST( retain_queue_multiple ),
     ADD_TEST( retain_mem_object_single ),
     ADD_TEST( retain_mem_object_multiple ),
+    ADD_TEST( retain_mem_object_set_kernel_arg ),
     ADD_TEST( min_data_type_align_size_alignment ),
 
     ADD_TEST( mem_object_destructor_callback ),

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -95,6 +95,7 @@ extern int        test_retain_queue_single(cl_device_id deviceID, cl_context con
 extern int        test_retain_queue_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_retain_mem_object_single(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_retain_mem_object_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_retain_mem_object_set_kernel_arg(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int      test_min_data_type_align_size_alignment(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems );
 
 extern int        test_mem_object_destructor_callback(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);

--- a/test_conformance/api/test_retain.cpp
+++ b/test_conformance/api/test_retain.cpp
@@ -232,3 +232,44 @@ int test_retain_mem_object_multiple(cl_device_id deviceID, cl_context context, c
     return 0;
 }
 
+int test_retain_mem_object_set_kernel_arg(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+{
+    int err;
+    cl_mem buffer = nullptr;
+    cl_program program;
+    cl_kernel kernel;
+    static volatile uint32_t sValue;
+    sValue = 0;
+    auto callback = []( cl_mem, void * ) {
+      ++sValue;
+    };
+    const char *testProgram[] = { "__kernel void sample_test(__global int *data){}" };
+
+    buffer = clCreateBuffer( context, CL_MEM_READ_ONLY, 32, NULL, &err );
+    test_error( err, "Unable to create buffer to test with" );
+
+    err = clSetMemObjectDestructorCallback( buffer, callback, nullptr );
+    test_error( err, "Unable to set destructor callback" );
+
+    err = create_single_kernel_helper( context, &program, nullptr, 1, testProgram, nullptr );
+    test_error( err, "Unable to build sample program" );
+
+    kernel = clCreateKernel( program, "sample_test", &err );
+    test_error( err, "Unable to create sample_test kernel" );
+
+    err = clSetKernelArg( kernel, 0, sizeof(cl_mem), &buffer );
+    test_error( err, "Unable to set kernel argument" );
+
+    err = clReleaseMemObject( buffer );
+    test_error( err, "Unable to release buffer" );
+
+    // Spin waiting for the release to finish.  If you don't call the mem_destructor_callback, you will not
+    // pass the test.  bugzilla 6316
+    while (sValue == 0) { }
+
+    clReleaseKernel( kernel );
+    clReleaseProgram( program );
+
+    // If we got this far, we succeeded.
+    return 0;
+}


### PR DESCRIPTION
* Add `retain_mem_object_set_kernel_arg` to test that calling
clSetKernelArg with a cl_mem object does not retain that mem object

This issue came up from https://github.com/kpet/clvk/issues/157. @kpet requested I add a conformance test to cover it. Tested on a desktop implementation and clvk.