### PR TITLE
Set new minimum version for the spirv_new tests.

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -1041,9 +1041,9 @@ test_status check_spirv_compilation_readiness(cl_device_id device)
         }
         else
         {
-            version_expected_info("Test", "OpenCL",
-                                  ocl_expected_min_version.to_string().c_str(),
-                                  ocl_version.to_string().c_str());
+            log_error("SPIR-V intermediate language support on OpenCL version "
+                      "%s requires cl_khr_il_program extension.\n",
+                      ocl_version.to_string().c_str());
             return TEST_SKIP;
         }
     }

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -81,7 +81,7 @@ void spirvTestsRegistry::addTestClass(baseTestClass *test, const char *testName)
     test_definition testDef;
     testDef.func = test->getFunction();
     testDef.name = testName;
-    testDef.min_version = Version(2, 1);
+    testDef.min_version = Version(1, 2);
     testDefinitions.push_back(testDef);
 }
 


### PR DESCRIPTION
This allows 1.2 implementations with the cl_khr_il_program extension to run them.