### PR TITLE
Enable -Werror for GCC/Clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ endif (GL_IS_SUPPORTED AND CLConform_GL_LIBRARIES_DIR)
 
 include(CheckFunctionExists)
 include(CheckIncludeFiles)
+include(CheckCXXCompilerFlag)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
     set(CLConform_TARGET_ARCH ARM)
@@ -139,16 +140,22 @@ if(NOT DEFINED CLConform_TARGET_ARCH)
     message (FATAL_ERROR "Target architecture not recognised. Exiting.")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=cpp") # Allow #warning
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unknown-pragmas")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=absolute-value")
-    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=asm-operand-widths")
+macro(add_cxx_flag_if_supported flag)
+    string(REGEX REPLACE "[-=+]" "" FLAG_NO_SIGNS ${flag})
+    check_cxx_compiler_flag(${flag} COMPILER_SUPPORTS_${FLAG_NO_SIGNS})
+    if(COMPILER_SUPPORTS_${FLAG_NO_SIGNS})
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
     endif()
+endmacro(add_cxx_flag_if_supported)
+
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+    add_cxx_flag_if_supported(-Wno-narrowing)
+    add_cxx_flag_if_supported(-Wno-format)
+    add_cxx_flag_if_supported(-Werror)
+    add_cxx_flag_if_supported(-Wno-error=cpp)
+    add_cxx_flag_if_supported(-Wno-error=absolute-value)
+    add_cxx_flag_if_supported(-Wno-error=unknown-pragmas)
+    add_cxx_flag_if_supported(-Wno-error=asm-operand-widths)
 
     # -msse -mfpmath=sse to force gcc to use sse for float math,
     # avoiding excess precision problems that cause tests like int2float

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
     add_cxx_flag_if_supported(-Wno-error=absolute-value)
     add_cxx_flag_if_supported(-Wno-error=unknown-pragmas)
     add_cxx_flag_if_supported(-Wno-error=asm-operand-widths)
+    add_cxx_flag_if_supported(-Wno-error=overflow) # Fixed by #699
 
     # -msse -mfpmath=sse to force gcc to use sse for float math,
     # avoiding excess precision problems that cause tests like int2float

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,10 +152,10 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
     add_cxx_flag_if_supported(-Wno-narrowing)
     add_cxx_flag_if_supported(-Wno-format)
     add_cxx_flag_if_supported(-Werror)
-    add_cxx_flag_if_supported(-Wno-error=cpp)
-    add_cxx_flag_if_supported(-Wno-error=absolute-value)
-    add_cxx_flag_if_supported(-Wno-error=unknown-pragmas)
-    add_cxx_flag_if_supported(-Wno-error=asm-operand-widths)
+    add_cxx_flag_if_supported(-Wno-error=cpp) # Allow #warning directive
+    add_cxx_flag_if_supported(-Wno-error=absolute-value) # Issue 783
+    add_cxx_flag_if_supported(-Wno-error=unknown-pragmas) # Issue #785
+    add_cxx_flag_if_supported(-Wno-error=asm-operand-widths) # Issue #784
     add_cxx_flag_if_supported(-Wno-error=overflow) # Fixed by #699
 
     # -msse -mfpmath=sse to force gcc to use sse for float math,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,16 @@ if(NOT DEFINED CLConform_TARGET_ARCH)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-narrowing")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=cpp") # Allow #warning
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unknown-pragmas")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=absolute-value")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=asm-operand-widths")
+    endif()
+
     # -msse -mfpmath=sse to force gcc to use sse for float math,
     # avoiding excess precision problems that cause tests like int2float
     # to falsely fail. -ffloat-store also works, but WG suggested

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -899,8 +899,7 @@ int get_format_min_int( cl_image_format *format )
         case CL_UNORM_INT_101010:
             return 0;
 
-        case CL_HALF_FLOAT:
-            return -1<<10;
+        case CL_HALF_FLOAT: return -(1 << 10);
 
 #ifdef CL_SFIXED14_APPLE
         case CL_SFIXED14_APPLE:

