### PR TITLE
Generic Address Space: Skip test on unsupported devices.

### DIFF
--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -70,11 +70,34 @@ const int test_num = ARRAY_SIZE( test_list );
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
     auto expected_min_version = Version(2, 0);
+
     if (version < expected_min_version)
     {
         version_expected_info("Test", expected_min_version.to_string().c_str(), version.to_string().c_str());
         return TEST_SKIP;
     }
+
+#ifdef CL_EXPERIMENTAL
+    if (version > Version(2,2))
+    {
+        cl_int error;
+        cl_bool support_generic;
+
+        error = clGetDeviceInfo(device, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT,
+                                sizeof(support_generic), &support_generic, NULL);
+        if (error != CL_SUCCESS)
+        {
+            print_error(error, "Unable to get generic address space support");
+            return TEST_FAIL;
+        }
+
+        if (!support_generic)
+        {
+            return TEST_SKIP;
+        }
+    }
+#endif
+
     return TEST_PASS;
 }
 

--- a/travis.sh
+++ b/travis.sh
@@ -63,6 +63,7 @@ cmake -DCL_INCLUDE_DIR=${TOP}/OpenCL-Headers \
       -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
       -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=./bin \
       -DOPENCL_LIBRARIES="-lOpenCL -lpthread" \
+      -DUSE_CL_EXPERIMENTAL=ON \
       ..
 make -j2
 


### PR DESCRIPTION
Where a device does not have to support this test, skip it.