### PR TITLE
Arbitrary output directory support for compiler test build copies (#848)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,17 +232,4 @@ else(WIN32)
   add_custom_target( COPY_FILES${CONFORMANCE_SUFFIX} )
 endif(WIN32)
 
-# Copy required CL include directories into the build directory
-# as required for the compiler testing.
-
-# ... For running the compiler test on the command line.
-file(COPY "${CLConform_SOURCE_DIR}/test_conformance/compiler/includeTestDirectory" DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_conformance/compiler)
-file(COPY "${CLConform_SOURCE_DIR}/test_conformance/compiler/secondIncludeTestDirectory" DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_conformance/compiler)
-
-# ... For running the compiler test with VisualStudio.
-if(MSVC)
-  file(COPY "${CLConform_SOURCE_DIR}/test_conformance/compiler/includeTestDirectory" DESTINATION "${CLConform_SOURCE_DIR}/build/test_conformance/compiler")
-  file(COPY "${CLConform_SOURCE_DIR}/test_conformance/compiler/secondIncludeTestDirectory" DESTINATION "${CLConform_SOURCE_DIR}/build/test_conformance/compiler")
-endif(MSVC)
-
 set_property(TARGET COPY_FILES${CONFORMANCE_SUFFIX} PROPERTY FOLDER "CONFORMANCE${CONFORMANCE_SUFFIX}")

--- a/test_conformance/compiler/CMakeLists.txt
+++ b/test_conformance/compiler/CMakeLists.txt
@@ -13,3 +13,20 @@ set(${MODULE_NAME}_SOURCES
 )
 
 include(../CMakeCommon.txt)
+
+# Copy required CL include directories into the binary directory
+
+set(COMPILER_SOURCE_DIR ${CLConform_SOURCE_DIR}/test_conformance/compiler)
+set(COMPILER_TARGET ${${MODULE_NAME}_OUT})
+
+add_custom_command(
+    TARGET  ${COMPILER_TARGET}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${COMPILER_SOURCE_DIR}/includeTestDirectory"
+            $<TARGET_FILE_DIR:${COMPILER_TARGET}>/includeTestDirectory)
+
+add_custom_command(
+    TARGET  ${COMPILER_TARGET}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${COMPILER_SOURCE_DIR}/secondIncludeTestDirectory"
+            $<TARGET_FILE_DIR:${COMPILER_TARGET}>/secondIncludeTestDirectory)

--- a/test_conformance/computeinfo/extended_versioning.cpp
+++ b/test_conformance/computeinfo/extended_versioning.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <set>
+#include <iterator>
 #include <algorithm>
 #include <cstring>
 #include "harness/testHarness.h"


### PR DESCRIPTION
* Move headers copy from top level CMakeLists.txt down to test_compile module as post-build copy
* Fix windows VS2015 build break

resolves #848