### PR TITLE
Fix test_gl error reporting

### DIFF
--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -813,7 +813,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
             get_base_gl_target(targets[ tidx ]) == GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
         {
             bool supports_msaa;
-            error = supportsMsaa(context, &supports_msaa);
+            bool error = supportsMsaa(context, &supports_msaa);
             if( error != 0 ) return error;
             if (!supports_msaa) return 0;
         }
@@ -821,7 +821,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
             formats[ fidx ].formattype == GL_DEPTH_STENCIL)
         {
             bool supports_depth;
-            error = supportsDepth(context, &supports_depth);
+            bool error = supportsDepth(context, &supports_depth);
             if( error != 0 ) return error;
             if (!supports_depth) return 0;
         }

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -814,7 +814,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
         {
             bool supports_msaa;
             int errorInGetInfo = supportsMsaa(context, &supports_msaa);
-            if( errorInGetInfo != 0 ) return errorInGetInfo;
+            if(errorInGetInfo != 0) return errorInGetInfo;
             if (!supports_msaa) return 0;
         }
         if (formats[ fidx ].formattype == GL_DEPTH_COMPONENT ||
@@ -822,7 +822,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
         {
             bool supports_depth;
             int errorInGetInfo = supportsDepth(context, &supports_depth);
-            if( errorInGetInfo != 0 ) return errorInGetInfo;
+            if(errorInGetInfo != 0) return errorInGetInfo;
             if (!supports_depth) return 0;
         }
 #endif

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -813,16 +813,16 @@ int test_images_write_common(cl_device_id device, cl_context context,
             get_base_gl_target(targets[ tidx ]) == GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
         {
             bool supports_msaa;
-            bool error = supportsMsaa(context, &supports_msaa);
-            if( error != 0 ) return error;
+            int errorInGetInfo = supportsMsaa(context, &supports_msaa);
+            if( errorInGetInfo != 0 ) return errorInGetInfo;
             if (!supports_msaa) return 0;
         }
         if (formats[ fidx ].formattype == GL_DEPTH_COMPONENT ||
             formats[ fidx ].formattype == GL_DEPTH_STENCIL)
         {
             bool supports_depth;
-            bool error = supportsDepth(context, &supports_depth);
-            if( error != 0 ) return error;
+            int errorInGetInfo = supportsDepth(context, &supports_depth);
+            if( errorInGetInfo != 0 ) return errorInGetInfo;
             if (!supports_depth) return 0;
         }
 #endif

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -814,7 +814,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
         {
             bool supports_msaa;
             int errorInGetInfo = supportsMsaa(context, &supports_msaa);
-            if(errorInGetInfo != 0) return errorInGetInfo;
+            if (errorInGetInfo != 0) return errorInGetInfo;
             if (!supports_msaa) return 0;
         }
         if (formats[ fidx ].formattype == GL_DEPTH_COMPONENT ||
@@ -822,7 +822,7 @@ int test_images_write_common(cl_device_id device, cl_context context,
         {
             bool supports_depth;
             int errorInGetInfo = supportsDepth(context, &supports_depth);
-            if(errorInGetInfo != 0) return errorInGetInfo;
+            if (errorInGetInfo != 0) return errorInGetInfo;
             if (!supports_depth) return 0;
         }
 #endif


### PR DESCRIPTION
Overwriting 'error' variable after check for Msaa/Depth support was clearing
the error counter incremented after failure in test_image_format_write. In
effect the test might return 0 even if there were errors.