### PR TITLE
Fix return-type warnings with harness library and basic test

### DIFF
--- a/test_common/harness/deviceInfo.h
+++ b/test_common/harness/deviceInfo.h
@@ -30,6 +30,10 @@ extern "C" {
 /* Determines if an extension is supported by a device. */
 int is_extension_available(cl_device_id device, const char *extensionName);
 
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
 /* Returns a string containing the supported extensions list for a device. */
 std::string get_device_extensions_string(cl_device_id device);
 
@@ -38,9 +42,5 @@ std::string get_device_il_version_string(cl_device_id device);
 
 /* Returns a string containing the supported OpenCL version for a device. */
 std::string get_device_version_string(cl_device_id device);
-
-#ifdef __cplusplus
-}
-#endif // __cplusplus
 
 #endif // _deviceInfo_h

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -23,16 +23,6 @@
 
 #include <string>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define ADD_TEST(fn) {test_##fn, #fn, Version(1, 0)}
-#define ADD_TEST_VERSION(fn, ver) {test_##fn, #fn, ver}
-#define NOT_IMPLEMENTED_TEST(fn) {NULL, #fn, Version(0, 0)}
-
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-
 class Version
 {
 public:
@@ -55,6 +45,27 @@ private:
     int m_major;
     int m_minor;
 };
+
+Version get_device_cl_version(cl_device_id device);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ADD_TEST(fn)                                                           \
+    {                                                                          \
+        test_##fn, #fn, Version(1, 0)                                          \
+    }
+#define ADD_TEST_VERSION(fn, ver)                                              \
+    {                                                                          \
+        test_##fn, #fn, ver                                                    \
+    }
+#define NOT_IMPLEMENTED_TEST(fn)                                               \
+    {                                                                          \
+        NULL, #fn, Version(0, 0)                                               \
+    }
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 typedef struct test_definition
 {
@@ -128,7 +139,6 @@ extern cl_device_type GetDeviceType( cl_device_id );
 // is the only device available, the SAME device is returned, so check!
 extern cl_device_id GetOpposingDevice( cl_device_id device );
 
-Version get_device_cl_version(cl_device_id device);
 void version_expected_info(const char * test_name, const char * expected_version, const char * device_version);
 
 

--- a/test_conformance/basic/test_progvar.cpp
+++ b/test_conformance/basic/test_progvar.cpp
@@ -599,6 +599,7 @@ static const TypeInfo& l_find_type( const char* name )
         if ( 0 == strcmp( name, type_info[i].get_name_c_str() ) ) return type_info[i];
     }
     assert(0);
+    return TypeInfo();
 }
 
 


### PR DESCRIPTION
Reproduction steps - Compile with flags `-Werror -Wreturn-type`