### PR TITLE
Ensure is_extension_available is used where possible

### DIFF
--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -473,30 +473,7 @@ test_status InitCL( cl_device_id device )
         gForceFTZ ^= 1;
 
     // check for cl_khr_fp64
-    size_t extensions_size = 0;
-    if( (error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, 0, NULL, &extensions_size )))
-    {
-        vlog_error( "clGetDeviceInfo(CL_DEVICE_EXTENSIONS) failed. %d\n", error );
-        return TEST_FAIL;
-    }
-    if( extensions_size )
-    {
-        char *extensions = (char*)malloc(extensions_size);
-        if( NULL == extensions )
-        {
-            vlog_error( "ERROR: Unable to allocate %ld bytes to hold extensions string\n", extensions_size );
-            return TEST_FAIL;
-        }
-
-        if( (error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, extensions_size, extensions, NULL )))
-        {
-            vlog_error( "clGetDeviceInfo(CL_DEVICE_EXTENSIONS) failed 2. %d\n", error );
-            return TEST_FAIL;
-        }
-
-        gHasDouble = NULL != strstr( extensions, "cl_khr_fp64" );
-        free( extensions );
-    }
+    gHasDouble = is_extension_available(device, "cl_khr_fp64" );
 
     if(0 == (CL_FP_INF_NAN & floatCapabilities) )
         gSkipNanInf = 1;

--- a/test_conformance/d3d11/harness.cpp
+++ b/test_conformance/d3d11/harness.cpp
@@ -74,15 +74,7 @@ HarnessD3D11_ExtensionCheck()
     cl_uint num_devices_d3d11 = 0; // Number of devices supporting cl_khr_d3d11_sharing.
     for ( cl_uint i = 0; i < devices.size(); ++ i )
     {
-        std::vector< char > buffer;
-        size_t size = 0;
-        result = clGetDeviceInfo( devices[ i ], CL_DEVICE_EXTENSIONS, 0, NULL, & size );
-            NonTestRequire( result == CL_SUCCESS, "Failed to get size of extension string." );
-        buffer.resize( size );
-        result = clGetDeviceInfo( devices[ i ], CL_DEVICE_EXTENSIONS, buffer.size(), & buffer.front(), & size );
-            NonTestRequire( result == CL_SUCCESS, "Failed to get extension string." );
-        std::string extensions = std::string( " " ) + & buffer.front() + " ";
-        if ( extensions.find( " cl_khr_d3d11_sharing " ) != std::string::npos )
+        if (is_extension_available( devices[i], " cl_khr_d3d11_sharing " ))
         {
             ++ num_devices_d3d11;
         }

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -442,22 +442,7 @@ int supportsHalf(cl_context context, bool* supports_half)
   error = clGetContextInfo(context, CL_CONTEXT_DEVICES, numDev * sizeof(cl_device_id), devices, NULL);
   test_error(error, "clGetContextInfo for CL_CONTEXT_DEVICES failed");
 
-  // Get the extensions string for the device
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS size failed");
-
-  char *extensions = new char[size+1];
-  if (extensions == 0) {
-      log_error("Failed to allocate memory for extensions string.\n");
-      return -1;
-  }
-  memset( extensions, CHAR_MIN, sizeof(char)*(size+1) );
-
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, sizeof(char)*size, extensions, NULL);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-
-  *supports_half = strstr(extensions, "cl_khr_fp16");
-  delete [] extensions;
+  *supports_half = is_extension_available(devices[0], "cl_khr_fp16");
   delete [] devices;
 
   return error;
@@ -476,22 +461,7 @@ int supportsMsaa(cl_context context, bool* supports_msaa)
   error = clGetContextInfo(context, CL_CONTEXT_DEVICES, numDev * sizeof(cl_device_id), devices, NULL);
   test_error(error, "clGetContextInfo for CL_CONTEXT_DEVICES failed");
 
