### PR TITLE
Fix test executable names in CSV files

### DIFF
--- a/test_conformance/opencl_conformance_tests_12_quick.csv
+++ b/test_conformance/opencl_conformance_tests_12_quick.csv
@@ -75,7 +75,7 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 #Conversions,conversions/test_conversions
-Contractions,contractions/contractions
+Contractions,contractions/test_contractions
 Math,math_brute_force/test_bruteforce -w
 Integer Ops,integer_ops/test_integer_ops integer_* quick_*
 Half Ops,half/test_half -w

--- a/test_conformance/opencl_conformance_tests_20_full.csv
+++ b/test_conformance/opencl_conformance_tests_20_full.csv
@@ -5,7 +5,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -76,10 +76,10 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 Conversions,conversions/test_conversions
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce
 Integer Ops,integer_ops/test_integer_ops
-Half Ops,half/Test_half
+Half Ops,half/test_half
 
 #####################################
 # OpenCL 2.0 tests
@@ -89,7 +89,7 @@ Execution Model,device_execution/test_device_execution
 Generic Address Space,generic_address_space/test_generic_address_space
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group
 Pipes,pipes/test_pipes
-SVM,SVM/test_SVM
+SVM,SVM/test_svm
 Workgroups,workgroups/test_workgroups
 
 #########################################

--- a/test_conformance/opencl_conformance_tests_20_full_no_math_or_conversions.csv
+++ b/test_conformance/opencl_conformance_tests_20_full_no_math_or_conversions.csv
@@ -5,7 +5,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -73,7 +73,7 @@ OpenCL-GL Sharing,gl/test_gl
 # Thorough math and conversions tests
 # #########################################
 Select,select/test_select
-Contractions,contractions/contractions
+Contractions,contractions/test_contractions
 Integer Ops,integer_ops/test_integer_ops
-Half Ops,half/Test_half
+Half Ops,half/test_half
 

--- a/test_conformance/opencl_conformance_tests_20_quick.csv
+++ b/test_conformance/opencl_conformance_tests_20_quick.csv
@@ -7,7 +7,7 @@
 # #########################################
 # Basic Information on the compute device
 # #########################################
-Compute Info,computeinfo/computeinfo
+Compute Info,computeinfo/test_computeinfo
 
 # #########################################
 # Basic operation tests
@@ -75,7 +75,7 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 #Conversions,conversions/test_conversions
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce -w
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce -w
 Integer Ops,integer_ops/test_integer_ops integer_* quick_*
-Half Ops,half/Test_half -w
+Half Ops,half/test_half -w

--- a/test_conformance/opencl_conformance_tests_21_full_spirv.csv
+++ b/test_conformance/opencl_conformance_tests_21_full_spirv.csv
@@ -76,10 +76,10 @@ OpenCL-GL Sharing,gl/test_gl -offlineCompiler spir_v cache .
 # #########################################
 Select,select/test_select -offlineCompiler spir_v cache .
 Conversions,conversions/test_conversions -offlineCompiler spir_v cache .
-Contractions,contractions/contractions -offlineCompiler spir_v cache .
-Math,math_brute_force/bruteforce -offlineCompiler spir_v cache .
+Contractions,contractions/test_contractions -offlineCompiler spir_v cache .
+Math,math_brute_force/test_bruteforce -offlineCompiler spir_v cache .
 Integer Ops,integer_ops/test_integer_ops -offlineCompiler spir_v cache .
-Half Ops,half/Test_half -offlineCompiler spir_v cache .
+Half Ops,half/test_half -offlineCompiler spir_v cache .
 
 #####################################
 # OpenCL 2.0 tests
@@ -89,7 +89,7 @@ Execution Model,device_execution/test_device_execution -offlineCompiler spir_v c
 Generic Address Space,generic_address_space/test_generic_address_space -offlineCompiler spir_v cache .
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group -offlineCompiler spir_v cache .
 Pipes,pipes/test_pipes -offlineCompiler spir_v cache .
-SVM,SVM/test_SVM -offlineCompiler spir_v cache .
+SVM,SVM/test_svm -offlineCompiler spir_v cache .
 Workgroups,workgroups/test_workgroups -offlineCompiler spir_v cache .
 
 #####################################

--- a/test_conformance/opencl_conformance_tests_21_legacy_wimpy.csv
+++ b/test_conformance/opencl_conformance_tests_21_legacy_wimpy.csv
@@ -68,10 +68,10 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 Conversions,conversions/test_conversions -w
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce -w
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce -w
 Integer Ops,integer_ops/test_integer_ops integer_* quick_*
-Half Ops,half/Test_half -w
+Half Ops,half/test_half -w
 
 #####################################
 # OpenCL 2.0 tests
