### PR TITLE
Remove duplicated function declaration in clCopyImage

### DIFF
--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -23,9 +23,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
   size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -23,9 +23,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -24,9 +24,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t arraySize, size_t rowPadding, size_t slicePadding )
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -24,9 +24,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t rowPadding, size_t slicePadding )
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -22,10 +22,6 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 
-// Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 int test_copy_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t srcPos[] = { 0, 0, 0, 0}, dstPos[] = {0, 0, 0, 0};

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -22,10 +22,6 @@ extern bool            gDebugTrace, gDisableOffsets, gTestSmallImages, gTestMaxI
 extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 
-// Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 int test_copy_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
 {
     size_t origin[] = { 0, 0, 0, 0};

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -24,9 +24,6 @@ extern cl_filter_mode    gFilterModeToUse;
 extern cl_addressing_mode    gAddressModeToUse;
 extern uint64_t gRoundingStartValue;
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
-
 static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t arraySize, size_t rowPadding, size_t slicePadding )
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -72,6 +72,13 @@ extern int test_write_image_formats( cl_device_id device, cl_context context, cl
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
 
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d);
+
 #endif // _testBase_h
 
 


### PR DESCRIPTION
There's no need to redeclare test_copy_image_generic in each file, you
can just do it once in a common file, which is already included where
it's needed.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>