-  // Get the extensions string for the device
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS size failed");
-
-  char *extensions = new char[size+1];
-  if (extensions == 0) {
-      log_error("Failed to allocate memory for extensions string.\n");
-      return -1;
-  }
-  memset( extensions, CHAR_MIN, sizeof(char)*(size+1) );
-
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, sizeof(char)*size, extensions, NULL);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-
-  *supports_msaa = strstr(extensions, "cl_khr_gl_msaa_sharing");
-  delete [] extensions;
+  *supports_msaa = is_extension_available(devices[0], "cl_khr_gl_msaa_sharing");
   delete [] devices;
 
   return error;
@@ -510,22 +480,7 @@ int supportsDepth(cl_context context, bool* supports_depth)
   error = clGetContextInfo(context, CL_CONTEXT_DEVICES, numDev * sizeof(cl_device_id), devices, NULL);
   test_error(error, "clGetContextInfo for CL_CONTEXT_DEVICES failed");
 
-  // Get the extensions string for the device
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS size failed");
-
-  char *extensions = new char[size+1];
-  if (extensions == 0) {
-      log_error("Failed to allocate memory for extensions string.\n");
-      return -1;
-  }
-  memset( extensions, CHAR_MIN, sizeof(char)*(size+1) );
-
-  error = clGetDeviceInfo(devices[0], CL_DEVICE_EXTENSIONS, sizeof(char)*size, extensions, NULL);
-  test_error(error, "clGetDeviceInfo for CL_DEVICE_EXTENSIONS failed");
-
-  *supports_depth = strstr(extensions, "cl_khr_gl_depth_images");
-  delete [] extensions;
+  *supports_depth = is_extension_available(devices[0], "cl_khr_gl_depth_images");
   delete [] devices;
 
   return error;

--- a/test_conformance/gles/setup_egl.cpp
+++ b/test_conformance/gles/setup_egl.cpp
@@ -163,15 +163,8 @@ public:
         }
 
         // Check all devices, search for one that supports cl_khr_gl_sharing
