### PR TITLE
Use std::string for get_device_*_string helpers

### DIFF
--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -13,13 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include <stdexcept>
+#include <vector>
+
 #include "deviceInfo.h"
 #include "errorHelpers.h"
 #include "typeWrappers.h"
 
-/* Helper to allocate and return a buffer containing device information for the specified device info parameter. */
-static void *alloc_and_get_device_info( cl_device_id device, cl_device_info param_name, const char *param_description )
+/* Helper to return a string containing device information for the specified
+ * device info parameter. */
+static std::string get_device_info(cl_device_id device,
+                                   cl_device_info param_name)
 {
     size_t size = 0;
     int err;
@@ -29,44 +34,40 @@ static void *alloc_and_get_device_info( cl_device_id device, cl_device_info para
         throw std::runtime_error("clGetDeviceInfo failed\n");
     }
 
-    if (0 == size)
-        return NULL;
+    if (0 == size) return "";
 
-    auto buffer = new uint8_t[size];
+    std::vector<char> info(size);
 
-    if ((err = clGetDeviceInfo(device, param_name, size, buffer, NULL)) != CL_SUCCESS)
+    if ((err = clGetDeviceInfo(device, param_name, size, info.data(), NULL))
+        != CL_SUCCESS)
     {
-        delete [] buffer;
         throw std::runtime_error("clGetDeviceInfo failed\n");
     }
 
-    return buffer;
+    return std::string(info.begin(), info.end());
 }
 
 /* Determines if an extension is supported by a device. */
 int is_extension_available(cl_device_id device, const char *extensionName)
 {
-    char *extString = alloc_and_get_device_extensions_string(device);
-
-    BufferOwningPtr<char> extStringBuf(extString);
-
-    return strstr(extString, extensionName) != NULL;
+    std::string extString = get_device_extensions_string(device);
+    return extString.find(extensionName) != std::string::npos;
 }
 
-/* Returns a newly allocated C string containing the supported extensions list for a device. */
-char *alloc_and_get_device_extensions_string(cl_device_id device)
+/* Returns a string containing the supported extensions list for a device. */
+std::string get_device_extensions_string(cl_device_id device)
 {
-    return (char *) alloc_and_get_device_info(device, CL_DEVICE_EXTENSIONS, "extensions string");
+    return get_device_info(device, CL_DEVICE_EXTENSIONS);
 }
 
-/* Returns a newly allocated C string containing the supported IL version(s) for a device. */
-char *alloc_and_get_device_il_version_string(cl_device_id device)
+/* Returns a string containing the supported IL version(s) for a device. */
+std::string get_device_il_version_string(cl_device_id device)
 {
-    return (char *) alloc_and_get_device_info(device, CL_DEVICE_IL_VERSION, "IL version string");
+    return get_device_info(device, CL_DEVICE_IL_VERSION);
 }
 
-/* Returns a newly allocated C string containing the supported OpenCL version for a device. */
-char *alloc_and_get_device_version_string(cl_device_id device)
+/* Returns a string containing the supported OpenCL version for a device. */
+std::string get_device_version_string(cl_device_id device)
 {
-    return (char *) alloc_and_get_device_info(device, CL_DEVICE_VERSION, "version string");
+    return get_device_info(device, CL_DEVICE_VERSION);
 }

