### PR TITLE
Add argument to specify branch for clang-format check

### DIFF
--- a/check-format.sh
+++ b/check-format.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+# Arg used to specify non-'origin/master' comparison branch
+ORIGIN_BRANCH=${1:-"origin/master"}
+
 # Run git-clang-format to check for violations
 if [ "$TRAVIS" == "true" ]; then
     EXTRA_OPTS="--binary `which clang-format-9`"
 fi
-CLANG_FORMAT_OUTPUT=$(git-clang-format --diff origin/master --extensions c,cpp,h,hpp $EXTRA_OPTS)
+CLANG_FORMAT_OUTPUT=$(git-clang-format --diff $ORIGIN_BRANCH --extensions c,cpp,h,hpp $EXTRA_OPTS)
 
 # Check for no-ops
 grep '^no modified files to format$' <<<"$CLANG_FORMAT_OUTPUT" && exit 0


### PR DESCRIPTION
If a change is not added to an origin/master branch, an argument
can be used to specify the relevant branch name for the clang-format
comparison.

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>