-        char extensions[8192];
         for (int i=0; i<(int)num_of_devices; i++) {
-            error = clGetDeviceInfo(devices[i], CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
-            if (error) {
-                print_error(error, "clGetDeviceInfo failed");
-                return -1;
-            }
-
-            if (strstr(extensions, "cl_khr_gl_sharing ") == NULL) {
+            if (!is_extension_available(devices[i], "cl_khr_gl_sharing"){
                 log_info("Device %d of %d does not support required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
             } else {
                 log_info("Device %d of %d supports required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);

--- a/test_conformance/half/cl_utils.cpp
+++ b/test_conformance/half/cl_utils.cpp
@@ -95,30 +95,8 @@ test_status InitCL( cl_device_id device )
         gDeviceFrequency = 1;
 
     // Check extensions
-    size_t extSize = 0;
-    int hasDouble = 0;
-    if((error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, 0, NULL, &extSize)))
-    {   vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
-    else
-    {
-        char *ext = (char *)malloc( extSize );
-        if( NULL == ext )
-        { vlog_error( "malloc failed at %s:%d\nUnable to determine if double present.\n", __FILE__, __LINE__ ); }
-        else
-        {
-            if((error = clGetDeviceInfo( device, CL_DEVICE_EXTENSIONS, extSize, ext, NULL)))
-            {    vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
-            else
-            {
-                if( strstr( ext, "cl_khr_fp64" ))
-                    hasDouble = 1;
-            }
-            free(ext);
-        }
-    }
+    int hasDouble = is_extension_available(device, "cl_khr_fp64");
     gTestDouble ^= hasDouble;
-
-
 
     //detect whether profile of the device is embedded
     char profile[64] = "";

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -1201,98 +1201,77 @@ test_status InitCL( cl_device_id device )
         gComputeDevices = 1;
 
     // Check extensions
-    size_t extSize = 0;
-    if((error = clGetDeviceInfo( gDevice, CL_DEVICE_EXTENSIONS, 0, NULL, &extSize)))
-    {   vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
-    else
+    if(is_extension_available(gDevice, "cl_khr_fp64"))
     {
-        char *ext = (char*) malloc( extSize );
-        if( NULL == ext )
-        { vlog_error( "malloc failed at %s:%d\nUnable to determine if double present.\n", __FILE__, __LINE__ ); }
-        else
+        gHasDouble ^= 1;
+#if defined( CL_DEVICE_DOUBLE_FP_CONFIG )
+        if( (error = clGetDeviceInfo(gDevice, CL_DEVICE_DOUBLE_FP_CONFIG, sizeof(gDoubleCapabilities), &gDoubleCapabilities, NULL)))
         {
-            if((error = clGetDeviceInfo( gDevice, CL_DEVICE_EXTENSIONS, extSize, ext, NULL)))
-            {    vlog_error( "Unable to get device extension string to see if double present. (%d) \n", error ); }
-            else
-            {
-                if( strstr( ext, "cl_khr_fp64" ))
-                {
-                    gHasDouble ^= 1;
-
-#if defined( CL_DEVICE_DOUBLE_FP_CONFIG )
-                    if( (error = clGetDeviceInfo(gDevice, CL_DEVICE_DOUBLE_FP_CONFIG, sizeof(gDoubleCapabilities), &gDoubleCapabilities, NULL)))
-                    {
-                        vlog_error( "ERROR: Unable to get device CL_DEVICE_DOUBLE_FP_CONFIG. (%d)\n", error );
-                        return TEST_FAIL;
-                    }
-
-                    if( DOUBLE_REQUIRED_FEATURES != (gDoubleCapabilities & DOUBLE_REQUIRED_FEATURES) )
-                    {
-                        char list[300] = "";
-                        if( 0 == (gDoubleCapabilities & CL_FP_FMA) )
-                            strncat( list, "CL_FP_FMA, ", sizeof( list )-1 );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_NEAREST) )
-                            strncat( list, "CL_FP_ROUND_TO_NEAREST, ", sizeof( list )-1 );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_ZERO) )
-                            strncat( list, "CL_FP_ROUND_TO_ZERO, ", sizeof( list )-1 );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_INF) )
-                            strncat( list, "CL_FP_ROUND_TO_INF, ", sizeof( list )-1 );
-                        if( 0 == (gDoubleCapabilities & CL_FP_INF_NAN) )
-                            strncat( list, "CL_FP_INF_NAN, ", sizeof( list )-1 );
-                        if( 0 == (gDoubleCapabilities & CL_FP_DENORM) )
-                            strncat( list, "CL_FP_DENORM, ", sizeof( list )-1 );
-                        vlog_error( "ERROR: required double features are missing: %s\n", list );
-
-                        free(ext);
-                        return TEST_FAIL;
-                    }
-#else
-                    vlog_error( "FAIL: device says it supports cl_khr_fp64 but CL_DEVICE_DOUBLE_FP_CONFIG is not in the headers!\n" );
-                    return TEST_FAIL;
-#endif
-                }
-#if defined( __APPLE__ )
-                else if( strstr( ext, "cl_APPLE_fp64_basic_ops" ))
-                {
-                    gHasBasicDouble ^= 1;
-
-#if defined( CL_DEVICE_DOUBLE_FP_CONFIG )
-                    if( (error = clGetDeviceInfo(gDevice, CL_DEVICE_DOUBLE_FP_CONFIG, sizeof(gDoubleCapabilities), &gDoubleCapabilities, NULL)))
-                    {
-                        vlog_error( "ERROR: Unable to get device CL_DEVICE_DOUBLE_FP_CONFIG. (%d)\n", error );
-                        return TEST_FAIL;
-                    }
-
-                    if( DOUBLE_REQUIRED_FEATURES != (gDoubleCapabilities & DOUBLE_REQUIRED_FEATURES) )
-                    {
-                        char list[300] = "";
-                        if( 0 == (gDoubleCapabilities & CL_FP_FMA) )
-                            strncat( list, "CL_FP_FMA, ", sizeof( list ) );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_NEAREST) )
-                            strncat( list, "CL_FP_ROUND_TO_NEAREST, ", sizeof( list ) );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_ZERO) )
-                            strncat( list, "CL_FP_ROUND_TO_ZERO, ", sizeof( list ) );
-                        if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_INF) )
-                            strncat( list, "CL_FP_ROUND_TO_INF, ", sizeof( list ) );
-                        if( 0 == (gDoubleCapabilities & CL_FP_INF_NAN) )
-                            strncat( list, "CL_FP_INF_NAN, ", sizeof( list ) );
-                        if( 0 == (gDoubleCapabilities & CL_FP_DENORM) )
-                            strncat( list, "CL_FP_DENORM, ", sizeof( list ) );
-                        vlog_error( "ERROR: required double features are missing: %s\n", list );
-
-                        free(ext);
-                        return TEST_FAIL;
-                    }
-#else
-                    vlog_error( "FAIL: device says it supports cl_khr_fp64 but CL_DEVICE_DOUBLE_FP_CONFIG is not in the headers!\n" );
-                    return TEST_FAIL;
-#endif
-                }
-#endif /* __APPLE__ */
-            }
-            free(ext);
+            vlog_error( "ERROR: Unable to get device CL_DEVICE_DOUBLE_FP_CONFIG. (%d)\n", error );
+            return TEST_FAIL;
         }