--- a/test_conformance/api/test_null_buffer_arg.cpp
+++ b/test_conformance/api/test_null_buffer_arg.cpp
@@ -62,7 +62,7 @@ static int test_setargs_and_execution(cl_command_queue queue, cl_kernel kernel,
 
     unsigned int i;
     cl_int status;
-    char *typestr;
+    const char *typestr;
 
     if (type == NON_NULL_PATH) {
         status = clSetKernelArg(kernel, 0, sizeof(cl_mem), &test_buf);

--- a/test_conformance/basic/test_work_item_functions.cpp
+++ b/test_conformance/basic/test_work_item_functions.cpp
@@ -130,7 +130,7 @@ int test_work_item_functions(cl_device_id deviceID, cl_context context, cl_comma
                         free_mtdata(d);
                         return -1;
                     }
-                    if( testData[ q ].globalID[ j ] < 0 || testData[ q ].globalID[ j ] >= (cl_uint)threads[ j ] )
+                    if (testData[q].globalID[j] >= (cl_uint)threads[j])
                     {
                         log_error( "ERROR: get_global_id(%d) did not return proper value for %d dimensions (max %d, got %d)\n",
                                   (int)j, (int)dim, (int)threads[ j ], (int)testData[ q ].globalID[ j ] );
@@ -144,7 +144,7 @@ int test_work_item_functions(cl_device_id deviceID, cl_context context, cl_comma
                         free_mtdata(d);
                         return -1;
                     }
-                    if( testData[ q ].localID[ j ] < 0 && testData[ q ].localID[ j ] >= (cl_uint)localThreads[ j ] )
+                    if (testData[q].localID[j] >= (cl_uint)localThreads[j])
                     {
                         log_error( "ERROR: get_local_id(%d) did not return proper value for %d dimensions (max %d, got %d)\n",
                                   (int)j, (int)dim, (int)localThreads[ j ], (int)testData[ q ].localID[ j ] );
@@ -159,7 +159,7 @@ int test_work_item_functions(cl_device_id deviceID, cl_context context, cl_comma
                         free_mtdata(d);
                         return -1;
                     }
-                    if( testData[ q ].groupID[ j ] < 0 || testData[ q ].groupID[ j ] >= (cl_uint)groupCount )
+                    if (testData[q].groupID[j] >= (cl_uint)groupCount)
                     {
                         log_error( "ERROR: get_group_id(%d) did not return proper value for %d dimensions (max %d, got %d)\n",
                                   (int)j, (int)dim, (int)groupCount, (int)testData[ q ].groupID[ j ] );

--- a/test_conformance/buffers/test_buffer_migrate.cpp
+++ b/test_conformance/buffers/test_buffer_migrate.cpp
@@ -69,6 +69,7 @@ static cl_int migrateMemObject(enum migrations migrate, cl_command_queue *queues
         // Choose a random set of flags
         flags[i] = (cl_mem_migration_flags)(genrand_int32(d) & (CL_MIGRATE_MEM_OBJECT_HOST | CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED));;
         break;
+      default: log_error("Unhandled migration type: %d\n", migrate); return -1;
     }
     if ((err = clEnqueueMigrateMemObjects(queues[j], 1, (const cl_mem *)(&mem_objects[i]), flags[i], 0, NULL, NULL)) != CL_SUCCESS) {
       print_error(err, "Failed migrating memory object.");
@@ -218,10 +219,13 @@ int test_buffer_migrate(cl_device_id deviceID, cl_context context, cl_command_qu
     }
 
     // Build the kernel program.
-    if (err = create_single_kernel_helper(ctx, &program, &kernel, 1, &buffer_migrate_kernel_code, "test_buffer_migrate")) {
-      print_error(err, "Failed creating kernel.");
-      failed = 1;
-      goto cleanup;
+    if ((err = create_single_kernel_helper(ctx, &program, &kernel, 1,
+                                           &buffer_migrate_kernel_code,
+                                           "test_buffer_migrate")))
+    {
+        print_error(err, "Failed creating kernel.");
+        failed = 1;
+        goto cleanup;
     }
 
     num_devices_limited = num_devices;

--- a/test_conformance/buffers/test_image_migrate.cpp
+++ b/test_conformance/buffers/test_image_migrate.cpp
@@ -80,6 +80,7 @@ static cl_int migrateMemObject(enum migrations migrate, cl_command_queue *queues
         // Choose a random set of flags
         flags[i] = (cl_mem_migration_flags)(genrand_int32(d) & (CL_MIGRATE_MEM_OBJECT_HOST | CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED));
         break;
+      default: log_error("Unhandled migration type: %d\n", migrate); return -1;
     }
     if ((err = clEnqueueMigrateMemObjects(queues[j], 1, (const cl_mem *)(&mem_objects[i]),
                                           flags[i], 0, NULL, NULL)) != CL_SUCCESS) {
@@ -251,10 +252,13 @@ int test_image_migrate(cl_device_id deviceID, cl_context context, cl_command_que
     }
 
     // Build the kernel program.
-    if (err = create_single_kernel_helper(ctx, &program, &kernel, 1, &image_migrate_kernel_code, "test_image_migrate")) {
-      print_error(err, "Failed creating kernel.");
-      failed = 1;
-      goto cleanup;
+    if ((err = create_single_kernel_helper(ctx, &program, &kernel, 1,
+                                           &image_migrate_kernel_code,
+                                           "test_image_migrate")))
+    {
+        print_error(err, "Failed creating kernel.");
+        failed = 1;
+        goto cleanup;
     }
 
     // Create sampler.

--- a/test_conformance/compiler/test_image_macro.cpp
+++ b/test_conformance/compiler/test_image_macro.cpp
@@ -57,7 +57,7 @@ int test_image_macro(cl_device_id deviceID, cl_context context, cl_command_queue
       return status;
     }
 
-    if( (image_support == CL_TRUE) )
+    if (image_support == CL_TRUE)
     {
         status = create_single_kernel_helper_create_program(context, &program, 1, (const char**)&image_supported_source);
 

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -96,7 +96,7 @@ typedef struct _extensions extensions_t;
 // first is greater).
 int vercmp(version_t a, version_t b)
 {
-    if (a.major < b.major || a.major == b.major && a.minor < b.minor)
+    if (a.major < b.major || (a.major == b.major && a.minor < b.minor))
     {
         return -1;
     }

--- a/test_conformance/half/cl_utils.h
+++ b/test_conformance/half/cl_utils.h
@@ -93,11 +93,6 @@ void ReleaseCL( void );
 int RunKernel( cl_device_id device, cl_kernel kernel, void *inBuf, void *outBuf, uint32_t blockCount , int extraArg);
 cl_program MakeProgram( cl_device_id device, const char *source[], int count );
 
-#define STRING( _x )    STRINGIFY( _x )
-#ifndef STRINGIFY
-#define STRINGIFY(x)    #x
-#endif
-
 static inline float as_float(cl_uint u) { union { cl_uint u; float f; }v; v.u = u; return v.f; }
 static inline double as_double(cl_ulong u) { union { cl_ulong u; double d; }v; v.u = u; return v.d; }
 

--- a/test_conformance/half/cl_utils.h
+++ b/test_conformance/half/cl_utils.h
@@ -94,7 +94,9 @@ int RunKernel( cl_device_id device, cl_kernel kernel, void *inBuf, void *outBuf,
 cl_program MakeProgram( cl_device_id device, const char *source[], int count );
 
 #define STRING( _x )    STRINGIFY( _x )
+#ifndef STRINGIFY
 #define STRINGIFY(x)    #x
+#endif
 
 static inline float as_float(cl_uint u) { union { cl_uint u; float f; }v; v.u = u; return v.f; }
 static inline double as_double(cl_ulong u) { union { cl_ulong u; double d; }v; v.u = u; return v.d; }

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -166,7 +166,8 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
         sourcePos[ 0 ] = ( srcImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         sourcePos[ 1 ] = ( srcImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         sourcePos[ 2 ] = ( srcImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->arraySize - 1 ), d ) : gTestMipmaps ? twoImage_lod : 0;
-        if ( gTestMipmaps )
+        if (gTestMipmaps)
+        {
             if( srcImageInfo->arraySize > 0 )
             {
                 sourcePos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
@@ -179,11 +180,13 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
                 sourcePos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
             }
+        }
 
         destPos[ 0 ] = ( dstImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         destPos[ 1 ] = ( dstImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         destPos[ 2 ] = ( dstImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->arraySize - 1 ), d ) : gTestMipmaps ? twoImage_lod : 0;
-        if ( gTestMipmaps )
+        if (gTestMipmaps)
+        {
             if( dstImageInfo->arraySize > 0 )
             {
                 destPos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
@@ -196,6 +199,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
                 destPos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
             }
+        }
 
         // Go for it!
         retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -167,7 +167,8 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         sourcePos[ 1 ] = ( srcImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         sourcePos[ 2 ] = ( srcImageInfo->depth > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->depth - 1 ), d ) : 0;
 
-        if ( gTestMipmaps )
+        if (gTestMipmaps)
+        {
             if( srcImageInfo->depth > 0 )
             {
                 sourcePos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
@@ -181,12 +182,14 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
                 sourcePos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
             }
+        }
 
         destPos[ 0 ] = ( dstImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         destPos[ 1 ] = ( dstImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         destPos[ 2 ] = ( dstImageInfo->depth > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->depth - 1 ), d ) : 0;
 
-        if ( gTestMipmaps )
+        if (gTestMipmaps)
+        {
             if( dstImageInfo->depth > 0 )
             {
                 destPos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
@@ -200,6 +203,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
                 destPos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
             }
+        }
 
         // Go for it!
         retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -20,7 +20,7 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
 
-typedef struct image_kernel_data
+struct image_kernel_data
 {
     cl_int width;
     cl_int channelType;

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -20,7 +20,7 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
 
-typedef struct image_kernel_data
+struct image_kernel_data
 {
     cl_int width;
     cl_int arraySize;

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -20,7 +20,7 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
 
-typedef struct image_kernel_data
+struct image_kernel_data
 {
     cl_int width;
     cl_int height;

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -20,7 +20,7 @@
 
 extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
 
-typedef struct image_kernel_data
+struct image_kernel_data
 {
     cl_int width;
     cl_int height;

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -111,7 +111,8 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
         gDeviceLt20 = true;
     }
 
-    if (version_check = (version < Version(1,2))) {
+    if ((version_check = (version < Version(1, 2))))
+    {
         switch (imageType) {
             case CL_MEM_OBJECT_IMAGE1D:
             test_missing_feature(version_check, "image_1D");
@@ -120,7 +121,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
             test_missing_feature(version_check, "image_2D_array");
     }
-  }
+    }
 
   int ret = 0;
     ret += test_image_type( device, context, queue, imageType, CL_MEM_READ_ONLY );

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -1,5 +1,7 @@
 
 #include "../testBase.h"
 
+#define ABS_ERROR(result, expected) (fabs(expected - result))
+
 extern cl_sampler create_sampler(cl_context context, image_sampler_data *sdata, bool test_mipmaps, cl_int *error);
 

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -85,7 +85,7 @@ static const char *lodOffsetSource =
 static const char *offsetSource =
 "   int offset = tidY*get_image_width(input) + tidX;\n";
 
-#define ABS_ERROR( result, expected ) ( fabsf( (float)expected - (float)result ) )
+#define ABS_ERROR(result, expected) (std::abs(expected - result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                             int x, int y, int z, float *outData );
@@ -453,7 +453,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                                                                     xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                     imageSampler, expected, 0, &containsDenormals );
 
-                        float err1 = fabsf( resultPtr[0] - expected[0] );
+                        float err1 = ABS_ERROR(resultPtr[0], expected[0]);
                         // Clamp to the minimum absolute error for the format
                         if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                         float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
@@ -472,7 +472,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                                                                              xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                              imageSampler, expected, 0, NULL );
 
-                                err1 = fabsf( resultPtr[0] - expected[0] );
+                                err1 = ABS_ERROR(resultPtr[0], expected[0]);
                             }
                         }
 
@@ -505,7 +505,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                     imageSampler, expected, 0, &containsDenormals );
 
-                            float err1 = fabsf( resultPtr[0] - expected[0] );
+                            float err1 = ABS_ERROR(resultPtr[0], expected[0]);
                             float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
 
 
@@ -520,7 +520,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL );
 
-                                    err1 = fabsf( resultPtr[0] - expected[0] );
+                                    err1 = ABS_ERROR(resultPtr[0], expected[0]);
                                 }
                             }
                             if( ! (err1 <= maxErr1) )
@@ -611,10 +611,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                         imageSampler, expected, 0, &containsDenormals );
 
-                        float err1 = fabsf( resultPtr[0] - expected[0] );
-                        float err2 = fabsf( resultPtr[1] - expected[1] );
-                        float err3 = fabsf( resultPtr[2] - expected[2] );
-                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                        float err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                        float err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                        float err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                        float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                         // Clamp to the minimum absolute error for the format
                         if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                         if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -648,10 +648,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL );
 
-                                err1 = fabsf( resultPtr[0] - expected[0] );
-                                err2 = fabsf( resultPtr[1] - expected[1] );
-                                err3 = fabsf( resultPtr[2] - expected[2] );
-                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                                err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                                err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                                err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             }
                         }
 
@@ -689,10 +689,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals );
 
-                            float err1 = fabsf( resultPtr[0] - expected[0] );
-                            float err2 = fabsf( resultPtr[1] - expected[1] );
-                            float err3 = fabsf( resultPtr[2] - expected[2] );
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                            float err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                            float err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
                             float maxErr2 = MAX( maxErr * maxPixel.p[1], FLT_MIN );
                             float maxErr3 = MAX( maxErr * maxPixel.p[2], FLT_MIN );
@@ -719,10 +719,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                                                                      xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                      imageSampler, expected, 0, NULL );
 
-                                    err1 = fabsf( resultPtr[0] - expected[0] );
-                                    err2 = fabsf( resultPtr[1] - expected[1] );
-                                    err3 = fabsf( resultPtr[2] - expected[2] );
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                                    err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                                    err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
                             if( ! (err1 <= maxErr1) || ! (err2 <= maxErr2)    ||
@@ -1008,13 +1008,13 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                             maxPixel = sample_image_pixel_float_offset( imageValues, imageInfo,
                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                         imageSampler, expected, 0, &containsDenormals );
-                        float err1 =
-                            fabs(sRGBmap(resultPtr[0]) - sRGBmap(expected[0]));
-                        float err2 =
-                            fabs(sRGBmap(resultPtr[1]) - sRGBmap(expected[1]));
-                        float err3 =
-                            fabs(sRGBmap(resultPtr[2]) - sRGBmap(expected[2]));
-                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                        float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                               sRGBmap(expected[0]));
+                        float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                               sRGBmap(expected[1]));
+                        float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                               sRGBmap(expected[2]));
+                        float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                         float maxErr = 0.5;
 
                         // Check if the result matches.
@@ -1037,13 +1037,13 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL );
 
-                                err1 = fabs(sRGBmap(resultPtr[0])
-                                            - sRGBmap(expected[0]));
-                                err2 = fabs(sRGBmap(resultPtr[1])
-                                            - sRGBmap(expected[1]));
-                                err3 = fabs(sRGBmap(resultPtr[2])
-                                            - sRGBmap(expected[2]));
-                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                 sRGBmap(expected[0]));
+                                err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                 sRGBmap(expected[1]));
+                                err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                 sRGBmap(expected[2]));
+                                err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             }
                         }
 
