### PR TITLE
Add minimum version for relaxed precision bruteforce tests.

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -79,7 +79,7 @@ int fail_init_info(int count) {
     return EXIT_FAILURE;
 }
 void version_expected_info(const char * test_name, const char * expected_version, const char * device_version) {
-    log_info("%s skipped (requires at least version %s, but the device reports version %s)\n",
+    log_info("%s skipped (requires version %s, but the device reports version %s)\n",
         test_name, expected_version, device_version);
 }
 int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_definition testList[],
@@ -705,6 +705,12 @@ test_status callSingleTestFunction( test_definition test, cl_device_id deviceToU
     if (test.min_version > device_version)
     {
         version_expected_info(test.name, test.min_version.to_string().c_str(), device_version.to_string().c_str());
+        return TEST_SKIP;
+    }
+
+    if(test.max_version < device_version)
+    {
+        version_expected_info(test.name, test.max_version.to_string().c_str(), device_version.to_string().c_str());
         return TEST_SKIP;
     }
 

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -27,9 +27,10 @@
 extern "C" {
 #endif
 
-#define ADD_TEST(fn) {test_##fn, #fn, Version(1, 0)}
-#define ADD_TEST_VERSION(fn, ver) {test_##fn, #fn, ver}
-#define NOT_IMPLEMENTED_TEST(fn) {NULL, #fn, Version(0, 0)}
+#define ADD_TEST(fn) {test_##fn, #fn, Version(1, 0), Version(2, 2)}
+#define ADD_TEST_VERSION(fn, ver) {test_##fn, #fn, ver, Version(2, 2)}
+#define ADD_TEST_MAX_VERSION(fn, ver) {test_##fn, #fn, Version(1, 0), ver}
+#define NOT_IMPLEMENTED_TEST(fn) {NULL, #fn, Version(0, 0), Version(0, 0)}
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
@@ -61,6 +62,7 @@ typedef struct test_definition
     basefn func;
     const char* name;
     Version min_version;
+    Version max_version;
 } test_definition;
 
 

--- a/test_conformance/math_brute_force/FunctionList.cpp
+++ b/test_conformance/math_brute_force/FunctionList.cpp
@@ -202,6 +202,7 @@ const Func  functionList[] = {
                                     OPERATOR_ENTRY( add, "+",         0.0f,         0.0f,     FTZ_OFF,     binaryOperatorF),
                                     OPERATOR_ENTRY( subtract, "-",     0.0f,         0.0f,     FTZ_OFF,     binaryOperatorF),
                                     { "divide", "/",  {(void*)reference_divide}, {(void*)reference_dividel}, {(void*)reference_relaxed_divide}, 2.5f, 0.0f,         3.0f, 2.5f, FTZ_OFF, RELAXED_ON, binaryOperatorF },
+                                    { "divide_no_relaxed", "/",  {(void*)reference_divide}, {(void*)reference_dividel}, {(void*)reference_relaxed_divide}, 2.5f, 0.0f,         3.0f, 2.5f, FTZ_OFF, RELAXED_OFF, binaryOperatorF },
                                     { "divide_cr", "/",  {(void*)reference_divide}, {(void*)reference_dividel}, {(void*)reference_relaxed_divide}, 0.0f, 0.0f,         0.0f, 0.f, FTZ_OFF, RELAXED_OFF, binaryOperatorF },
                                     OPERATOR_ENTRY( multiply, "*",     0.0f,         0.0f,     FTZ_OFF,     binaryOperatorF),
                                     OPERATOR_ENTRY( assignment, "", 0.0f,       0.0f,     FTZ_OFF,     unaryF),        // A simple copy operation

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -682,6 +682,10 @@ int test_divide( cl_device_id deviceID, cl_context context, cl_command_queue que
 {
     return doTest( "divide" );
 }
+int test_divide_no_relaxed( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
+{
+    return doTest( "divide_no_relaxed" );
+}
 int test_divide_cr( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
     return doTest( "divide_cr" );
@@ -795,7 +799,8 @@ test_definition test_list[] = {
     ADD_TEST( half_tan ),
     ADD_TEST( add ),
     ADD_TEST( subtract ),
-    ADD_TEST( divide ),
+    ADD_TEST_VERSION( divide, Version(2, 0) ),
+    ADD_TEST_MAX_VERSION( divide_no_relaxed, Version(1, 2) ),
     ADD_TEST( divide_cr ),
     ADD_TEST( multiply ),
     ADD_TEST( assignment ),


### PR DESCRIPTION
OpenCL 1.2 does not specify any ULP requirements when fast relaxed math
is enabled.