### PR TITLE
Fix minor resource leaks in test_api.

### DIFF
--- a/test_conformance/api/test_bool.cpp
+++ b/test_conformance/api/test_bool.cpp
@@ -38,8 +38,8 @@ const char *kernel_with_bool[] = {
 int test_bool_type(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
 
-    cl_program program;
-    cl_kernel kernel;
+    clProgramWrapper program;
+    clKernelWrapper kernel;
 
     int err = create_single_kernel_helper(context,
                       &program,

--- a/test_conformance/api/test_kernel_arg_info.cpp
+++ b/test_conformance/api/test_kernel_arg_info.cpp
@@ -5585,15 +5585,14 @@ const char * long_arg_info[][72] = {
 template<typename arg_info_t>
 int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, cl_uint lines_count, arg_info_t arg_info, size_t total_kernels_in_program) {
 
-  cl_program program;
-    cl_kernel kernel;
     const size_t max_name_len = 512;
     cl_char name[ max_name_len ];
     cl_uint arg_count, numArgs;
     size_t i, j, size;
     int error;
 
-  program = clCreateProgramWithSource( context, lines_count, kernel_args, NULL, &error );
+    clProgramWrapper program =
+    clCreateProgramWithSource(context, lines_count, kernel_args, NULL, &error);
     if ( program == NULL || error != CL_SUCCESS )
     {
         print_error( error, "Unable to create required arguments kernel program" );
@@ -5704,7 +5703,7 @@ int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, c
     {
         int kernel_rc = 0;
         const char* kernel_name = arg_info[ i ][ 0 ];
-        kernel = clCreateKernel( program, kernel_name, &error );
+        clKernelWrapper kernel = clCreateKernel(program, kernel_name, &error);
         if( kernel == NULL || error != CL_SUCCESS )
         {
             log_error( "ERROR: Could not get kernel: %s\n", kernel_name );
@@ -5824,8 +5823,6 @@ int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, c
 
 int    test_get_kernel_arg_info( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    clProgramWrapper program;
-    clKernelWrapper kernel;
     size_t size;
     int error;
 

--- a/test_conformance/api/test_kernel_arg_info_compatibility.cpp
+++ b/test_conformance/api/test_kernel_arg_info_compatibility.cpp
@@ -4842,15 +4842,14 @@ static const char * half_arg_info[][77] = {
 template<typename arg_info_t>
 int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, cl_uint lines_count, arg_info_t arg_info, size_t total_kernels_in_program) {
 
-  cl_program program;
-    cl_kernel kernel;
     const size_t max_name_len = 512;
     cl_char name[ max_name_len ];
     cl_uint arg_count, numArgs;
     size_t i, j, size;
     int error;
 
-  program = clCreateProgramWithSource( context, lines_count, kernel_args, NULL, &error );
+    clProgramWrapper program =
+    clCreateProgramWithSource(context, lines_count, kernel_args, NULL, &error);
     if ( program == NULL || error != CL_SUCCESS )
     {
         print_error( error, "Unable to create required arguments kernel program" );
@@ -4961,7 +4960,7 @@ int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, c
     {
         int kernel_rc = 0;
         const char* kernel_name = arg_info[ i ][ 0 ];
-        kernel = clCreateKernel( program, kernel_name, &error );
+        clKernelWrapper kernel = clCreateKernel(program, kernel_name, &error);
         if( kernel == NULL || error != CL_SUCCESS )
         {
             log_error( "ERROR: Could not get kernel: %s\n", kernel_name );
@@ -5081,8 +5080,6 @@ int test(cl_device_id deviceID, cl_context context, kernel_args_t kernel_args, c
 
 int test_get_kernel_arg_info_compatibility( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements )
 {
-    clProgramWrapper program;
-    clKernelWrapper kernel;
     size_t size;
     int error;
 


### PR DESCRIPTION
Added some missing clProgramWrapper/clkernelWrapper, to avoid 
resource leaks.

Signed-off-by: John Kesapides <john.kesapides@arm.com>