### PR TITLE
build an OpenCL 3.0 ICD loader for CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ before_build:
   - ps: cd OpenCL-ICD-Loader
   - ps: mkdir build
   - ps: cd build
-  - cmake -A%PLATFORM% -DOPENCL_ICD_LOADER_HEADERS_DIR=%TOP%/OpenCL-Headers/ ..
+  - cmake -A%PLATFORM% -DENABLE_OPENCL30_PROVISIONAL=1 -DOPENCL_ICD_LOADER_HEADERS_DIR=%TOP%/OpenCL-Headers/ ..
   - cmake --build . --config %CONFIGURATION%
   - ps: cd $env:TOP
   # Get the libclcxx standard library:

--- a/travis.sh
+++ b/travis.sh
@@ -57,7 +57,7 @@ git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
 cd ${TOP}/OpenCL-ICD-Loader
 mkdir build
 cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DOPENCL_ICD_LOADER_HEADERS_DIR=${TOP}/OpenCL-Headers/ ..
+cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DENABLE_OPENCL30_PROVISIONAL=1 -DOPENCL_ICD_LOADER_HEADERS_DIR=${TOP}/OpenCL-Headers/ ..
 make
 
 # Get libclcxx


### PR DESCRIPTION
Until OpenCL 3.0 is finalized and supported by default in the OpenCL ICD loader, we need to pass a special flag to enable OpenCL 3.0 provisional APIs in the OpenCL ICD loader.  This will be necessary when we start testing OpenCL 3.0 APIs, such as in PR #857.

Fixes #859 