@@ -1081,13 +1081,13 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals );
 
-                            float err1 = fabs(sRGBmap(resultPtr[0])
-                                              - sRGBmap(expected[0]));
-                            float err2 = fabs(sRGBmap(resultPtr[1])
-                                              - sRGBmap(expected[1]));
-                            float err3 = fabs(sRGBmap(resultPtr[2])
-                                              - sRGBmap(expected[2]));
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                   sRGBmap(expected[0]));
+                            float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                   sRGBmap(expected[1]));
+                            float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                   sRGBmap(expected[2]));
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             float maxErr = 0.6;
 
                             if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    ||
@@ -1108,13 +1108,13 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                      xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                      imageSampler, expected, 0, NULL );
 
-                                    err1 = fabs(sRGBmap(resultPtr[0])
-                                                - sRGBmap(expected[0]));
-                                    err2 = fabs(sRGBmap(resultPtr[1])
-                                                - sRGBmap(expected[1]));
-                                    err3 = fabs(sRGBmap(resultPtr[2])
-                                                - sRGBmap(expected[2]));
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                     sRGBmap(expected[0]));
+                                    err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                     sRGBmap(expected[1]));
+                                    err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                     sRGBmap(expected[2]));
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
                             if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    ||

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1008,9 +1008,12 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                             maxPixel = sample_image_pixel_float_offset( imageValues, imageInfo,
                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                         imageSampler, expected, 0, &containsDenormals );
-                        float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                        float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                        float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                        float err1 =
+                            fabs(sRGBmap(resultPtr[0]) - sRGBmap(expected[0]));
+                        float err2 =
+                            fabs(sRGBmap(resultPtr[1]) - sRGBmap(expected[1]));
+                        float err3 =
+                            fabs(sRGBmap(resultPtr[2]) - sRGBmap(expected[2]));
                         float err4 = fabsf( resultPtr[3] - expected[3] );
                         float maxErr = 0.5;
 
@@ -1034,9 +1037,12 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL );
 
-                                err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                err1 = fabs(sRGBmap(resultPtr[0])
+                                            - sRGBmap(expected[0]));
+                                err2 = fabs(sRGBmap(resultPtr[1])
+                                            - sRGBmap(expected[1]));
+                                err3 = fabs(sRGBmap(resultPtr[2])
+                                            - sRGBmap(expected[2]));
                                 err4 = fabsf( resultPtr[3] - expected[3] );
                             }
                         }
@@ -1075,9 +1081,12 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals );
 
-                            float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                            float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                            float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                            float err1 = fabs(sRGBmap(resultPtr[0])
+                                              - sRGBmap(expected[0]));
+                            float err2 = fabs(sRGBmap(resultPtr[1])
+                                              - sRGBmap(expected[1]));
+                            float err3 = fabs(sRGBmap(resultPtr[2])
+                                              - sRGBmap(expected[2]));
                             float err4 = fabsf( resultPtr[3] - expected[3] );
                             float maxErr = 0.6;
 
@@ -1099,9 +1108,12 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                                                                      xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                      imageSampler, expected, 0, NULL );
 
-                                    err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                    err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                    err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                    err1 = fabs(sRGBmap(resultPtr[0])
+                                                - sRGBmap(expected[0]));
+                                    err2 = fabs(sRGBmap(resultPtr[1])
+                                                - sRGBmap(expected[1]));
+                                    err3 = fabs(sRGBmap(resultPtr[2])
+                                                - sRGBmap(expected[2]));
                                     err4 = fabsf( resultPtr[3] - expected[3] );
                                 }
                             }

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -85,7 +85,7 @@ static const char *lodOffsetSource =
 static const char *offsetSource =
 "   int offset = tidY*get_image_width(input) + tidX;\n";
 
-#define ABS_ERROR(result, expected) (std::abs(expected - result))
+#define ABS_ERROR(result, expected) (fabs(expected - result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                             int x, int y, int z, float *outData );

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -85,8 +85,6 @@ static const char *lodOffsetSource =
 static const char *offsetSource =
 "   int offset = tidY*get_image_width(input) + tidX;\n";
 
-#define ABS_ERROR(result, expected) (fabs(expected - result))
-
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                             int x, int y, int z, float *outData );
 template <class T> int determine_validation_error( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -522,9 +522,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                             xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                             imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                            float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                            float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                            float err1 = fabs(sRGBmap(resultPtr[0])
+                                              - sRGBmap(expected[0]));
+                            float err2 = fabs(sRGBmap(resultPtr[1])
+                                              - sRGBmap(expected[1]));
+                            float err3 = fabs(sRGBmap(resultPtr[2])
+                                              - sRGBmap(expected[2]));
                             float err4 = fabsf( resultPtr[3] - expected[3] );
 
                             float maxErr = 0.5;
@@ -544,9 +547,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                  xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                  imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                    err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                    err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                    err1 = fabs(sRGBmap(resultPtr[0])
+                                                - sRGBmap(expected[0]));
+                                    err2 = fabs(sRGBmap(resultPtr[1])
+                                                - sRGBmap(expected[1]));
+                                    err3 = fabs(sRGBmap(resultPtr[2])
+                                                - sRGBmap(expected[2]));
                                     err4 = fabsf( resultPtr[3] - expected[3] );
                                 }
                             }