+
+        if( DOUBLE_REQUIRED_FEATURES != (gDoubleCapabilities & DOUBLE_REQUIRED_FEATURES) )
+        {
+            char list[300] = "";
+            if( 0 == (gDoubleCapabilities & CL_FP_FMA) )
+                strncat( list, "CL_FP_FMA, ", sizeof( list )-1 );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_NEAREST) )
+                strncat( list, "CL_FP_ROUND_TO_NEAREST, ", sizeof( list )-1 );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_ZERO) )
+                strncat( list, "CL_FP_ROUND_TO_ZERO, ", sizeof( list )-1 );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_INF) )
+                strncat( list, "CL_FP_ROUND_TO_INF, ", sizeof( list )-1 );
+            if( 0 == (gDoubleCapabilities & CL_FP_INF_NAN) )
+                strncat( list, "CL_FP_INF_NAN, ", sizeof( list )-1 );
+            if( 0 == (gDoubleCapabilities & CL_FP_DENORM) )
+                strncat( list, "CL_FP_DENORM, ", sizeof( list )-1 );
+            vlog_error( "ERROR: required double features are missing: %s\n", list );
+
+            return TEST_FAIL;
+        }
+#else
+        vlog_error( "FAIL: device says it supports cl_khr_fp64 but CL_DEVICE_DOUBLE_FP_CONFIG is not in the headers!\n" );
+        return TEST_FAIL;
+#endif
     }
+#if defined( __APPLE__ )
+    else if(is_extension_available(gDevice, "cl_APPLE_fp64_basic_ops" ))
+    {
+        gHasBasicDouble ^= 1;
+
+#if defined( CL_DEVICE_DOUBLE_FP_CONFIG )
+        if( (error = clGetDeviceInfo(gDevice, CL_DEVICE_DOUBLE_FP_CONFIG, sizeof(gDoubleCapabilities), &gDoubleCapabilities, NULL)))
+        {
+            vlog_error( "ERROR: Unable to get device CL_DEVICE_DOUBLE_FP_CONFIG. (%d)\n", error );
+            return TEST_FAIL;
+        }
+
+        if( DOUBLE_REQUIRED_FEATURES != (gDoubleCapabilities & DOUBLE_REQUIRED_FEATURES) )
+        {
+            char list[300] = "";
+            if( 0 == (gDoubleCapabilities & CL_FP_FMA) )
+                strncat( list, "CL_FP_FMA, ", sizeof( list ) );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_NEAREST) )
+                strncat( list, "CL_FP_ROUND_TO_NEAREST, ", sizeof( list ) );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_ZERO) )
+                strncat( list, "CL_FP_ROUND_TO_ZERO, ", sizeof( list ) );
+            if( 0 == (gDoubleCapabilities & CL_FP_ROUND_TO_INF) )
+                strncat( list, "CL_FP_ROUND_TO_INF, ", sizeof( list ) );
+            if( 0 == (gDoubleCapabilities & CL_FP_INF_NAN) )
+                strncat( list, "CL_FP_INF_NAN, ", sizeof( list ) );
+            if( 0 == (gDoubleCapabilities & CL_FP_DENORM) )
+                strncat( list, "CL_FP_DENORM, ", sizeof( list ) );
+            vlog_error( "ERROR: required double features are missing: %s\n", list );
+
+            return TEST_FAIL;
+        }
+#else
+        vlog_error( "FAIL: device says it supports cl_khr_fp64 but CL_DEVICE_DOUBLE_FP_CONFIG is not in the headers!\n" );
+        return TEST_FAIL;
+#endif
+    }
+#endif /* __APPLE__ */
 
     configSize = sizeof( gDeviceFrequency );
     if( (error = clGetDeviceInfo( gDevice, CL_DEVICE_MAX_CLOCK_FREQUENCY, configSize, &gDeviceFrequency, NULL )) )

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -366,35 +366,7 @@ static bool isLongSupported(cl_device_id device_id)
 
     if(!strcmp("EMBEDDED_PROFILE",profileType.get()))
     {
-        // Device extention
-        status = clGetDeviceInfo(
-            device_id,
-            CL_DEVICE_EXTENSIONS,
-            0,
-            NULL,
-            &tempSize);
-
-        if(status != CL_SUCCESS)
-        {
-            log_error("*** clGetDeviceInfo FAILED ***\n\n");
-            return false;
-        }
-
-        std::unique_ptr<char[]> devExt(new char[tempSize]);
-        if(devExt == NULL)
-        {
-            log_error("Failed to allocate memory(devExt)");
-            return false;
-        }
-
-        status = clGetDeviceInfo(
-            device_id,
-            CL_DEVICE_EXTENSIONS,
-            sizeof(char) * tempSize,
-            devExt.get(),
-            NULL);
-
-        extSupport  = (strstr(devExt.get(),"cles_khr_int64") != NULL);
+        extSupport = is_extension_available(device_id, "cles_khr_int64");
     }
     return extSupport;
 }

