### PR TITLE
API: Fixed condition based on is_extension_available.

### DIFF
--- a/test_conformance/api/test_queue_properties.cpp
+++ b/test_conformance/api/test_queue_properties.cpp
@@ -111,7 +111,7 @@ int test_queue_properties(cl_device_id deviceID, cl_context context, cl_command_
     cl_queue_properties_khr queue_prop_def[] = { CL_QUEUE_PROPERTIES, 0, 0 };
 
     // Query extension
-    if (is_extension_available(deviceID, "cl_khr_create_command_queue"))
+    if (!is_extension_available(deviceID, "cl_khr_create_command_queue"))
     {
         log_info("extension cl_khr_create_command_queue is not supported.\n");
         return 0;


### PR DESCRIPTION
enqueue_kernel was being run when the cl_khr_create_command_queue was *not* present. The test should only be run when the extension *is* present.

Regressed in 93e76a8a4a7d63b7e507ac72ae13a7e755cbda88.