### PR TITLE
Remove duplicated random_in_ranges function

### DIFF
--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
@@ -25,17 +26,6 @@ extern uint64_t gRoundingStartValue;
 
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
-
-static size_t random_in_ranges( size_t minimum, size_t rangeA, size_t rangeB, MTdata d )
-{
-    if( rangeB < rangeA )
-        rangeA = rangeB;
-    if( rangeA < minimum )
-        return rangeA;
-    return (size_t)random_in_range( (int)minimum, (int)rangeA - 1, d );
-}
-
 
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t arraySize, size_t rowPadding, size_t slicePadding )
 {

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
@@ -25,17 +26,6 @@ extern uint64_t gRoundingStartValue;
 
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
-
-static size_t random_in_ranges( size_t minimum, size_t rangeA, size_t rangeB, MTdata d )
-{
-    if( rangeB < rangeA )
-        rangeA = rangeB;
-    if( rangeA < minimum )
-        return rangeA;
-    return (size_t)random_in_range( (int)minimum, (int)rangeA - 1, d );
-}
-
 
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t rowPadding, size_t slicePadding )
 {

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 
 #define MAX_ERR 0.005f
 #define MAX_HALF_LINEAR_ERR 0.3f
@@ -25,17 +26,6 @@ extern uint64_t gRoundingStartValue;
 
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
-
-static size_t random_in_ranges( size_t minimum, size_t rangeA, size_t rangeB, MTdata d )
-{
-    if( rangeB < rangeA )
-        rangeA = rangeB;
-    if( rangeA < minimum )
-        return rangeA;
-    return (size_t)random_in_range( (int)minimum, (int)rangeA - 1, d );
-}
-
 
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t arraySize, size_t rowPadding, size_t slicePadding )
 {

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -23,15 +23,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-size_t random_in_ranges( size_t minimum, size_t rangeA, size_t rangeB, MTdata d )
-{
-    if( rangeB < rangeA )
-        rangeA = rangeB;
-    if( rangeA < minimum )
-        return rangeA;
-    return (size_t)random_in_range( (int)minimum, (int)rangeA - 1, d );
-}
-
 static void CL_CALLBACK free_pitch_buffer( cl_mem image, void *buf )
 {
     free( buf );

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -158,3 +158,10 @@ int get_format_list(cl_context context, cl_mem_object_type imageType,
     test_error(error, "Unable to get list of supported image formats");
     return 0;
 }
+
+size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d)
+{
+    if (rangeB < rangeA) rangeA = rangeB;
+    if (rangeA < minimum) return rangeA;
+    return (size_t)random_in_range((int)minimum, (int)rangeA - 1, d);
+}

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -48,5 +48,6 @@ int filter_formats(cl_image_format *formatList, bool *filterFlags,
 int get_format_list(cl_context context, cl_mem_object_type imageType,
                     cl_image_format *&outFormatList,
                     unsigned int &outFormatCount, cl_mem_flags flags);
+size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d);
 
 #endif // IMAGES_COMMON_H


### PR DESCRIPTION
This function is duplicated across clCopyImages files, so just keep one
definition in common file, and get rid of the duplicated ones.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>