@@ -576,9 +582,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                         xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                float err1 = fabs(sRGBmap(resultPtr[0])
+                                                  - sRGBmap(expected[0]));
+                                float err2 = fabs(sRGBmap(resultPtr[1])
+                                                  - sRGBmap(expected[1]));
+                                float err3 = fabs(sRGBmap(resultPtr[2])
+                                                  - sRGBmap(expected[2]));
                                 float err4 = fabsf( resultPtr[3] - expected[3] );
 
                                 float maxErr = 0.6;
@@ -597,9 +606,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                      xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                      imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                        err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                        err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                        err1 = fabs(sRGBmap(resultPtr[0])
+                                                    - sRGBmap(expected[0]));
+                                        err2 = fabs(sRGBmap(resultPtr[1])
+                                                    - sRGBmap(expected[1]));
+                                        err3 = fabs(sRGBmap(resultPtr[2])
+                                                    - sRGBmap(expected[2]));
                                         err4 = fabsf( resultPtr[3] - expected[3] );
                                     }
                                 }

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -66,7 +66,7 @@ const char *float1DKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR( result, expected ) ( fabsf( (float)expected - (float)result ) )
+#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                             int x, int y, int z, float *outData );

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -66,8 +66,6 @@ const char *float1DKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
-
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                             int x, int y, int z, float *outData );
 template <class T> int determine_validation_error_1D( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -522,13 +522,13 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                             xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                             imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabs(sRGBmap(resultPtr[0])
-                                              - sRGBmap(expected[0]));
-                            float err2 = fabs(sRGBmap(resultPtr[1])
-                                              - sRGBmap(expected[1]));
-                            float err3 = fabs(sRGBmap(resultPtr[2])
-                                              - sRGBmap(expected[2]));
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                   sRGBmap(expected[0]));
+                            float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                   sRGBmap(expected[1]));
+                            float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                   sRGBmap(expected[2]));
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
 
                             float maxErr = 0.5;
 
@@ -547,13 +547,13 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                  xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                  imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabs(sRGBmap(resultPtr[0])
-                                                - sRGBmap(expected[0]));
-                                    err2 = fabs(sRGBmap(resultPtr[1])
-                                                - sRGBmap(expected[1]));
-                                    err3 = fabs(sRGBmap(resultPtr[2])
-                                                - sRGBmap(expected[2]));
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                     sRGBmap(expected[0]));
+                                    err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                     sRGBmap(expected[1]));
+                                    err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                     sRGBmap(expected[2]));
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
 
@@ -582,13 +582,14 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                         xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabs(sRGBmap(resultPtr[0])
-                                                  - sRGBmap(expected[0]));
-                                float err2 = fabs(sRGBmap(resultPtr[1])
-                                                  - sRGBmap(expected[1]));
-                                float err3 = fabs(sRGBmap(resultPtr[2])
-                                                  - sRGBmap(expected[2]));
-                                float err4 = fabsf( resultPtr[3] - expected[3] );
+                                float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                       sRGBmap(expected[0]));
+                                float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                       sRGBmap(expected[1]));
+                                float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                       sRGBmap(expected[2]));
+                                float err4 =
+                                    ABS_ERROR(resultPtr[3], expected[3]);
 
                                 float maxErr = 0.6;
 
@@ -606,13 +607,14 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                      xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                      imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabs(sRGBmap(resultPtr[0])
-                                                    - sRGBmap(expected[0]));
-                                        err2 = fabs(sRGBmap(resultPtr[1])
-                                                    - sRGBmap(expected[1]));
-                                        err3 = fabs(sRGBmap(resultPtr[2])
-                                                    - sRGBmap(expected[2]));
-                                        err4 = fabsf( resultPtr[3] - expected[3] );
+                                        err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                         sRGBmap(expected[0]));
+                                        err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                         sRGBmap(expected[1]));
+                                        err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                         sRGBmap(expected[2]));
+                                        err4 = ABS_ERROR(resultPtr[3],
+                                                         expected[3]);
                                     }
                                 }
                                 if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    ||
@@ -679,10 +681,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                             xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                             imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabsf( resultPtr[0] - expected[0] );
-                            float err2 = fabsf( resultPtr[1] - expected[1] );
-                            float err3 = fabsf( resultPtr[2] - expected[2] );
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                            float err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                            float err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             // Clamp to the minimum absolute error for the format
                             if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                             if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -711,10 +713,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                  xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                  imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabsf( resultPtr[0] - expected[0] );
-                                    err2 = fabsf( resultPtr[1] - expected[1] );
-                                    err3 = fabsf( resultPtr[2] - expected[2] );
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                                    err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                                    err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
 
@@ -743,10 +745,14 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                         xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabsf( resultPtr[0] - expected[0] );
-                                float err2 = fabsf( resultPtr[1] - expected[1] );
-                                float err3 = fabsf( resultPtr[2] - expected[2] );
-                                float err4 = fabsf( resultPtr[3] - expected[3] );
+                                float err1 =
+                                    ABS_ERROR(resultPtr[0], expected[0]);
+                                float err2 =
+                                    ABS_ERROR(resultPtr[1], expected[1]);
+                                float err3 =
+                                    ABS_ERROR(resultPtr[2], expected[2]);
+                                float err4 =
+                                    ABS_ERROR(resultPtr[3], expected[3]);
                                 float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
                                 float maxErr2 = MAX( maxErr * maxPixel.p[1], FLT_MIN );
                                 float maxErr3 = MAX( maxErr * maxPixel.p[2], FLT_MIN );
@@ -768,10 +774,14 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                      xOffsetValues[ j ], 0.0f, 0.0f, norm_offset_x, 0.0f, 0.0f,
                                                                                      imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabsf( resultPtr[0] - expected[0] );
-                                        err2 = fabsf( resultPtr[1] - expected[1] );
-                                        err3 = fabsf( resultPtr[2] - expected[2] );
-                                        err4 = fabsf( resultPtr[3] - expected[3] );
+                                        err1 = ABS_ERROR(resultPtr[0],
+                                                         expected[0]);
+                                        err2 = ABS_ERROR(resultPtr[1],
+                                                         expected[1]);
+                                        err3 = ABS_ERROR(resultPtr[2],
+                                                         expected[2]);
+                                        err4 = ABS_ERROR(resultPtr[3],
+                                                         expected[3]);
                                     }
                                 }
                                 if( ! (err1 <= maxErr1) || ! (err2 <= maxErr2)    ||

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -618,13 +618,13 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                 xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                 imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabs(sRGBmap(resultPtr[0])
-                                              - sRGBmap(expected[0]));
-                            float err2 = fabs(sRGBmap(resultPtr[1])
-                                              - sRGBmap(expected[1]));
-                            float err3 = fabs(sRGBmap(resultPtr[2])
-                                              - sRGBmap(expected[2]));
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                   sRGBmap(expected[0]));
+                            float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                   sRGBmap(expected[1]));
+                            float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                   sRGBmap(expected[2]));
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             float maxErr = 0.5;
 
                             // Check if the result matches.
@@ -642,13 +642,13 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabs(sRGBmap(resultPtr[0])
-                                                - sRGBmap(expected[0]));
-                                    err2 = fabs(sRGBmap(resultPtr[1])
-                                                - sRGBmap(expected[1]));
-                                    err3 = fabs(sRGBmap(resultPtr[2])
-                                                - sRGBmap(expected[2]));
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                     sRGBmap(expected[0]));
+                                    err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                     sRGBmap(expected[1]));
+                                    err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                     sRGBmap(expected[2]));
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
 
@@ -680,13 +680,14 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                       xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                       imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabs(sRGBmap(resultPtr[0])
-                                                  - sRGBmap(expected[0]));
-                                float err2 = fabs(sRGBmap(resultPtr[1])
-                                                  - sRGBmap(expected[1]));
-                                float err3 = fabs(sRGBmap(resultPtr[2])
-                                                  - sRGBmap(expected[2]));
-                                float err4 = fabsf( resultPtr[3] - expected[3] );
+                                float err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                       sRGBmap(expected[0]));
+                                float err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                       sRGBmap(expected[1]));
+                                float err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                       sRGBmap(expected[2]));
+                                float err4 =
+                                    ABS_ERROR(resultPtr[3], expected[3]);
 
                                 float maxErr = 0.6;
 
