### PR TITLE
Remove explicit_s2v_bool test

### DIFF
--- a/test_conformance/basic/main.cpp
+++ b/test_conformance/basic/main.cpp
@@ -91,7 +91,6 @@ test_definition test_list[] = {
     ADD_TEST( image_param ),
     ADD_TEST( image_multipass_integer_coord ),
     ADD_TEST( image_multipass_float_coord ),
-    ADD_TEST( explicit_s2v_bool ),
     ADD_TEST( explicit_s2v_char ),
     ADD_TEST( explicit_s2v_uchar ),
     ADD_TEST( explicit_s2v_short ),

--- a/test_conformance/basic/procs.h
+++ b/test_conformance/basic/procs.h
@@ -91,7 +91,6 @@ extern int      test_vstore_global(cl_device_id deviceID, cl_context context, cl
 extern int      test_vstore_local(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int      test_vstore_private(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int      test_explicit_s2v_bool(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int      test_explicit_s2v_char(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int      test_explicit_s2v_uchar(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int      test_explicit_s2v_short(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);

--- a/test_conformance/basic/test_explicit_s2v.cpp
+++ b/test_conformance/basic/test_explicit_s2v.cpp
@@ -237,19 +237,6 @@ int test_explicit_s2v_function_set(cl_device_id deviceID, cl_context context, cl
     return failed;
 }
 
-int test_explicit_s2v_bool(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
-{
-    log_info( "NOTE: Boolean vectors not defined in OpenCL 1.0. Skipping test.\n" );
-    return 0;
-#if 0
-    bool    data[128];
-
-    generate_random_data( kBool, 128, data );
-
-    return test_explicit_s2v_function_set( deviceID, context, queue, kBool, 128, data );
-#endif
-}
-
 int test_explicit_s2v_char(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
     char    data[128];


### PR DESCRIPTION
The test does not do anything other than print a skipping test
message.

Fixes #438

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>