### PR TITLE
Fix test skip handling while test initialization - device_timer

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -67,6 +67,21 @@ int runTestHarness( int argc, const char *argv[], int testNum, test_definition t
                           ( imageSupportRequired ) ? verifyImageSupport : NULL );
 }
 
+int skip_init_info(int count) {
+    log_info("Test skipped while initialization\n");
+    log_info("SKIPPED %d of %d tests.\n", count, count);
+    return EXIT_SUCCESS;
+}
+
+int fail_init_info(int count) {
+    log_info("Test failed while initialization\n");
+    log_info("FAILED %d of %d tests.\n", count, count);
+    return EXIT_FAILURE;
+}
+void version_expected_info(const char * test_name, const char * expected_version, const char * device_version) {
+    log_info("%s skipped (requires at least version %s, but the device reports version %s)\n",
+        test_name, expected_version, device_version);
+}
 int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_definition testList[],
                              int forceNoContextCreation, cl_command_queue_properties queueProps,
                              DeviceCheckFn deviceCheckFn )
@@ -447,9 +462,9 @@ int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_def
             case TEST_PASS:
                 break;
             case TEST_FAIL:
-                return EXIT_FAILURE;
+                return fail_init_info(testNum);
             case TEST_SKIP:
-                return EXIT_SUCCESS;
+                return skip_init_info(testNum);
         }
     }
 
@@ -689,8 +704,7 @@ test_status callSingleTestFunction( test_definition test, cl_device_id deviceToU
     const Version device_version = get_device_cl_version(deviceToUse);
     if (test.min_version > device_version)
     {
-        log_info("%s skipped (requires at least version %s, but the device reports version %s)\n",
-                 test.name, test.min_version.to_string().c_str(), device_version.to_string().c_str());
+        version_expected_info(test.name, test.min_version.to_string().c_str(), device_version.to_string().c_str());
         return TEST_SKIP;
     }
 
@@ -936,3 +950,4 @@ void PrintArch( void )
     }
 #endif
 }
+

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -129,6 +129,7 @@ extern cl_device_type GetDeviceType( cl_device_id );
 extern cl_device_id GetOpposingDevice( cl_device_id device );
 
 Version get_device_cl_version(cl_device_id device);
+void version_expected_info(const char * test_name, const char * expected_version, const char * device_version);
 
 
 extern int      gFlushDenormsToZero;    // This is set to 1 if the device does not support denorms (CL_FP_DENORM)

--- a/test_conformance/device_timer/main.cpp
+++ b/test_conformance/device_timer/main.cpp
@@ -32,12 +32,14 @@ test_definition test_list[] = {
 
 test_status InitCL(cl_device_id device) {
 	auto version = get_device_cl_version(device);
+	auto expected_min_version = Version(2, 1);
 	cl_platform_id platform;
 	cl_ulong timer_res;
 	cl_int error;
 
-	if (version < Version(2, 1))
+	if (version < expected_min_version)
 	{
+		version_expected_info("Test", expected_min_version.to_string().c_str(), version.to_string().c_str());
 		return TEST_SKIP;
 	}
 


### PR DESCRIPTION
This is part of the fix #664 