@@ -704,13 +705,14 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                    imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabs(sRGBmap(resultPtr[0])
-                                                    - sRGBmap(expected[0]));
-                                        err2 = fabs(sRGBmap(resultPtr[1])
-                                                    - sRGBmap(expected[1]));
-                                        err3 = fabs(sRGBmap(resultPtr[2])
-                                                    - sRGBmap(expected[2]));
-                                        err4 = fabsf( resultPtr[3] - expected[3] );
+                                        err1 = ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                         sRGBmap(expected[0]));
+                                        err2 = ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                         sRGBmap(expected[1]));
+                                        err3 = ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                         sRGBmap(expected[2]));
+                                        err4 = ABS_ERROR(resultPtr[3],
+                                                         expected[3]);
                                     }
                                 }
                                 if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    ||
@@ -784,10 +786,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                 xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                 imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabsf( resultPtr[0] - expected[0] );
-                            float err2 = fabsf( resultPtr[1] - expected[1] );
-                            float err3 = fabsf( resultPtr[2] - expected[2] );
-                            float err4 = fabsf( resultPtr[3] - expected[3] );
+                            float err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                            float err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                            float err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                            float err4 = ABS_ERROR(resultPtr[3], expected[3]);
                             // Clamp to the minimum absolute error for the format
                             if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                             if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -816,10 +818,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabsf( resultPtr[0] - expected[0] );
-                                    err2 = fabsf( resultPtr[1] - expected[1] );
-                                    err3 = fabsf( resultPtr[2] - expected[2] );
-                                    err4 = fabsf( resultPtr[3] - expected[3] );
+                                    err1 = ABS_ERROR(resultPtr[0], expected[0]);
+                                    err2 = ABS_ERROR(resultPtr[1], expected[1]);
+                                    err3 = ABS_ERROR(resultPtr[2], expected[2]);
+                                    err4 = ABS_ERROR(resultPtr[3], expected[3]);
                                 }
                             }
 
@@ -851,10 +853,14 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                       xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                       imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabsf( resultPtr[0] - expected[0] );
-                                float err2 = fabsf( resultPtr[1] - expected[1] );
-                                float err3 = fabsf( resultPtr[2] - expected[2] );
-                                float err4 = fabsf( resultPtr[3] - expected[3] );
+                                float err1 =
+                                    ABS_ERROR(resultPtr[0], expected[0]);
+                                float err2 =
+                                    ABS_ERROR(resultPtr[1], expected[1]);
+                                float err3 =
+                                    ABS_ERROR(resultPtr[2], expected[2]);
+                                float err4 =
+                                    ABS_ERROR(resultPtr[3], expected[3]);
                                 float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
                                 float maxErr2 = MAX( maxErr * maxPixel.p[1], FLT_MIN );
                                 float maxErr3 = MAX( maxErr * maxPixel.p[2], FLT_MIN );
@@ -876,10 +882,14 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                    imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabsf( resultPtr[0] - expected[0] );
-                                        err2 = fabsf( resultPtr[1] - expected[1] );
-                                        err3 = fabsf( resultPtr[2] - expected[2] );
-                                        err4 = fabsf( resultPtr[3] - expected[3] );
+                                        err1 = ABS_ERROR(resultPtr[0],
+                                                         expected[0]);
+                                        err2 = ABS_ERROR(resultPtr[1],
+                                                         expected[1]);
+                                        err3 = ABS_ERROR(resultPtr[2],
+                                                         expected[2]);
+                                        err4 = ABS_ERROR(resultPtr[3],
+                                                         expected[3]);
                                     }
                                 }
                                 if( ! (err1 <= maxErr1) || ! (err2 <= maxErr2)    ||

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -73,7 +73,7 @@ const char *floatKernelSource1DArray =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR( result, expected ) ( fabsf( (float)expected - (float)result ) )
+#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                                    int x, int y, int z, float *outData );

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -618,9 +618,12 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                 xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                 imageSampler, expected, 0, &containsDenormals, lod );
 
-                            float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                            float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                            float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                            float err1 = fabs(sRGBmap(resultPtr[0])
+                                              - sRGBmap(expected[0]));
+                            float err2 = fabs(sRGBmap(resultPtr[1])
+                                              - sRGBmap(expected[1]));
+                            float err3 = fabs(sRGBmap(resultPtr[2])
+                                              - sRGBmap(expected[2]));
                             float err4 = fabsf( resultPtr[3] - expected[3] );
                             float maxErr = 0.5;
 
@@ -639,9 +642,12 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                imageSampler, expected, 0, NULL, lod );
 
-                                    err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                    err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                    err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                    err1 = fabs(sRGBmap(resultPtr[0])
+                                                - sRGBmap(expected[0]));
+                                    err2 = fabs(sRGBmap(resultPtr[1])
+                                                - sRGBmap(expected[1]));
+                                    err3 = fabs(sRGBmap(resultPtr[2])
+                                                - sRGBmap(expected[2]));
                                     err4 = fabsf( resultPtr[3] - expected[3] );
                                 }
                             }
@@ -674,9 +680,12 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                       xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                       imageSampler, expected, 0, &containsDenormals, lod );
 
-                                float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                float err1 = fabs(sRGBmap(resultPtr[0])
+                                                  - sRGBmap(expected[0]));
+                                float err2 = fabs(sRGBmap(resultPtr[1])
+                                                  - sRGBmap(expected[1]));
+                                float err3 = fabs(sRGBmap(resultPtr[2])
+                                                  - sRGBmap(expected[2]));
                                 float err4 = fabsf( resultPtr[3] - expected[3] );
 
                                 float maxErr = 0.6;
@@ -695,9 +704,12 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                    imageSampler, expected, 0, NULL, lod );
 
-                                        err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                        err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                        err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                        err1 = fabs(sRGBmap(resultPtr[0])
+                                                    - sRGBmap(expected[0]));
+                                        err2 = fabs(sRGBmap(resultPtr[1])
+                                                    - sRGBmap(expected[1]));
+                                        err3 = fabs(sRGBmap(resultPtr[2])
+                                                    - sRGBmap(expected[2]));
                                         err4 = fabsf( resultPtr[3] - expected[3] );
                                     }
                                 }

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -73,8 +73,6 @@ const char *floatKernelSource1DArray =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
-
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo,
                                    int x, int y, int z, float *outData );
 

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -88,7 +88,7 @@ const char *float2DArrayUnnormalizedCoordKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR( result, expected ) ( fabsf( (float)expected - (float)result ) )
+#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo, int x, int y, int z, float *outData );
 template <class T> int determine_validation_error_offset_2D_array( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -757,9 +757,12 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                    float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                    float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                    float err1 = fabs(sRGBmap(resultPtr[0])
+                                                      - sRGBmap(expected[0]));
+                                    float err2 = fabs(sRGBmap(resultPtr[1])
+                                                      - sRGBmap(expected[1]));
+                                    float err3 = fabs(sRGBmap(resultPtr[2])
+                                                      - sRGBmap(expected[2]));
                                     float err4 = fabsf( resultPtr[3] - expected[3] );
                                     float maxErr = 0.5;
 
@@ -777,9 +780,12 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                            err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                            err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                            err1 = fabs(sRGBmap(resultPtr[0])
+                                                        - sRGBmap(expected[0]));
+                                            err2 = fabs(sRGBmap(resultPtr[1])
+                                                        - sRGBmap(expected[1]));
+                                            err3 = fabs(sRGBmap(resultPtr[2])
+                                                        - sRGBmap(expected[2]));
                                             err4 = fabsf( resultPtr[3] - expected[3] );
                                         }
                                     }
@@ -805,9 +811,15 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                               norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
-                                        float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                        float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                        float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                        float err1 =
+                                            fabs(sRGBmap(resultPtr[0])
+                                                 - sRGBmap(expected[0]));
+                                        float err2 =
+                                            fabs(sRGBmap(resultPtr[1])
+                                                 - sRGBmap(expected[1]));
+                                        float err3 =
+                                            fabs(sRGBmap(resultPtr[2])
+                                                 - sRGBmap(expected[2]));
                                         float err4 = fabsf( resultPtr[3] - expected[3] );
                                         float maxErr = 0.6;
 
