### PR TITLE
[QC] cl20: bruteforce: Fix domains used in fast math mode. 

### DIFF
--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -506,14 +506,18 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
         float p_j = *(float *) &p[j];
         if ( strcmp(fname,"sin")==0 || strcmp(fname,"cos")==0 )  //the domain of the function is [-pi,pi]
         {
-          if( fabs(p_j) > M_PI )
-            p[j] = NAN;
+            if (fabs(p_j) > M_PI) ((float *)p)[j] = NAN;
         }
 
         if ( strcmp( fname, "reciprocal" ) == 0 )
         {
-          if( fabs(p_j) > 0x7E800000 ) //the domain of the function is [2^-126,2^126]
-            p[j] = NAN;
+            const float l_limit = HEX_FLT(+, 1, 0, -, 126);
+            const float u_limit = HEX_FLT(+, 1, 0, +, 126);
+
+            if (fabs(p_j) < l_limit
+                || fabs(p_j)
+                    > u_limit) // the domain of the function is [2^-126,2^126]
+                ((float *)p)[j] = NAN;
         }
       }
     }

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -239,8 +239,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
             if (relaxedMode && strcmp(f->name, "sincos") == 0)
             {
               float pj = *(float *)&p[j];
-              if(fabs(pj) > M_PI)
-                p[j] = NAN;
+              if (fabs(pj) > M_PI) ((float *)p)[j] = NAN;
             }
           }
         }
@@ -252,8 +251,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
             if (relaxedMode && strcmp(f->name, "sincos") == 0)
             {
               float pj = *(float *)&p[j];
-              if(fabs(pj) > M_PI)
-                p[j] = NAN;
+              if (fabs(pj) > M_PI) ((float *)p)[j] = NAN;
             }
           }
         }


### PR DESCRIPTION
Clamp input arrays to valid domains of several math functions being
tested.

Khronos Bug: https://github.com/KhronosGroup/OpenCL-CTS/issues/491
Test Suite Affected: bruteforce Subtests: sin, cos, sincos, reciprocal