### PR TITLE
add OpenCL 3.0 test for CL_COMMAND_SVM_MIGRATE_MEM

### DIFF
--- a/test_conformance/SVM/test_migrate.cpp
+++ b/test_conformance/SVM/test_migrate.cpp
@@ -199,6 +199,24 @@ int test_svm_migrate(cl_device_id deviceID, cl_context c, cl_command_queue queue
     error = clFlush(queues[1]);
     test_error(error, "clFlush failed");
 
+    // Check the event command type for clEnqueueSVMMigrateMem (OpenCL 3.0 and
+    // newer)
+    Version version = get_device_cl_version(deviceID);
+    if (version >= Version(3, 0))
+    {
+        cl_command_type commandType;
+        error = clGetEventInfo(evs[3], CL_EVENT_COMMAND_TYPE,
+                               sizeof(commandType), &commandType, NULL);
+        test_error(error, "clGetEventInfo failed");
+        if (commandType != CL_COMMAND_SVM_MIGRATE_MEM)
+        {
+            log_error("Invalid command type returned for "
+                      "clEnqueueSVMMigrateMem: %X\n",
+                      commandType);
+            return TEST_FAIL;
+        }
+    }
+
     error = wait_and_release("first batch", evs, 8);
     if (error)
         return -1;


### PR DESCRIPTION
This is a basic test to ensure that the new OpenCL 3.0 event command type `CL_COMMAND_SVM_MIGRATE_MEM` is properly returned for events from `clEnqueueSVMMigrateMem`.  This is not a test that exhaustively tests all event command types - see https://github.com/KhronosGroup/OpenCL-CTS/issues/613 - but it does ensure that we have coverage for the new event type added in OpenCL 3.0.

Note, I considered adding this test to [test_enqueue_api.cpp](https://github.com/KhronosGroup/OpenCL-CTS/blob/master/test_conformance/SVM/test_enqueue_api.cpp) since it includes tests for the event command type for other SVM-related APIs, but I ultimately decided this was a better place for it because the other SVM APIs were introduced in OpenCL 2.0 and the SVM migrate API was included in OpenCL 2.1.  I'm happy to move it elsewhere though, so long as the scope of the changes are reasonable.