### PR TITLE
Remove duplicate format functions

### DIFF
--- a/test_conformance/images/clCopyImage/CMakeLists.txt
+++ b/test_conformance/images/clCopyImage/CMakeLists.txt
@@ -12,6 +12,7 @@ set(${MODULE_NAME}_SOURCES
     test_copy_3D_2D_array.cpp
     test_copy_generic.cpp
     test_loops.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
@@ -35,79 +36,6 @@ extern int test_copy_image_set_2D_array( cl_device_id device, cl_context context
 extern int test_copy_image_set_2D_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
 extern int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
 extern int test_copy_image_set_3D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse );
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded this via the command line?
-        if( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-    // Have we already discarded the channel order via the command line?
-        if( gChannelOrderToUse != (cl_channel_order)-1 && gChannelOrderToUse != formatList[ j ].image_channel_order )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-      int i;
-      for( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-      {
-        if( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-        {
-          numSupported++;
-          break;
-        }
-      }
-      if( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-      {
-        // Format is NOT supported, so mark it as such
-        filterFlags[ j ] = true;
-      }
-    }
-    return numSupported;
-}
-
-int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error;
-
-    cl_image_format tempList[ 128 ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       imageType, 128, tempList, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       imageType, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-    return 0;
-}
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {

--- a/test_conformance/images/clFillImage/CMakeLists.txt
+++ b/test_conformance/images/clFillImage/CMakeLists.txt
@@ -11,6 +11,7 @@ set(${MODULE_NAME}_SOURCES
     test_loops.cpp
     test_fill_3D.cpp
 #    test_fill_2D_3D.cpp
+    ../common.cpp
 )
 
 

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 extern bool               gDebugTrace;
 extern cl_filter_mode     gFilterModeToUse;
@@ -29,84 +30,6 @@ extern int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_c
 extern int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
 extern int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
 extern int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for ( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if ( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded this via the command line?
-        if ( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-    // Have we already discarded the channel order via the command line?
-        if ( gChannelOrderToUse != (cl_channel_order)-1 && gChannelOrderToUse != formatList[ j ].image_channel_order )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-        int i;
-        for ( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-        {
-            if ( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-            {
-                numSupported++;
-                break;
-            }
-        }
-        if ( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-        {
-            // Format is NOT supported, so mark it as such
-            filterFlags[ j ] = true;
-        }
-
-
-    }
-    return numSupported;
-}
-
-
-int get_format_list( cl_context context, cl_mem_object_type image_type, cl_image_format * &outFormatList,
-                    unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error;
-
-    cl_image_format tempList[ 128 ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       image_type, 128, tempList, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       image_type, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-    return 0;
-}
-
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {

--- a/test_conformance/images/clGetInfo/CMakeLists.txt
+++ b/test_conformance/images/clGetInfo/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${MODULE_NAME}_SOURCES
     test_2D.cpp
     test_loops.cpp
     test_3D.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -30,6 +30,7 @@ bool gTestSmallImages;
 bool gTestMaxImages;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
+cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_mem_object_type image_type );
 static void printUsage( const char *execName );

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "harness/imageHelpers.h"
 #include <algorithm>
 #include <iterator>
@@ -32,12 +33,6 @@ extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_i
 extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
 extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
 extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
-
-static const char *str_1d_image = "1D";
-static const char *str_2d_image = "2D";
-static const char *str_3d_image = "3D";
-static const char *str_1d_image_array = "1D array";
-static const char *str_2d_image_array = "2D array";
 
 static bool check_minimum_supported(cl_image_format *formatList,
                                     unsigned int numFormats,
@@ -61,97 +56,6 @@ static bool check_minimum_supported(cl_image_format *formatList,
 	}
 
 	return passed;
-}
-
-static const char *convert_image_type_to_string(cl_mem_object_type image_type)
-{
-    const char *p;
-    switch (image_type)
-    {
-        case CL_MEM_OBJECT_IMAGE1D:
-            p = str_1d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D:
-            p = str_2d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE3D:
-            p = str_3d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            p = str_1d_image_array;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            p = str_2d_image_array;
-            break;
-    }
-    return p;
-}
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded this via the command line?
-        if( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-        int i;
-        for( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-        {
-            if( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-            {
-                numSupported++;
-                break;
-            }
-        }
-        if( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-        {
-            // Format is NOT supported, so mark it as such
-            filterFlags[ j ] = true;
-        }
-    }
-    return numSupported;
-}
-
-int get_format_list( cl_context context, cl_mem_object_type image_type, cl_image_format * &outFormatList,
-                                                         unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error;
-
-    cl_image_format tempList[ 128 ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       image_type, 128, tempList, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                        image_type, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-    return 0;
 }
 
 int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type image_type, cl_mem_flags flags )

--- a/test_conformance/images/clReadWriteImage/CMakeLists.txt
+++ b/test_conformance/images/clReadWriteImage/CMakeLists.txt
@@ -8,6 +8,7 @@ set(${MODULE_NAME}_SOURCES
     test_read_2D_array.cpp
     test_loops.cpp
     test_read_3D.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -32,6 +32,7 @@ bool gUseRamp;
 bool gTestMipmaps;
 int  gTypesToTest;
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
+cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 bool            gEnablePitch = false;
 
 #define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
@@ -30,102 +31,6 @@ extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_c
 extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-
-static const char *str_1d_image = "1D";
-static const char *str_2d_image = "2D";
-static const char *str_3d_image = "3D";
-static const char *str_1d_image_array = "1D array";
-static const char *str_2d_image_array = "2D array";
-
-static const char *convert_image_type_to_string(cl_mem_object_type imageType)
-{
-    const char *p;
-    switch (imageType)
-    {
-        case CL_MEM_OBJECT_IMAGE1D:
-            p = str_1d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D:
-            p = str_2d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE3D:
-            p = str_3d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            p = str_1d_image_array;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            p = str_2d_image_array;
-            break;
-    }
-    return p;
-}
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded this via the command line?
-        if( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-        int i;
-        for( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-        {
-            if( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-            {
-                numSupported++;
-                break;
-            }
-        }
-        if( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-        {
-            // Format is NOT supported, so mark it as such
-            filterFlags[ j ] = true;
-        }
-    }
-    return numSupported;
-}
-
-int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error;
-
-    cl_image_format tempList[ 128 ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       imageType, 128, tempList, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                        imageType, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-    return 0;
-}
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
 {

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "common.h"
+
+const char *convert_image_type_to_string(cl_mem_object_type image_type)
+{
+    switch (image_type)
+    {
+        case CL_MEM_OBJECT_IMAGE1D: return "1D";
+        case CL_MEM_OBJECT_IMAGE2D: return "2D";
+        case CL_MEM_OBJECT_IMAGE3D: return "3D";
+        case CL_MEM_OBJECT_IMAGE1D_ARRAY: return "1D array";
+        case CL_MEM_OBJECT_IMAGE2D_ARRAY: return "2D array";
+        case CL_MEM_OBJECT_IMAGE1D_BUFFER: return "1D image buffer";
+        default: return "unrecognized object type";
+    }
+}
+
+int filter_formats(cl_image_format *formatList, bool *filterFlags,
+                   unsigned int formatCount,
+                   cl_channel_type *channelDataTypesToFilter,
+                   bool testMipmaps /*=false*/)
+{
+    int numSupported = 0;
+    for (unsigned int j = 0; j < formatCount; j++)
+    {
+        // If this format has been previously filtered, remove the filter
+        if (filterFlags[j]) filterFlags[j] = false;
+
+        // skip mipmap tests for CL_DEPTH formats (re# Khronos Bug 13762)
+        if (testMipmaps && (formatList[j].image_channel_order == CL_DEPTH))
+        {
+            log_info("Skip mipmap tests for CL_DEPTH format\n");
+            filterFlags[j] = true;
+            continue;
+        }
+
+        // Have we already discarded the channel type via the command line?
+        if (gChannelTypeToUse != (cl_channel_type)-1
+            && gChannelTypeToUse != formatList[j].image_channel_data_type)
+        {
+            filterFlags[j] = true;
+            continue;
+        }
+
+        // Have we already discarded the channel order via the command line?
+        if (gChannelOrderToUse != (cl_channel_order)-1
+            && gChannelOrderToUse != formatList[j].image_channel_order)
+        {
+            filterFlags[j] = true;
+            continue;
+        }
+
+        // Is given format standard channel order and type given by spec. We
+        // don't want to test it if this is vendor extension
+        if (!IsChannelOrderSupported(formatList[j].image_channel_order)
+            || !IsChannelTypeSupported(formatList[j].image_channel_data_type))
+        {
+            filterFlags[j] = true;
+            continue;
+        }
+
+        if (!channelDataTypesToFilter)
+        {
+            numSupported++;
+            continue;
+        }
+
+        // Is the format supported?
+        int i;
+        for (i = 0; channelDataTypesToFilter[i] != (cl_channel_type)-1; i++)
+        {
+            if (formatList[j].image_channel_data_type
+                == channelDataTypesToFilter[i])
+            {
+                numSupported++;
+                break;
+            }
+        }
+        if (channelDataTypesToFilter[i] == (cl_channel_type)-1)
+        {
+            // Format is NOT supported, so mark it as such
+            filterFlags[j] = true;
+        }
+    }
+    return numSupported;
+}
+
+int get_format_list(cl_context context, cl_mem_object_type imageType,
+                    cl_image_format *&outFormatList,
+                    unsigned int &outFormatCount, cl_mem_flags flags)
+{
+    int error = clGetSupportedImageFormats(context, flags, imageType, 0, NULL,
+                                           &outFormatCount);
+    test_error(error, "Unable to get count of supported image formats");
+
+    outFormatList =
+    (outFormatCount > 0) ? new cl_image_format[outFormatCount] : NULL;
+
+    error = clGetSupportedImageFormats(context, flags, imageType,
+                                       outFormatCount, outFormatList, NULL);
+    test_error(error, "Unable to get list of supported image formats");
+    return 0;
+}

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef IMAGES_COMMON_H
+#define IMAGES_COMMON_H
+
+#include "harness/kernelHelpers.h"
+#include "harness/errorHelpers.h"
+
+extern cl_channel_type gChannelTypeToUse;
+extern cl_channel_order gChannelOrderToUse;
+
+const char *convert_image_type_to_string(cl_mem_object_type imageType);
+int filter_formats(cl_image_format *formatList, bool *filterFlags,
+                   unsigned int formatCount,
+                   cl_channel_type *channelDataTypesToFilter,
+                   bool testMipmaps = false);
+int get_format_list(cl_context context, cl_mem_object_type imageType,
+                    cl_image_format *&outFormatList,
+                    unsigned int &outFormatCount, cl_mem_flags flags);
+
+#endif // IMAGES_COMMON_H

--- a/test_conformance/images/kernel_image_methods/CMakeLists.txt
+++ b/test_conformance/images/kernel_image_methods/CMakeLists.txt
@@ -8,6 +8,7 @@ set(${MODULE_NAME}_SOURCES
     test_2D_array.cpp
     test_loops.cpp
     test_3D.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -33,6 +33,7 @@ int  gTypesToTest;
 bool gDeviceLt20 = false;
 
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
+cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 extern cl_filter_mode     gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
@@ -29,100 +30,6 @@ extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_c
 extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-
-static const char *str_1d_image = "1D";
-static const char *str_2d_image = "2D";
-static const char *str_3d_image = "3D";
-static const char *str_1d_image_array = "1D array";
-static const char *str_2d_image_array = "2D array";
-
-static const char *convert_image_type_to_string(cl_mem_object_type imageType)
-{
-    const char *p;
-    switch (imageType)
-    {
-        case CL_MEM_OBJECT_IMAGE1D:
-            p = str_1d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D:
-            p = str_2d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE3D:
-            p = str_3d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            p = str_1d_image_array;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            p = str_2d_image_array;
-            break;
-    }
-    return p;
-}
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded this via the command line?
-        if( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-        int i;
-        for( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-        {
-            if( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-            {
-                numSupported++;
-                break;
-            }
-        }
-        if( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-        {
-            // Format is NOT supported, so mark it as such
-            filterFlags[ j ] = true;
-        }
-    }
-    return numSupported;
-}
-
-int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                       imageType, 0, NULL, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, (cl_mem_flags)flags,
-                                        imageType, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-    return 0;
-}
-
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
 {

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${MODULE_NAME}_SOURCES
     test_write_1D_array.cpp
     test_write_2D_array.cpp
     test_write_3D.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/samplerlessReads/CMakeLists.txt
+++ b/test_conformance/images/samplerlessReads/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${MODULE_NAME}_SOURCES
     test_read_1D_buffer.cpp
     test_read_1D_array.cpp
     test_read_2D_array.cpp
+    ../common.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 extern int                  gTypesToTest;
 extern cl_channel_type      gChannelTypeToUse;
@@ -30,113 +31,6 @@ extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_c
 extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
 extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
 extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-
-static const char *str_1d_image = "1D";
-static const char *str_2d_image = "2D";
-static const char *str_3d_image = "3D";
-static const char *str_1d_image_array = "1D array";
-static const char *str_2d_image_array = "2D array";
-static const char *str_1d_image_buffer = "1D image buffer";
-
-static const char *convert_image_type_to_string(cl_mem_object_type imageType)
-{
-    const char *p;
-    switch (imageType)
-    {
-        case CL_MEM_OBJECT_IMAGE1D:
-            p = str_1d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D:
-            p = str_2d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE3D:
-            p = str_3d_image;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            p = str_1d_image_array;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            p = str_2d_image_array;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-            p = str_1d_image_buffer;
-    }
-    return p;
-}
-
-
-int filter_formats( cl_image_format *formatList, bool *filterFlags, unsigned int formatCount, cl_channel_type *channelDataTypesToFilter )
-{
-    int numSupported = 0;
-    for ( unsigned int j = 0; j < formatCount; j++ )
-    {
-        // If this format has been previously filtered, remove the filter
-        if ( filterFlags[ j ] )
-            filterFlags[ j ] = false;
-
-        // Have we already discarded the channel type via the command line?
-        if ( gChannelTypeToUse != (cl_channel_type)-1 && gChannelTypeToUse != formatList[ j ].image_channel_data_type )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Have we already discarded the channel order via the command line?
-        if ( gChannelOrderToUse != (cl_channel_order)-1 && gChannelOrderToUse != formatList[ j ].image_channel_order )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // Is given format standard channel order and type given by spec. We don't want to test it if this is vendor extension
-        if( !IsChannelOrderSupported( formatList[ j ].image_channel_order ) || !IsChannelTypeSupported( formatList[ j ].image_channel_data_type ) )
-        {
-            filterFlags[ j ] = true;
-            continue;
-        }
-
-        // We don't filter by channel type
-        if( !channelDataTypesToFilter )
-        {
-            numSupported++;
-            continue;
-        }
-
-        // Is the format supported?
-        int i;
-        for ( i = 0; channelDataTypesToFilter[ i ] != (cl_channel_type)-1; i++ )
-        {
-            if ( formatList[ j ].image_channel_data_type == channelDataTypesToFilter[ i ] )
-            {
-                numSupported++;
-                break;
-            }
-        }
-        if ( channelDataTypesToFilter[ i ] == (cl_channel_type)-1 )
-        {
-            // Format is NOT supported, so mark it as such
-            filterFlags[ j ] = true;
-        }
-    }
-    return numSupported;
-}
-
-int get_format_list( cl_context context, cl_mem_object_type imageType, cl_image_format * &outFormatList, unsigned int &outFormatCount, cl_mem_flags flags )
-{
-    int error;
-
-    cl_image_format tempList[ 128 ];
-    error = clGetSupportedImageFormats( context, flags,
-                                        imageType, 128, tempList, &outFormatCount );
-    test_error( error, "Unable to get count of supported image formats" );
-
-    outFormatList = new cl_image_format[ outFormatCount ];
-    error = clGetSupportedImageFormats( context, flags,
-                                        imageType, outFormatCount, outFormatList, NULL );
-    test_error( error, "Unable to get list of supported image formats" );
-
-    return 0;
-}
 
 int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
                           image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )


### PR DESCRIPTION
This moves the filter_formats and get_format_list functions to a common
file. These functions were roughly the same, with an optional filtering
in some tests for testing mipmaps.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>