### PR TITLE
Printf fixes for reference results #673 #675

### DIFF
--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -705,17 +705,19 @@ int test_float_17(cl_device_id deviceID, cl_context context, cl_command_queue qu
 {
     return doTest(gQueue, gContext, TYPE_FLOAT, 17, deviceID);
 }
-int test_float_18(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+
+
+int test_float_limits_0(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest(gQueue, gContext, TYPE_FLOAT, 18, deviceID);
+    return doTest(gQueue, gContext, TYPE_FLOAT_LIMITS, 0, deviceID);
 }
-int test_float_19(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_float_limits_1(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest(gQueue, gContext, TYPE_FLOAT, 19, deviceID);
+    return doTest(gQueue, gContext, TYPE_FLOAT_LIMITS, 1, deviceID);
 }
-int test_float_20(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
+int test_float_limits_2(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-    return doTest(gQueue, gContext, TYPE_FLOAT, 20, deviceID);
+    return doTest(gQueue, gContext, TYPE_FLOAT_LIMITS, 2, deviceID);
 }
 
 
@@ -869,9 +871,10 @@ test_definition test_list[] = {
     ADD_TEST( float_15 ),
     ADD_TEST( float_16 ),
     ADD_TEST( float_17 ),
-    ADD_TEST( float_18 ),
-    ADD_TEST( float_19 ),
-    ADD_TEST( float_20 ),
+
+    ADD_TEST( float_limits_0 ),
+    ADD_TEST( float_limits_1 ),
+    ADD_TEST( float_limits_2 ),
 
     ADD_TEST( octal_0 ),
     ADD_TEST( octal_1 ),

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -1066,5 +1066,8 @@ test_status InitCL( cl_device_id device )
 
     releaseOutputStream(gFd);
 
+    // Generate reference results
+    generateRef(device);
+
     return TEST_PASS;
 }

--- a/test_conformance/printf/test_printf.h
+++ b/test_conformance/printf/test_printf.h
@@ -17,6 +17,8 @@
 #define TESTPRINTF_INCLUDED_H
 
 #include "harness/compat.h"
+#include "harness/testHarness.h"
+#include "harness/rounding_mode.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -39,7 +41,7 @@
 //-----------------------------------------
 // Types
 //-----------------------------------------
-enum Type
+enum PrintfTestType
  {
      TYPE_INT,
      TYPE_FLOAT,
@@ -68,22 +70,39 @@ struct printDataGenParameters
     const char* addrSpacePAdd;
 };
 
+// Reference results - filled out at run-time
+static std::vector<std::string> correctBufferInt;
+static std::vector<std::string> correctBufferFloat;
+static std::vector<std::string> correctBufferOctal;
+static std::vector<std::string> correctBufferUnsigned;
+static std::vector<std::string> correctBufferHexadecimal;
+// Reference results - Compile-time known
+extern std::vector<std::string> correctBufferChar;
+extern std::vector<std::string> correctBufferString;
+extern std::vector<std::string> correctBufferFloatLimits;
+extern std::vector<std::string> correctBufferVector;
+extern std::vector<std::string> correctAddrSpace;
+
+// Helper for generating reference results
+void generateRef(const cl_device_id device);
+
 //-----------------------------------------
 //Test Case
 //-----------------------------------------
 
 struct testCase
 {
-    unsigned int _testNum;                         //test number
-    enum Type _type;                               //(data)type for test
-    //const char** _strPrint;                      //auxiliary data to build the code for kernel source
-    std::vector<const char*> _correctBuffer;       //look-up table for correct results for printf
-    struct printDataGenParameters* _genParameters; //auxiliary data to build the code for kernel source
+    enum PrintfTestType _type;                           //(data)type for test
+    std::vector<std::string>& _correctBuffer;            //look-up table for correct results for printf
+    std::vector<printDataGenParameters>& _genParameters; //auxiliary data to build the code for kernel source
+    void (*printFN)(printDataGenParameters&,
+                    char*,
+                    const size_t);                       //function pointer for generating reference results
+    Type dataType;                                       //the data type that will be printed during reference result generation (used for setting rounding mode)
 };
 
-
 extern const char* strType[];
-extern testCase* allTestCase[];
+extern std::vector<testCase*> allTestCase;
 
 size_t verifyOutputBuffer(char *analysisBuffer,testCase* pTestCase,size_t testId,cl_ulong pAddr = 0);
 

--- a/test_conformance/printf/test_printf.h
+++ b/test_conformance/printf/test_printf.h
@@ -42,6 +42,7 @@ enum Type
  {
      TYPE_INT,
      TYPE_FLOAT,
+     TYPE_FLOAT_LIMITS,
      TYPE_OCTAL,
      TYPE_UNSIGNED,
      TYPE_HEXADEC,

--- a/test_conformance/printf/test_printf.h
+++ b/test_conformance/printf/test_printf.h
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <vector>
 
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
@@ -73,11 +74,11 @@ struct printDataGenParameters
 
 struct testCase
 {
-    unsigned int _testNum;                           //test number
-    enum Type _type;                                 //(data)type for test
-    //const char** _strPrint;                          //auxiliary data to build the code for kernel source
-    const char** _correctBuffer;                     //look-up table for correct results for printf
-    struct printDataGenParameters* _genParameters;   //auxiliary data to build the code for kernel source
+    unsigned int _testNum;                         //test number
+    enum Type _type;                               //(data)type for test
+    //const char** _strPrint;                      //auxiliary data to build the code for kernel source
+    std::vector<const char*> _correctBuffer;       //look-up table for correct results for printf
+    struct printDataGenParameters* _genParameters; //auxiliary data to build the code for kernel source
 };
 
 

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,9 +14,17 @@
 // limitations under the License.
 //
 #include "harness/compat.h"
+#include "harness/rounding_mode.h"
 
 #include "test_printf.h"
+#include <assert.h>
 
+// Helpers for generating runtime reference results
+static void intRefBuilder(printDataGenParameters&, char*, const size_t);
+static void floatRefBuilder(printDataGenParameters&, char* rResult, const size_t);
+static void octalRefBuilder(printDataGenParameters&, char*, const size_t);
+static void unsignedRefBuilder(printDataGenParameters&, char*, const size_t);
+static void hexRefBuilder(printDataGenParameters&, char*, const size_t);
 
 //==================================
 
@@ -30,7 +38,7 @@
 
 //------------------------------------------------------
 
-struct printDataGenParameters printIntGenParameters[] = {
+std::vector<printDataGenParameters> printIntGenParameters = {
 
     //(Minimum)Five-wide,default(right)-justified
 
@@ -70,37 +78,6 @@ struct printDataGenParameters printIntGenParameters[] = {
 
 };
 
-//------------------------------------------------
-
-// Lookup table - [string]int-correct buffer     |
-
-//------------------------------------------------
-
-std::vector<const char*> correctBufferInt = {
-    "   10",
-
-    "10   ",
-
-    "00010",
-
-    "  +10",
-
-    "+10  ",
-
-    "00100",
-
-    " 00100",
-
-    "100   ",
-
-    " 00100"
-
-};
-
-
-
-
-
 //-----------------------------------------------
 
 //test case for int                             |
@@ -109,13 +86,15 @@ std::vector<const char*> correctBufferInt = {
 
 testCase testCaseInt = {
 
-    sizeof(correctBufferInt)/sizeof(char*),
-
     TYPE_INT,
 
     correctBufferInt,
 
-    printIntGenParameters
+    printIntGenParameters,
+
+    intRefBuilder,
+
+    kint
 
 };
 
@@ -137,7 +116,7 @@ testCase testCaseInt = {
 
 //--------------------------------------------------------
 
-struct printDataGenParameters printFloatGenParameters[] = {
+std::vector<printDataGenParameters> printFloatGenParameters = {
 
     //Default(right)-justified
 
@@ -210,56 +189,6 @@ struct printDataGenParameters printFloatGenParameters[] = {
     //(Minimum)Ten-wide,Double argument representing floating-point,in xh.hhhhpAd style,default(right)-justified
 
     {"%10.2a","9990.235"},
-    };
-//--------------------------------------------------------
-
-//  Lookup table - [string]float-correct buffer             |
-
-//--------------------------------------------------------
-
-std::vector<const char*> correctBufferFloat = {
-
-    "10.345600",
-
-    "10.3",
-
-    "10.35",
-
-    "  10.346",
-
-    "00010.35",
-
-    "10.35   ",
-
-    "  -10.35",
-
-    "0",
-
-    "1",
-
-    "0.600000",
-
-    "12345.7",
-
-    "1.2e+4",
-
-    "2.3E-6",
-
-    "0.023",
-
-    "7.894561230000000e+8",
-
-    "+7.894561230000000E+8",
-
-    "0x1.99999ap-4",
-
-    "0x1.38p+13",
-
-    "inf",
-
-    "-nan",
-
-    "nan"
 };
 
 //---------------------------------------------------------
@@ -270,13 +199,15 @@ std::vector<const char*> correctBufferFloat = {
 
 testCase testCaseFloat = {
 
-    sizeof(correctBufferFloat)/sizeof(char*),
-
     TYPE_FLOAT,
 
     correctBufferFloat,
 
-    printFloatGenParameters
+    printFloatGenParameters,
+
+    floatRefBuilder,
+
+    kfloat
 
 };
 
@@ -295,7 +226,7 @@ testCase testCaseFloat = {
 //--------------------------------------------------------
 
 
-struct printDataGenParameters printFloatLimitsGenParameters[] = {
+std::vector<printDataGenParameters> printFloatLimitsGenParameters = {
 
     //Infinity (1.0/0.0)
 
@@ -314,7 +245,7 @@ struct printDataGenParameters printFloatLimitsGenParameters[] = {
 
 //--------------------------------------------------------
 
-std::vector<const char*> correctBufferFloatLimits = {
+std::vector<std::string> correctBufferFloatLimits = {
 
     "inf",
 
@@ -331,13 +262,13 @@ std::vector<const char*> correctBufferFloatLimits = {
 
 testCase testCaseFloatLimits = {
 
-    sizeof(correctBufferFloatLimits)/sizeof(char*),
-
     TYPE_FLOAT_LIMITS,
 
     correctBufferFloatLimits,
 
-    printFloatLimitsGenParameters
+    printFloatLimitsGenParameters,
+
+    NULL
 
 };
 
@@ -355,7 +286,7 @@ testCase testCaseFloatLimits = {
 
 //---------------------------------------------------------
 
-struct printDataGenParameters printOctalGenParameters[] = {
+std::vector<printDataGenParameters> printOctalGenParameters = {
 
     //Default(right)-justified
 
@@ -377,39 +308,21 @@ struct printDataGenParameters printOctalGenParameters[] = {
 
 //-------------------------------------------------------
 
-// Lookup table - [string] octal-correct buffer            |
-
-//-------------------------------------------------------
-
-
-
-std::vector<const char*> correctBufferOctal = {
-
-    "12",
-
-    "00012",
-
-    "0575360400",
-
-    "00012"
-
-};
-
-//-------------------------------------------------------
-
 //Test case for octal                                   |
 
 //-------------------------------------------------------
 
 testCase testCaseOctal = {
 
-    sizeof(correctBufferOctal)/sizeof(char*),
-
     TYPE_OCTAL,
 
     correctBufferOctal,
 
-    printOctalGenParameters
+    printOctalGenParameters,
+
+    octalRefBuilder,
+
+    kulong
 
 };
 
@@ -429,7 +342,7 @@ testCase testCaseOctal = {
 
 //---------------------------------------------------------
 
-struct printDataGenParameters printUnsignedGenParameters[] = {
+std::vector<printDataGenParameters> printUnsignedGenParameters = {
 
     //Default(right)-justified
 
@@ -443,35 +356,21 @@ struct printDataGenParameters printUnsignedGenParameters[] = {
 
 //-------------------------------------------------------
 
-// Lookup table - [string] octal-correct buffer            |
-
-//-------------------------------------------------------
-
-
-
-std::vector<const char*> correctBufferUnsigned = {
-
-    "10",
-
-    ""
-
-};
-
-//-------------------------------------------------------
-
 //Test case for octal                                   |
 
 //-------------------------------------------------------
 
 testCase testCaseUnsigned = {
 
-    sizeof(correctBufferUnsigned)/sizeof(char*),
-
     TYPE_UNSIGNED,
 
     correctBufferUnsigned,
 
-    printUnsignedGenParameters
+    printUnsignedGenParameters,
+
+    unsignedRefBuilder,
+
+    kulong
 
 };
 
@@ -491,7 +390,7 @@ testCase testCaseUnsigned = {
 
 //--------------------------------------------------------------
 
-struct printDataGenParameters printHexadecimalGenParameters[] = {
+std::vector<printDataGenParameters> printHexadecimalGenParameters = {
 
     //Add 0x,low x,default(right)-justified
 
@@ -517,41 +416,21 @@ struct printDataGenParameters printHexadecimalGenParameters[] = {
 
 //--------------------------------------------------------------
 
-// Lookup table - [string]hexadecimal-correct buffer           |
-
-//--------------------------------------------------------------
-
-
-
-std::vector<const char*> correctBufferHexadecimal= {
-
-    "0xabcdef",
-
-    "0XABCDEF",
-
-    "0",
-
-    "     18f",
-
-    "018f"
-
-};
-
-//--------------------------------------------------------------
-
 //Test case for hexadecimal                                    |
 
 //--------------------------------------------------------------
 
 testCase testCaseHexadecimal = {
 
-    sizeof(correctBufferHexadecimal)/sizeof(char*),
-
     TYPE_HEXADEC,
 
     correctBufferHexadecimal,
 
-    printHexadecimalGenParameters
+    printHexadecimalGenParameters,
+
+    hexRefBuilder,
+
+    kulong
 
 };
 
@@ -571,7 +450,7 @@ testCase testCaseHexadecimal = {
 
 //-----------------------------------------------------------
 
-struct printDataGenParameters printCharGenParameters[] = {
+std::vector<printDataGenParameters> printCharGenParameters = {
 
     //Four-wide,zero-filled,default(right)-justified
 
@@ -593,7 +472,7 @@ struct printDataGenParameters printCharGenParameters[] = {
 
 //---------------------------------------------------------
 
-std::vector<const char*> correctBufferChar= {
+std::vector<std::string> correctBufferChar = {
 
     "   1",
 
@@ -605,6 +484,7 @@ std::vector<const char*> correctBufferChar= {
 
 
 
+
 //----------------------------------------------------------
 
 //Test case for char                                       |
@@ -613,13 +493,15 @@ std::vector<const char*> correctBufferChar= {
 
 testCase testCaseChar = {
 
-    sizeof(correctBufferChar)/sizeof(char*),
-
     TYPE_CHAR,
 
     correctBufferChar,
 
-    printCharGenParameters
+    printCharGenParameters,
+
+    NULL,
+
+    kchar
 
 };
 
@@ -639,7 +521,7 @@ testCase testCaseChar = {
 
 //--------------------------------------------------------
 
-struct printDataGenParameters printStringGenParameters[] = {
+std::vector<printDataGenParameters> printStringGenParameters = {
 
     //(Minimum)Four-wide,zero-filled,default(right)-justified
 
@@ -660,7 +542,7 @@ struct printDataGenParameters printStringGenParameters[] = {
 
 //---------------------------------------------------------
 
-std::vector<const char*> correctBufferString = {
+std::vector<std::string> correctBufferString = {
 
     " foo",
 
@@ -668,6 +550,7 @@ std::vector<const char*> correctBufferString = {
 
     "%%",
 };
+
 
 //---------------------------------------------------------
 
@@ -677,13 +560,15 @@ std::vector<const char*> correctBufferString = {
 
 testCase testCaseString = {
 
-    sizeof(correctBufferString)/sizeof(char*),
-
     TYPE_STRING,
 
     correctBufferString,
 
-    printStringGenParameters
+    printStringGenParameters,
+
+    NULL,
+
+    kchar
 
 };
 
@@ -703,7 +588,7 @@ testCase testCaseString = {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct printDataGenParameters printVectorGenParameters[]={
+std::vector<printDataGenParameters> printVectorGenParameters = {
 
     //(Minimum)Two-wide,two positions after decimal
 
@@ -733,7 +618,7 @@ struct printDataGenParameters printVectorGenParameters[]={
 
 //------------------------------------------------------------
 
-std::vector<const char*> correctBufferVector = {
+std::vector<std::string> correctBufferVector = {
 
     "1.00,2.00,3.00,4.00",
 
@@ -755,13 +640,13 @@ std::vector<const char*> correctBufferVector = {
 
 testCase testCaseVector = {
 
-    sizeof(correctBufferVector)/(sizeof(char *)),
-
     TYPE_VECTOR,
 
     correctBufferVector,
 
-    printVectorGenParameters
+    printVectorGenParameters,
+
+    NULL
 
 };
 
@@ -783,7 +668,7 @@ testCase testCaseVector = {
 
 
 
-struct printDataGenParameters printAddrSpaceGenParameters[]={
+std::vector<printDataGenParameters> printAddrSpaceGenParameters = {
 
     //Global memory region
 
@@ -813,7 +698,7 @@ struct printDataGenParameters printAddrSpaceGenParameters[]={
 
 //-------------------------------------------------------------------------------
 
-std::vector<const char*> correctAddrSpace = {
+std::vector<std::string> correctAddrSpace = {
 
     "2","2","+3","-1",""
 
@@ -827,13 +712,13 @@ std::vector<const char*> correctAddrSpace = {
 
 testCase testCaseAddrSpace = {
 
-    sizeof(correctAddrSpace)/(sizeof(char *)),
-
     TYPE_ADDRESS_SPACE,
 
     correctAddrSpace,
 
-    printAddrSpaceGenParameters
+    printAddrSpaceGenParameters,
+
+    NULL
 
 };
 
@@ -845,7 +730,7 @@ testCase testCaseAddrSpace = {
 
 //-------------------------------------------------------------------------------
 
-testCase* allTestCase[] = {&testCaseInt,&testCaseFloat,&testCaseFloatLimits,&testCaseOctal,&testCaseUnsigned,&testCaseHexadecimal,&testCaseChar,&testCaseString,&testCaseVector,&testCaseAddrSpace};
+std::vector<testCase*> allTestCase = {&testCaseInt,&testCaseFloat,&testCaseFloatLimits,&testCaseOctal,&testCaseUnsigned,&testCaseHexadecimal,&testCaseChar,&testCaseString,&testCaseVector,&testCaseAddrSpace};
 
 
 //-----------------------------------------
@@ -891,8 +776,7 @@ size_t verifyOutputBuffer(char *analysisBuffer,testCase* pTestCase,size_t testId
         char correctExp[3]={0};
         strncpy(correctExp,exp,2);
 
-
-        char* eCorrectBuffer = strstr((char*)pTestCase->_correctBuffer[testId],correctExp);
+        char* eCorrectBuffer = strstr((char*)pTestCase->_correctBuffer[testId].c_str(),correctExp);
         if(eCorrectBuffer == NULL)
             return 1;
 
@@ -902,16 +786,119 @@ size_t verifyOutputBuffer(char *analysisBuffer,testCase* pTestCase,size_t testId
         //Exponent always contains at least two digits
         if(strlen(exp) < 2)
             return 1;
-        //Scip leading zeros in the exponent
-        while(*exp == '0')
-            ++exp;
         return strcmp(eCorrectBuffer,exp);
     }
-    if(!strcmp(pTestCase->_correctBuffer[testId],"inf"))
+    if(!strcmp(pTestCase->_correctBuffer[testId].c_str(),"inf"))
     return strcmp(analysisBuffer,"inf")&&strcmp(analysisBuffer,"infinity")&&strcmp(analysisBuffer,"1.#INF00")&&strcmp(analysisBuffer,"Inf");
-    if(!strcmp(pTestCase->_correctBuffer[testId],"nan") || !strcmp(pTestCase->_correctBuffer[testId],"-nan")) {
+    if(!strcmp(pTestCase->_correctBuffer[testId].c_str(),"nan") || !strcmp(pTestCase->_correctBuffer[testId].c_str(),"-nan")) {
        return strcmp(analysisBuffer,"nan")&&strcmp(analysisBuffer,"-nan")&&strcmp(analysisBuffer,"1.#IND00")&&strcmp(analysisBuffer,"-1.#IND00")&&strcmp(analysisBuffer,"NaN")&&strcmp(analysisBuffer,"nan(ind)")&&strcmp(analysisBuffer,"nan(snan)")&&strcmp(analysisBuffer,"-nan(ind)");
     }
-    return strcmp(analysisBuffer,pTestCase->_correctBuffer[testId]);
+    return strcmp(analysisBuffer,pTestCase->_correctBuffer[testId].c_str());
 }
 
+static void intRefBuilder(printDataGenParameters& params, char* refResult, const size_t refSize)
+{
+    snprintf(refResult, refSize, params.genericFormat, atoi(params.dataRepresentation));
+}
+
+static void floatRefBuilder(printDataGenParameters& params, char* refResult, const size_t refSize)
+{
+    snprintf(refResult, refSize, params.genericFormat, strtof(params.dataRepresentation, NULL));
+}
+
+static void octalRefBuilder(printDataGenParameters& params, char* refResult, const size_t refSize)
+{
+    const unsigned long int data = strtoul(params.dataRepresentation, NULL, 10);
+    snprintf(refResult, refSize, params.genericFormat, data);
+}
+
+static void unsignedRefBuilder(printDataGenParameters& params, char* refResult, const size_t refSize)
+{
+    const unsigned long int data = strtoul(params.dataRepresentation, NULL, 10);
+    snprintf(refResult, refSize, params.genericFormat, data);
+}
+
+static void hexRefBuilder(printDataGenParameters& params, char* refResult, const size_t refSize)
+{
+    const unsigned long int data = strtoul(params.dataRepresentation, NULL, 0);
+    snprintf(refResult, refSize, params.genericFormat, data);
+}
+
+/*
+    Generate reference results.
+
+    Results are only generated for test cases
+    that can easily be generated by using CPU
+    printf.
+
+    If that is not the case, results are constants
+    that have been hard-coded.
+*/
+void generateRef(const cl_device_id device)
+{
+    int fd = -1;
+    char _refBuffer[ANALYSIS_BUFFER_SIZE];
+    cl_device_fp_config fpConfig;
+    const RoundingMode hostRound = get_round();
+    RoundingMode deviceRound;
+
+    // Discover device rounding mode
+    cl_int err = clGetDeviceInfo(device,
+                                CL_DEVICE_SINGLE_FP_CONFIG,
+                                sizeof(fpConfig),
+                                &fpConfig,
+                                NULL);
+    if (err != CL_SUCCESS)
+    {
+        log_error("clGetDeviceInfo failed");
+        return;
+    }
+
+    // Map device rounding to CTS rounding type
+    if (fpConfig & CL_FP_ROUND_TO_NEAREST)
+    {
+        deviceRound = kRoundToNearestEven;
+    }
+    else if (fpConfig & CL_FP_ROUND_TO_ZERO)
+    {
+        deviceRound = kRoundTowardZero;
+    }
+    else if (fpConfig & CL_FP_ROUND_TO_INF)
+    {
+        // Can be either round up or round down
+        deviceRound = kRoundUp;
+    }
+    else
+    {
+        assert(false && "Unreachable");
+    }
+
+    // Loop through all test cases
+    for (auto &caseToTest: allTestCase)
+    {
+        /*
+            Cases that have a NULL function pointer
+            already have their reference results
+            as they're constant and hard-coded
+        */
+        if (caseToTest->printFN == NULL)
+            continue;
+
+        // Make sure the reference result is empty
+        assert(caseToTest->_correctBuffer.size() == 0);
+
+        // Loop through each input
+        for (auto &params: caseToTest->_genParameters)
+        {
+            char refResult[ANALYSIS_BUFFER_SIZE];
+            // Set CPU rounding mode to match that of the device
+            set_round(deviceRound, caseToTest->dataType);
+            // Generate the result
+            caseToTest->printFN(params, refResult, ARRAY_SIZE(refResult));
+            // Restore the original CPU rounding mode
+            set_round(hostRound, kfloat);
+            // Save the reference result
+            caseToTest->_correctBuffer.push_back(refResult);
+        }
+    }
+}

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -76,8 +76,7 @@ struct printDataGenParameters printIntGenParameters[] = {
 
 //------------------------------------------------
 
-const char *correctBufferInt[] = {
-
+std::vector<const char*> correctBufferInt = {
     "   10",
 
     "10   ",
@@ -218,7 +217,7 @@ struct printDataGenParameters printFloatGenParameters[] = {
 
 //--------------------------------------------------------
 
-const char* correctBufferFloat[] = {
+std::vector<const char*> correctBufferFloat = {
 
     "10.345600",
 
@@ -315,7 +314,7 @@ struct printDataGenParameters printFloatLimitsGenParameters[] = {
 
 //--------------------------------------------------------
 
-const char* correctBufferFloatLimits[] = {
+std::vector<const char*> correctBufferFloatLimits = {
 
     "inf",
 
@@ -384,7 +383,7 @@ struct printDataGenParameters printOctalGenParameters[] = {
 
 
 
-const char* correctBufferOctal[] = {
+std::vector<const char*> correctBufferOctal = {
 
     "12",
 
@@ -450,7 +449,7 @@ struct printDataGenParameters printUnsignedGenParameters[] = {
 
 
 
-const char* correctBufferUnsigned[] = {
+std::vector<const char*> correctBufferUnsigned = {
 
     "10",
 
@@ -524,7 +523,7 @@ struct printDataGenParameters printHexadecimalGenParameters[] = {
 
 
 
-const char* correctBufferHexadecimal[] = {
+std::vector<const char*> correctBufferHexadecimal= {
 
     "0xabcdef",
 
@@ -594,7 +593,7 @@ struct printDataGenParameters printCharGenParameters[] = {
 
 //---------------------------------------------------------
 
-const char * correctBufferChar[] = {
+std::vector<const char*> correctBufferChar= {
 
     "   1",
 
@@ -661,7 +660,7 @@ struct printDataGenParameters printStringGenParameters[] = {
 
 //---------------------------------------------------------
 
-const char * correctBufferString[] = {
+std::vector<const char*> correctBufferString = {
 
     " foo",
 
@@ -734,7 +733,7 @@ struct printDataGenParameters printVectorGenParameters[]={
 
 //------------------------------------------------------------
 
-const char * correctBufferVector[] = {
+std::vector<const char*> correctBufferVector = {
 
     "1.00,2.00,3.00,4.00",
 
@@ -814,7 +813,7 @@ struct printDataGenParameters printAddrSpaceGenParameters[]={
 
 //-------------------------------------------------------------------------------
 
-const char * correctAddrSpace[] = {
+std::vector<const char*> correctAddrSpace = {
 
     "2","2","+3","-1",""
 

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -215,17 +215,6 @@ struct printDataGenParameters printFloatGenParameters[] = {
     //(Minimum)Ten-wide,Double argument representing floating-point,in xh.hhhhpAd style,default(right)-justified
 
     {"%10.2a","9990.235"},
-
-    //Infinity (1.0/0.0)
-
-    {"%f","1.0f/0.0f"},
-
-    //NaN
-
-    {"%f","sqrt(-1.0f)"},
-
-    //NaN
-    {"%f","acospi(2.0f)"}
     };
 //--------------------------------------------------------
 
@@ -296,7 +285,66 @@ testCase testCaseFloat = {
 
 };
 
+//==============================================
 
+// float limits
+
+//==============================================
+
+
+
+//--------------------------------------------------------
+
+// [string] format |  [string] float-data representation |
+
+//--------------------------------------------------------
+
+
+struct printDataGenParameters printFloatLimitsGenParameters[] = {
+
+    //Infinity (1.0/0.0)
+
+    {"%f","1.0f/0.0f"},
+
+    //NaN
+
+    {"%f","sqrt(-1.0f)"},
+
+    //NaN
+    {"%f","acospi(2.0f)"}
+    };
+//--------------------------------------------------------
+
+//  Lookup table - [string]float-correct buffer             |
+
+//--------------------------------------------------------
+
+const char* correctBufferFloatLimits[] = {
+
+    "inf",
+
+    "-nan",
+
+    "nan"
+};
+
+//---------------------------------------------------------
+
+//Test case for float                                     |
+
+//---------------------------------------------------------
+
+testCase testCaseFloatLimits = {
+
+    sizeof(correctBufferFloatLimits)/sizeof(char*),
+
+    TYPE_FLOAT_LIMITS,
+
+    correctBufferFloatLimits,
+
+    printFloatLimitsGenParameters
+
+};
 
 //=========================================================
 
@@ -802,7 +850,7 @@ testCase testCaseAddrSpace = {
 
 //-------------------------------------------------------------------------------
 
-testCase* allTestCase[] = {&testCaseInt,&testCaseFloat,&testCaseOctal,&testCaseUnsigned,&testCaseHexadecimal,&testCaseChar,&testCaseString,&testCaseVector,&testCaseAddrSpace};
+testCase* allTestCase[] = {&testCaseInt,&testCaseFloat,&testCaseFloatLimits,&testCaseOctal,&testCaseUnsigned,&testCaseHexadecimal,&testCaseChar,&testCaseString,&testCaseVector,&testCaseAddrSpace};
 
 
 //-----------------------------------------

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -786,6 +786,11 @@ size_t verifyOutputBuffer(char *analysisBuffer,testCase* pTestCase,size_t testId
         //Exponent always contains at least two digits
         if(strlen(exp) < 2)
             return 1;
+        //Skip leading zeros in the exponent
+        while(*exp == '0')
+            ++exp;
+        while(*eCorrectBuffer == '0')
+            ++eCorrectBuffer;
         return strcmp(eCorrectBuffer,exp);
     }
     if(!strcmp(pTestCase->_correctBuffer[testId].c_str(),"inf"))

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -18,10 +18,6 @@
 #include "test_printf.h"
 
 
-const char* strType[] = {"int","float","octal","unsigned","hexadecimal","char","string","vector","address space"};
-
-
-
 //==================================
 
 // int


### PR DESCRIPTION
The PR aims to fix issues identified in #673 and #675.

The reference results had two issues:
- They did not take into account the rounding mode of the device.
- Scientific notation results did not have trailing zero's, meaning that the exponent could be a single digit, despite the requirement being at least two digits.

This PR introduces runtime generated reference results for types with numerical representations (float, int, hex, etc) where a direct mapping to standard C99 printf is possible to execute on the CPU (as opposed to tests such as address space, vectors etc which cannot be directly mapped to C99 printf).