### PR TITLE
Improve async build callback testing

### DIFF
--- a/test_conformance/compiler/test_async_build.cpp
+++ b/test_conformance/compiler/test_async_build.cpp
@@ -55,7 +55,7 @@ std::atomic<int> callbackResult;
 
 }
 
-void CL_CALLBACK test_notify_build_complete( cl_program program, void *userData )
+void CL_CALLBACK test_notify_build_complete(cl_program program, void *userData)
 {
     TestData *data = reinterpret_cast<TestData *>(userData);
 


### PR DESCRIPTION
Check that the program build status can be queried from inside the
program completion callback, and also add a test to ensure that the
completion callback is called when the build fails.

This was clarified in the specification in [a recent change](https://github.com/KhronosGroup/OpenCL-Docs/pull/285).