@@ -824,9 +836,15 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                                err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                                err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                                err1 = fabs(
+                                                    sRGBmap(resultPtr[0])
+                                                    - sRGBmap(expected[0]));
+                                                err2 = fabs(
+                                                    sRGBmap(resultPtr[1])
+                                                    - sRGBmap(expected[1]));
+                                                err3 = fabs(
+                                                    sRGBmap(resultPtr[2])
+                                                    - sRGBmap(expected[2]));
                                                 err4 = fabsf( resultPtr[3] - expected[3] );
                                             }
                                         }

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -88,8 +88,6 @@ const char *float2DArrayUnnormalizedCoordKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
-
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo, int x, int y, int z, float *outData );
 template <class T> int determine_validation_error_offset_2D_array( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,
                                                          T *resultPtr, T * expected, float error,

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -622,7 +622,8 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabsf( resultPtr[0] - expected[0] );
+                                    float err1 =
+                                        ABS_ERROR(resultPtr[0], expected[0]);
                                     // Clamp to the minimum absolute error for the format
                                     if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                                     float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
@@ -641,7 +642,8 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabsf( resultPtr[0] - expected[0] );
+                                            err1 = ABS_ERROR(resultPtr[0],
+                                                             expected[0]);
                                         }
                                     }
 
@@ -666,7 +668,8 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                               norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
-                                        float err1 = fabsf( resultPtr[0] - expected[0] );
+                                        float err1 = ABS_ERROR(resultPtr[0],
+                                                               expected[0]);
                                         float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
 
 
@@ -681,7 +684,8 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabsf( resultPtr[0] - expected[0] );
+                                                err1 = ABS_ERROR(resultPtr[0],
+                                                                 expected[0]);
                                             }
                                         }
 
@@ -757,13 +761,17 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabs(sRGBmap(resultPtr[0])
-                                                      - sRGBmap(expected[0]));
-                                    float err2 = fabs(sRGBmap(resultPtr[1])
-                                                      - sRGBmap(expected[1]));
-                                    float err3 = fabs(sRGBmap(resultPtr[2])
-                                                      - sRGBmap(expected[2]));
-                                    float err4 = fabsf( resultPtr[3] - expected[3] );
+                                    float err1 =
+                                        ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                  sRGBmap(expected[0]));
+                                    float err2 =
+                                        ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                  sRGBmap(expected[1]));
+                                    float err3 =
+                                        ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                  sRGBmap(expected[2]));
+                                    float err4 =
+                                        ABS_ERROR(resultPtr[3], expected[3]);
                                     float maxErr = 0.5;
 
                                     if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    || ! (err3 <= maxErr) || ! (err4 <= maxErr) )
@@ -780,13 +788,17 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabs(sRGBmap(resultPtr[0])
-                                                        - sRGBmap(expected[0]));
-                                            err2 = fabs(sRGBmap(resultPtr[1])
-                                                        - sRGBmap(expected[1]));
-                                            err3 = fabs(sRGBmap(resultPtr[2])
-                                                        - sRGBmap(expected[2]));
-                                            err4 = fabsf( resultPtr[3] - expected[3] );
+                                            err1 =
+                                                ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                          sRGBmap(expected[0]));
+                                            err2 =
+                                                ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                          sRGBmap(expected[1]));
+                                            err3 =
+                                                ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                          sRGBmap(expected[2]));
+                                            err4 = ABS_ERROR(resultPtr[3],
+                                                             expected[3]);
                                         }
                                     }
 
@@ -812,15 +824,16 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
                                         float err1 =
-                                            fabs(sRGBmap(resultPtr[0])
-                                                 - sRGBmap(expected[0]));
+                                            ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                      sRGBmap(expected[0]));
                                         float err2 =
-                                            fabs(sRGBmap(resultPtr[1])
-                                                 - sRGBmap(expected[1]));
+                                            ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                      sRGBmap(expected[1]));
                                         float err3 =
-                                            fabs(sRGBmap(resultPtr[2])
-                                                 - sRGBmap(expected[2]));
-                                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                                            ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                      sRGBmap(expected[2]));
+                                        float err4 = ABS_ERROR(resultPtr[3],
+                                                               expected[3]);
                                         float maxErr = 0.6;
 
                                         if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    || ! (err3 <= maxErr) || ! (err4 <= maxErr) )
@@ -836,16 +849,17 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabs(
-                                                    sRGBmap(resultPtr[0])
-                                                    - sRGBmap(expected[0]));
-                                                err2 = fabs(
-                                                    sRGBmap(resultPtr[1])
-                                                    - sRGBmap(expected[1]));
-                                                err3 = fabs(
-                                                    sRGBmap(resultPtr[2])
-                                                    - sRGBmap(expected[2]));
-                                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                                err1 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[0]),
+                                                    sRGBmap(expected[0]));
+                                                err2 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[1]),
+                                                    sRGBmap(expected[1]));
+                                                err3 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[2]),
+                                                    sRGBmap(expected[2]));
+                                                err4 = ABS_ERROR(resultPtr[3],
+                                                                 expected[3]);
                                             }
                                         }
 
@@ -924,10 +938,14 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabsf( resultPtr[0] - expected[0] );
-                                    float err2 = fabsf( resultPtr[1] - expected[1] );
-                                    float err3 = fabsf( resultPtr[2] - expected[2] );
-                                    float err4 = fabsf( resultPtr[3] - expected[3] );
+                                    float err1 =
+                                        ABS_ERROR(resultPtr[0], expected[0]);
+                                    float err2 =
+                                        ABS_ERROR(resultPtr[1], expected[1]);
+                                    float err3 =
+                                        ABS_ERROR(resultPtr[2], expected[2]);
+                                    float err4 =
+                                        ABS_ERROR(resultPtr[3], expected[3]);
                                     // Clamp to the minimum absolute error for the format
                                     if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                                     if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -955,10 +973,14 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabsf( resultPtr[0] - expected[0] );
-                                            err2 = fabsf( resultPtr[1] - expected[1] );
-                                            err3 = fabsf( resultPtr[2] - expected[2] );
-                                            err4 = fabsf( resultPtr[3] - expected[3] );
+                                            err1 = ABS_ERROR(resultPtr[0],
+                                                             expected[0]);
+                                            err2 = ABS_ERROR(resultPtr[1],
+                                                             expected[1]);
+                                            err3 = ABS_ERROR(resultPtr[2],
+                                                             expected[2]);
+                                            err4 = ABS_ERROR(resultPtr[3],
+                                                             expected[3]);
                                         }
                                     }
 
@@ -983,10 +1005,14 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                               norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
-                                        float err1 = fabsf( resultPtr[0] - expected[0] );
-                                        float err2 = fabsf( resultPtr[1] - expected[1] );
-                                        float err3 = fabsf( resultPtr[2] - expected[2] );
-                                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                                        float err1 = ABS_ERROR(resultPtr[0],
+                                                               expected[0]);
+                                        float err2 = ABS_ERROR(resultPtr[1],
+                                                               expected[1]);
+                                        float err3 = ABS_ERROR(resultPtr[2],
+                                                               expected[2]);
+                                        float err4 = ABS_ERROR(resultPtr[3],
+                                                               expected[3]);
                                         float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
                                         float maxErr2 = MAX( maxErr * maxPixel.p[1], FLT_MIN );
                                         float maxErr3 = MAX( maxErr * maxPixel.p[2], FLT_MIN );
@@ -1007,10 +1033,14 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabsf( resultPtr[0] - expected[0] );
-                                                err2 = fabsf( resultPtr[1] - expected[1] );
-                                                err3 = fabsf( resultPtr[2] - expected[2] );
-                                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                                err1 = ABS_ERROR(resultPtr[0],
+                                                                 expected[0]);
+                                                err2 = ABS_ERROR(resultPtr[1],
+                                                                 expected[1]);
+                                                err3 = ABS_ERROR(resultPtr[2],
+                                                                 expected[2]);
+                                                err4 = ABS_ERROR(resultPtr[3],
+                                                                 expected[3]);
                                             }
                                         }
 

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -638,9 +638,12 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                    float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                    float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                    float err1 = fabs(sRGBmap(resultPtr[0])
+                                                      - sRGBmap(expected[0]));
+                                    float err2 = fabs(sRGBmap(resultPtr[1])
+                                                      - sRGBmap(expected[1]));
+                                    float err3 = fabs(sRGBmap(resultPtr[2])
+                                                      - sRGBmap(expected[2]));
                                     float err4 = fabsf( resultPtr[3] - expected[3] );
                                     // Clamp to the minimum absolute error for the format
                                     if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
@@ -663,9 +666,12 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                            err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                            err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                            err1 = fabs(sRGBmap(resultPtr[0])
+                                                        - sRGBmap(expected[0]));
+                                            err2 = fabs(sRGBmap(resultPtr[1])
+                                                        - sRGBmap(expected[1]));
+                                            err3 = fabs(sRGBmap(resultPtr[2])
+                                                        - sRGBmap(expected[2]));
                                             err4 = fabsf( resultPtr[3] - expected[3] );
                                         }
                                     }