--- a/test_extensions/media_sharing/main.cpp
+++ b/test_extensions/media_sharing/main.cpp
@@ -116,7 +116,7 @@ bool DetectPlatformAndDevice()
 
     for (size_t j = 0; j < devicesNum; ++j)
     {
-      if (ExtensionCheck("cl_khr_dx9_media_sharing", devices[j]))
+      if (is_extension_available(devices[j], "cl_khr_dx9_media_sharing"))
       {
         gPlatformIDdetected = platforms[i];
         gDeviceIDdetected = devices[j];

--- a/test_extensions/media_sharing/utils.cpp
+++ b/test_extensions/media_sharing/utils.cpp
@@ -67,37 +67,6 @@ void CResult::ResultSub( TTestResult result )
     _result = result;
 }
 
-bool ExtensionCheck(const std::string &extension, cl_device_id deviceID)
-{
-  std::string extensions;
-  size_t size = 0;
-  cl_int error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, 0, 0, &size);
-  if (error != CL_SUCCESS)
-  {
-    print_error(error, "clGetDeviceInfo failed\n");
-    return false;
-  }
-
-  if (size == 0)
-  {
-    print_error(error, "Invalid extension string size\n");
-    return false;
-  }
-
-  extensions.resize(size);
-  error = clGetDeviceInfo(deviceID, CL_DEVICE_EXTENSIONS, size, &extensions[0], 0);
-  if (error != CL_SUCCESS)
-  {
-    print_error(error, "clGetDeviceInfo failed\n");
-    return false;
-  }
-
-  if (extensions.find(extension) != std::string::npos)
-    return true;
-
-  return false;
-}
-
 void FunctionContextCreateToString(TContextFuncType contextCreateFunction, std::string &contextFunction)
 {
   switch(contextCreateFunction)

--- a/test_extensions/media_sharing/utils.h
+++ b/test_extensions/media_sharing/utils.h
@@ -98,7 +98,6 @@ private:
   TTestResult _resultLast;
 };
 
-bool ExtensionCheck(const std::string &extension, cl_device_id deviceID);
 void FunctionContextCreateToString(TContextFuncType contextCreateFunction, std::string &contextFunction);
 void AdapterToString(cl_dx9_media_adapter_type_khr adapterType, std::string &adapter);
 cl_context_info AdapterTypeToContextInfo(cl_dx9_media_adapter_type_khr adapterType);


### PR DESCRIPTION
(Patch2)
A number of tests have got their own code for checking the presence of
extensions. This change replaces that code with is_extension_available
function.

Contributes to #627

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>