### PR TITLE
Accept OpenCL 3.0 in version parsing code and use where appropriate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ else(CMAKE_BUILD_TYPE STREQUAL "release")
     set (BUILD_FLAVOR "debug")
 endif(CMAKE_BUILD_TYPE STREQUAL "release")
 
-add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
+add_definitions(-DCL_TARGET_OPENCL_VERSION=300)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_2_1_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_2_0_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_2_APIS=1)

--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -885,6 +885,8 @@ Version get_device_cl_version(cl_device_id device)
         return Version(2, 1);
     else if (strstr(str.data(), "OpenCL 2.2") != NULL)
         return Version(2, 2);
+    else if (strstr(str.data(), "OpenCL 3.0") != NULL)
+        return Version(3, 0);
 
     throw std::runtime_error(std::string("Unknown OpenCL version: ") + str.data());
 }

--- a/test_conformance/SVM/main.cpp
+++ b/test_conformance/SVM/main.cpp
@@ -294,7 +294,7 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((svm_caps == 0) && (version > Version(2,2))) {
+  if ((svm_caps == 0) && (version >= Version(3,0))) {
     return TEST_SKIP;
   }
 

--- a/test_conformance/SVM/main.cpp
+++ b/test_conformance/SVM/main.cpp
@@ -294,8 +294,9 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((svm_caps == 0) && (version >= Version(3,0))) {
-    return TEST_SKIP;
+  if ((svm_caps == 0) && (version >= Version(3, 0)))
+  {
+      return TEST_SKIP;
   }
 
   return TEST_PASS;

--- a/test_conformance/device_execution/main.cpp
+++ b/test_conformance/device_execution/main.cpp
@@ -45,7 +45,7 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((max_queues_size == 0) && (version > Version(2,2))) {
+  if ((max_queues_size == 0) && (version >= Version(3,0))) {
     return TEST_SKIP;
   }
 

--- a/test_conformance/device_execution/main.cpp
+++ b/test_conformance/device_execution/main.cpp
@@ -45,8 +45,9 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((max_queues_size == 0) && (version >= Version(3,0))) {
-    return TEST_SKIP;
+  if ((max_queues_size == 0) && (version >= Version(3, 0)))
+  {
+      return TEST_SKIP;
   }
 
   return TEST_PASS;

--- a/test_conformance/device_timer/main.cpp
+++ b/test_conformance/device_timer/main.cpp
@@ -59,7 +59,7 @@ test_status InitCL(cl_device_id device) {
 		return TEST_FAIL;
 	}
 
-	if ((timer_res == 0) && (version > Version(2,2)))
+	if ((timer_res == 0) && (version >= Version(3,0)))
 	{
 		return TEST_SKIP;
 	}

--- a/test_conformance/device_timer/main.cpp
+++ b/test_conformance/device_timer/main.cpp
@@ -61,10 +61,10 @@ test_status InitCL(cl_device_id device) {
 
     if ((timer_res == 0) && (version >= Version(3, 0)))
     {
-		return TEST_SKIP;
-	}
+        return TEST_SKIP;
+    }
 
-	return TEST_PASS;
+    return TEST_PASS;
 }
 
 

--- a/test_conformance/device_timer/main.cpp
+++ b/test_conformance/device_timer/main.cpp
@@ -59,8 +59,8 @@ test_status InitCL(cl_device_id device) {
 		return TEST_FAIL;
 	}
 
-	if ((timer_res == 0) && (version >= Version(3,0)))
-	{
+    if ((timer_res == 0) && (version >= Version(3, 0)))
+    {
 		return TEST_SKIP;
 	}
 

--- a/test_conformance/generic_address_space/advanced_tests.cpp
+++ b/test_conformance/generic_address_space/advanced_tests.cpp
@@ -958,7 +958,7 @@ int test_generic_ptr_to_host_mem_svm(cl_device_id deviceID, cl_context context, 
     cl_int error = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES, sizeof(caps), &caps, NULL);
     test_error(error, "clGetDeviceInfo(CL_DEVICE_SVM_CAPABILITIES) failed");
 
-    if ((version < expected_min_version) || (version > Version(2,2) && caps == 0))
+    if ((version < expected_min_version) || (version >= Version(3,0) && caps == 0))
         return TEST_SKIPPED_ITSELF;
 
     if (caps & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) {

--- a/test_conformance/generic_address_space/advanced_tests.cpp
+++ b/test_conformance/generic_address_space/advanced_tests.cpp
@@ -958,7 +958,8 @@ int test_generic_ptr_to_host_mem_svm(cl_device_id deviceID, cl_context context, 
     cl_int error = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES, sizeof(caps), &caps, NULL);
     test_error(error, "clGetDeviceInfo(CL_DEVICE_SVM_CAPABILITIES) failed");
 
-    if ((version < expected_min_version) || (version >= Version(3,0) && caps == 0))
+    if ((version < expected_min_version)
+        || (version >= Version(3, 0) && caps == 0))
         return TEST_SKIPPED_ITSELF;
 
     if (caps & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) {

--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -79,7 +79,7 @@ test_status InitCL(cl_device_id device) {
         return TEST_SKIP;
     }
 
-    if (version >= Version(3,0))
+    if (version >= Version(3, 0))
     {
         cl_int error;
         cl_bool support_generic;

--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -80,7 +80,7 @@ test_status InitCL(cl_device_id device) {
     }
 
 #ifdef CL_EXPERIMENTAL
-    if (version > Version(2,2))
+    if (version >= Version(3,0))
     {
         cl_int error;
         cl_bool support_generic;

--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -79,7 +79,6 @@ test_status InitCL(cl_device_id device) {
         return TEST_SKIP;
     }
 
-#ifdef CL_EXPERIMENTAL
     if (version >= Version(3,0))
     {
         cl_int error;
@@ -98,7 +97,6 @@ test_status InitCL(cl_device_id device) {
             return TEST_SKIP;
         }
     }
-#endif
 
     return TEST_PASS;
 }

--- a/test_conformance/pipes/main.cpp
+++ b/test_conformance/pipes/main.cpp
@@ -37,8 +37,9 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((max_packet_size == 0) && (version >= Version(3,0))) {
-    return TEST_SKIP;
+  if ((max_packet_size == 0) && (version >= Version(3, 0)))
+  {
+      return TEST_SKIP;
   }
 
   return TEST_PASS;

--- a/test_conformance/pipes/main.cpp
+++ b/test_conformance/pipes/main.cpp
@@ -37,7 +37,7 @@ test_status InitCL(cl_device_id device) {
     return TEST_FAIL;
   }
 
-  if ((max_packet_size == 0) && (version > Version(2,2))) {
+  if ((max_packet_size == 0) && (version >= Version(3,0))) {
     return TEST_SKIP;
   }
 

--- a/test_conformance/subgroups/main.cpp
+++ b/test_conformance/subgroups/main.cpp
@@ -62,7 +62,8 @@ static test_status InitCL(cl_device_id device) {
 
     auto version = get_device_cl_version(device);
     test_status ret = TEST_PASS;
-    if (version >= Version(3, 0)) {
+    if (version >= Version(3, 0))
+    {
         cl_uint max_sub_groups;
         int error;
 
@@ -76,7 +77,9 @@ static test_status InitCL(cl_device_id device) {
         if (max_sub_groups == 0) {
             ret = TEST_SKIP;
         }
-    } else {
+    }
+    else
+    {
         ret = checkSubGroupsExtension(device);
     }
     return ret;

--- a/test_conformance/subgroups/main.cpp
+++ b/test_conformance/subgroups/main.cpp
@@ -62,7 +62,7 @@ static test_status InitCL(cl_device_id device) {
 
     auto version = get_device_cl_version(device);
     test_status ret = TEST_PASS;
-    if (version > Version(2, 2)) {
+    if (version >= Version(3, 0)) {
         cl_uint max_sub_groups;
         int error;
 

--- a/test_conformance/workgroups/main.cpp
+++ b/test_conformance/workgroups/main.cpp
@@ -50,7 +50,6 @@ test_status InitCL(cl_device_id device) {
         version_expected_info("Test", expected_min_version.to_string().c_str(), version.to_string().c_str());
         return TEST_SKIP;
     }
-#ifdef CL_EXPERIMENTAL
 
   if(version >= Version(3,0)) {
     int error;
@@ -67,7 +66,7 @@ test_status InitCL(cl_device_id device) {
       return TEST_SKIP;
     }
   }
-#endif
+
   return TEST_PASS;
 }
 

--- a/test_conformance/workgroups/main.cpp
+++ b/test_conformance/workgroups/main.cpp
@@ -51,21 +51,25 @@ test_status InitCL(cl_device_id device) {
         return TEST_SKIP;
     }
 
-  if(version >= Version(3,0)) {
-    int error;
-    cl_bool isSupported;
-    error = clGetDeviceInfo(device,
-                            CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT,
-                            sizeof(isSupported), &isSupported, NULL);
-    if (error != CL_SUCCESS) {
-      print_error(error, "Unable to query support for collective functions");
-      return TEST_FAIL;
-    }
+    if (version >= Version(3, 0))
+    {
+        int error;
+        cl_bool isSupported;
+        error = clGetDeviceInfo(
+            device, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT,
+            sizeof(isSupported), &isSupported, NULL);
+        if (error != CL_SUCCESS)
+        {
+            print_error(error,
+                        "Unable to query support for collective functions");
+            return TEST_FAIL;
+        }
 
-    if (isSupported == CL_FALSE) {
-      return TEST_SKIP;
+        if (isSupported == CL_FALSE)
+        {
+            return TEST_SKIP;
+        }
     }
-  }
 
   return TEST_PASS;
 }

--- a/test_conformance/workgroups/main.cpp
+++ b/test_conformance/workgroups/main.cpp
@@ -52,7 +52,7 @@ test_status InitCL(cl_device_id device) {
     }
 #ifdef CL_EXPERIMENTAL
 
-  if(version > Version(2,2)) {
+  if(version >= Version(3,0)) {
     int error;
     cl_bool isSupported;
     error = clGetDeviceInfo(device,


### PR DESCRIPTION
There were a number of tests against 2.2 that are clearer against 3.0.

Fixes #751

Signed-off-by: Kévin Petit <kpet@free.fr>