### PR TITLE
is_extension_available used throughout code

### DIFF
--- a/test_common/gl/setup_osx.cpp
+++ b/test_common/gl/setup_osx.cpp
@@ -92,16 +92,9 @@ class OSXGLEnvironment : public GLEnvironment
         return NULL;
       }
 
-      char extensions[8192];
       for (int i=0; i<(int)(size_out/sizeof(cl_device_id)); i++) {
-        error = clGetDeviceInfo(devices[i], CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
-        if (error) {
-          print_error(error, "clGetDeviceInfo failed");
-          return NULL;
-        }
-
-        if (strstr(extensions, "cl_APPLE_gl_sharing") == NULL) {
-          log_error("Device %d does not supporte required extension cl_APPLE_gl_sharing.\n", i);
+        if (!is_extension_available(devices[i], "cl_APPLE_gl_sharing")) {
+          log_error("Device %d does not support required extension cl_APPLE_gl_sharing.\n", i);
           return NULL;
         }
       }
@@ -120,15 +113,8 @@ class OSXGLEnvironment : public GLEnvironment
         return -1;
       }
 
-      char extensions[8192];
       for (int i=0; i<(int)num_of_devices; i++) {
-        error = clGetDeviceInfo(devices[i], CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
-        if (error) {
-          print_error(error, "clGetDeviceInfo failed");
-          return -1;
-        }
-
-        if (strstr(extensions, "cl_APPLE_gl_sharing") == NULL) {
+        if (!is_extension_available(devices[i], "cl_APPLE_gl_sharing")) {
           log_info("Device %d of %d does not support required extension cl_APPLE_gl_sharing.\n", i, num_of_devices);
         } else {
           log_info("Device %d of %d does support required extension cl_APPLE_gl_sharing.\n", i, num_of_devices);

--- a/test_common/gl/setup_win32.cpp
+++ b/test_common/gl/setup_win32.cpp
@@ -175,15 +175,8 @@ public:
         }
 
         // Check all devices, search for one that supports cl_khr_gl_sharing
-        char extensions[8192];
         for (int i=0; i<(int)num_of_devices; i++) {
-            error = clGetDeviceInfo(devices[i], CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
-            if (error) {
-                print_error(error, "clGetDeviceInfo failed");
-                return -1;
-            }
-
-            if (strstr(extensions, "cl_khr_gl_sharing") == NULL) {
+            if (!is_extension_available(device[i], "cl_khr_gl_sharing")) {
                 log_info("Device %d of %d does not support required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
             } else {
                 log_info("Device %d of %d supports required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);

--- a/test_common/gl/setup_x11.cpp
+++ b/test_common/gl/setup_x11.cpp
@@ -89,15 +89,8 @@ public:
             return -1;
         }
 
-        char extensions[8192];
         for (int i=0; i<(int)num_of_devices; i++) {
-            error = clGetDeviceInfo(devices[i], CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
-            if (error) {
-                print_error(error, "clGetDeviceInfo failed");
-                return -1;
-            }
-
-            if (strstr(extensions, "cl_khr_gl_sharing ") == NULL) {
+            if (!is_extension_available(devices[i], "cl_khr_gl_sharing ")) {
                 log_info("Device %d of %d does not support required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
             } else {
                 log_info("Device %d of %d supports required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);

--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -372,33 +372,7 @@ int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_def
             gInfNanSupport = 0;
 
         // check the extensions list to see if ulong and long are supported
-        size_t extensionsStringSize = 0;
-        if( (err = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, 0, NULL, &extensionsStringSize ) ))
-        {
-            print_error( err, "Unable to get extensions string size for embedded device" );
-            return EXIT_FAILURE;
-        }
-        char *extensions_string = (char*) malloc(extensionsStringSize);
-        if( NULL == extensions_string )
-        {
-            print_error( CL_OUT_OF_HOST_MEMORY, "Unable to allocate storage for extensions string for embedded device" );
-            return EXIT_FAILURE;
-        }
-        BufferOwningPtr<char> extensions_stringBuf(extensions_string);
-
-        if( (err = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, extensionsStringSize, extensions_string, NULL ) ))
-        {
-            print_error( err, "Unable to get extensions string for embedded device" );
-            return EXIT_FAILURE;
-        }
-
-        if( extensions_string[extensionsStringSize-1] != '\0' )
-        {
-            log_error( "FAILURE: extensions string for embedded device is not NUL terminated" );
-            return EXIT_FAILURE;
-        }
-
-        if( NULL == strstr( extensions_string, "cles_khr_int64" ))
+        if( !is_extension_available(device, "cles_khr_int64" ))
             gHasLong = 0;
     }
 

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -1969,55 +1969,12 @@ int test_min_max_device_version(cl_device_id deviceID, cl_context context, cl_co
 
     if( major * 10 + minor >= 11 )
     {
-        char *extensions;
-        size_t extensions_size = 0;
-
         log_info( "Checking for required extensions for OpenCL 1.1 and later devices...\n" );
-
-        if( (error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, NULL, &extensions_size)))
-        {
-            log_error( "ERROR: could not get extensions size.  Err # %d\n", error );
-            return -1;
-        }
-
-        if( extensions_size < 1 )
-        {
-            log_error( "ERROR: invalid extensions size.  Err # %d\n", error );
-            return -1;
-        }
-
-        extensions = (char*) malloc(extensions_size);
-        if( NULL == extensions )
-        {
-            log_error( "ERROR: cannot allocate %ld bytes to hold extension string.\n", extensions_size );
-            return -1;
-        }
-        memset( extensions, -1, extensions_size );
-
-        if( (error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, extensions_size, extensions, NULL)))
-        {
-            log_error( "ERROR: could not get extensions.  Err # %d\n", error );
-            free( extensions );
-            return -1;
-        }
-
-        if( '\0' != extensions[ extensions_size - 1 ] )
-        {
-            if( -1 == extensions[ extensions_size - 1 ] )
-                log_error( "ERROR: extensions size reported incorrectly.  Last byte is not NUL. Size too big. Reported: %ld.  Should be: %ld\n", extensions_size, strlen(extensions) + 1  );
-            else
-                log_error( "ERROR: extensions size reported incorrectly.  Last byte is not NUL. Size too small. \n" );
-
-            free( extensions );
-            return -1;
-        }
-
         for( i = 0; NULL != requiredExtensions[i]; i++ )
         {
-            if( NULL == strstr( extensions, requiredExtensions[i] ) )
+            if(!is_extension_available(deviceID, requiredExtensions[i]))
             {
                 log_error( "ERROR: Required extension for 1.1 and greater devices is not in extension string: %s\n", requiredExtensions[i] );
-                free( extensions );
                 return -1;
             }
             else
@@ -2040,18 +1997,15 @@ int test_min_max_device_version(cl_device_id deviceID, cl_context context, cl_co
 
             for( i = 0; i<numRequiredExtension20; i++ )
             {
-                if( NULL == strstr( extensions, requiredExtensions20[i] ) )
+                if(!is_extension_available(deviceID, requiredExtensions20[i]))
                 {
                     log_error( "ERROR: Required extension for 2.0 and greater devices is not in extension string: %s\n", requiredExtensions20[i] );
-                    free( extensions );
                     return -1;
                 }
                 else
                     log_info( "\t%s\n", requiredExtensions20[i] );
             }
         }
-
-        free( extensions );
     }
     else
         log_info( "WARNING: skipping required extension test -- OpenCL 1.0 device.\n" );

--- a/test_conformance/api/test_clone_kernel.cpp
+++ b/test_conformance/api/test_clone_kernel.cpp
@@ -261,28 +261,9 @@ int test_clone_kernel(cl_device_id deviceID, cl_context context, cl_command_queu
     test_error( error, "clGetDeviceInfo failed." );
 
     // test double support
-    size_t ext_str_size;
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, NULL, &ext_str_size);
-    test_error( error, "clGetDeviceInfo failed." );
-    char* ext_str = new char[ext_str_size+1];
-
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, ext_str_size, ext_str, NULL);
-    test_error( error, "clGetDeviceInfo failed." );
-
-    ext_str[ext_str_size] = '\0';
-
-    stringstream ss;
-    ss << ext_str;
-
-    while (!ss.eof())
+    if (is_extension_available(deviceID, "cl_khr_fp64"))
     {
-        string s;
-        ss >> s;
-        if (s == "cl_khr_fp64")
-        {
-            bdouble = CL_TRUE;
-            break;
-        }
+        bdouble = CL_TRUE;
     }
 
     /* Create kernels to test with */
@@ -404,7 +385,6 @@ int test_clone_kernel(cl_device_id deviceID, cl_context context, cl_command_queu
 
     delete [] pbuf;
     delete [] pbufRes;
-    delete [] ext_str;
 
     return 0;
 }

--- a/test_conformance/api/test_kernel_arg_info.cpp
+++ b/test_conformance/api/test_kernel_arg_info.cpp
@@ -5848,37 +5848,7 @@ int    test_get_kernel_arg_info( cl_device_id deviceID, cl_context context, cl_c
     log_info(" o Not testing image kernel arguments.\n");
   }
 
-    // Get the extensions string for the device
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS size failed");
-
-    char *extensions = (char*)malloc(sizeof(char)*(size + 1));
-    if (extensions == 0) {
-        log_error("Failed to allocate memory for extensions string.\n");
-        return -1;
-    }
-    memset( extensions, CHAR_MIN, sizeof(char)*(size+1) );
-
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, sizeof(char)*size, extensions, NULL);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-
-    // Check to make sure the extension string is NUL terminated.
-    if( extensions[size] != CHAR_MIN )
-    {
-        test_error( -1, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS wrote past the end of the array!" );
-        return -1;
-    }
-    extensions[size] = '\0';    // set last char to NUL to avoid problems with string functions later
-
-    // test for termination with '\0'
-    size_t stringSize = strlen( extensions );
-    if( stringSize == size )
-    {
-        test_error( -1, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS is not NUL terminated!" );
-        return -1;
-    }
-
-    if (strstr(extensions, "cl_khr_fp64")) {
+    if (is_extension_available(deviceID, "cl_khr_fp64")) {
         log_info(" o Device claims extension 'cl_khr_fp64'\n");
         log_info(" o Expecting SUCCESS when testing double kernel arguments.\n");
         supports_double = 1;
@@ -5895,7 +5865,7 @@ int    test_get_kernel_arg_info( cl_device_id deviceID, cl_context context, cl_c
         }
     }
 
-    if (strstr(extensions, "cl_khr_fp16")) {
+    if (is_extension_available(deviceID, "cl_khr_fp16")) {
         log_info(" o Device claims extension 'cl_khr_fp16'\n");
         log_info(" o Expecting SUCCESS when testing halfn* kernel arguments.\n");
         supports_half = 1;
@@ -5905,7 +5875,7 @@ int    test_get_kernel_arg_info( cl_device_id deviceID, cl_context context, cl_c
         supports_half = 0;
     }
 
-    if (strstr(extensions, "cl_khr_int64"))
+    if (is_extension_available(deviceID, "cl_khr_int64"))
     {
         log_info(" o Device claims extension 'cl_khr_int64'\n");
         log_info(" o Expecting SUCCESS when testing long kernel arguments.\n");

--- a/test_conformance/api/test_kernel_arg_info_compatibility.cpp
+++ b/test_conformance/api/test_kernel_arg_info_compatibility.cpp
@@ -5103,37 +5103,7 @@ int test_get_kernel_arg_info_compatibility( cl_device_id deviceID, cl_context co
     log_info(" o Not testing image kernel arguments.\n");
   }
 
-    // Get the extensions string for the device
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS size failed");
-
-    char *extensions = (char*)malloc(sizeof(char)*(size + 1));
-    if (extensions == 0) {
-        log_error("Failed to allocate memory for extensions string.\n");
-        return -1;
-    }
-    memset( extensions, CHAR_MIN, sizeof(char)*(size+1) );
-
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, sizeof(char)*size, extensions, NULL);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-
-    // Check to make sure the extension string is NUL terminated.
-    if( extensions[size] != CHAR_MIN )
-    {
-        test_error( -1, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS wrote past the end of the array!" );
-        return -1;
-    }
-    extensions[size] = '\0';    // set last char to NUL to avoid problems with string functions later
-
-    // test for termination with '\0'
-    size_t stringSize = strlen( extensions );
-    if( stringSize == size )
-    {
-        test_error( -1, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS is not NUL terminated!" );
-        return -1;
-    }
-
-    if (strstr(extensions, "cl_khr_fp64")) {
+    if (is_extension_available(deviceID, "cl_khr_fp64")) {
         log_info(" o Device claims extension 'cl_khr_fp64'\n");
         log_info(" o Expecting SUCCESS when testing double kernel arguments.\n");
         supports_double = 1;
@@ -5150,7 +5120,7 @@ int test_get_kernel_arg_info_compatibility( cl_device_id deviceID, cl_context co
         }
     }
 
-    if (strstr(extensions, "cl_khr_fp16")) {
+    if (is_extension_available(deviceID, "cl_khr_fp16")) {
         log_info(" o Device claims extension 'cl_khr_fp16'\n");
         log_info(" o Expecting SUCCESS when testing halfn* kernel arguments.\n");
         supports_half = 1;

--- a/test_conformance/api/test_queue_properties.cpp
+++ b/test_conformance/api/test_queue_properties.cpp
@@ -107,20 +107,11 @@ int test_queue_properties(cl_device_id deviceID, cl_context context, cl_command_
 
     clProgramWrapper program;
     clKernelWrapper kernel;
-    size_t strSize;
-    std::string strExt(0, '\0');
     cl_queue_properties_khr device_props = 0;
     cl_queue_properties_khr queue_prop_def[] = { CL_QUEUE_PROPERTIES, 0, 0 };
 
     // Query extension
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, NULL, &strSize);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-    strExt.resize(strSize);
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, strExt.size(), &strExt[0], NULL);
-    test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-    log_info("CL_DEVICE_EXTENSIONS:\n%s\n\n", strExt.c_str());
-
-    if (strExt.find("cl_khr_create_command_queue") == string::npos)
+    if (is_extension_available(deviceID, "cl_khr_create_command_queue"))
     {
         log_info("extension cl_khr_create_command_queue is not supported.\n");
         return 0;


### PR DESCRIPTION
(Patch1)
A number of tests have got their own code for checking the presence of
extensions. This change replaces that code with is_extension_available
function.

Contributes to #627

Change-Id: I8dd2233719aa8c84841ac61776437d7f6e3fafe6
Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>