@@ -81,7 +81,7 @@ Execution Model,device_execution/test_device_execution
 Generic Address Space,generic_address_space/test_generic_address_space
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group
 Pipes,pipes/test_pipes
-SVM,SVM/test_SVM
+SVM,SVM/test_svm
 Workgroups,workgroups/test_workgroups
 
 #####################################

--- a/test_conformance/opencl_conformance_tests_full.csv
+++ b/test_conformance/opencl_conformance_tests_full.csv
@@ -76,8 +76,8 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 Conversions,conversions/test_conversions
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce
 Integer Ops,integer_ops/test_integer_ops
 Half Ops,half/test_half
 
@@ -89,7 +89,7 @@ Execution Model,device_execution/test_device_execution
 Generic Address Space,generic_address_space/test_generic_address_space
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group
 Pipes,pipes/test_pipes
-SVM,SVM/test_SVM
+SVM,SVM/test_svm
 Workgroups,workgroups/test_workgroups
 
 #####################################

--- a/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
+++ b/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
@@ -75,7 +75,7 @@ OpenCL-GL Sharing,gl/test_gl
 # Thorough math and conversions tests
 # #########################################
 Select,select/test_select
-Contractions,contractions/contractions
+Contractions,contractions/test_contractions
 Integer Ops,integer_ops/test_integer_ops
 Half Ops,half/test_half
 
@@ -87,7 +87,7 @@ Execution Model,device_execution/test_device_execution
 Generic Address Space,generic_address_space/test_generic_address_space
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group
 Pipes,pipes/test_pipes
-SVM,SVM/test_SVM
+SVM,SVM/test_svm
 Workgroups,workgroups/test_workgroups
 
 #####################################

--- a/test_conformance/opencl_conformance_tests_generate_spirv.csv
+++ b/test_conformance/opencl_conformance_tests_generate_spirv.csv
@@ -49,8 +49,8 @@ OpenCL-GL Sharing,gl/test_gl -offlineCompiler spir_v generate .
 # #########################################
 Select,select/test_select -offlineCompiler spir_v generate .
 Conversions,conversions/test_conversions -w  -offlineCompiler spir_v generate .
-Contractions,contractions/contractions -offlineCompiler spir_v generate .
-Math,math_brute_force/bruteforce -w  -offlineCompiler spir_v generate .
+Contractions,contractions/test_contractions -offlineCompiler spir_v generate .
+Math,math_brute_force/test_bruteforce -w  -offlineCompiler spir_v generate .
 Integer Ops,integer_ops/test_integer_ops integer_* quick_* -offlineCompiler spir_v generate .
 Half Ops,half/test_half -w -offlineCompiler spir_v generate .
 
@@ -62,7 +62,7 @@ Execution Model,device_execution/test_device_execution -offlineCompiler spir_v g
 Generic Address Space,generic_address_space/test_generic_address_space -offlineCompiler spir_v generate .
 Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group -offlineCompiler spir_v generate .
 Pipes,pipes/test_pipes -offlineCompiler spir_v generate .
-SVM,SVM/test_SVM -offlineCompiler spir_v generate .
+SVM,SVM/test_svm -offlineCompiler spir_v generate .
 Workgroups,workgroups/test_workgroups -offlineCompiler spir_v generate .
 
 #########################################

--- a/test_conformance/opencl_conformance_tests_math.csv
+++ b/test_conformance/opencl_conformance_tests_math.csv
@@ -1,4 +1,4 @@
 #
 # OpenCL Conformance Test Suite (math only)
 #
-Math,math_brute_force/bruteforce 
+Math,math_brute_force/test_bruteforce 

--- a/test_conformance/opencl_conformance_tests_quick.csv
+++ b/test_conformance/opencl_conformance_tests_quick.csv
@@ -75,7 +75,7 @@ OpenCL-GL Sharing,gl/test_gl
 # #########################################
 Select,select/test_select
 #Conversions,conversions/test_conversions
-Contractions,contractions/contractions
-Math,math_brute_force/bruteforce -w
+Contractions,contractions/test_contractions
+Math,math_brute_force/test_bruteforce -w
 Integer Ops,integer_ops/test_integer_ops integer_* quick_*
-Half Ops,half/Test_half -w
+Half Ops,half/test_half -w


### PR DESCRIPTION
The following test executable name changes have been made in the
conformance CSV files to match those found in the `test_conformance`
build directory:

* `contractions` -> `test_contractions`
* `computeinfo` -> `test_computeinfo`
* `bruteforce` -> `test_bruteforce`
* `Test_half` -> `test_half`
* `test_SVM` -> `test_svm`