### PR TITLE
Reduce code duplication in images

### DIFF
--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -30,36 +30,45 @@ extern int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_c
 extern int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
 extern int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
 extern int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
+typedef int (*test_func)(cl_device_id device, cl_context context,
+                         cl_command_queue queue, cl_image_format *format,
+                         ExplicitType outputType);
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {
     const char *name;
     cl_mem_object_type imageType;
+    test_func test_fn;
 
     if ( testMethod == k1D )
     {
         name = "1D Image Fill";
         imageType = CL_MEM_OBJECT_IMAGE1D;
+        test_fn = &test_fill_image_set_1D;
     }
     else if ( testMethod == k2D )
     {
         name = "2D Image Fill";
         imageType = CL_MEM_OBJECT_IMAGE2D;
+        test_fn = &test_fill_image_set_2D;
     }
     else if ( testMethod == k1DArray )
     {
         name = "1D Image Array Fill";
         imageType = CL_MEM_OBJECT_IMAGE1D_ARRAY;
+        test_fn = &test_fill_image_set_1D_array;
     }
     else if ( testMethod == k2DArray )
     {
         name = "2D Image Array Fill";
         imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+        test_fn = &test_fill_image_set_2D_array;
     }
     else if ( testMethod == k3D )
     {
         name = "3D Image Fill";
         imageType = CL_MEM_OBJECT_IMAGE3D;
+        test_fn = &test_fill_image_set_3D;
     }
 
     log_info( "Running %s tests...\n", name );
@@ -82,157 +91,49 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     }
     memset( filterFlags, 0, sizeof( bool ) * numFormats );
 
-    /////// float tests ///////
-
-    if( gTypesToTest & kTestFloat )
+    for (auto test : imageTestTypes)
     {
-        cl_channel_type floatFormats[] = { CL_UNORM_SHORT_565, CL_UNORM_SHORT_555, CL_UNORM_INT_101010,
-#ifdef OBSOLETE_FORAMT
-            CL_UNORM_SHORT_565_REV, CL_UNORM_SHORT_555_REV, CL_UNORM_INT_8888, CL_UNORM_INT_8888_REV, CL_UNORM_INT_101010_REV,
-#endif
-#ifdef CL_SFIXED14_APPLE
-            CL_SFIXED14_APPLE,
-#endif
-            CL_UNORM_INT8, CL_SNORM_INT8,
-            CL_UNORM_INT16, CL_SNORM_INT16, CL_FLOAT, CL_HALF_FLOAT, (cl_channel_type)-1 };
-        if( filter_formats( formatList, filterFlags, numFormats, floatFormats ) == 0 )
+        if (gTypesToTest & test.type)
         {
-            log_info( "No formats supported for float type\n" );
-        }
-        else
-        {
-            // Run the format list
-            for ( unsigned int i = 0; i < numFormats; i++ )
+            if (filter_formats(formatList, filterFlags, numFormats,
+                               test.channelTypes)
+                == 0)
             {
-                int test_return = 0;
-                if ( filterFlags[i] )
+                log_info("No formats supported for %s type\n", test.name);
+            }
+            else
+            {
+                // Run the format list
+                for (unsigned int i = 0; i < numFormats; i++)
                 {
-                    continue;
+                    if (filterFlags[i])
+                    {
+                        continue;
+                    }
+
+                    print_header(&formatList[i], false);
+
+                    gTestCount++;
+
+                    int test_return =
+                        test_fn(device, context, queue, &formatList[i],
+                                test.explicitType);
+                    if (test_return)
+                    {
+                        gFailCount++;
+                        log_error("FAILED: ");
+                        print_header(&formatList[i], true);
+                        log_info("\n");
+                    }
+
+                    ret += test_return;
                 }
-
-                print_header( &formatList[ i ], false );
-
-                gTestCount++;
-
-                if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kFloat );
-                else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kFloat );
-                else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kFloat );
-                else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kFloat );
-                else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kFloat );
-
-                if (test_return)
-                {
-                    gFailCount++;
-                    log_error( "FAILED: " );
-                    print_header( &formatList[ i ], true );
-                    log_info( "\n" );
-                }
-
-                ret += test_return;
             }
         }
     }
 
