### PR TITLE
Update computeinfo tests

### DIFF
--- a/test_conformance/computeinfo/extended_versioning.cpp
+++ b/test_conformance/computeinfo/extended_versioning.cpp
@@ -56,7 +56,8 @@ static bool is_same_version(const char* const format,
 
     if (2 != matched)
     {
-        log_error("sscanf() fail on version string \"%s\", format=\"%s\"\n");
+        log_error("sscanf() fail on version string \"%s\", format=\"%s\"\n",
+                  version_string, format);
         return false;
     }
 

--- a/test_conformance/computeinfo/extended_versioning.cpp
+++ b/test_conformance/computeinfo/extended_versioning.cpp
@@ -24,7 +24,8 @@
 
 using name_version_set = std::set<cl_name_version_khr>;
 
-static bool operator<(const cl_name_version_khr& lhs, const cl_name_version_khr& rhs)
+static bool operator<(const cl_name_version_khr& lhs,
+                      const cl_name_version_khr& rhs)
 {
     const int cmp = strcmp(lhs.name, rhs.name);
     if (0 == cmp)
@@ -35,7 +36,8 @@ static bool operator<(const cl_name_version_khr& lhs, const cl_name_version_khr&
     return cmp < 0;
 }
 
-static bool operator==(const cl_name_version_khr& lhs, const cl_name_version_khr& rhs)
+static bool operator==(const cl_name_version_khr& lhs,
+                       const cl_name_version_khr& rhs)
 {
     return (0 == strcmp(lhs.name, rhs.name)) && (lhs.version == rhs.version);
 }
@@ -43,11 +45,14 @@ static bool operator==(const cl_name_version_khr& lhs, const cl_name_version_khr
 /* Parse major and minor version numbers out of version_string according to
  * format, which is a scanf-format with two %u specifiers, then compare the
  * version to the major and minor versions of version_numeric */
-static bool is_same_version(const char* const format, const char* const version_string, const cl_version_khr version_numeric)
+static bool is_same_version(const char* const format,
+                            const char* const version_string,
+                            const cl_version_khr version_numeric)
 {
     unsigned int string_major = 0;
     unsigned int string_minor = 0;
-    const int matched = sscanf(version_string, format, &string_major, &string_minor);
+    const int matched =
+        sscanf(version_string, format, &string_major, &string_minor);
 
     if (2 != matched)
     {
@@ -61,11 +66,13 @@ static bool is_same_version(const char* const format, const char* const version_
     return (string_major == numeric_major) && (string_minor == numeric_minor);
 }
 
-static std::vector<char> get_platform_string(cl_platform_id platform, cl_platform_info name)
+static std::vector<char> get_platform_string(cl_platform_id platform,
+                                             cl_platform_info name)
 {
     size_t size{};
     cl_int err = clGetPlatformInfo(platform, name, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetPlatformInfo failed\n");
         return {};
     }
@@ -73,7 +80,8 @@ static std::vector<char> get_platform_string(cl_platform_id platform, cl_platfor
     std::vector<char> result(size);
 
     err = clGetPlatformInfo(platform, name, size, result.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetPlatformInfo failed\n");
         return {};
     }
@@ -81,11 +89,13 @@ static std::vector<char> get_platform_string(cl_platform_id platform, cl_platfor
     return result;
 }
 
-static std::vector<char> get_device_string(cl_device_id device, cl_device_info name)
+static std::vector<char> get_device_string(cl_device_id device,
+                                           cl_device_info name)
 {
     size_t size{};
     cl_int err = clGetDeviceInfo(device, name, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return {};
     }
@@ -93,7 +103,8 @@ static std::vector<char> get_device_string(cl_device_id device, cl_device_info n
     std::vector<char> result(size);
 
     err = clGetDeviceInfo(device, name, size, result.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return {};
     }
@@ -101,13 +112,16 @@ static std::vector<char> get_device_string(cl_device_id device, cl_device_info n
     return result;
 }
 
-/* Parse an extension string into a cl_name_version_khr set. Error out if we have
- * an invalid extension string */
-static bool name_version_set_from_extension_string(char* const src, name_version_set& dest)
+/* Parse an extension string into a cl_name_version_khr set. Error out if we
+ * have an invalid extension string */
+static bool name_version_set_from_extension_string(char* const src,
+                                                   name_version_set& dest)
 {
-    for (char* token = strtok(src, " "); nullptr != token; token = strtok(nullptr, " "))
+    for (char* token = strtok(src, " "); nullptr != token;
+         token = strtok(nullptr, " "))
     {
-        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(token)) {
+        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(token))
+        {
             log_error("Extension name is longer than allowed\n");
             return false;
         }
@@ -115,7 +129,8 @@ static bool name_version_set_from_extension_string(char* const src, name_version
         cl_name_version_khr name_version{};
         strncpy(name_version.name, token, CL_NAME_VERSION_MAX_NAME_SIZE_KHR);
 
-        if (dest.find(name_version) != dest.cend()) {
+        if (dest.find(name_version) != dest.cend())
+        {
             log_error("Duplicate extension in extension string\n");
             return false;
         }
@@ -126,13 +141,16 @@ static bool name_version_set_from_extension_string(char* const src, name_version
     return true;
 }
 
-/* Parse a built-in kernels string into a cl_name_version_khr set. Error out if we
- * have an invalid built-in kernels string */
-static bool name_version_set_from_built_in_kernel_string(char* const src, name_version_set& dest)
+/* Parse a built-in kernels string into a cl_name_version_khr set. Error out if
+ * we have an invalid built-in kernels string */
+static bool name_version_set_from_built_in_kernel_string(char* const src,
+                                                         name_version_set& dest)
 {
-    for (char* token = strtok(src, ";"); nullptr != token; token = strtok(nullptr, ";"))
+    for (char* token = strtok(src, ";"); nullptr != token;
+         token = strtok(nullptr, ";"))
     {
-        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(token)) {
+        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(token))
+        {
             log_error("Kernel name is longer than allowed\n");
             return false;
         }
@@ -140,7 +158,8 @@ static bool name_version_set_from_built_in_kernel_string(char* const src, name_v
         cl_name_version_khr name_version{};
         strncpy(name_version.name, token, CL_NAME_VERSION_MAX_NAME_SIZE_KHR);
 
-        if (dest.find(name_version) != dest.cend()) {
+        if (dest.find(name_version) != dest.cend())
+        {
             log_error("Duplicate kernel name in kernel string\n");
             return false;
         }
@@ -151,14 +170,14 @@ static bool name_version_set_from_built_in_kernel_string(char* const src, name_v
     return true;
 }
 
-/* Helper to log the names of elements of the set difference of two cl_name_version_khr sets */
-static void log_name_only_set_difference(const name_version_set& lhs, const name_version_set& rhs)
+/* Helper to log the names of elements of the set difference of two
+ * cl_name_version_khr sets */
+static void log_name_only_set_difference(const name_version_set& lhs,
+                                         const name_version_set& rhs)
 {
     std::vector<cl_name_version_khr> difference;
-    std::set_difference(
-        lhs.cbegin(), lhs.cend(),
-        rhs.cbegin(), rhs.cend(),
-        std::back_inserter(difference));
+    std::set_difference(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
+                        std::back_inserter(difference));
 
     for (const cl_name_version_khr& il : difference)
     {
@@ -168,13 +187,12 @@ static void log_name_only_set_difference(const name_version_set& lhs, const name
 
 /* Helper to log as IL versions the elements of the set difference of two
  * cl_name_version_khr sets */
-static void log_il_set_difference(const name_version_set& lhs, const name_version_set& rhs)
+static void log_il_set_difference(const name_version_set& lhs,
+                                  const name_version_set& rhs)
 {
     std::vector<cl_name_version_khr> difference;
-    std::set_difference(
-        lhs.cbegin(), lhs.cend(),
-        rhs.cbegin(), rhs.cend(),
-        std::back_inserter(difference));
+    std::set_difference(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
+                        std::back_inserter(difference));
 
     for (const cl_name_version_khr& il : difference)
     {
@@ -184,27 +202,35 @@ static void log_il_set_difference(const name_version_set& lhs, const name_versio
     }
 }
 
-/* Check that CL_PLATFORM_NUMERIC_VERSION_KHR returns the same version as CL_PLATFORM_VERSION */
+/* Check that CL_PLATFORM_NUMERIC_VERSION_KHR returns the same version as
+ * CL_PLATFORM_VERSION */
 static int test_extended_versioning_platform_version(cl_platform_id platform)
 {
     log_info("Platform versions:\n");
 
-    const std::vector<char> version_string(get_platform_string(platform, CL_PLATFORM_VERSION));
-    if (version_string.empty()) {
+    const std::vector<char> version_string(
+        get_platform_string(platform, CL_PLATFORM_VERSION));
+    if (version_string.empty())
+    {
         log_error("Could not get CL platform version string\n");
         return 1;
     }
 
-    cl_version_khr version_numeric {};
-    cl_int err = clGetPlatformInfo(platform, CL_PLATFORM_NUMERIC_VERSION_KHR, sizeof(version_numeric), &version_numeric, nullptr);
-    if (err != CL_SUCCESS) {
+    cl_version_khr version_numeric{};
+    cl_int err =
+        clGetPlatformInfo(platform, CL_PLATFORM_NUMERIC_VERSION_KHR,
+                          sizeof(version_numeric), &version_numeric, nullptr);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetPlatformInfo failed\n");
         return 1;
     }
 
-    if (!is_same_version("OpenCL %u.%u", version_string.data(), version_numeric))
+    if (!is_same_version("OpenCL %u.%u", version_string.data(),
+                         version_numeric))
     {
-        log_error("Numeric platform version does not match the version string\n");
+        log_error(
+            "Numeric platform version does not match the version string\n");
         return 1;
     }
 
@@ -213,38 +239,48 @@ static int test_extended_versioning_platform_version(cl_platform_id platform)
     return 0;
 }
 
-/* Check that CL_DEVICE{,_OPENCL_C}_NUMERIC_VERSION_KHR return the same versions as CL_DEVICE{,_OPENCL_C}_VERSION */
+/* Check that CL_DEVICE{,_OPENCL_C}_NUMERIC_VERSION_KHR return the same versions
+ * as CL_DEVICE{,_OPENCL_C}_VERSION */
 static int test_extended_versioning_device_versions(cl_device_id deviceID)
 {
     log_info("Device versions:\n");
 
-    static constexpr struct {
+    static constexpr struct
+    {
         cl_platform_info param_name_numeric;
         cl_platform_info param_name_string;
         const char* format;
-    } device_version_queries[] {
+    } device_version_queries[]{
         { CL_DEVICE_NUMERIC_VERSION_KHR, CL_DEVICE_VERSION, "OpenCL %u.%u" },
-        { CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, CL_DEVICE_OPENCL_C_VERSION, "OpenCL C %u.%u" },
+        { CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, CL_DEVICE_OPENCL_C_VERSION,
+          "OpenCL C %u.%u" },
     };
 
     for (const auto& query : device_version_queries)
     {
-        const std::vector<char> version_string(get_device_string(deviceID, query.param_name_string));
-        if (version_string.empty()) {
+        const std::vector<char> version_string(
+            get_device_string(deviceID, query.param_name_string));
+        if (version_string.empty())
+        {
             log_error("Could not get CL platform version string\n");
             return 1;
         }
 
-        cl_version_khr version_numeric {};
-        cl_int err = clGetDeviceInfo(deviceID, query.param_name_numeric, sizeof(version_numeric), &version_numeric, nullptr);
-        if (err != CL_SUCCESS) {
+        cl_version_khr version_numeric{};
+        cl_int err =
+            clGetDeviceInfo(deviceID, query.param_name_numeric,
+                            sizeof(version_numeric), &version_numeric, nullptr);
+        if (err != CL_SUCCESS)
+        {
             log_error("clGetDeviceInfo failed\n");
             return 1;
         }
 
-        if (!is_same_version(query.format, version_string.data(), version_numeric))
+        if (!is_same_version(query.format, version_string.data(),
+                             version_numeric))
         {
-            log_error("Numeric device version does not match the version string\n");
+            log_error(
+                "Numeric device version does not match the version string\n");
             return 1;
         }
     }
@@ -254,33 +290,43 @@ static int test_extended_versioning_device_versions(cl_device_id deviceID)
     return 0;
 }
 
-/* Check that the platform extension string and name_version queries return the same set */
+/* Check that the platform extension string and name_version queries return the
+ * same set */
 static int test_extended_versioning_platform_extensions(cl_platform_id platform)
 {
     log_info("Platform extensions:\n");
-    std::vector<char> extension_string { get_platform_string(platform, CL_PLATFORM_EXTENSIONS) };
-    if (extension_string.empty()) {
+    std::vector<char> extension_string{ get_platform_string(
+        platform, CL_PLATFORM_EXTENSIONS) };
+    if (extension_string.empty())
+    {
         log_error("Could not get CL platform extensions string\n");
         return 1;
     }
 
     size_t size{};
-    cl_int err = clGetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    cl_int err = clGetPlatformInfo(
+        platform, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR, 0, nullptr, &size);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetPlatformInfo failed\n");
         return 1;
     }
 
-    if ((size % sizeof(cl_name_version_khr)) != 0) {
-        log_error("CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR return size not a multiple of sizeof(cl_name_version_khr)\n");
+    if ((size % sizeof(cl_name_version_khr)) != 0)
+    {
+        log_error("CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR return size not a "
+                  "multiple of sizeof(cl_name_version_khr)\n");
         return 1;
     }
 
     const size_t extension_name_vers_count = size / sizeof(cl_name_version_khr);
-    std::vector<cl_name_version_khr> extension_name_vers(extension_name_vers_count);
+    std::vector<cl_name_version_khr> extension_name_vers(
+        extension_name_vers_count);
 
-    err = clGetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR, size, extension_name_vers.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    err = clGetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR,
+                            size, extension_name_vers.data(), nullptr);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetPlatformInfo failed\n");
         return 1;
     }
@@ -288,11 +334,14 @@ static int test_extended_versioning_platform_extensions(cl_platform_id platform)
     name_version_set extension_name_vers_set;
     for (const auto& extension : extension_name_vers)
     {
-        /* Extension string doesn't have versions, so set it to all zeroes for matching */
+        /* Extension string doesn't have versions, so set it to all zeroes for
+         * matching */
         cl_name_version_khr name_version = extension;
         name_version.version = CL_MAKE_VERSION_KHR(0, 0, 0);
 
-        if (extension_name_vers_set.find(name_version) != extension_name_vers_set.cend()) {
+        if (extension_name_vers_set.find(name_version)
+            != extension_name_vers_set.cend())
+        {
             log_error("Duplicate extension in extension name-version array\n");
             return 1;
         }
@@ -301,18 +350,23 @@ static int test_extended_versioning_platform_extensions(cl_platform_id platform)
     }
 
     name_version_set extension_string_set;
-    if (!name_version_set_from_extension_string(extension_string.data(), extension_string_set)) {
+    if (!name_version_set_from_extension_string(extension_string.data(),
+                                                extension_string_set))
+    {
         log_error("Failed to parse platform extension string\n");
         return 1;
     }
 
-    if (extension_string_set != extension_name_vers_set) {
+    if (extension_string_set != extension_name_vers_set)
+    {
         log_error("Platform extension mismatch\n");
 
         log_info("\tExtensions only in numeric:");
-        log_name_only_set_difference(extension_name_vers_set, extension_string_set);
+        log_name_only_set_difference(extension_name_vers_set,
+                                     extension_string_set);
         log_info("\n\tExtensions only in string:");
-        log_name_only_set_difference(extension_string_set, extension_name_vers_set);
+        log_name_only_set_difference(extension_string_set,
+                                     extension_name_vers_set);
         log_info("\n");
 
         return 1;
@@ -323,33 +377,43 @@ static int test_extended_versioning_platform_extensions(cl_platform_id platform)
     return 0;
 }
 
-/* Check that the device extension string and name_version queries return the same set */
+/* Check that the device extension string and name_version queries return the
+ * same set */
 static int test_extended_versioning_device_extensions(cl_device_id device)
 {
     log_info("Device extensions:\n");
-    std::vector<char> extension_string { get_device_string(device, CL_DEVICE_EXTENSIONS) };
-    if (extension_string.empty()) {
+    std::vector<char> extension_string{ get_device_string(
+        device, CL_DEVICE_EXTENSIONS) };
+    if (extension_string.empty())
+    {
         log_error("Could not get CL device extensions string\n");
         return 1;
     }
 
     size_t size{};
-    cl_int err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    cl_int err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR,
+                                 0, nullptr, &size);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
 
-    if ((size % sizeof(cl_name_version_khr)) != 0) {
-        log_error("CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR return size not a multiple of sizeof(cl_name_version_khr)\n");
+    if ((size % sizeof(cl_name_version_khr)) != 0)
+    {
+        log_error("CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR return size not a "
+                  "multiple of sizeof(cl_name_version_khr)\n");
         return 1;
     }
 
     const size_t extension_name_vers_count = size / sizeof(cl_name_version_khr);
-    std::vector<cl_name_version_khr> extension_name_vers(extension_name_vers_count);
+    std::vector<cl_name_version_khr> extension_name_vers(
+        extension_name_vers_count);
 
-    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR, size, extension_name_vers.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR, size,
+                          extension_name_vers.data(), nullptr);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
@@ -357,11 +421,14 @@ static int test_extended_versioning_device_extensions(cl_device_id device)
     name_version_set extension_name_vers_set;
     for (const auto& extension : extension_name_vers)
     {
-        /* Extension string doesn't have versions, so set it to all zeroes for matching */
+        /* Extension string doesn't have versions, so set it to all zeroes for
+         * matching */
         cl_name_version_khr name_version = extension;
         name_version.version = CL_MAKE_VERSION_KHR(0, 0, 0);
 
-        if (extension_name_vers_set.find(name_version) != extension_name_vers_set.cend()) {
+        if (extension_name_vers_set.find(name_version)
+            != extension_name_vers_set.cend())
+        {
             log_error("Duplicate extension in extension name-version array\n");
             return 1;
         }
@@ -370,18 +437,23 @@ static int test_extended_versioning_device_extensions(cl_device_id device)
     }
 
     name_version_set extension_string_set;
-    if (!name_version_set_from_extension_string(extension_string.data(), extension_string_set)) {
+    if (!name_version_set_from_extension_string(extension_string.data(),
+                                                extension_string_set))
+    {
         log_error("Failed to parse device extension string\n");
         return 1;
     }
 
-    if (extension_string_set != extension_name_vers_set) {
+    if (extension_string_set != extension_name_vers_set)
+    {
         log_error("Device extension mismatch\n");
 
         log_info("\tExtensions only in numeric:");
-        log_name_only_set_difference(extension_name_vers_set, extension_string_set);
+        log_name_only_set_difference(extension_name_vers_set,
+                                     extension_string_set);
         log_info("\n\tExtensions only in string:");
-        log_name_only_set_difference(extension_string_set, extension_name_vers_set);
+        log_name_only_set_difference(extension_string_set,
+                                     extension_name_vers_set);
         log_info("\n");
 
         return 1;
@@ -398,54 +470,74 @@ static int test_extended_versioning_device_il(cl_device_id device)
     log_info("Device ILs:\n");
 
     size_t size{};
-    cl_int err = clGetDeviceInfo(device, CL_DEVICE_ILS_WITH_VERSION_KHR, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    cl_int err = clGetDeviceInfo(device, CL_DEVICE_ILS_WITH_VERSION_KHR, 0,
+                                 nullptr, &size);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
 
-    if ((size % sizeof(cl_name_version_khr)) != 0) {
-        log_error("CL_DEVICE_ILS_WITH_VERSION_KHR return size not a multiple of sizeof(cl_name_version_khr)\n");
+    if ((size % sizeof(cl_name_version_khr)) != 0)
+    {
+        log_error("CL_DEVICE_ILS_WITH_VERSION_KHR return size not a multiple "
+                  "of sizeof(cl_name_version_khr)\n");
         return 1;
     }
 
     const size_t il_name_vers_count = size / sizeof(cl_name_version_khr);
     std::vector<cl_name_version_khr> il_name_vers(il_name_vers_count);
 
-    err = clGetDeviceInfo(device, CL_DEVICE_ILS_WITH_VERSION_KHR, size, il_name_vers.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    err = clGetDeviceInfo(device, CL_DEVICE_ILS_WITH_VERSION_KHR, size,
+                          il_name_vers.data(), nullptr);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
 
-    const bool has_khr_il_program = is_extension_available(device, "cl_khr_il_program");
-    const bool has_core_il_program = get_device_cl_version(device) > Version(2, 0);
+    const bool has_khr_il_program =
+        is_extension_available(device, "cl_khr_il_program");
+    const bool has_core_il_program =
+        get_device_cl_version(device) > Version(2, 0);
 
-    // IL query should return an empty list if the device does not support IL programs
-    if (!(has_khr_il_program || has_core_il_program)) {
+    // IL query should return an empty list if the device does not support IL
+    // programs
+    if (!(has_khr_il_program || has_core_il_program))
+    {
         const bool success = il_name_vers.empty();
-        if (!success) {
-            log_error("No il_program support, but CL_DEVICE_ILS_WITH_VERSION_KHR returned a non-empty list\n");
+        if (!success)
+        {
+            log_error(
+                "No il_program support, but CL_DEVICE_ILS_WITH_VERSION_KHR "
+                "returned a non-empty list\n");
             return 1;
-        } else {
-            log_info("\tNo il_program support, and CL_DEVICE_ILS_WITH_VERSION_KHR correctly returned the empty list\n");
+        }
+        else
+        {
+            log_info(
+                "\tNo il_program support, and CL_DEVICE_ILS_WITH_VERSION_KHR "
+                "correctly returned the empty list\n");
             return 0;
         }
     }
 
     // Pick the core or extension version of the query parameter name
-    const cl_device_info il_version_param_name = has_core_il_program ? CL_DEVICE_IL_VERSION : CL_DEVICE_IL_VERSION_KHR;
+    const cl_device_info il_version_param_name =
+        has_core_il_program ? CL_DEVICE_IL_VERSION : CL_DEVICE_IL_VERSION_KHR;
 
-    std::vector<char> il_string { get_device_string(device, il_version_param_name) };
-    if (il_string.empty()) {
+    std::vector<char> il_string{ get_device_string(device,
+                                                   il_version_param_name) };
+    if (il_string.empty())
+    {
         log_error("Couldn't get device IL string\n");
         return 1;
     }
 
     name_version_set il_string_set;
     char* saveptr_outer = nullptr;
-    for (char* token = strtok_r(il_string.data(),  " ", &saveptr_outer); nullptr != token;
-         token       = strtok_r(nullptr, " ", &saveptr_outer))
+    for (char* token = strtok_r(il_string.data(), " ", &saveptr_outer);
+         nullptr != token; token = strtok_r(nullptr, " ", &saveptr_outer))
     {
         char* saveptr_inner = nullptr;
         const char* const prefix = strtok_r(token, "_", &saveptr_inner);
@@ -454,11 +546,13 @@ static int test_extended_versioning_device_il(cl_device_id device)
         unsigned major = 0;
         unsigned minor = 0;
         const int matched = sscanf(version, "%u.%u", &major, &minor);
-        if (2 != matched) {
+        if (2 != matched)
+        {
             log_error("IL version string scan mismatch\n");
             return 1;
         }
-        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(prefix)) {
+        if (CL_NAME_VERSION_MAX_NAME_SIZE_KHR <= strlen(prefix))
+        {
             log_error("IL name longer than allowed\n");
             return 1;
         }
@@ -467,7 +561,8 @@ static int test_extended_versioning_device_il(cl_device_id device)
         strncpy(name_version.name, prefix, CL_NAME_VERSION_MAX_NAME_SIZE_KHR);
         name_version.version = CL_MAKE_VERSION_KHR(major, minor, 0);
 
-        if (il_string_set.find(name_version) != il_string_set.end()) {
+        if (il_string_set.find(name_version) != il_string_set.end())
+        {
             log_error("Duplicate IL version in IL string\n");
             return 1;
         }
@@ -484,7 +579,8 @@ static int test_extended_versioning_device_il(cl_device_id device)
         cl_name_version_khr name_version = il;
         name_version.version = CL_MAKE_VERSION_KHR(major, minor, 0);
 
-        if (il_name_vers_set.find(name_version) != il_name_vers_set.cend()) {
+        if (il_name_vers_set.find(name_version) != il_name_vers_set.cend())
+        {
             log_error("Duplicate IL in name-version array\n");
             return 1;
         }
@@ -492,7 +588,8 @@ static int test_extended_versioning_device_il(cl_device_id device)
         il_name_vers_set.insert(name_version);
     }
 
-    if (il_string_set != il_name_vers_set) {
+    if (il_string_set != il_name_vers_set)
+    {
         log_error("Device IL mismatch\n");
 
         log_info("\tILs only in numeric:");
@@ -512,29 +609,37 @@ static int test_extended_versioning_device_il(cl_device_id device)
 static int test_extended_versioning_device_built_in_kernels(cl_device_id device)
 {
     log_info("Device built-in kernels:\n");
-    std::vector<char> kernel_string { get_device_string(device, CL_DEVICE_BUILT_IN_KERNELS) };
-    if (kernel_string.empty()) {
+    std::vector<char> kernel_string{ get_device_string(
+        device, CL_DEVICE_BUILT_IN_KERNELS) };
+    if (kernel_string.empty())
+    {
         log_error("Could not get CL device extensions string\n");
         return 1;
     }
 
     size_t size{};
-    cl_int err = clGetDeviceInfo(device, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR, 0, nullptr, &size);
-    if (err != CL_SUCCESS) {
+    cl_int err = clGetDeviceInfo(
+        device, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR, 0, nullptr, &size);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
 
-    if ((size % sizeof(cl_name_version_khr)) != 0) {
-        log_error("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR return size not a multiple of sizeof(cl_name_version_khr)\n");
+    if ((size % sizeof(cl_name_version_khr)) != 0)
+    {
+        log_error("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR return size not "
+                  "a multiple of sizeof(cl_name_version_khr)\n");
         return 1;
     }
 
     const size_t kernel_name_vers_count = size / sizeof(cl_name_version_khr);
     std::vector<cl_name_version_khr> kernel_name_vers(kernel_name_vers_count);
 
-    err = clGetDeviceInfo(device, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR, size, kernel_name_vers.data(), nullptr);
-    if (err != CL_SUCCESS) {
+    err = clGetDeviceInfo(device, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR,
+                          size, kernel_name_vers.data(), nullptr);
+    if (err != CL_SUCCESS)
+    {
         log_error("clGetDeviceInfo failed\n");
         return 1;
     }
@@ -545,7 +650,9 @@ static int test_extended_versioning_device_built_in_kernels(cl_device_id device)
         cl_name_version_khr name_version = kernel;
         name_version.version = CL_MAKE_VERSION_KHR(0, 0, 0);
 
-        if (kernel_name_vers_set.find(name_version) != kernel_name_vers_set.cend()) {
+        if (kernel_name_vers_set.find(name_version)
+            != kernel_name_vers_set.cend())
+        {
             log_error("Duplicate kernel in kernel name-version array\n");
             return 1;
         }
@@ -554,12 +661,15 @@ static int test_extended_versioning_device_built_in_kernels(cl_device_id device)
     }
 
     name_version_set kernel_string_set;
-    if (!name_version_set_from_built_in_kernel_string(kernel_string.data(), kernel_string_set)) {
+    if (!name_version_set_from_built_in_kernel_string(kernel_string.data(),
+                                                      kernel_string_set))
+    {
         log_error("Failed to parse device kernel string\n");
         return 1;
     }
 
-    if (kernel_string_set != kernel_name_vers_set) {
+    if (kernel_string_set != kernel_name_vers_set)
+    {
         log_error("Device kernel mismatch\n");
 
         log_info("\tKernels only in numeric:");
@@ -576,15 +686,19 @@ static int test_extended_versioning_device_built_in_kernels(cl_device_id device)
     return 0;
 }
 
-int test_extended_versioning(cl_device_id deviceID, cl_context context, cl_command_queue ignoreQueue, int num_elements)
+int test_extended_versioning(cl_device_id deviceID, cl_context context,
+                             cl_command_queue ignoreQueue, int num_elements)
 {
-    if (!is_extension_available(deviceID, "cl_khr_extended_versioning")) {
-        log_info("cl_khr_extended_versioning not supported. Skipping test...\n");
+    if (!is_extension_available(deviceID, "cl_khr_extended_versioning"))
+    {
+        log_info(
+            "cl_khr_extended_versioning not supported. Skipping test...\n");
         return 0;
     }
 
     cl_platform_id platform;
-    cl_int err = clGetDeviceInfo(deviceID, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr);
+    cl_int err = clGetDeviceInfo(deviceID, CL_DEVICE_PLATFORM, sizeof(platform),
+                                 &platform, nullptr);
     test_error(err, "clGetDeviceInfo failed\n");
 
     int total_errors = 0;

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -15,6 +15,7 @@
 //
 #include "harness/compat.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -489,7 +490,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     | CL_DEVICE_TYPE_DEFAULT;
                 if (info->config.fp_config & ~all_device_types)
                 {
-                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                    log_info("WARNING: %s unknown bits found 0x%08" PRIX64,
                              info->opcode_name,
                              (info->config.fp_config & ~all_device_types));
                 }
@@ -519,7 +520,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     | CL_FP_ROUND_TO_INF | CL_FP_FMA
                     | CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT;
                 if (info->config.fp_config & ~all_fp_config)
-                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                    log_info("WARNING: %s unknown bits found 0x%08" PRIX64,
                              info->opcode_name,
                              (info->config.fp_config & ~all_fp_config));
             }
@@ -573,7 +574,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                 cl_device_exec_capabilities all_exec_cap =
                     CL_EXEC_KERNEL | CL_EXEC_NATIVE_KERNEL;
                 if (info->config.exec_capabilities & ~all_exec_cap)
-                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                    log_info("WARNING: %s unknown bits found 0x%08" PRIX64,
                              info->opcode_name,
                              (info->config.exec_capabilities & ~all_exec_cap));
             }
@@ -592,7 +593,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
                     | CL_QUEUE_PROFILING_ENABLE;
                 if (info->config.queue_properties & ~all_queue_properties)
-                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                    log_info("WARNING: %s unknown bits found 0x%08" PRIX64,
                              info->opcode_name,
                              (info->config.exec_capabilities
                               & ~all_queue_properties));
@@ -638,7 +639,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     | CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE;
                 if (info->config.affinity_domain & ~all_affinity_domain)
                     log_error(
-                        "ERROR: %s unknown bits found 0x%08llX",
+                        "ERROR: %s unknown bits found 0x%08" PRIX64,
                         info->opcode_name,
                         (info->config.affinity_domain & ~all_affinity_domain));
             }
@@ -655,7 +656,8 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
             log_info("\t%s == %zu\n", info->opcode_name, info->config.sizet);
             break;
         case type_cl_ulong:
-            log_info("\t%s == %lld\n", info->opcode_name, info->config.ull);
+            log_info("\t%s == %" PRIu64 "\n", info->opcode_name,
+                     info->config.ull);
             break;
         case type_string:
             log_info("\t%s == \"%s\"\n", info->opcode_name,
@@ -684,7 +686,7 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     | CL_DEVICE_SVM_FINE_GRAIN_SYSTEM | CL_DEVICE_SVM_ATOMICS;
                 if (info->config.svmCapabilities & ~all_svm_capabilities)
                     log_info(
-                        "WARNING: %s unknown bits found 0x%08llX",
+                        "WARNING: %s unknown bits found 0x%08" PRIX64,
                         info->opcode_name,
                         (info->config.svmCapabilities & ~all_svm_capabilities));
             }

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -27,19 +27,18 @@ static int dump_supported_formats;
 typedef struct
 {
     cl_device_type device_type;
-    const char*    device_type_name;
-    unsigned       num_devices;
-    cl_device_id*  devices;
+    const char* device_type_name;
+    unsigned num_devices;
+    cl_device_id* devices;
     // more infos here
 } device_info;
 
-device_info device_infos[] =
-{
-    {CL_DEVICE_TYPE_DEFAULT,     "CL_DEVICE_TYPE_DEFAULT",     -1, NULL},
-    {CL_DEVICE_TYPE_CPU,         "CL_DEVICE_TYPE_CPU",         -1, NULL},
-    {CL_DEVICE_TYPE_GPU,         "CL_DEVICE_TYPE_GPU",         -1, NULL},
-    {CL_DEVICE_TYPE_ACCELERATOR, "CL_DEVICE_TYPE_ACCELERATOR", -1, NULL},
-    {CL_DEVICE_TYPE_ALL,         "CL_DEVICE_TYPE_ALL",         -1, NULL},
+device_info device_infos[] = {
+    { CL_DEVICE_TYPE_DEFAULT, "CL_DEVICE_TYPE_DEFAULT", -1, NULL },
+    { CL_DEVICE_TYPE_CPU, "CL_DEVICE_TYPE_CPU", -1, NULL },
+    { CL_DEVICE_TYPE_GPU, "CL_DEVICE_TYPE_GPU", -1, NULL },
+    { CL_DEVICE_TYPE_ACCELERATOR, "CL_DEVICE_TYPE_ACCELERATOR", -1, NULL },
+    { CL_DEVICE_TYPE_ALL, "CL_DEVICE_TYPE_ALL", -1, NULL },
 };
 
 // config types
@@ -61,197 +60,219 @@ enum
     type_cl_device_svm_capabilities,
 };
 
-typedef union
-{
-    cl_device_type                  type;
-    cl_device_fp_config             fp_config;
-    cl_device_mem_cache_type        mem_cache_type;
-    cl_device_local_mem_type        local_mem_type;
-    cl_device_exec_capabilities     exec_capabilities;
-    cl_command_queue_properties     queue_properties;
-    cl_device_id                    device_id;
-    cl_device_affinity_domain       affinity_domain;
-    cl_int                          uint;
-    size_t                          sizet;
-    size_t                          sizet_arr[3];
-    cl_ulong                        ull;
-    char *                          string;
-    cl_device_svm_capabilities      svmCapabilities;
+typedef union {
+    cl_device_type type;
+    cl_device_fp_config fp_config;
+    cl_device_mem_cache_type mem_cache_type;
+    cl_device_local_mem_type local_mem_type;
+    cl_device_exec_capabilities exec_capabilities;
+    cl_command_queue_properties queue_properties;
+    cl_device_id device_id;
+    cl_device_affinity_domain affinity_domain;
+    cl_int uint;
+    size_t sizet;
+    size_t sizet_arr[3];
+    cl_ulong ull;
+    char* string;
+    cl_device_svm_capabilities svmCapabilities;
 } config_data;
 
-struct _version {
-  int major;
-  int minor;
+struct _version
+{
+    int major;
+    int minor;
 };
 typedef struct _version version_t;
 
-struct _extensions {
-  int cl_khr_fp64;
-  int cl_khr_fp16;
+struct _extensions
+{
+    int cl_khr_fp64;
+    int cl_khr_fp16;
 };
 typedef struct _extensions extensions_t;
 
-// Compare two versions, return -1 (the first is lesser), 0 (equal), 1 (the first is greater).
-int vercmp( version_t a, version_t b ) {
-  if ( a.major < b.major || a.major == b.major && a.minor < b.minor ) {
-    return -1;
-  } else if ( a.major == b.major && a.minor == b.minor ) {
-    return 0;
-  } else {
-    return 1;
-  }
+// Compare two versions, return -1 (the first is lesser), 0 (equal), 1 (the
+// first is greater).
+int vercmp(version_t a, version_t b)
+{
+    if (a.major < b.major || a.major == b.major && a.minor < b.minor)
+    {
+        return -1;
+    }
+    else if (a.major == b.major && a.minor == b.minor)
+    {
+        return 0;
+    }
+    else
+    {
+        return 1;
+    }
 }
 
 typedef struct
 {
-    version_t             version;    // Opcode is introduced in this version of OpenCL spec.
-    cl_device_info        opcode;
-    const char*           opcode_name;
-    int                   config_type;
-    config_data           config;
+    version_t version; // Opcode is introduced in this version of OpenCL spec.
+    cl_device_info opcode;
+    const char* opcode_name;
+    int config_type;
+    config_data config;
 } config_info;
 
-#define CONFIG_INFO( major, minor, opcode, type ) { { major, minor }, opcode, #opcode, type_ ## type, { 0 } }
+#define CONFIG_INFO(major, minor, opcode, type)                                \
+    {                                                                          \
+        { major, minor }, opcode, #opcode, type_##type, { 0 }                  \
+    }
 
-config_info image_buffer_config_infos[] =
-{
+config_info image_buffer_config_infos[] = {
 #ifdef CL_DEVICE_IMAGE_PITCH_ALIGNMENT
-    CONFIG_INFO( 1, 2, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, cl_uint),
-    CONFIG_INFO( 1, 2, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, cl_uint),
 #endif
 };
 
-config_info config_infos[] =
-{
-    // `CL_DEVICE_VERSION' must be the first item in the list! It's version must be 0, 0.
-    CONFIG_INFO( 0, 0, CL_DEVICE_VERSION, string),
+config_info config_infos[] = {
+    // `CL_DEVICE_VERSION' must be the first item in the list! It's version must
+    // be 0, 0.
+    CONFIG_INFO(0, 0, CL_DEVICE_VERSION, string),
     // `CL_DEVICE_EXTENSIONS' must be the second!
-    CONFIG_INFO( 1, 1, CL_DEVICE_EXTENSIONS, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_EXTENSIONS, string),
 
-    CONFIG_INFO( 1, 1, CL_DEVICE_TYPE, cl_device_type),
-    CONFIG_INFO( 1, 1, CL_DEVICE_VENDOR_ID, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_WORK_ITEM_SIZES, size_t_arr),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_WORK_GROUP_SIZE, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_TYPE, cl_device_type),
+    CONFIG_INFO(1, 1, CL_DEVICE_VENDOR_ID, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_WORK_ITEM_SIZES, size_t_arr),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_WORK_GROUP_SIZE, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint),
 
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_ADDRESS_BITS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE2D_MAX_WIDTH, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE2D_MAX_HEIGHT, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE3D_MAX_WIDTH, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE3D_MAX_HEIGHT, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE3D_MAX_DEPTH, size_t),
-    CONFIG_INFO( 1, 2, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, size_t),
-    CONFIG_INFO( 1, 2, CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_IMAGE_SUPPORT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_PARAMETER_SIZE, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_SAMPLERS, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_ADDRESS_BITS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE2D_MAX_WIDTH, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE2D_MAX_HEIGHT, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE3D_MAX_WIDTH, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE3D_MAX_HEIGHT, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE3D_MAX_DEPTH, size_t),
+    CONFIG_INFO(1, 2, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, size_t),
+    CONFIG_INFO(1, 2, CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_IMAGE_SUPPORT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_PARAMETER_SIZE, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_SAMPLERS, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, cl_uint),
 
-    CONFIG_INFO( 1, 1, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config),
-    CONFIG_INFO( 1, 1, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config),
-    CONFIG_INFO( 1, 1, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type),
-    CONFIG_INFO( 1, 1, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong),
-    CONFIG_INFO( 1, 1, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong),
+    CONFIG_INFO(1, 1, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config),
+    CONFIG_INFO(1, 1, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config),
+    CONFIG_INFO(1, 1, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE,
+                cl_device_mem_cache_type),
+    CONFIG_INFO(1, 1, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong),
+    CONFIG_INFO(1, 1, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong),
 
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong),
-    CONFIG_INFO( 1, 1, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_LOCAL_MEM_TYPE, cl_local_mem_type),
-    CONFIG_INFO( 1, 1, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong),
-    CONFIG_INFO( 1, 1, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PROFILING_TIMER_RESOLUTION, size_t),
-    CONFIG_INFO( 1, 1, CL_DEVICE_ENDIAN_LITTLE, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_AVAILABLE, cl_uint),
-    CONFIG_INFO( 1, 1, CL_DEVICE_COMPILER_AVAILABLE, cl_uint),
-    CONFIG_INFO( 1, 2, CL_DEVICE_LINKER_AVAILABLE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong),
+    CONFIG_INFO(1, 1, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_LOCAL_MEM_TYPE, cl_local_mem_type),
+    CONFIG_INFO(1, 1, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong),
+    CONFIG_INFO(1, 1, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_PROFILING_TIMER_RESOLUTION, size_t),
+    CONFIG_INFO(1, 1, CL_DEVICE_ENDIAN_LITTLE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_AVAILABLE, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_COMPILER_AVAILABLE, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_LINKER_AVAILABLE, cl_uint),
 
-    CONFIG_INFO( 1, 2, CL_DEVICE_BUILT_IN_KERNELS, string),
+    CONFIG_INFO(1, 2, CL_DEVICE_BUILT_IN_KERNELS, string),
 
-    CONFIG_INFO( 1, 2, CL_DEVICE_PRINTF_BUFFER_SIZE, size_t),
-    CONFIG_INFO( 1, 2, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_PRINTF_BUFFER_SIZE, size_t),
+    CONFIG_INFO(1, 2, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, cl_uint),
 
-    CONFIG_INFO( 1, 2, CL_DEVICE_PARENT_DEVICE, cl_device_id),
-    CONFIG_INFO( 1, 2, CL_DEVICE_PARTITION_MAX_SUB_DEVICES, cl_uint),
-    CONFIG_INFO( 1, 2, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain),
-    CONFIG_INFO( 1, 2, CL_DEVICE_REFERENCE_COUNT, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_PARENT_DEVICE, cl_device_id),
+    CONFIG_INFO(1, 2, CL_DEVICE_PARTITION_MAX_SUB_DEVICES, cl_uint),
+    CONFIG_INFO(1, 2, CL_DEVICE_PARTITION_AFFINITY_DOMAIN,
+                cl_device_affinity_domain),
+    CONFIG_INFO(1, 2, CL_DEVICE_REFERENCE_COUNT, cl_uint),
 
-    CONFIG_INFO( 1, 1, CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities),
-    CONFIG_INFO( 1, 1, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, cl_command_queue_properties),
-    CONFIG_INFO( 1, 1, CL_DEVICE_NAME, string),
-    CONFIG_INFO( 1, 1, CL_DEVICE_VENDOR, string),
-    CONFIG_INFO( 1, 1, CL_DRIVER_VERSION, string),
-    CONFIG_INFO( 1, 1, CL_DEVICE_PROFILE, string),
-    CONFIG_INFO( 1, 1, CL_DEVICE_VERSION, string),
-    CONFIG_INFO( 1, 1, CL_DEVICE_OPENCL_C_VERSION, string),
-    CONFIG_INFO( 1, 1, CL_DEVICE_EXTENSIONS, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_EXECUTION_CAPABILITIES,
+                cl_device_exec_capabilities),
+    CONFIG_INFO(1, 1, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,
+                cl_command_queue_properties),
+    CONFIG_INFO(1, 1, CL_DEVICE_NAME, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_VENDOR, string),
+    CONFIG_INFO(1, 1, CL_DRIVER_VERSION, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_PROFILE, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_VERSION, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_OPENCL_C_VERSION, string),
+    CONFIG_INFO(1, 1, CL_DEVICE_EXTENSIONS, string),
 
-    CONFIG_INFO( 2, 0, CL_DEVICE_MAX_PIPE_ARGS, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_PIPE_MAX_PACKET_SIZE, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_MAX_PIPE_ARGS, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_PIPE_MAX_PACKET_SIZE, cl_uint),
 
-    CONFIG_INFO( 2, 0, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE, size_t),
-    CONFIG_INFO( 2, 0, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE, size_t),
+    CONFIG_INFO(2, 0, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE, size_t),
+    CONFIG_INFO(2, 0, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE, size_t),
 
-    CONFIG_INFO( 2, 0, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, cl_command_queue_properties),
-    CONFIG_INFO( 2, 0, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES, cl_command_queue_properties),
-    CONFIG_INFO( 2, 0, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_MAX_ON_DEVICE_QUEUES, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_MAX_ON_DEVICE_EVENTS, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,
+                cl_command_queue_properties),
+    CONFIG_INFO(2, 0, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES,
+                cl_command_queue_properties),
+    CONFIG_INFO(2, 0, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_MAX_ON_DEVICE_QUEUES, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_MAX_ON_DEVICE_EVENTS, cl_uint),
 
-    CONFIG_INFO( 2, 0, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint),
-    CONFIG_INFO( 2, 0, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT , cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint),
+    CONFIG_INFO(2, 0, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT, cl_uint),
 
-    CONFIG_INFO( 2, 0, CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities),
+    CONFIG_INFO(2, 0, CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities),
 
-    CONFIG_INFO( 2, 1, CL_DEVICE_IL_VERSION, string),
-    CONFIG_INFO( 2, 1, CL_DEVICE_MAX_NUM_SUB_GROUPS, cl_uint),
-    CONFIG_INFO( 2, 1, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, cl_uint),
+    CONFIG_INFO(2, 1, CL_DEVICE_IL_VERSION, string),
+    CONFIG_INFO(2, 1, CL_DEVICE_MAX_NUM_SUB_GROUPS, cl_uint),
+    CONFIG_INFO(2, 1, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
+                cl_uint),
 };
 
-#define ENTRY(T) { T, #T }
-struct image_type_entry {
+#define ENTRY(T)                                                               \
+    {                                                                          \
+        T, #T                                                                  \
+    }
+struct image_type_entry
+{
     cl_mem_object_type val;
-    const char *str;
+    const char* str;
 };
 static const struct image_type_entry image_types[] = {
-    ENTRY(CL_MEM_OBJECT_IMAGE1D), ENTRY(CL_MEM_OBJECT_IMAGE1D_BUFFER),
-    ENTRY(CL_MEM_OBJECT_IMAGE2D), ENTRY(CL_MEM_OBJECT_IMAGE3D),
+    ENTRY(CL_MEM_OBJECT_IMAGE1D),       ENTRY(CL_MEM_OBJECT_IMAGE1D_BUFFER),
+    ENTRY(CL_MEM_OBJECT_IMAGE2D),       ENTRY(CL_MEM_OBJECT_IMAGE3D),
     ENTRY(CL_MEM_OBJECT_IMAGE1D_ARRAY), ENTRY(CL_MEM_OBJECT_IMAGE2D_ARRAY)
 };
 
-struct supported_flags_entry {
+struct supported_flags_entry
+{
     cl_mem_flags val;
-    const char *str;
+    const char* str;
 };
 
 static const struct supported_flags_entry supported_flags[] = {
-    ENTRY(CL_MEM_READ_ONLY), ENTRY(CL_MEM_WRITE_ONLY),
-    ENTRY(CL_MEM_READ_WRITE), ENTRY(CL_MEM_KERNEL_READ_AND_WRITE)
+    ENTRY(CL_MEM_READ_ONLY), ENTRY(CL_MEM_WRITE_ONLY), ENTRY(CL_MEM_READ_WRITE),
+    ENTRY(CL_MEM_KERNEL_READ_AND_WRITE)
 };
 
 int getImageInfo(cl_device_id device)
@@ -259,60 +280,73 @@ int getImageInfo(cl_device_id device)
     cl_context ctx;
     cl_int err;
     cl_uint i, num_supported;
-    cl_image_format *formats;
+    cl_image_format* formats;
     int num_errors;
-    int ii, ni = sizeof(image_types)/sizeof(image_types[0]);
-    int fi, nf = sizeof(supported_flags)/sizeof(supported_flags[0]);
+    int ii, ni = sizeof(image_types) / sizeof(image_types[0]);
+    int fi, nf = sizeof(supported_flags) / sizeof(supported_flags[0]);
 
     ctx = clCreateContext(NULL, 1, &device, notify_callback, NULL, &err);
-    if (!ctx) {
+    if (!ctx)
+    {
         print_error(err, "Unable to create context from device");
         return 1;
     }
 
     num_errors = 0;
-    for (ii=0; ii<ni; ++ii) {
+    for (ii = 0; ii < ni; ++ii)
+    {
         log_info("\t%s supported formats:\n", image_types[ii].str);
-        for (fi=0; fi<nf; ++fi) {
+        for (fi = 0; fi < nf; ++fi)
+        {
 
-            err = clGetSupportedImageFormats(ctx, supported_flags[fi].val, image_types[ii].val, 5000, NULL, &num_supported);
-            if (err != CL_SUCCESS) {
+            err = clGetSupportedImageFormats(ctx, supported_flags[fi].val,
+                                             image_types[ii].val, 5000, NULL,
+                                             &num_supported);
+            if (err != CL_SUCCESS)
+            {
                 print_error(err, "clGetSupportedImageFormats failed");
                 ++num_errors;
                 continue;
             }
 
-            log_info("\t\t%s: %u supported formats\n", supported_flags[fi].str, num_supported);
+            log_info("\t\t%s: %u supported formats\n", supported_flags[fi].str,
+                     num_supported);
 
-            if (num_supported == 0 || dump_supported_formats == 0)
-                continue;
+            if (num_supported == 0 || dump_supported_formats == 0) continue;
 
-            formats = (cl_image_format *)malloc(num_supported * sizeof(cl_image_format));
-            if (formats == NULL) {
+            formats = (cl_image_format*)malloc(num_supported
+                                               * sizeof(cl_image_format));
+            if (formats == NULL)
+            {
                 log_error("malloc failed\n");
                 clReleaseContext(ctx);
                 return num_errors + 1;
             }
 
-            err = clGetSupportedImageFormats(ctx, supported_flags[fi].val, image_types[ii].val, num_supported, formats, NULL);
-            if (err != CL_SUCCESS) {
+            err = clGetSupportedImageFormats(ctx, supported_flags[fi].val,
+                                             image_types[ii].val, num_supported,
+                                             formats, NULL);
+            if (err != CL_SUCCESS)
+            {
                 print_error(err, "clGetSupportedImageFormats failed");
                 ++num_errors;
                 free(formats);
                 continue;
             }
 
-            for (i=0; i<num_supported; ++i)
-                log_info("\t\t\t%s / %s\n",
-                         GetChannelOrderName(formats[i].image_channel_order),
-                         GetChannelTypeName(formats[i].image_channel_data_type));
+            for (i = 0; i < num_supported; ++i)
+                log_info(
+                    "\t\t\t%s / %s\n",
+                    GetChannelOrderName(formats[i].image_channel_order),
+                    GetChannelTypeName(formats[i].image_channel_data_type));
 
             free(formats);
         }
     }
 
     err = clReleaseContext(ctx);
-    if (err) {
+    if (err)
+    {
         print_error(err, "Failed to release context\n");
         ++num_errors;
     }
@@ -326,78 +360,106 @@ int getConfigInfo(cl_device_id device, config_info* info)
     int size_err = 0;
     size_t config_size_set;
     size_t config_size_ret;
-    switch(info->config_type)
+    switch (info->config_type)
     {
         case type_cl_device_type:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.type), &info->config.type, &config_size_ret);
+            err =
+                clGetDeviceInfo(device, info->opcode, sizeof(info->config.type),
+                                &info->config.type, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.type);
             break;
         case type_cl_device_fp_config:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.fp_config), &info->config.fp_config, &config_size_ret);
+            err = clGetDeviceInfo(device, info->opcode,
+                                  sizeof(info->config.fp_config),
+                                  &info->config.fp_config, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.fp_config);
             break;
         case type_cl_device_mem_cache_type:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.mem_cache_type), &info->config.mem_cache_type, &config_size_ret);
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.mem_cache_type),
+                &info->config.mem_cache_type, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.mem_cache_type);
             break;
         case type_cl_local_mem_type:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.local_mem_type), &info->config.local_mem_type, &config_size_ret);
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.local_mem_type),
+                &info->config.local_mem_type, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.local_mem_type);
             break;
         case type_cl_device_exec_capabilities:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.exec_capabilities), &info->config.exec_capabilities, &config_size_ret);
-            size_err = config_size_ret != sizeof(info->config.exec_capabilities);
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.exec_capabilities),
+                &info->config.exec_capabilities, &config_size_ret);
+            size_err =
+                config_size_ret != sizeof(info->config.exec_capabilities);
             break;
         case type_cl_command_queue_properties:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.queue_properties), &info->config.queue_properties, &config_size_ret);
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.queue_properties),
+                &info->config.queue_properties, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.queue_properties);
             break;
         case type_cl_device_id:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.device_id), &info->config.device_id, &config_size_ret);
+            err = clGetDeviceInfo(device, info->opcode,
+                                  sizeof(info->config.device_id),
+                                  &info->config.device_id, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.device_id);
             break;
         case type_cl_device_affinity_domain:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.affinity_domain), &info->config.affinity_domain, &config_size_ret);
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.affinity_domain),
+                &info->config.affinity_domain, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.affinity_domain);
             break;
         case type_cl_uint:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.uint), &info->config.uint, &config_size_ret);
+            err =
+                clGetDeviceInfo(device, info->opcode, sizeof(info->config.uint),
+                                &info->config.uint, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.uint);
             break;
         case type_size_t_arr:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.sizet_arr), &info->config.sizet_arr, &config_size_ret);
+            err = clGetDeviceInfo(device, info->opcode,
+                                  sizeof(info->config.sizet_arr),
+                                  &info->config.sizet_arr, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.sizet_arr);
             break;
         case type_size_t:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.sizet), &info->config.sizet, &config_size_ret);
+            err = clGetDeviceInfo(device, info->opcode,
+                                  sizeof(info->config.sizet),
+                                  &info->config.sizet, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.sizet);
             break;
         case type_cl_ulong:
-            err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.ull), &info->config.ull, &config_size_ret);
+            err =
+                clGetDeviceInfo(device, info->opcode, sizeof(info->config.ull),
+                                &info->config.ull, &config_size_ret);
             size_err = config_size_ret != sizeof(info->config.ull);
             break;
         case type_string:
-            err = clGetDeviceInfo(device, info->opcode, 0, NULL, &config_size_set);
+            err = clGetDeviceInfo(device, info->opcode, 0, NULL,
+                                  &config_size_set);
             info->config.string = NULL;
-            if (err == CL_SUCCESS && config_size_set > 0) {
+            if (err == CL_SUCCESS && config_size_set > 0)
+            {
                 info->config.string = (char*)malloc(config_size_set);
-                err = clGetDeviceInfo(device, info->opcode, config_size_set, info->config.string, &config_size_ret);
+                err = clGetDeviceInfo(device, info->opcode, config_size_set,
+                                      info->config.string, &config_size_ret);
                 size_err = config_size_set != config_size_ret;
             }
             break;
         case type_cl_device_svm_capabilities:
-          err = clGetDeviceInfo(device, info->opcode, sizeof(info->config.svmCapabilities), &info->config.svmCapabilities, &config_size_ret);
-          break;
+            err = clGetDeviceInfo(
+                device, info->opcode, sizeof(info->config.svmCapabilities),
+                &info->config.svmCapabilities, &config_size_ret);
+            break;
         default:
             log_error("Unknown config type: %d\n", info->config_type);
             break;
     }
     if (err || size_err)
         log_error("\tFailed clGetDeviceInfo for %s.\n", info->opcode_name);
-    if(err)
-        print_error(err, "\t\tclGetDeviceInfo failed.");
-    if (size_err)
-        log_error("\t\tWrong size return from clGetDeviceInfo.\n");
+    if (err) print_error(err, "\t\tclGetDeviceInfo failed.");
+    if (size_err) log_error("\t\tWrong size return from clGetDeviceInfo.\n");
     return err || size_err;
 }
 
@@ -405,43 +467,65 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
 {
     // We should not error if we find an unknown configuration since vendors
     // may specify their own options beyond the list in the specification.
-    switch(info->config_type)
+    switch (info->config_type)
     {
         case type_cl_device_type:
             log_info("\t%s == %s|%s|%s|%s\n", info->opcode_name,
-                     (info->config.fp_config & CL_DEVICE_TYPE_CPU) ? "CL_DEVICE_TYPE_CPU":"",
-                     (info->config.fp_config & CL_DEVICE_TYPE_GPU) ? "CL_DEVICE_TYPE_GPU":"",
-                     (info->config.fp_config & CL_DEVICE_TYPE_ACCELERATOR) ? "CL_DEVICE_TYPE_ACCELERATOR":"",
-                     (info->config.fp_config & CL_DEVICE_TYPE_DEFAULT) ? "CL_DEVICE_TYPE_DEFAULT":""
-                     );
+                     (info->config.fp_config & CL_DEVICE_TYPE_CPU)
+                         ? "CL_DEVICE_TYPE_CPU"
+                         : "",
+                     (info->config.fp_config & CL_DEVICE_TYPE_GPU)
+                         ? "CL_DEVICE_TYPE_GPU"
+                         : "",
+                     (info->config.fp_config & CL_DEVICE_TYPE_ACCELERATOR)
+                         ? "CL_DEVICE_TYPE_ACCELERATOR"
+                         : "",
+                     (info->config.fp_config & CL_DEVICE_TYPE_DEFAULT)
+                         ? "CL_DEVICE_TYPE_DEFAULT"
+                         : "");
             {
-                cl_device_type all_device_types = CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR | CL_DEVICE_TYPE_DEFAULT;
-                if(info->config.fp_config & ~all_device_types)
+                cl_device_type all_device_types = CL_DEVICE_TYPE_CPU
+                    | CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR
+                    | CL_DEVICE_TYPE_DEFAULT;
+                if (info->config.fp_config & ~all_device_types)
                 {
-                    log_info("WARNING: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.fp_config & ~all_device_types));
+                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                             info->opcode_name,
+                             (info->config.fp_config & ~all_device_types));
                 }
             }
             break;
         case type_cl_device_fp_config:
-            log_info("\t%s == %s|%s|%s|%s|%s|%s|%s\n", info->opcode_name,
-                     (info->config.fp_config & CL_FP_DENORM) ? "CL_FP_DENORM":"",
-                     (info->config.fp_config & CL_FP_INF_NAN) ? "CL_FP_INF_NAN":"",
-                     (info->config.fp_config & CL_FP_ROUND_TO_NEAREST) ? "CL_FP_ROUND_TO_NEAREST":"",
-                     (info->config.fp_config & CL_FP_ROUND_TO_ZERO) ? "CL_FP_ROUND_TO_ZERO":"",
-                     (info->config.fp_config & CL_FP_ROUND_TO_INF) ? "CL_FP_ROUND_TO_INF":"",
-                     (info->config.fp_config & CL_FP_FMA) ? "CL_FP_FMA":"",
-                     (info->config.fp_config & CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT) ? "CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT":""
-                     );
+            log_info(
+                "\t%s == %s|%s|%s|%s|%s|%s|%s\n", info->opcode_name,
+                (info->config.fp_config & CL_FP_DENORM) ? "CL_FP_DENORM" : "",
+                (info->config.fp_config & CL_FP_INF_NAN) ? "CL_FP_INF_NAN" : "",
+                (info->config.fp_config & CL_FP_ROUND_TO_NEAREST)
+                    ? "CL_FP_ROUND_TO_NEAREST"
+                    : "",
+                (info->config.fp_config & CL_FP_ROUND_TO_ZERO)
+                    ? "CL_FP_ROUND_TO_ZERO"
+                    : "",
+                (info->config.fp_config & CL_FP_ROUND_TO_INF)
+                    ? "CL_FP_ROUND_TO_INF"
+                    : "",
+                (info->config.fp_config & CL_FP_FMA) ? "CL_FP_FMA" : "",
+                (info->config.fp_config & CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT)
+                    ? "CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT"
+                    : "");
             {
-                cl_device_fp_config all_fp_config = CL_FP_DENORM | CL_FP_INF_NAN | CL_FP_ROUND_TO_NEAREST |
-                                                    CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF | CL_FP_FMA |
-                                                    CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT;
-                if(info->config.fp_config & ~all_fp_config)
-                    log_info("WARNING: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.fp_config & ~all_fp_config));
+                cl_device_fp_config all_fp_config = CL_FP_DENORM | CL_FP_INF_NAN
+                    | CL_FP_ROUND_TO_NEAREST | CL_FP_ROUND_TO_ZERO
+                    | CL_FP_ROUND_TO_INF | CL_FP_FMA
+                    | CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT;
+                if (info->config.fp_config & ~all_fp_config)
+                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                             info->opcode_name,
+                             (info->config.fp_config & ~all_fp_config));
             }
             break;
         case type_cl_device_mem_cache_type:
-            switch(info->config.mem_cache_type)
+            switch (info->config.mem_cache_type)
             {
                 case CL_NONE:
                     log_info("\t%s == CL_NONE\n", info->opcode_name);
@@ -450,15 +534,17 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     log_info("\t%s == CL_READ_ONLY_CACHE\n", info->opcode_name);
                     break;
                 case CL_READ_WRITE_CACHE:
-                    log_info("\t%s == CL_READ_WRITE_CACHE\n", info->opcode_name);
+                    log_info("\t%s == CL_READ_WRITE_CACHE\n",
+                             info->opcode_name);
                     break;
                 default:
-                    log_error("ERROR: %s out of range, %d\n", info->opcode_name, info->config.mem_cache_type);
+                    log_error("ERROR: %s out of range, %d\n", info->opcode_name,
+                              info->config.mem_cache_type);
                     break;
             }
             break;
         case type_cl_local_mem_type:
-            switch(info->config.local_mem_type)
+            switch (info->config.local_mem_type)
             {
                 case CL_NONE:
                     log_info("\t%s == CL_NONE\n", info->opcode_name);
@@ -470,59 +556,100 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
                     log_info("\t%s == CL_GLOBAL\n", info->opcode_name);
                     break;
                 default:
-                    log_info("WARNING: %s out of range, %d\n", info->opcode_name, info->config.local_mem_type);
+                    log_info("WARNING: %s out of range, %d\n",
+                             info->opcode_name, info->config.local_mem_type);
                     break;
             }
             break;
         case type_cl_device_exec_capabilities:
             log_info("\t%s == %s|%s\n", info->opcode_name,
-                     (info->config.exec_capabilities & CL_EXEC_KERNEL) ? "CL_EXEC_KERNEL":"",
-                     (info->config.exec_capabilities & CL_EXEC_NATIVE_KERNEL) ? "CL_EXEC_NATIVE_KERNEL":"" );
+                     (info->config.exec_capabilities & CL_EXEC_KERNEL)
+                         ? "CL_EXEC_KERNEL"
+                         : "",
+                     (info->config.exec_capabilities & CL_EXEC_NATIVE_KERNEL)
+                         ? "CL_EXEC_NATIVE_KERNEL"
+                         : "");
             {
-                cl_device_exec_capabilities all_exec_cap = CL_EXEC_KERNEL | CL_EXEC_NATIVE_KERNEL;
-                if(info->config.exec_capabilities & ~all_exec_cap)
-                    log_info("WARNING: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.exec_capabilities & ~all_exec_cap));
+                cl_device_exec_capabilities all_exec_cap =
+                    CL_EXEC_KERNEL | CL_EXEC_NATIVE_KERNEL;
+                if (info->config.exec_capabilities & ~all_exec_cap)
+                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                             info->opcode_name,
+                             (info->config.exec_capabilities & ~all_exec_cap));
             }
             break;
         case type_cl_command_queue_properties:
             log_info("\t%s == %s|%s\n", info->opcode_name,
-                     (info->config.queue_properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) ? "CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE":"",
-                     (info->config.queue_properties & CL_QUEUE_PROFILING_ENABLE) ? "CL_QUEUE_PROFILING_ENABLE":"");
+                     (info->config.queue_properties
+                      & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
+                         ? "CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE"
+                         : "",
+                     (info->config.queue_properties & CL_QUEUE_PROFILING_ENABLE)
+                         ? "CL_QUEUE_PROFILING_ENABLE"
+                         : "");
             {
-                cl_command_queue_properties all_queue_properties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_PROFILING_ENABLE;
-                if(info->config.queue_properties & ~all_queue_properties)
-                    log_info("WARNING: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.exec_capabilities & ~all_queue_properties));
+                cl_command_queue_properties all_queue_properties =
+                    CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
+                    | CL_QUEUE_PROFILING_ENABLE;
+                if (info->config.queue_properties & ~all_queue_properties)
+                    log_info("WARNING: %s unknown bits found 0x%08llX",
+                             info->opcode_name,
+                             (info->config.exec_capabilities
+                              & ~all_queue_properties));
             }
             break;
         case type_cl_device_id:
-            log_info("\t%s == %ld\n", info->opcode_name, (intptr_t)info->config.device_id);
+            log_info("\t%s == %ld\n", info->opcode_name,
+                     (intptr_t)info->config.device_id);
             break;
         case type_cl_device_affinity_domain:
-            log_info("\t%s == %s|%s|%s|%s|%s|%s\n", info->opcode_name,
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_NUMA) ? "CL_DEVICE_AFFINITY_DOMAIN_NUMA":"",
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE) ? "CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE":"",
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE) ? "CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE":"",
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE) ? "CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE":"",
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE) ? "CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE":"",
-                     (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE) ? "CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE":""
-                     );
+            log_info(
+                "\t%s == %s|%s|%s|%s|%s|%s\n", info->opcode_name,
+                (info->config.affinity_domain & CL_DEVICE_AFFINITY_DOMAIN_NUMA)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_NUMA"
+                    : "",
+                (info->config.affinity_domain
+                 & CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE"
+                    : "",
+                (info->config.affinity_domain
+                 & CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE"
+                    : "",
+                (info->config.affinity_domain
+                 & CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE"
+                    : "",
+                (info->config.affinity_domain
+                 & CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE"
+                    : "",
+                (info->config.affinity_domain
+                 & CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE)
+                    ? "CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE"
+                    : "");
             {
-                cl_device_affinity_domain all_affinity_domain = CL_DEVICE_AFFINITY_DOMAIN_NUMA |
-                                                                CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE |
-                                                                CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE |
-                                                                CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE |
-                                                                CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE |
-                                                                CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE;
-                if(info->config.affinity_domain & ~all_affinity_domain)
-                    log_error("ERROR: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.affinity_domain & ~all_affinity_domain));
+                cl_device_affinity_domain all_affinity_domain =
+                    CL_DEVICE_AFFINITY_DOMAIN_NUMA
+                    | CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE
+                    | CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE
+                    | CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE
+                    | CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE
+                    | CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE;
+                if (info->config.affinity_domain & ~all_affinity_domain)
+                    log_error(
+                        "ERROR: %s unknown bits found 0x%08llX",
+                        info->opcode_name,
+                        (info->config.affinity_domain & ~all_affinity_domain));
             }
             break;
         case type_cl_uint:
             log_info("\t%s == %u\n", info->opcode_name, info->config.uint);
             break;
         case type_size_t_arr:
-            log_info("\t%s == %zu %zu %zu\n", info->opcode_name, info->config.sizet_arr[0],
-                     info->config.sizet_arr[1], info->config.sizet_arr[2]);
+            log_info("\t%s == %zu %zu %zu\n", info->opcode_name,
+                     info->config.sizet_arr[0], info->config.sizet_arr[1],
+                     info->config.sizet_arr[2]);
             break;
         case type_size_t:
             log_info("\t%s == %zu\n", info->opcode_name, info->config.sizet);
@@ -531,223 +658,299 @@ void dumpConfigInfo(cl_device_id device, config_info* info)
             log_info("\t%s == %lld\n", info->opcode_name, info->config.ull);
             break;
         case type_string:
-            log_info("\t%s == \"%s\"\n", info->opcode_name, info->config.string ? info->config.string : "");
+            log_info("\t%s == \"%s\"\n", info->opcode_name,
+                     info->config.string ? info->config.string : "");
             break;
         case type_cl_device_svm_capabilities:
-          log_info("\t%s == %s|%s|%s|%s\n", info->opcode_name,
-            (info->config.svmCapabilities & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) ? "CL_DEVICE_SVM_COARSE_GRAIN_BUFFER":"",
-            (info->config.svmCapabilities & CL_DEVICE_SVM_FINE_GRAIN_BUFFER) ? "CL_DEVICE_SVM_FINE_GRAIN_BUFFER":"",
-            (info->config.svmCapabilities & CL_DEVICE_SVM_FINE_GRAIN_SYSTEM) ? "CL_DEVICE_SVM_FINE_GRAIN_SYSTEM":"",
-            (info->config.svmCapabilities & CL_DEVICE_SVM_ATOMICS) ? "CL_DEVICE_SVM_ATOMICS":"");
-          {
-            cl_device_svm_capabilities all_svm_capabilities = CL_DEVICE_SVM_COARSE_GRAIN_BUFFER |
-                                                              CL_DEVICE_SVM_FINE_GRAIN_BUFFER |
-                                                              CL_DEVICE_SVM_FINE_GRAIN_SYSTEM |
-                                                              CL_DEVICE_SVM_ATOMICS;
-            if(info->config.svmCapabilities & ~all_svm_capabilities)
-              log_info("WARNING: %s unknown bits found 0x%08llX", info->opcode_name, (info->config.svmCapabilities & ~all_svm_capabilities));
-          }
-          break;
+            log_info(
+                "\t%s == %s|%s|%s|%s\n", info->opcode_name,
+                (info->config.svmCapabilities
+                 & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER)
+                    ? "CL_DEVICE_SVM_COARSE_GRAIN_BUFFER"
+                    : "",
+                (info->config.svmCapabilities & CL_DEVICE_SVM_FINE_GRAIN_BUFFER)
+                    ? "CL_DEVICE_SVM_FINE_GRAIN_BUFFER"
+                    : "",
+                (info->config.svmCapabilities & CL_DEVICE_SVM_FINE_GRAIN_SYSTEM)
+                    ? "CL_DEVICE_SVM_FINE_GRAIN_SYSTEM"
+                    : "",
+                (info->config.svmCapabilities & CL_DEVICE_SVM_ATOMICS)
+                    ? "CL_DEVICE_SVM_ATOMICS"
+                    : "");
+            {
+                cl_device_svm_capabilities all_svm_capabilities =
+                    CL_DEVICE_SVM_COARSE_GRAIN_BUFFER
+                    | CL_DEVICE_SVM_FINE_GRAIN_BUFFER
+                    | CL_DEVICE_SVM_FINE_GRAIN_SYSTEM | CL_DEVICE_SVM_ATOMICS;
+                if (info->config.svmCapabilities & ~all_svm_capabilities)
+                    log_info(
+                        "WARNING: %s unknown bits found 0x%08llX",
+                        info->opcode_name,
+                        (info->config.svmCapabilities & ~all_svm_capabilities));
+            }
+            break;
     }
 }
 
-void print_platform_string_selector( cl_platform_id platform, const char *selector_name, cl_platform_info selector )
+void print_platform_string_selector(cl_platform_id platform,
+                                    const char* selector_name,
+                                    cl_platform_info selector)
 {
     // Currently all the selectors are strings
     size_t size = 0;
-    char *value;
+    char* value;
     int err;
 
-    if(( err = clGetPlatformInfo( platform, selector, 0, NULL, &size )))
+    if ((err = clGetPlatformInfo(platform, selector, 0, NULL, &size)))
     {
-        log_error( "FAILURE: Unable to get platform info size for %s.\n", selector_name );
-        exit( -1 );
-    }
-
-    if( size == 0 )
-    {
-        log_error( "FAILURE: The size of %s was returned to be zero.\n", selector_name );
-        exit( -1 );
-    }
-
-    value = (char*) malloc( size );
-    if( NULL == value )
-    {
-        log_error( "Internal test failure:  Unable to allocate %zu bytes\n", size );
+        log_error("FAILURE: Unable to get platform info size for %s.\n",
+                  selector_name);
         exit(-1);
     }
 
-    memset( value, -1, size );
-    if(( err = clGetPlatformInfo( platform, selector, size, value, NULL )))
+    if (size == 0)
     {
-        log_error( "FAILURE: Unable to get platform info for %s.\n", selector_name );
-        free( value );
-        exit( -1 );
+        log_error("FAILURE: The size of %s was returned to be zero.\n",
+                  selector_name);
+        exit(-1);
     }
 
-    if( value[size-1] != '\0' )
+    value = (char*)malloc(size);
+    if (NULL == value)
     {
-        log_error( "FAILURE: platform info for %s is either not NUL terminated, or the size is wrong.\n", selector_name );
-        free( value );
-        exit( -1 );
+        log_error("Internal test failure:  Unable to allocate %zu bytes\n",
+                  size);
+        exit(-1);
     }
 
-    log_info( "\t%s: %s\n", selector_name, value );
-    free( value );
+    memset(value, -1, size);
+    if ((err = clGetPlatformInfo(platform, selector, size, value, NULL)))
+    {
+        log_error("FAILURE: Unable to get platform info for %s.\n",
+                  selector_name);
+        free(value);
+        exit(-1);
+    }
+
+    if (value[size - 1] != '\0')
+    {
+        log_error("FAILURE: platform info for %s is either not NUL terminated, "
+                  "or the size is wrong.\n",
+                  selector_name);
+        free(value);
+        exit(-1);
+    }
+
+    log_info("\t%s: %s\n", selector_name, value);
+    free(value);
 }
 
-int parseVersion( char const * str, version_t * version )
+int parseVersion(char const* str, version_t* version)
 {
-  int rc = -1;
-  version->major = 0;
-  version->minor = 0;
-  if ( strncmp( str, "OpenCL 1.2", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 1;
-    version->minor = 2;
-    rc = 0;
-  } else if ( strncmp( str, "OpenCL 1.0", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 1;
+    int rc = -1;
+    version->major = 0;
     version->minor = 0;
-    rc = 0;
-  } else if ( strncmp( str, "OpenCL 1.1", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 1;
-    version->minor = 1;
-    rc = 0;
-  } else if ( strncmp( str, "OpenCL 2.0", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 2;
-    version->minor = 0;
-    rc = 0;
-  } else if ( strncmp( str, "OpenCL 2.1", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 2;
-    version->minor = 1;
-    rc = 0;
-  } else if ( strncmp( str, "OpenCL 2.2", 10 ) == 0 && ( str[ 10 ] == 0 || str[ 10 ] == ' ' ) ) {
-    version->major = 2;
-    version->minor = 2;
-    rc = 0;
-  }
-  else if (strncmp(str, "OpenCL 3.0", 10) == 0
-           && (str[10] == 0 || str[10] == ' '))
-  {
-      version->major = 3;
-      version->minor = 0;
-      rc = 0;
-  }
-  else
-  {
-      log_error("ERROR: Unexpected version string: `%s'.\n", str);
-  };
-  return rc;
-}
-
-int parseExtensions( char const * str, extensions_t * extensions )
-{
-  char const * begin  = NULL;
-  char const * space  = NULL;
-  size_t       length = 0;
-
-  memset( extensions, 0, sizeof ( extensions_t ) );
-
-  begin = str;
-  while ( begin[ 0 ] != 0 ) {
-    space = strchr( begin, ' ' );    // Find space position.
-    if ( space != NULL ) {           // Calculate length of word.
-      length = space - begin;
-    } else {
-      length = strlen( begin );
+    if (strncmp(str, "OpenCL 1.2", 10) == 0 && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 1;
+        version->minor = 2;
+        rc = 0;
     }
-    if ( strncmp( begin, "cl_khr_fp64", length ) == 0 ) {
-      extensions->cl_khr_fp64 = 1;
+    else if (strncmp(str, "OpenCL 1.0", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 1;
+        version->minor = 0;
+        rc = 0;
     }
-    if ( strncmp( begin, "cl_khr_fp16", length ) == 0 ) {
-      extensions->cl_khr_fp16 = 1;
+    else if (strncmp(str, "OpenCL 1.1", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 1;
+        version->minor = 1;
+        rc = 0;
     }
-    begin += length;                 // Skip word.
-    if ( begin[ 0 ] == ' ' ) {       // Skip space, if any.
-      begin += 1;
+    else if (strncmp(str, "OpenCL 2.0", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 2;
+        version->minor = 0;
+        rc = 0;
     }
-  }
-
-  return 0;
-}
-
-int getConfigInfos( cl_device_id device )
-{
-  int             total_errors = 0;
-  unsigned        onConfigInfo;
-  version_t       version = { 0, 0 }; // Version of the device. Will get real value on the first loop iteration.
-  version_t const ver11   = { 1, 1 }; // Version 1.1.
-  extensions_t    extensions = { 0 };
-  int             get;                // Boolean flag: true = get property, false = skip it.
-  int             err;
-  for ( onConfigInfo = 0; onConfigInfo < sizeof(config_infos) / sizeof(config_infos[0]); onConfigInfo++) {
-    config_info info = config_infos[ onConfigInfo ];
-    // Get a property only if device version is equal or greater than property version.
-    get = ( vercmp( version, info.version ) >= 0 );
-    if ( info.opcode == CL_DEVICE_DOUBLE_FP_CONFIG && vercmp( version, ver11 ) <= 0 ) {
-      // CL_DEVICE_DOUBLE_FP_CONFIG is a special case. It was introduced in OpenCL 1.1, but
-      // device is required to report it only if doubles are supported. So, before querying
-      // it on device version 1.1, we have to check doubles are sopported.
-      // In OpenCL 1.2 CL_DEVICE_DOUBLE_FP_CONFIG should be reported unconditionally.
-      get = extensions.cl_khr_fp64;
+    else if (strncmp(str, "OpenCL 2.1", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 2;
+        version->minor = 1;
+        rc = 0;
+    }
+    else if (strncmp(str, "OpenCL 2.2", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 2;
+        version->minor = 2;
+        rc = 0;
+    }
+    else if (strncmp(str, "OpenCL 3.0", 10) == 0
+             && (str[10] == 0 || str[10] == ' '))
+    {
+        version->major = 3;
+        version->minor = 0;
+        rc = 0;
+    }
+    else
+    {
+        log_error("ERROR: Unexpected version string: `%s'.\n", str);
     };
-    if ( info.opcode == CL_DEVICE_HALF_FP_CONFIG ) {
-      // CL_DEVICE_HALF_FP_CONFIG should be reported only when cl_khr_fp16 extension is available
-      get = extensions.cl_khr_fp16;
-    };
-    if ( get ) {
-      err = getConfigInfo(device, & info);
-      if ( ! err ) {
-        dumpConfigInfo(device, & info);
-        if ( info.opcode == CL_DEVICE_VERSION ) {
-          err = parseVersion( info.config.string, & version );
-          if ( err ) {
-            total_errors++;
-            free(info.config.string);
-            break;
-          }
-        } else if ( info.opcode == CL_DEVICE_EXTENSIONS ) {
-          err = parseExtensions( info.config.string, & extensions );
-          if ( err ) {
-            total_errors++;
-            free(info.config.string);
-            break;
-          }
+    return rc;
+}
+
+int parseExtensions(char const* str, extensions_t* extensions)
+{
+    char const* begin = NULL;
+    char const* space = NULL;
+    size_t length = 0;
+
+    memset(extensions, 0, sizeof(extensions_t));
+
+    begin = str;
+    while (begin[0] != 0)
+    {
+        space = strchr(begin, ' '); // Find space position.
+        if (space != NULL)
+        { // Calculate length of word.
+            length = space - begin;
         }
-        if (info.config_type == type_string) {
-          free(info.config.string);
+        else
+        {
+            length = strlen(begin);
         }
-      } else {
-        total_errors++;
-      }
-    } else {
-      log_info( "\tSkipped: %s.\n", info.opcode_name );
+        if (strncmp(begin, "cl_khr_fp64", length) == 0)
+        {
+            extensions->cl_khr_fp64 = 1;
+        }
+        if (strncmp(begin, "cl_khr_fp16", length) == 0)
+        {
+            extensions->cl_khr_fp16 = 1;
+        }
+        begin += length; // Skip word.
+        if (begin[0] == ' ')
+        { // Skip space, if any.
+            begin += 1;
+        }
     }
-  }
 
-  if (is_extension_available(device, "cl_khr_image2d_from_buffer")){
-    for ( onConfigInfo = 0; onConfigInfo < sizeof(image_buffer_config_infos) / sizeof(image_buffer_config_infos[0]); onConfigInfo++) {
-      config_info info = image_buffer_config_infos[ onConfigInfo ];
-      get = ( vercmp( version, info.version ) >= 0 );
-      if ( get ) {
-        err = getConfigInfo(device, & info);
-        if ( ! err ) {
-          dumpConfigInfo(device, & info);
+    return 0;
+}
+
+int getConfigInfos(cl_device_id device)
+{
+    int total_errors = 0;
+    unsigned onConfigInfo;
+    version_t version = { 0, 0 }; // Version of the device. Will get real value
+                                  // on the first loop iteration.
+    version_t const ver11 = { 1, 1 }; // Version 1.1.
+    extensions_t extensions = { 0 };
+    int get; // Boolean flag: true = get property, false = skip it.
+    int err;
+    for (onConfigInfo = 0;
+         onConfigInfo < sizeof(config_infos) / sizeof(config_infos[0]);
+         onConfigInfo++)
+    {
+        config_info info = config_infos[onConfigInfo];
+        // Get a property only if device version is equal or greater than
+        // property version.
+        get = (vercmp(version, info.version) >= 0);
+        if (info.opcode == CL_DEVICE_DOUBLE_FP_CONFIG
+            && vercmp(version, ver11) <= 0)
+        {
+            // CL_DEVICE_DOUBLE_FP_CONFIG is a special case. It was introduced
+            // in OpenCL 1.1, but device is required to report it only if
+            // doubles are supported. So, before querying it on device
+            // version 1.1, we have to check doubles are sopported. In
+            // OpenCL 1.2 CL_DEVICE_DOUBLE_FP_CONFIG should be reported
+            // unconditionally.
+            get = extensions.cl_khr_fp64;
+        };
+        if (info.opcode == CL_DEVICE_HALF_FP_CONFIG)
+        {
+            // CL_DEVICE_HALF_FP_CONFIG should be reported only when cl_khr_fp16
+            // extension is available
+            get = extensions.cl_khr_fp16;
+        };
+        if (get)
+        {
+            err = getConfigInfo(device, &info);
+            if (!err)
+            {
+                dumpConfigInfo(device, &info);
+                if (info.opcode == CL_DEVICE_VERSION)
+                {
+                    err = parseVersion(info.config.string, &version);
+                    if (err)
+                    {
+                        total_errors++;
+                        free(info.config.string);
+                        break;
+                    }
+                }
+                else if (info.opcode == CL_DEVICE_EXTENSIONS)
+                {
+                    err = parseExtensions(info.config.string, &extensions);
+                    if (err)
+                    {
+                        total_errors++;
+                        free(info.config.string);
+                        break;
+                    }
+                }
+                if (info.config_type == type_string)
+                {
+                    free(info.config.string);
+                }
+            }
+            else
+            {
+                total_errors++;
+            }
         }
-        else {
-          total_errors++;
+        else
+        {
+            log_info("\tSkipped: %s.\n", info.opcode_name);
         }
-      }
     }
-  }
 
-  total_errors += getImageInfo(device);
+    if (is_extension_available(device, "cl_khr_image2d_from_buffer"))
+    {
+        for (onConfigInfo = 0; onConfigInfo < sizeof(image_buffer_config_infos)
+                 / sizeof(image_buffer_config_infos[0]);
+             onConfigInfo++)
+        {
+            config_info info = image_buffer_config_infos[onConfigInfo];
+            get = (vercmp(version, info.version) >= 0);
+            if (get)
+            {
+                err = getConfigInfo(device, &info);
+                if (!err)
+                {
+                    dumpConfigInfo(device, &info);
+                }
+                else
+                {
+                    total_errors++;
+                }
+            }
+        }
+    }
 
-  return total_errors;
+    total_errors += getImageInfo(device);
+
+    return total_errors;
 }
 
 
-int test_computeinfo( cl_device_id deviceID, cl_context context, cl_command_queue ignoreQueue, int num_elements )
+int test_computeinfo(cl_device_id deviceID, cl_context context,
+                     cl_command_queue ignoreQueue, int num_elements)
 {
     int err;
     int total_errors = 0;
@@ -755,160 +958,196 @@ int test_computeinfo( cl_device_id deviceID, cl_context context, cl_command_queu
 
     err = clGetPlatformIDs(1, &platform, NULL);
     test_error(err, "clGetPlatformIDs failed");
-    if (err != CL_SUCCESS) {
+    if (err != CL_SUCCESS)
+    {
         total_errors++;
     }
 
     // print platform info
-    log_info( "\nclGetPlatformInfo:\n------------------\n" );
-    print_platform_string_selector( platform, "CL_PLATFORM_PROFILE", CL_PLATFORM_PROFILE );
-    print_platform_string_selector( platform, "CL_PLATFORM_VERSION", CL_PLATFORM_VERSION );
-    print_platform_string_selector( platform, "CL_PLATFORM_NAME", CL_PLATFORM_NAME );
-    print_platform_string_selector( platform, "CL_PLATFORM_VENDOR", CL_PLATFORM_VENDOR );
-    print_platform_string_selector( platform, "CL_PLATFORM_EXTENSIONS", CL_PLATFORM_EXTENSIONS );
-    log_info( "\n" );
+    log_info("\nclGetPlatformInfo:\n------------------\n");
+    print_platform_string_selector(platform, "CL_PLATFORM_PROFILE",
+                                   CL_PLATFORM_PROFILE);
+    print_platform_string_selector(platform, "CL_PLATFORM_VERSION",
+                                   CL_PLATFORM_VERSION);
+    print_platform_string_selector(platform, "CL_PLATFORM_NAME",
+                                   CL_PLATFORM_NAME);
+    print_platform_string_selector(platform, "CL_PLATFORM_VENDOR",
+                                   CL_PLATFORM_VENDOR);
+    print_platform_string_selector(platform, "CL_PLATFORM_EXTENSIONS",
+                                   CL_PLATFORM_EXTENSIONS);
+    log_info("\n");
 
     // Check to see if this test is being run on a specific device
     char* device_type_env = getenv("CL_DEVICE_TYPE");
     char* device_index_env = getenv("CL_DEVICE_INDEX");
 
-    if (device_type_env || device_index_env) {
+    if (device_type_env || device_index_env)
+    {
 
-      cl_device_type device_type = CL_DEVICE_TYPE_DEFAULT;
-      size_t device_type_idx = 0;
-      size_t device_index = 0;
+        cl_device_type device_type = CL_DEVICE_TYPE_DEFAULT;
+        size_t device_type_idx = 0;
+        size_t device_index = 0;
 
-      // Check to see if a device type was specified.
-      if (device_type_env) {
-        if (!strcmp(device_type_env,"default") || !strcmp(device_type_env,"CL_DEVICE_TYPE_DEFAULT")) {
-          device_type = CL_DEVICE_TYPE_DEFAULT;
-          device_type_idx = 0;
+        // Check to see if a device type was specified.
+        if (device_type_env)
+        {
+            if (!strcmp(device_type_env, "default")
+                || !strcmp(device_type_env, "CL_DEVICE_TYPE_DEFAULT"))
+            {
+                device_type = CL_DEVICE_TYPE_DEFAULT;
+                device_type_idx = 0;
+            }
+            else if (!strcmp(device_type_env, "cpu")
+                     || !strcmp(device_type_env, "CL_DEVICE_TYPE_CPU"))
+            {
+                device_type = CL_DEVICE_TYPE_CPU;
+                device_type_idx = 1;
+            }
+            else if (!strcmp(device_type_env, "gpu")
+                     || !strcmp(device_type_env, "CL_DEVICE_TYPE_GPU"))
+            {
+                device_type = CL_DEVICE_TYPE_GPU;
+                device_type_idx = 2;
+            }
+            else if (!strcmp(device_type_env, "accelerator")
+                     || !strcmp(device_type_env, "CL_DEVICE_TYPE_ACCELERATOR"))
+            {
+                device_type = CL_DEVICE_TYPE_ACCELERATOR;
+                device_type_idx = 3;
+            }
+            else
+            {
+                log_error("CL_DEVICE_TYPE=\"%s\" is invalid\n",
+                          device_type_env);
+                return -1;
+            }
         }
-        else if (!strcmp(device_type_env,"cpu") || !strcmp(device_type_env,"CL_DEVICE_TYPE_CPU")) {
-          device_type = CL_DEVICE_TYPE_CPU;
-          device_type_idx = 1;
+
+        // Check to see if a device index was specified
+        if (device_index_env) device_index = atoi(device_index_env);
+
+        // Look up the device
+        cl_uint num_devices;
+        err = clGetDeviceIDs(platform, device_type, 0, NULL, &num_devices);
+        if (err)
+        {
+            log_error("No devices of type %s found.\n", device_type_env);
+            return -1;
         }
-        else if (!strcmp(device_type_env,"gpu") || !strcmp(device_type_env,"CL_DEVICE_TYPE_GPU")) {
-          device_type = CL_DEVICE_TYPE_GPU;
-          device_type_idx = 2;
+
+        if (device_index >= num_devices)
+        {
+            log_error("CL_DEVICE_INDEX=%d is greater than the number of "
+                      "matching devices %d\n",
+                      (unsigned)device_index, num_devices);
+            return -1;
         }
-        else if (!strcmp(device_type_env,"accelerator") || !strcmp(device_type_env,"CL_DEVICE_TYPE_ACCELERATOR")) {
-          device_type = CL_DEVICE_TYPE_ACCELERATOR;
-          device_type_idx = 3;
+
+        if (num_devices == 0)
+        {
+            log_error("No devices of type %s found.\n", device_type_env);
+            return -1;
         }
-        else {
-          log_error("CL_DEVICE_TYPE=\"%s\" is invalid\n",device_type_env);
-          return -1;
+
+        cl_device_id* devices =
+            (cl_device_id*)malloc(num_devices * sizeof(cl_device_id));
+        err = clGetDeviceIDs(platform, device_type, num_devices, devices, NULL);
+        if (err)
+        {
+            log_error("No devices of type %s found.\n", device_type_env);
+            free(devices);
+            return -1;
         }
-      }
 
-      // Check to see if a device index was specified
-      if (device_index_env)
-        device_index = atoi(device_index_env);
-
-      // Look up the device
-      cl_uint num_devices;
-      err = clGetDeviceIDs(platform, device_type, 0, NULL, &num_devices);
-      if (err)
-      {
-        log_error("No devices of type %s found.\n", device_type_env);
-        return -1;
-      }
-
-      if (device_index >= num_devices) {
-        log_error("CL_DEVICE_INDEX=%d is greater than the number of matching devices %d\n",(unsigned)device_index,num_devices);
-        return -1;
-      }
-
-      if (num_devices == 0)
-      {
-        log_error("No devices of type %s found.\n", device_type_env);
-        return -1;
-      }
-
-      cl_device_id *devices = (cl_device_id *) malloc( num_devices * sizeof( cl_device_id ) );
-      err = clGetDeviceIDs(platform, device_type, num_devices, devices, NULL);
-      if (err)
-      {
-        log_error("No devices of type %s found.\n", device_type_env);
+        cl_device_id device = devices[device_index];
         free(devices);
-        return -1;
-      }
 
-      cl_device_id device = devices[device_index];
-      free(devices);
-
-      log_info("%s Device %d of %d Info:\n", device_infos[device_type_idx].device_type_name, (unsigned)device_index+1, num_devices);
-      total_errors += getConfigInfos( device );
-      log_info("\n");
-
+        log_info("%s Device %d of %d Info:\n",
+                 device_infos[device_type_idx].device_type_name,
+                 (unsigned)device_index + 1, num_devices);
+        total_errors += getConfigInfos(device);
+        log_info("\n");
     }
 
     // Otherwise iterate over all of the devices in the platform
-    else {
-      //print device info
-      int onInfo;
-      for(onInfo = 0; onInfo < sizeof(device_infos) / sizeof(device_infos[0]); onInfo++)
-      {
-          log_info("Getting device IDs for %s devices\n", device_infos[onInfo].device_type_name);
-          err = clGetDeviceIDs(platform, device_infos[onInfo].device_type, 0, NULL, &device_infos[onInfo].num_devices);
-          if (err == CL_DEVICE_NOT_FOUND)
-          {
-              log_info("No devices of type %s found.\n", device_infos[onInfo].device_type_name);
-              continue;
-          }
-          test_error(err, "clGetDeviceIDs failed");
+    else
+    {
+        // print device info
+        int onInfo;
+        for (onInfo = 0;
+             onInfo < sizeof(device_infos) / sizeof(device_infos[0]); onInfo++)
+        {
+            log_info("Getting device IDs for %s devices\n",
+                     device_infos[onInfo].device_type_name);
+            err = clGetDeviceIDs(platform, device_infos[onInfo].device_type, 0,
+                                 NULL, &device_infos[onInfo].num_devices);
+            if (err == CL_DEVICE_NOT_FOUND)
+            {
+                log_info("No devices of type %s found.\n",
+                         device_infos[onInfo].device_type_name);
+                continue;
+            }
+            test_error(err, "clGetDeviceIDs failed");
 
-          log_info("Found %d %s devices:\n", device_infos[onInfo].num_devices, device_infos[onInfo].device_type_name);
-          if(device_infos[onInfo].num_devices)
-          {
-              device_infos[onInfo].devices = (cl_device_id *)malloc(sizeof(cl_device_id) * device_infos[onInfo].num_devices);
-              err = clGetDeviceIDs(platform, device_infos[onInfo].device_type, device_infos[onInfo].num_devices, device_infos[onInfo].devices, NULL);
-              test_error(err, "clGetDeviceIDs failed");
-          }
+            log_info("Found %d %s devices:\n", device_infos[onInfo].num_devices,
+                     device_infos[onInfo].device_type_name);
+            if (device_infos[onInfo].num_devices)
+            {
+                device_infos[onInfo].devices = (cl_device_id*)malloc(
+                    sizeof(cl_device_id) * device_infos[onInfo].num_devices);
+                err = clGetDeviceIDs(platform, device_infos[onInfo].device_type,
+                                     device_infos[onInfo].num_devices,
+                                     device_infos[onInfo].devices, NULL);
+                test_error(err, "clGetDeviceIDs failed");
+            }
 
-          int onDevice;
-          for(onDevice = 0; onDevice < device_infos[onInfo].num_devices; onDevice++)
-          {
-              log_info("%s Device %d of %d Info:\n", device_infos[onInfo].device_type_name, onDevice+1, device_infos[onInfo].num_devices);
-              total_errors += getConfigInfos( device_infos[onInfo].devices[onDevice] );
-              log_info("\n");
-          }
+            int onDevice;
+            for (onDevice = 0; onDevice < device_infos[onInfo].num_devices;
+                 onDevice++)
+            {
+                log_info("%s Device %d of %d Info:\n",
+                         device_infos[onInfo].device_type_name, onDevice + 1,
+                         device_infos[onInfo].num_devices);
+                total_errors +=
+                    getConfigInfos(device_infos[onInfo].devices[onDevice]);
+                log_info("\n");
+            }
 
-          if(device_infos[onInfo].num_devices)
-          {
-              free(device_infos[onInfo].devices);
-          }
-      }
+            if (device_infos[onInfo].num_devices)
+            {
+                free(device_infos[onInfo].devices);
+            }
+        }
     }
 
     return total_errors;
 }
 
-extern int test_extended_versioning(cl_device_id, cl_context, cl_command_queue, int);
+extern int test_extended_versioning(cl_device_id, cl_context, cl_command_queue,
+                                    int);
 
 test_definition test_list[] = {
-    ADD_TEST( computeinfo ),
-    ADD_TEST( extended_versioning ),
+    ADD_TEST(computeinfo),
+    ADD_TEST(extended_versioning),
 };
 
-const int test_num = ARRAY_SIZE( test_list );
+const int test_num = ARRAY_SIZE(test_list);
 
 int main(int argc, const char** argv)
 {
-    const char** argList = (const char**)calloc( argc, sizeof(char*) );
-    if( NULL == argList )
+    const char** argList = (const char**)calloc(argc, sizeof(char*));
+    if (NULL == argList)
     {
-        log_error( "Failed to allocate memory for argList array.\n" );
+        log_error("Failed to allocate memory for argList array.\n");
         return 1;
     }
 
     argList[0] = argv[0];
     size_t argCount = 1;
 
-    for( int i = 1; i < argc; i++ )
+    for (int i = 1; i < argc; i++)
     {
-        if( strcmp(argv[1], "-v") == 0)
+        if (strcmp(argv[1], "-v") == 0)
         {
             dump_supported_formats = 1;
         }
@@ -919,6 +1158,6 @@ int main(int argc, const char** argv)
         }
     }
 
-    return runTestHarness( argCount, argList, test_num, test_list, false, true, 0 );
+    return runTestHarness(argCount, argList, test_num, test_list, false, true,
+                          0);
 }
-


### PR DESCRIPTION
Besides the code reformatting and addressing compilation warnings, the main contribution is to ensure that computeinfo does not test for image types and flags that are not supported by the OpenCL version being tested.