--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -30,12 +30,12 @@ static std::string get_device_info_string(cl_device_id device,
     size_t size = 0;
     int err;
 
-    if ((err = clGetDeviceInfo(device, param_name, 0, NULL, &size)) != CL_SUCCESS)
+    if ((err = clGetDeviceInfo(device, param_name, 0, NULL, &size))
+        != CL_SUCCESS
+        || size == 0)
     {
         throw std::runtime_error("clGetDeviceInfo failed\n");
     }
-
-    if (0 == size) return "";
 
     std::vector<char> info(size);
 

--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -23,8 +23,8 @@
 
 /* Helper to return a string containing device information for the specified
  * device info parameter. */
-static std::string get_device_info(cl_device_id device,
-                                   cl_device_info param_name)
+static std::string get_device_info_string(cl_device_id device,
+                                          cl_device_info param_name)
 {
     size_t size = 0;
     int err;
@@ -57,17 +57,17 @@ int is_extension_available(cl_device_id device, const char *extensionName)
 /* Returns a string containing the supported extensions list for a device. */
 std::string get_device_extensions_string(cl_device_id device)
 {
-    return get_device_info(device, CL_DEVICE_EXTENSIONS);
+    return get_device_info_string(device, CL_DEVICE_EXTENSIONS);
 }
 
 /* Returns a string containing the supported IL version(s) for a device. */
 std::string get_device_il_version_string(cl_device_id device)
 {
-    return get_device_info(device, CL_DEVICE_IL_VERSION);
+    return get_device_info_string(device, CL_DEVICE_IL_VERSION);
 }
 
 /* Returns a string containing the supported OpenCL version for a device. */
 std::string get_device_version_string(cl_device_id device)
 {
-    return get_device_info(device, CL_DEVICE_VERSION);
+    return get_device_info_string(device, CL_DEVICE_VERSION);
 }

--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 
@@ -51,7 +52,14 @@ static std::string get_device_info_string(cl_device_id device,
 int is_extension_available(cl_device_id device, const char *extensionName)
 {
     std::string extString = get_device_extensions_string(device);
-    return extString.find(extensionName) != std::string::npos;
+    std::istringstream ss(extString);
+    while (ss)
+    {
+        std::string found;
+        ss >> found;
+        if (found == extensionName) return true;
+    }
+    return false;
 }
 
 /* Returns a string containing the supported extensions list for a device. */

--- a/test_common/harness/deviceInfo.h
+++ b/test_common/harness/deviceInfo.h
@@ -19,6 +19,8 @@
 // Configuration
 #include "../config.hpp"
 
+#include <string>
+
 #include <CL/opencl.h>
 
 #ifdef __cplusplus
@@ -28,14 +30,14 @@ extern "C" {
 /* Determines if an extension is supported by a device. */
 int is_extension_available(cl_device_id device, const char *extensionName);
 
-/* Returns a newly allocated C string containing the supported extensions list for a device. */
-char *alloc_and_get_device_extensions_string(cl_device_id device);
+/* Returns a string containing the supported extensions list for a device. */
+std::string get_device_extensions_string(cl_device_id device);
 
-/* Returns a newly allocated C string containing the supported IL version(s) for a device. */
-char *alloc_and_get_device_il_version_string(cl_device_id device);
+/* Returns a string containing the supported IL version(s) for a device. */
+std::string get_device_il_version_string(cl_device_id device);
 
-/* Returns a newly allocated C string containing the supported OpenCL version for a device. */
-char *alloc_and_get_device_version_string(cl_device_id device);
+/* Returns a string containing the supported OpenCL version for a device. */
+std::string get_device_version_string(cl_device_id device);
 
 #ifdef __cplusplus
 }

--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -356,21 +356,17 @@ static std::string get_khronos_compiler_command(const cl_uint device_address_spa
 static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint device_address_space_size,
                                      const CompilationMode compilationMode, std::string &clDeviceInfo)
 {
-    char *extensionsString = alloc_and_get_device_extensions_string(device);
-    if ( NULL == extensionsString )
+    std::string extensionsString = get_device_extensions_string(device);
+    if (extensionsString.empty())
     {
         return -1;
     }
 
-    BufferOwningPtr<char> extensionsStringBuf(extensionsString);
-
-    char *versionString = alloc_and_get_device_version_string(device);
-    if ( NULL == versionString )
+    std::string versionString = get_device_version_string(device);
+    if (versionString.empty())
     {
         return -1;
     }
-
-    BufferOwningPtr<char> versionStringBuf(versionString);
 
     std::ostringstream clDeviceInfoStream;
     std::string file_type = get_offline_compilation_file_type_str(compilationMode);
@@ -381,13 +377,11 @@ static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint de
     * that will be loaded with clCreateProgramWithIL() */
     if (compilationMode == kSpir_v)
     {
-        char *ilVersionString = alloc_and_get_device_il_version_string(device);
-        if ( NULL == ilVersionString )
+        std::string ilVersionString = get_device_il_version_string(device);
+        if (ilVersionString.empty())
         {
             return -1;
         }
-
-        BufferOwningPtr<char> versionStringBuf(ilVersionString);
 
         clDeviceInfoStream << "CL_DEVICE_IL_VERSION=\"" << ilVersionString << "\"" << std::endl;
     }

--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -357,16 +357,7 @@ static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint de
                                      const CompilationMode compilationMode, std::string &clDeviceInfo)
 {
     std::string extensionsString = get_device_extensions_string(device);
-    if (extensionsString.empty())
-    {
-        return -1;
-    }
-
     std::string versionString = get_device_version_string(device);
-    if (versionString.empty())
-    {
-        return -1;
-    }
 
     std::ostringstream clDeviceInfoStream;
     std::string file_type = get_offline_compilation_file_type_str(compilationMode);
@@ -378,11 +369,6 @@ static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint de
     if (compilationMode == kSpir_v)
     {
         std::string ilVersionString = get_device_il_version_string(device);
-        if (ilVersionString.empty())
-        {
-            return -1;
-        }
-
         clDeviceInfoStream << "CL_DEVICE_IL_VERSION=\"" << ilVersionString << "\"" << std::endl;
     }
     clDeviceInfoStream << "CL_DEVICE_VERSION=\"" << versionString << "\"" << std::endl;


### PR DESCRIPTION
Removes need to use BufferOwningPtr to avoid memory leaks.

Contributes to #723. 