### PR TITLE
Use clang-format-9 for Travis CI formatting checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,12 @@ os:
 jobs:
   include:
   - os: linux
+    dist: bionic
     env: JOB_CHECK_FORMAT=1
+    addons:
+        apt:
+          packages:
+            - clang-format-9
   - os: linux
     env: JOB_ARCHITECTURE=arm
   - os: linux

--- a/check-format.sh
+++ b/check-format.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 # Run git-clang-format to check for violations
-CLANG_FORMAT_OUTPUT=$(git-clang-format --diff origin/master --extensions c,cpp,h,hpp)
+if [ "$TRAVIS" == "true" ]; then
+    EXTRA_OPTS="--binary `which clang-format-9`"
+fi
+CLANG_FORMAT_OUTPUT=$(git-clang-format --diff origin/master --extensions c,cpp,h,hpp $EXTRA_OPTS)
 
 # Check for no-ops
 grep '^no modified files to format$' <<<"$CLANG_FORMAT_OUTPUT" && exit 0


### PR DESCRIPTION
The default version on Xenial is old, and it doesn't understand the non-boolean version of `AllowShortIfStatementsOnASingleLine`.