### PR TITLE
Widen 3D images for array-image copy

### DIFF
--- a/test_conformance/basic/test_arrayimagecopy3d.cpp
+++ b/test_conformance/basic/test_arrayimagecopy3d.cpp
@@ -27,7 +27,7 @@ int test_arrayimagecopy3d_single_format(cl_device_id device, cl_context context,
 {
   cl_uchar    *bufptr, *imgptr;
   clMemWrapper      buffer, image;
-  int        img_width = 128;
+  int        img_width = 256;
   int        img_height = 128;
   int        img_depth = 32;
   size_t    elem_size;

--- a/test_conformance/basic/test_imagearraycopy3d.cpp
+++ b/test_conformance/basic/test_imagearraycopy3d.cpp
@@ -27,7 +27,7 @@ int test_imagearraycopy3d_single_format(cl_device_id device, cl_context context,
 {
   cl_uchar    *imgptr, *bufptr;
   clMemWrapper      image, buffer;
-  int        img_width = 128;
+  int        img_width = 256;
   int        img_height = 128;
   int        img_depth = 32;
   size_t    elem_size;


### PR DESCRIPTION
According to the OpenCL spec for clEnqueueCopyImageToBuffer (and similar for the reverse), the driver is allowed to fail requests that would result in using resource dimensions or pitches that are not supported:

> CL_​INVALID_​IMAGE_​SIZE if image dimensions (image width, height, specified or compute row and/or slice pitch) for src_image are not supported by device associated with queue.

For OpenCLOn12, we would like to require 256-byte row pitches and 512-byte slice pitches, because are the limits enforced by the [ID3D12GraphicsCommandList::CopyTextureRegion](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion) API. When the CTS gets down to one-byte-per-pixel image formats with a 128 texel wide image, that results in row pitches of 128 bytes. The simplest way to allow OpenCLOn12 to pass would be to just use wider textures.