@@ -691,9 +697,15 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                               norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
-                                        float err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                        float err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                        float err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                        float err1 =
+                                            fabs(sRGBmap(resultPtr[0])
+                                                 - sRGBmap(expected[0]));
+                                        float err2 =
+                                            fabs(sRGBmap(resultPtr[1])
+                                                 - sRGBmap(expected[1]));
+                                        float err3 =
+                                            fabs(sRGBmap(resultPtr[2])
+                                                 - sRGBmap(expected[2]));
                                         float err4 = fabsf( resultPtr[3] - expected[3] );
                                         float maxErr = 0.6;
 
@@ -710,9 +722,15 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabsf( sRGBmap( resultPtr[0] ) - sRGBmap( expected[0] ) );
-                                                err2 = fabsf( sRGBmap( resultPtr[1] ) - sRGBmap( expected[1] ) );
-                                                err3 = fabsf( sRGBmap( resultPtr[2] ) - sRGBmap( expected[2] ) );
+                                                err1 = fabs(
+                                                    sRGBmap(resultPtr[0])
+                                                    - sRGBmap(expected[0]));
+                                                err2 = fabs(
+                                                    sRGBmap(resultPtr[1])
+                                                    - sRGBmap(expected[1]));
+                                                err3 = fabs(
+                                                    sRGBmap(resultPtr[2])
+                                                    - sRGBmap(expected[2]));
                                                 err4 = fabsf( resultPtr[3] - expected[3] );
                                             }
                                         }
@@ -1311,7 +1329,3 @@ int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_
 
     return 0;
 }
-
-
-
-

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -88,7 +88,7 @@ const char *float3DUnnormalizedCoordKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR( result, expected ) ( fabsf( (float)expected - (float)result ) )
+#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
 
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo, int x, int y, int z, float *outData );
 template <class T> int determine_validation_error_offset( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -88,8 +88,6 @@ const char *float3DUnnormalizedCoordKernelSource =
 
 static const char *samplerKernelArg = " sampler_t imageSampler,";
 
-#define ABS_ERROR(result, expected) (fabs((float)expected - (float)result))
-
 extern void read_image_pixel_float( void *imageData, image_descriptor *imageInfo, int x, int y, int z, float *outData );
 template <class T> int determine_validation_error_offset( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,
                                                          T *resultPtr, T * expected, float error,

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -638,13 +638,17 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabs(sRGBmap(resultPtr[0])
-                                                      - sRGBmap(expected[0]));
-                                    float err2 = fabs(sRGBmap(resultPtr[1])
-                                                      - sRGBmap(expected[1]));
-                                    float err3 = fabs(sRGBmap(resultPtr[2])
-                                                      - sRGBmap(expected[2]));
-                                    float err4 = fabsf( resultPtr[3] - expected[3] );
+                                    float err1 =
+                                        ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                  sRGBmap(expected[0]));
+                                    float err2 =
+                                        ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                  sRGBmap(expected[1]));
+                                    float err3 =
+                                        ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                  sRGBmap(expected[2]));
+                                    float err4 =
+                                        ABS_ERROR(resultPtr[3], expected[3]);
                                     // Clamp to the minimum absolute error for the format
                                     if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                                     if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -666,13 +670,17 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabs(sRGBmap(resultPtr[0])
-                                                        - sRGBmap(expected[0]));
-                                            err2 = fabs(sRGBmap(resultPtr[1])
-                                                        - sRGBmap(expected[1]));
-                                            err3 = fabs(sRGBmap(resultPtr[2])
-                                                        - sRGBmap(expected[2]));
-                                            err4 = fabsf( resultPtr[3] - expected[3] );
+                                            err1 =
+                                                ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                          sRGBmap(expected[0]));
+                                            err2 =
+                                                ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                          sRGBmap(expected[1]));
+                                            err3 =
+                                                ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                          sRGBmap(expected[2]));
+                                            err4 = ABS_ERROR(resultPtr[3],
+                                                             expected[3]);
                                         }
                                     }
 
@@ -698,15 +706,16 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
                                         float err1 =
-                                            fabs(sRGBmap(resultPtr[0])
-                                                 - sRGBmap(expected[0]));
+                                            ABS_ERROR(sRGBmap(resultPtr[0]),
+                                                      sRGBmap(expected[0]));
                                         float err2 =
-                                            fabs(sRGBmap(resultPtr[1])
-                                                 - sRGBmap(expected[1]));
+                                            ABS_ERROR(sRGBmap(resultPtr[1]),
+                                                      sRGBmap(expected[1]));
                                         float err3 =
-                                            fabs(sRGBmap(resultPtr[2])
-                                                 - sRGBmap(expected[2]));
-                                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                                            ABS_ERROR(sRGBmap(resultPtr[2]),
+                                                      sRGBmap(expected[2]));
+                                        float err4 = ABS_ERROR(resultPtr[3],
+                                                               expected[3]);
                                         float maxErr = 0.6;
 
                                         if( ! (err1 <= maxErr) || ! (err2 <= maxErr)    || ! (err3 <= maxErr) || ! (err4 <= maxErr) )
@@ -722,16 +731,17 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabs(
-                                                    sRGBmap(resultPtr[0])
-                                                    - sRGBmap(expected[0]));
-                                                err2 = fabs(
-                                                    sRGBmap(resultPtr[1])
-                                                    - sRGBmap(expected[1]));
-                                                err3 = fabs(
-                                                    sRGBmap(resultPtr[2])
-                                                    - sRGBmap(expected[2]));
-                                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                                err1 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[0]),
+                                                    sRGBmap(expected[0]));
+                                                err2 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[1]),
+                                                    sRGBmap(expected[1]));
+                                                err3 = ABS_ERROR(
+                                                    sRGBmap(resultPtr[2]),
+                                                    sRGBmap(expected[2]));
+                                                err4 = ABS_ERROR(resultPtr[3],
+                                                                 expected[3]);
                                             }
                                         }
 
@@ -810,10 +820,14 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                           norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                           imageSampler, expected, 0, &hasDenormals, lod );
 
-                                    float err1 = fabsf( resultPtr[0] - expected[0] );
-                                    float err2 = fabsf( resultPtr[1] - expected[1] );
-                                    float err3 = fabsf( resultPtr[2] - expected[2] );
-                                    float err4 = fabsf( resultPtr[3] - expected[3] );
+                                    float err1 =
+                                        ABS_ERROR(resultPtr[0], expected[0]);
+                                    float err2 =
+                                        ABS_ERROR(resultPtr[1], expected[1]);
+                                    float err3 =
+                                        ABS_ERROR(resultPtr[2], expected[2]);
+                                    float err4 =
+                                        ABS_ERROR(resultPtr[3], expected[3]);
                                     // Clamp to the minimum absolute error for the format
                                     if (err1 > 0 && err1 < formatAbsoluteError) { err1 = 0.0f; }
                                     if (err2 > 0 && err2 < formatAbsoluteError) { err2 = 0.0f; }
@@ -841,10 +855,14 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                        norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                        imageSampler, expected, 0, NULL, lod );
 
-                                            err1 = fabsf( resultPtr[0] - expected[0] );
-                                            err2 = fabsf( resultPtr[1] - expected[1] );
-                                            err3 = fabsf( resultPtr[2] - expected[2] );
-                                            err4 = fabsf( resultPtr[3] - expected[3] );
+                                            err1 = ABS_ERROR(resultPtr[0],
+                                                             expected[0]);
+                                            err2 = ABS_ERROR(resultPtr[1],
+                                                             expected[1]);
+                                            err3 = ABS_ERROR(resultPtr[2],
+                                                             expected[2]);
+                                            err4 = ABS_ERROR(resultPtr[3],
+                                                             expected[3]);
                                         }
                                     }
 
@@ -869,10 +887,14 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                               norm_offset_x, norm_offset_y, norm_offset_z,
                                                                                               imageSampler, expected, 0, &hasDenormals, lod );
 
