### PR TITLE
Test for IL support in unload_platform_compiler

### DIFF
--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -262,7 +262,10 @@ public:
                   const cl_device_id device)
         : build_base{ context, device }
     {
-        if (get_device_cl_version(device) >= Version(2, 1))
+        Version version = get_device_cl_version(device);
+        std::string sILVersion = get_device_il_version_string(device);
+        if ((version >= Version(2, 1) && version < Version(3, 0))
+            || (version >= Version(3, 0) && sILVersion.length() != 1))
         {
             m_CreateProgramWithIL = clCreateProgramWithIL;
             m_enabled = true;


### PR DESCRIPTION
Test assumes all 3.0 devices support IL.