### PR TITLE
Add `CL_DEVICE_IMAGE_SUPPORT` to clDeviceInfo File

### DIFF
--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -372,6 +372,8 @@ static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint de
         clDeviceInfoStream << "CL_DEVICE_IL_VERSION=\"" << ilVersionString << "\"" << std::endl;
     }
     clDeviceInfoStream << "CL_DEVICE_VERSION=\"" << versionString << "\"" << std::endl;
+    clDeviceInfoStream << "CL_DEVICE_IMAGE_SUPPORT="
+                       << (0 == checkForImageSupport(device)) << std::endl;
 
     clDeviceInfo = clDeviceInfoStream.str();
 


### PR DESCRIPTION
- [x] Add `CL_DEVICE_IMAGE_SUPPORT` to the clDeviceInfo file
which contains
device specific information for the purposes of offline compilation. For
devices with images support `CL_DEVICE_IMAGE_SUPPORT=1` is printed,
otherwise `CL_DEVICE_IMAGE_SUPPORT=0`.