-    /////// int tests ///////
-    if( gTypesToTest & kTestInt )
-    {
-        cl_channel_type intFormats[] = { CL_SIGNED_INT8, CL_SIGNED_INT16, CL_SIGNED_INT32, (cl_channel_type)-1 };
-        if( filter_formats( formatList, filterFlags, numFormats, intFormats ) == 0 )
-        {
-            log_info( "No formats supported for integer type\n" );
-        }
-        else
-        {
-            // Run the format list
-            for ( unsigned int i = 0; i < numFormats; i++ )
-            {
-                int test_return = 0;
-                if ( filterFlags[i] )
-                {
-                    continue;
-                }
-
-                print_header( &formatList[ i ], false );
-
-                gTestCount++;
-
-                if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kInt );
-                else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kInt );
-                else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kInt );
-                else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kInt );
-                else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kInt );
-
-                if (test_return) {
-                    gFailCount++;
-                    log_error( "FAILED: " );
-                    print_header( &formatList[ i ], true );
-                    log_info( "\n" );
-                }
-
-                ret += test_return;
-            }
-        }
-    }
-
-    /////// uint tests ///////
-
-    if( gTypesToTest & kTestUInt )
-    {
-        cl_channel_type uintFormats[] = { CL_UNSIGNED_INT8, CL_UNSIGNED_INT16, CL_UNSIGNED_INT32, (cl_channel_type)-1 };
-        if( filter_formats( formatList, filterFlags, numFormats, uintFormats ) == 0 )
-        {
-            log_info( "No formats supported for unsigned int type\n" );
-        }
-        else
-        {
-            // Run the format list
-            for ( unsigned int i = 0; i < numFormats; i++ )
-            {
-                int test_return = 0;
-                if ( filterFlags[i] )
-                {
-                    continue;
-                }
-
-                print_header( &formatList[ i ], false );
-
-                gTestCount++;
-
-                if ( testMethod == k1D )
-                    test_return = test_fill_image_set_1D( device, context, queue, &formatList[ i ], kUInt );
-                else if ( testMethod == k2D )
-                    test_return = test_fill_image_set_2D( device, context, queue, &formatList[ i ], kUInt );
-                else if ( testMethod == k1DArray )
-                    test_return = test_fill_image_set_1D_array( device, context, queue, &formatList[ i ], kUInt );
-                else if ( testMethod == k2DArray )
-                    test_return = test_fill_image_set_2D_array( device, context, queue, &formatList[ i ], kUInt );
-                else if ( testMethod == k3D )
-                    test_return = test_fill_image_set_3D( device, context, queue, &formatList[ i ], kUInt );
-
-                if (test_return) {
-                    gFailCount++;
-                    log_error( "FAILED: " );
-                    print_header( &formatList[ i ], true );
-                    log_info( "\n" );
-                }
-
-                ret += test_return;
-            }
-        }
-    }
-
-    delete filterFlags;
-    delete formatList;
+    delete[] filterFlags;
+    delete[] formatList;
 
     return ret;
 }

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -15,6 +15,49 @@
 //
 #include "common.h"
 
