### PR TITLE
Add lock around offline-compiling

### DIFF
--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -28,12 +28,15 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <mutex>
 
 #if defined(_WIN32)
 std::string slash = "\\";
 #else
 std::string slash = "/";
 #endif
+
+static std::mutex gCompilerMutex;
 
 static cl_int get_first_device_id(const cl_context context, cl_device_id &device);
 
@@ -682,6 +685,8 @@ static int create_single_kernel_helper_create_program(cl_context context,
                                                       const bool openclCXX,
                                                       CompilationMode compilationMode)
 {
+    std::lock_guard<std::mutex> compiler_lock(gCompilerMutex);
+
     std::string filePrefix = get_unique_filename_prefix(numKernelLines,
                                                         kernelProgram,
                                                         buildOptions);


### PR DESCRIPTION
The offline compiler tries to compile the same source multiple times and
more importantly write out to the same filename. Adding a lock to prevent
simultaneous compilation solves this issue. This is particularly
noticeable in integer_ops testing.

Signed-off-by: Mats Petersson <mats.petersson@arm.com>
Signed-off-by: Stuart Brady <stuart.brady@arm.com>