### PR TITLE
Remove duplicate IsXSubnormal functions

### DIFF
--- a/test_common/harness/conversions.h
+++ b/test_common/harness/conversions.h
@@ -118,7 +118,8 @@ static inline int IsDoubleSubnormal( double x )
 }
 
 static inline int IsHalfSubnormal( cl_half x )
-{ 
+{
+    // this relies on interger overflow to exclude 0 as a subnormal
     return ( ( x & 0x7fffU ) - 1U ) < 0x03ffU; 
 }
 

--- a/test_conformance/half/cl_utils.h
+++ b/test_conformance/half/cl_utils.h
@@ -18,6 +18,7 @@
 
 #include "harness/testHarness.h"
 #include "harness/compat.h"
+#include "harness/conversions.h"
 
 #include <stdio.h>
 
@@ -110,43 +111,6 @@ static inline cl_ulong DoubleFromUInt( cl_uint bits )
     u -= (cl_ulong)((bits & 0x80U) << 1);
 
     return u;
-}
-
-static inline int IsHalfSubnormal( uint16_t x )
-{
-    // this relies on interger overflow to exclude 0 as a subnormal
-    return ( ( x & 0x7fffU ) - 1U ) < 0x03ffU;
-}
-
-// prevent silent failures due to missing FLT_RADIX
-#ifndef FLT_RADIX
-    #error FLT_RADIX is not defined by float.h
-#endif
-
-static inline int IsFloatSubnormal( double x )
-{
-#if 2 == FLT_RADIX
-    // Do this in integer to avoid problems with FTZ behavior
-    union{ float d; uint32_t u;}u;
-    u.d = fabsf((float) x);
-    return (u.u-1) < 0x007fffffU;
-#else
-    // rely on floating point hardware for non-radix2 non-IEEE-754 hardware -- will fail if you flush subnormals to zero
-    return fabs(x) < (double) FLT_MIN && x != 0.0;
-#endif
-}
-
-static inline int IsDoubleSubnormal( long double x )
-{
-#if 2 == FLT_RADIX
-    // Do this in integer to avoid problems with FTZ behavior
-    union{ double d; uint64_t u;}u;
-    u.d = fabs((double)x);
-    return (u.u-1) < 0x000fffffffffffffULL;
-#else
-    // rely on floating point hardware for non-radix2 non-IEEE-754 hardware -- will fail if you flush subnormals to zero
-    return fabs(x) < (double) DBL_MIN && x != 0.0;
-#endif
 }
 
 #endif /* CL_UTILS_H */

--- a/test_conformance/math_brute_force/Utility.h
+++ b/test_conformance/math_brute_force/Utility.h
@@ -28,6 +28,7 @@
 #include "harness/fpcontrol.h"
 #include "harness/testHarness.h"
 #include "harness/ThreadPool.h"
+#include "harness/conversions.h"
 #define BUFFER_SIZE         (1024*1024*2)
 
 #if defined( __GNUC__ )
@@ -127,34 +128,6 @@ void _LogBuildError( cl_program p, int line, const char *file );
 #define LogBuildError( program )        _LogBuildError( program, __LINE__, __FILE__ )
 
 #define PERF_LOOP_COUNT 100
-
-// Note: though this takes a double, this is for use with single precision tests
-static inline int IsFloatSubnormal( double x )
-{
-#if 2 == FLT_RADIX
-    // Do this in integer to avoid problems with FTZ behavior
-    union{ float d; uint32_t u;}u;
-    u.d = fabsf((float)x);
-    return (u.u-1) < 0x007fffffU;
-#else
-    // rely on floating point hardware for non-radix2 non-IEEE-754 hardware -- will fail if you flush subnormals to zero
-    return fabs(x) < (double) FLT_MIN && x != 0.0;
-#endif
-}
-
-
-static inline int IsDoubleSubnormal( long double x )
-{
-#if 2 == FLT_RADIX
-    // Do this in integer to avoid problems with FTZ behavior
-    union{ double d; uint64_t u;}u;
-    u.d = fabs((double) x);
-    return (u.u-1) < 0x000fffffffffffffULL;
-#else
-    // rely on floating point hardware for non-radix2 non-IEEE-754 hardware -- will fail if you flush subnormals to zero
-    return fabs(x) < (double) DBL_MIN && x != 0.0;
-#endif
-}
 
 //The spec is fairly clear that we may enforce a hard cutoff to prevent premature flushing to zero.
 // However, to avoid conflict for 1.0, we are letting results at TYPE_MIN + ulp_limit to be flushed to zero.


### PR DESCRIPTION
Is{Double,Float,Half}Subnormal function duplicates are currently in the codebase.

Fixes #511

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>