### PR TITLE
Remove `clCreatePipe` call from test_clone_kernel

### DIFF
--- a/test_conformance/api/test_clone_kernel.cpp
+++ b/test_conformance/api/test_clone_kernel.cpp
@@ -299,9 +299,6 @@ int test_clone_kernel(cl_device_id deviceID, cl_context context, cl_command_queu
     bufOut = clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR, BUF_SIZE, NULL, &error);
     test_error( error, "clCreateBuffer failed." );
 
-    clMemWrapper pipe = clCreatePipe(context, CL_MEM_HOST_NO_ACCESS, sizeof(int), 16, NULL, &error);
-    test_error( error, "clCreatePipe failed." );
-
     error = clSetKernelArg(kernel, 0, sizeof(int), &intarg);
     error += clSetKernelArg(kernel, 1, sizeof(float), &farg);
     error += clSetKernelArg(kernel, 2, sizeof(structArg), &sa);
@@ -319,7 +316,7 @@ int test_clone_kernel(cl_device_id deviceID, cl_context context, cl_command_queu
     error = clEnqueueNDRangeKernel(queue, clonek, 1, NULL, &ndrange1, NULL, 0, NULL, NULL);
     test_error( error, "clEnqueueNDRangeKernel failed." );
 
-    // shallow clone tests for buffer, svm and pipes
+    // shallow clone tests for buffer
     error = clSetKernelArg(kernel_buf_write, 0, sizeof(cl_mem), &buf);
     error += clSetKernelArg(kernel_buf_write, 1, sizeof(int), &write_val);
     test_error( error, "clSetKernelArg failed." );


### PR DESCRIPTION
* Remove the call to `clCreatePipe` in the `test_clone_kernel` test as
the result of this call (the pipe object) is unused. Further more
`clCreatePipe` is an optional API in OpenCL-3.0, so even if the pipe
object did have a use, support for this API would need to be queried in
the case of a OpenCL-3.0 driver where returning `CL_INVALID_OPERATION`
would be conformant behaviour. As it stands this test will incorrectly
fail for a 3.0 driver which does not support pipes.

* Correct comment regarding pipes and SVM since these features were not
actually tested in the source.