### PR TITLE
Add `CL_DEVICE_NAME` to clDeviceInfo File

### DIFF
--- a/test_common/harness/cl_offline_compiler-interface.txt
+++ b/test_common/harness/cl_offline_compiler-interface.txt
@@ -23,3 +23,5 @@ It is of the following form:
    CL_DEVICE_EXTENSIONS="<space separated list of CL extensions>"
    CL_DEVICE_IL_VERSION="<space separated list of IL versions>"
    CL_DEVICE_VERSION="OpenCL <version> <vendor info>"
+   CL_DEVICE_IMAGE_SUPPORT=<0|1>
+   CL_DEVICE_NAME="device name"

--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -79,3 +79,9 @@ std::string get_device_version_string(cl_device_id device)
 {
     return get_device_info_string(device, CL_DEVICE_VERSION);
 }
+
+/* Returns a string containing the device name. */
+std::string get_device_name(cl_device_id device)
+{
+    return get_device_info_string(device, CL_DEVICE_NAME);
+}

--- a/test_common/harness/deviceInfo.h
+++ b/test_common/harness/deviceInfo.h
@@ -35,4 +35,6 @@ std::string get_device_il_version_string(cl_device_id device);
 /* Returns a string containing the supported OpenCL version for a device. */
 std::string get_device_version_string(cl_device_id device);
 
+/* Returns a string containing the device name. */
+std::string get_device_name(cl_device_id device);
 #endif // _deviceInfo_h

--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -374,6 +374,8 @@ static cl_int get_cl_device_info_str(const cl_device_id device, const cl_uint de
     clDeviceInfoStream << "CL_DEVICE_VERSION=\"" << versionString << "\"" << std::endl;
     clDeviceInfoStream << "CL_DEVICE_IMAGE_SUPPORT="
                        << (0 == checkForImageSupport(device)) << std::endl;
+    clDeviceInfoStream << "CL_DEVICE_NAME=\"" << get_device_name(device).c_str()
+                       << "\"" << std::endl;
 
     clDeviceInfo = clDeviceInfoStream.str();
 


### PR DESCRIPTION
- [x] Add `CL_DEVICE_NAME` to list of device properties printed into the
clDeviceInfo file for offline compilation testing.
- [x] Add `get_device_name` helper function.
- [x] Update offline compiler interface explanation file with
`CL_DEVICE_NAME` and `CL_DEVICE_IMAGE_SUPPORT` which was missed from
this file when added.