+cl_channel_type floatFormats[] = {
+    CL_UNORM_SHORT_565,
+    CL_UNORM_SHORT_555,
+    CL_UNORM_INT_101010,
+#ifdef OBSOLETE_FORAMT
+    CL_UNORM_SHORT_565_REV,
+    CL_UNORM_SHORT_555_REV,
+    CL_UNORM_INT_8888,
+    CL_UNORM_INT_8888_REV,
+    CL_UNORM_INT_101010_REV,
+#endif
+#ifdef CL_SFIXED14_APPLE
+    CL_SFIXED14_APPLE,
+#endif
+    CL_UNORM_INT8,
+    CL_SNORM_INT8,
+    CL_UNORM_INT16,
+    CL_SNORM_INT16,
+    CL_FLOAT,
+    CL_HALF_FLOAT,
+    (cl_channel_type)-1,
+};
+
+cl_channel_type intFormats[] = {
+    CL_SIGNED_INT8,
+    CL_SIGNED_INT16,
+    CL_SIGNED_INT32,
+    (cl_channel_type)-1,
+};
+
+cl_channel_type uintFormats[] = {
+    CL_UNSIGNED_INT8,
+    CL_UNSIGNED_INT16,
+    CL_UNSIGNED_INT32,
+    (cl_channel_type)-1,
+};
+
+std::array<ImageTestTypes, 3> imageTestTypes = { {
+    { kTestInt, kInt, intFormats, "int" },
+    { kTestUInt, kUInt, uintFormats, "uint" },
+    { kTestFloat, kFloat, floatFormats, "float" },
+} };
+
 const char *convert_image_type_to_string(cl_mem_object_type image_type)
 {
     switch (image_type)
@@ -108,7 +151,7 @@ int get_format_list(cl_context context, cl_mem_object_type imageType,
     test_error(error, "Unable to get count of supported image formats");
 
     outFormatList =
-    (outFormatCount > 0) ? new cl_image_format[outFormatCount] : NULL;
+        (outFormatCount > 0) ? new cl_image_format[outFormatCount] : NULL;
 
     error = clGetSupportedImageFormats(context, flags, imageType,
                                        outFormatCount, outFormatList, NULL);

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -16,11 +16,29 @@
 #ifndef IMAGES_COMMON_H
 #define IMAGES_COMMON_H
 
+#include "testBase.h"
 #include "harness/kernelHelpers.h"
 #include "harness/errorHelpers.h"
+#include "harness/conversions.h"
+
+#include <array>
 
 extern cl_channel_type gChannelTypeToUse;
 extern cl_channel_order gChannelOrderToUse;
+
+extern cl_channel_type floatFormats[];
+extern cl_channel_type intFormats[];
+extern cl_channel_type uintFormats[];
+
+struct ImageTestTypes
+{
+    TypesToTest type;
+    ExplicitType explicitType;
+    cl_channel_type *channelTypes;
+    const char *name;
+};
+
+extern std::array<ImageTestTypes, 3> imageTestTypes;
 
 const char *convert_image_type_to_string(cl_mem_object_type imageType);
 int filter_formats(cl_image_format *formatList, bool *filterFlags,

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -294,69 +294,32 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
 
     image_sampler_data imageSampler;
 
-    /////// float tests ///////
-
-    if( gTypesToTest & kTestFloat )
+    for (auto test : imageTestTypes)
     {
-        cl_channel_type floatFormats[] = { CL_UNORM_SHORT_565, CL_UNORM_SHORT_555, CL_UNORM_INT_101010,
-#ifdef OBSOLETE_FORAMT
-            CL_UNORM_SHORT_565_REV, CL_UNORM_SHORT_555_REV, CL_UNORM_INT_8888, CL_UNORM_INT_8888_REV, CL_UNORM_INT_101010_REV,
-#endif
-#ifdef CL_SFIXED14_APPLE
-            CL_SFIXED14_APPLE,
-#endif
-            CL_UNORM_INT8, CL_SNORM_INT8,
-            CL_UNORM_INT16, CL_SNORM_INT16, CL_FLOAT, CL_HALF_FLOAT, (cl_channel_type)-1 };
-        if (filter_formats(formatList, filterFlags, numFormats, floatFormats,
-                           gTestMipmaps)
-            == 0)
+        if (gTypesToTest & test.type)
         {
-            log_info( "No formats supported for float type\n" );
-        }
-        else
-        {
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
+            if (filter_formats(formatList, filterFlags, numFormats,
+                               test.channelTypes, gTestMipmaps)
+                == 0)
+            {
+                log_info("No formats supported for %s type\n", test.name);
+            }
+            else
+            {
+                imageSampler.filter_mode = CL_FILTER_NEAREST;
+                ret += formatTestFn(device, context, queue, formatList,
+                                    filterFlags, numFormats, &imageSampler,
+                                    test.explicitType, imageType);
 
-            imageSampler.filter_mode = CL_FILTER_LINEAR;
-            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
-        }
-    }
-
-    /////// int tests ///////
-    if( gTypesToTest & kTestInt )
-    {
-        cl_channel_type intFormats[] = { CL_SIGNED_INT8, CL_SIGNED_INT16, CL_SIGNED_INT32, (cl_channel_type)-1 };
-        if (filter_formats(formatList, filterFlags, numFormats, intFormats,
-                           gTestMipmaps)
-            == 0)
-        {
-            log_info( "No formats supported for integer type\n" );
-        }
-        else
-        {
-            // Only filter mode we support on int is nearest
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
-        }
-    }
-
-    /////// uint tests ///////
-
-    if( gTypesToTest & kTestUInt )
-    {
-        cl_channel_type uintFormats[] = { CL_UNSIGNED_INT8, CL_UNSIGNED_INT16, CL_UNSIGNED_INT32, (cl_channel_type)-1 };
-        if (filter_formats(formatList, filterFlags, numFormats, uintFormats,
-                           gTestMipmaps)
-            == 0)
-        {
-            log_info( "No formats supported for unsigned int type\n" );
-        }
-        else
-        {
-            // Only filter mode we support on uint is nearest
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += formatTestFn( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
+                // Linear filtering is only supported with floats
+                if (test.type == kTestFloat)
+                {
+                    imageSampler.filter_mode = CL_FILTER_LINEAR;
+                    ret += formatTestFn(device, context, queue, formatList,
+                                        filterFlags, numFormats, &imageSampler,
+                                        test.explicitType, imageType);
+                }
+            }
         }
     }
     return ret;

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -143,63 +143,25 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
 
     image_sampler_data imageSampler;
 
-    /////// float tests ///////
-
-    if ( gTypesToTest & kTestFloat )
+    for (auto test : imageTestTypes)
     {
-        cl_channel_type floatFormats[] = { CL_UNORM_SHORT_565, CL_UNORM_SHORT_555, CL_UNORM_INT_101010,
-#ifdef OBSOLETE_FORAMT
-            CL_UNORM_SHORT_565_REV, CL_UNORM_SHORT_555_REV, CL_UNORM_INT_8888, CL_UNORM_INT_8888_REV, CL_UNORM_INT_101010_REV,
-#endif
-#ifdef CL_SFIXED14_APPLE
-            CL_SFIXED14_APPLE,
-#endif
-            CL_UNORM_INT8, CL_SNORM_INT8,
-            CL_UNORM_INT16, CL_SNORM_INT16, CL_FLOAT, CL_HALF_FLOAT, (cl_channel_type)-1 };
-        if ( filter_formats( formatList, filterFlags, numFormats, floatFormats ) == 0 )
+        if (gTypesToTest & test.type)
         {
-            log_info( "No formats supported for float type\n" );
-        }
-        else
-        {
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kFloat, imageType );
+            if (filter_formats(formatList, filterFlags, numFormats,
+                               test.channelTypes)
+                == 0)
+            {
+                log_info("No formats supported for %s type\n", test.name);
+            }
+            else
+            {
+                imageSampler.filter_mode = CL_FILTER_NEAREST;
+                ret += test_read_image_formats(
+                    device, context, queue, formatList, filterFlags, numFormats,
+                    &imageSampler, test.explicitType, imageType);
+            }
         }
     }
-
-    /////// int tests ///////
-    if ( gTypesToTest & kTestInt )
-    {
-        cl_channel_type intFormats[] = { CL_SIGNED_INT8, CL_SIGNED_INT16, CL_SIGNED_INT32, (cl_channel_type)-1 };
-        if ( filter_formats( formatList, filterFlags, numFormats, intFormats ) == 0 )
-        {
-            log_info( "No formats supported for integer type\n" );
-        }
-        else
-        {
-            // Only filter mode we support on int is nearest
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kInt, imageType );
-        }
-    }
-
-    /////// uint tests ///////
-
-    if ( gTypesToTest & kTestUInt )
-    {
-        cl_channel_type uintFormats[] = { CL_UNSIGNED_INT8, CL_UNSIGNED_INT16, CL_UNSIGNED_INT32, (cl_channel_type)-1 };
-        if ( filter_formats( formatList, filterFlags, numFormats, uintFormats ) == 0 )
-        {
-            log_info( "No formats supported for unsigned int type\n" );
-        }
-        else
-        {
-            // Only filter mode we support on uint is nearest
-            imageSampler.filter_mode = CL_FILTER_NEAREST;
-            ret += test_read_image_formats( device, context, queue, formatList, filterFlags, numFormats, &imageSampler, kUInt, imageType );
-        }
-    }
-
 
     delete[] filterFlags;
     delete[] formatList;


### PR DESCRIPTION
Some of the image code is needlessly copied over, where all you need is
a simple for loop.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>