### PR TITLE
Fix clang release build

### DIFF
--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -302,18 +302,11 @@ const std::string& DataRow::operator[](int column)const
 
 std::string& DataRow::operator[](int column)
 {
-    assert((column > -1) && "Index out of bound");
+    assert((column > -1 && (size_t)column <= m_row.size())
+           && "Index out of bound");
+    if ((size_t)column == m_row.size()) m_row.push_back("");
 
-    if ((size_t)column < m_row.size())
-        return m_row[column];
-
-    if (column == m_row.size())
-    {
-        m_row.push_back("");
-        return m_row[column];
-    }
-
-    assert(0 && "Index out of bound.");
+    return m_row[column];
 }
 
 /*


### PR DESCRIPTION
Avoid missing non-void function return 

Fixes #846