-                                        float err1 = fabsf( resultPtr[0] - expected[0] );
-                                        float err2 = fabsf( resultPtr[1] - expected[1] );
-                                        float err3 = fabsf( resultPtr[2] - expected[2] );
-                                        float err4 = fabsf( resultPtr[3] - expected[3] );
+                                        float err1 = ABS_ERROR(resultPtr[0],
+                                                               expected[0]);
+                                        float err2 = ABS_ERROR(resultPtr[1],
+                                                               expected[1]);
+                                        float err3 = ABS_ERROR(resultPtr[2],
+                                                               expected[2]);
+                                        float err4 = ABS_ERROR(resultPtr[3],
+                                                               expected[3]);
                                         float maxErr1 = MAX( maxErr * maxPixel.p[0], FLT_MIN );
                                         float maxErr2 = MAX( maxErr * maxPixel.p[1], FLT_MIN );
                                         float maxErr3 = MAX( maxErr * maxPixel.p[2], FLT_MIN );
@@ -893,10 +915,14 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], zOffsetValues[ j ],
                                                                                     imageSampler, expected, 0, NULL, lod );
 
-                                                err1 = fabsf( resultPtr[0] - expected[0] );
-                                                err2 = fabsf( resultPtr[1] - expected[1] );
-                                                err3 = fabsf( resultPtr[2] - expected[2] );
-                                                err4 = fabsf( resultPtr[3] - expected[3] );
+                                                err1 = ABS_ERROR(resultPtr[0],
+                                                                 expected[0]);
+                                                err2 = ABS_ERROR(resultPtr[1],
+                                                                 expected[1]);
+                                                err3 = ABS_ERROR(resultPtr[2],
+                                                                 expected[2]);
+                                                err4 = ABS_ERROR(resultPtr[3],
+                                                                 expected[3]);
                                             }
                                         }
 

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -37,39 +37,6 @@
 #define EVALUATE( x )       x
 #define CONCATENATE(x, y)  x ## EVALUATE(y)
 
-
-// Declare Classification macros for non-C99 platforms
-#ifndef isinf
-    #define isinf(x)    (    sizeof (x) == sizeof(float )    ?    fabsf(x) == INFINITY      \
-                        :    sizeof (x) == sizeof(double)    ?    fabs(x) == INFINITY      \
-                        :    fabsl(x) == INFINITY)
-#endif
-
-#ifndef isfinite
-    #define isfinite(x) (    sizeof (x) == sizeof(float )    ?    fabsf(x) < INFINITY      \
-                        :    sizeof (x) == sizeof(double)    ?    fabs(x) < INFINITY      \
-                        :    fabsl(x) < INFINITY)
-#endif
-
-#ifndef isnan
-    #define isnan(_a)       ( (_a) != (_a) )
-#endif
-
-#ifdef __MINGW32__
-    #undef isnormal
-#endif
-
-#ifndef isnormal
-    #define isnormal(x) (    sizeof (x) == sizeof(float )    ?    (fabsf(x) < INFINITY && fabsf(x) >= FLT_MIN)     \
-                        :    sizeof (x) == sizeof(double)    ?    (fabs(x) < INFINITY && fabs(x) >= DBL_MIN)     \
-                        :    (fabsl(x) < INFINITY && fabsl(x) >= LDBL_MIN)   )
-#endif
-
-#ifndef islessgreater
-    // Note: Non-C99 conformant. This will trigger floating point exceptions. We don't care about that here.
-    #define islessgreater( _x, _y )     ( (_x) < (_y) || (_x) > (_y) )
-#endif
-
 #pragma STDC FP_CONTRACT OFF
 static void __log2_ep(double *hi, double *lo, double x);
 

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -488,14 +488,13 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
         float p_j = *(float *) &p[j];
         if ( strcmp(fname,"sin")==0 || strcmp(fname,"cos")==0 )  //the domain of the function is [-pi,pi]
         {
-          if( fabs(p_j) > M_PI )
-            p[j] = NAN;
+            if (fabs(p_j) > M_PI) p[j] = 0;
         }
 
         if ( strcmp( fname, "reciprocal" ) == 0 )
         {
           if( fabs(p_j) > 0x7E800000 ) //the domain of the function is [2^-126,2^126]
-            p[j] = NAN;
+              p[j] = 0;
         }
       }
     }

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -488,13 +488,14 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
         float p_j = *(float *) &p[j];
         if ( strcmp(fname,"sin")==0 || strcmp(fname,"cos")==0 )  //the domain of the function is [-pi,pi]
         {
-            if (fabs(p_j) > M_PI) p[j] = 0;
+          if( fabs(p_j) > M_PI )
+            p[j] = NAN;
         }
 
         if ( strcmp( fname, "reciprocal" ) == 0 )
         {
           if( fabs(p_j) > 0x7E800000 ) //the domain of the function is [2^-126,2^126]
-              p[j] = 0;
+            p[j] = NAN;
         }
       }
     }

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -240,7 +240,8 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             if ( gTestFastRelaxed && strcmp(f->name,"sincos") == 0 )
             {
               float pj = *(float *)&p[j];
-              if (fabs(pj) > M_PI) p[j] = 0;
+              if(fabs(pj) > M_PI)
+                p[j] = NAN;
             }
           }
         }
@@ -252,7 +253,8 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             if ( gTestFastRelaxed && strcmp(f->name,"sincos") == 0 )
             {
               float pj = *(float *)&p[j];
-              if (fabs(pj) > M_PI) p[j] = 0;
+              if(fabs(pj) > M_PI)
+                p[j] = NAN;
             }
           }
         }

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -240,8 +240,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             if ( gTestFastRelaxed && strcmp(f->name,"sincos") == 0 )
             {
               float pj = *(float *)&p[j];
-              if(fabs(pj) > M_PI)
-                p[j] = NAN;
+              if (fabs(pj) > M_PI) p[j] = 0;
             }
           }
         }
@@ -253,8 +252,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d)
             if ( gTestFastRelaxed && strcmp(f->name,"sincos") == 0 )
             {
               float pj = *(float *)&p[j];
-              if(fabs(pj) > M_PI)
-                p[j] = NAN;
+              if (fabs(pj) > M_PI) p[j] = 0;
             }
           }
         }

--- a/test_conformance/spir/datagen.h
+++ b/test_conformance/spir/datagen.h
@@ -274,20 +274,16 @@ public:
         if (CL_SUCCESS != error)
             throw Exceptions::TestError("clGetSupportedImageFormats failed\n", error);
 
-        std::auto_ptr<cl_image_format> supportedFormats(new cl_image_format[actualNumFormats]);
-        error = clGetSupportedImageFormats(
-            context,
-            flags,
-            m_desc.image_type,
-            actualNumFormats,
-            supportedFormats.get(),
-            NULL);
+        std::vector<cl_image_format> supportedFormats(actualNumFormats);
+        error = clGetSupportedImageFormats(context, flags, m_desc.image_type,
+                                           actualNumFormats,
+                                           supportedFormats.data(), NULL);
         if (CL_SUCCESS != error)
             throw Exceptions::TestError("clGetSupportedImageFormats failed\n", error);
 
         for (size_t i=0; i<actualNumFormats; ++i)
         {
-            cl_image_format curFormat = supportedFormats.get()[i];
+            cl_image_format curFormat = supportedFormats[i];
 
             if(imgFormat.image_channel_order == curFormat.image_channel_order &&
                imgFormat.image_channel_data_type == curFormat.image_channel_data_type)

--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -147,8 +147,8 @@ static void get_spir_version(cl_device_id device, std::vector<float>& versions)
     cl_int err;
     size_t size = 0;
 
-    if (err = clGetDeviceInfo(device, CL_DEVICE_SPIR_VERSIONS, sizeof(version),
-                              (void*)version, &size))
+    if ((err = clGetDeviceInfo(device, CL_DEVICE_SPIR_VERSIONS, sizeof(version),
+                               (void *)version, &size)))
     {
         log_error( "Error: failed to obtain SPIR version at %s:%d (err = %d)\n",
                   __FILE__, __LINE__, err );

--- a/test_conformance/spir/run_build_test.cpp
+++ b/test_conformance/spir/run_build_test.cpp
@@ -268,7 +268,7 @@ static bool run_test(cl_context context, cl_command_queue queue, cl_program clpr
 {
     WorkSizeInfo ws;
     TestResult cl_result;
-    std::auto_ptr<TestResult> bc_result;
+    std::unique_ptr<TestResult> bc_result;
     // first, run the single CL test
     {
         // make sure that the kernel will be released before the program


### PR DESCRIPTION
Fixes many of the errors this produces, and disables a handful that
didn't have solutions that were obvious (to me).