### PR TITLE
skip test cases rather than fail without cl_khr_3d_image_writes

### DIFF
--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -186,14 +186,15 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     static int printedFormatList = -1;
 
 
-    if ( ( 0 == is_extension_available( device, "cl_khr_3d_image_writes" )) && (imageType == CL_MEM_OBJECT_IMAGE3D) && (formatTestFn == test_write_image_formats) )
+    if ( (imageType == CL_MEM_OBJECT_IMAGE3D) && (formatTestFn == test_write_image_formats) )
     {
-        gFailCount++;
-        log_error( "-----------------------------------------------------\n" );
-        log_error( "FAILED: test writing CL_MEM_OBJECT_IMAGE3D images\n" );
-        log_error( "This device does not support the mandated extension cl_khr_3d_image_writes.\n");
-        log_error( "-----------------------------------------------------\n\n" );
-        return -1;
+        if ( 0 == is_extension_available( device, "cl_khr_3d_image_writes" ))
+        {
+            log_info( "-----------------------------------------------------\n" );
+            log_info( "This device does not support cl_khr_3d_image_writes.\nSkipping 3d image write test. \n" );
+            log_info( "-----------------------------------------------------\n\n" );
+            return 0;
+        }
     }
 
     if ( gTestMipmaps )

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -16,43 +16,68 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern cl_filter_mode     gFilterModeToUse;
+extern cl_filter_mode gFilterModeToUse;
 extern cl_addressing_mode gAddressModeToUse;
-extern int                gTypesToTest;
-extern int                gNormalizedModeToUse;
-extern cl_channel_type      gChannelTypeToUse;
-extern cl_channel_order      gChannelOrderToUse;
+extern int gTypesToTest;
+extern int gNormalizedModeToUse;
+extern cl_channel_type gChannelTypeToUse;
+extern cl_channel_order gChannelOrderToUse;
 
 extern bool gDebugTrace;
 extern bool gTestMipmaps;
 
-extern int  gtestTypesToRun;
+extern int gtestTypesToRun;
 extern bool gDeviceLt20;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue,  cl_image_format *format, image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
-                                        bool floatCoords, ExplicitType outputType );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
-                                        bool floatCoords, ExplicitType outputType );
+extern int test_read_image_set_1D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  bool floatCoords, ExplicitType outputType);
+extern int test_read_image_set_2D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  bool floatCoords, ExplicitType outputType);
+extern int test_read_image_set_3D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  bool floatCoords, ExplicitType outputType);
+extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        image_sampler_data *imageSampler,
+                                        bool floatCoords,
+                                        ExplicitType outputType);
+extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        image_sampler_data *imageSampler,
+                                        bool floatCoords,
+                                        ExplicitType outputType);
 
-int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool floatCoords,
-                         image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
+int test_read_image_type(cl_device_id device, cl_context context,
+                         cl_command_queue queue, cl_image_format *format,
+                         bool floatCoords, image_sampler_data *imageSampler,
+                         ExplicitType outputType, cl_mem_object_type imageType)
 {
     int ret = 0;
     cl_addressing_mode *addressModes = NULL;
 
-    // The sampler-less read image functions behave exactly as the corresponding read image functions
-    // described in section 6.13.14.2 that take integer coordinates and a sampler with filter mode set to
-    // CLK_FILTER_NEAREST, normalized coordinates set to CLK_NORMALIZED_COORDS_FALSE and addressing mode to CLK_ADDRESS_NONE
-    cl_addressing_mode addressModes_rw[] = { CL_ADDRESS_NONE, (cl_addressing_mode)-1 };
-    cl_addressing_mode addressModes_ro[] = { /* CL_ADDRESS_CLAMP_NONE,*/ CL_ADDRESS_CLAMP_TO_EDGE, CL_ADDRESS_CLAMP, CL_ADDRESS_REPEAT, CL_ADDRESS_MIRRORED_REPEAT, (cl_addressing_mode)-1 };
+    // The sampler-less read image functions behave exactly as the corresponding
+    // read image functions described in section 6.13.14.2 that take integer
+    // coordinates and a sampler with filter mode set to CLK_FILTER_NEAREST,
+    // normalized coordinates set to CLK_NORMALIZED_COORDS_FALSE and addressing
+    // mode to CLK_ADDRESS_NONE
+    cl_addressing_mode addressModes_rw[] = { CL_ADDRESS_NONE,
+                                             (cl_addressing_mode)-1 };
+    cl_addressing_mode addressModes_ro[] = {
+        /* CL_ADDRESS_CLAMP_NONE,*/ CL_ADDRESS_CLAMP_TO_EDGE, CL_ADDRESS_CLAMP,
+        CL_ADDRESS_REPEAT, CL_ADDRESS_MIRRORED_REPEAT, (cl_addressing_mode)-1
+    };
 
-    if(gtestTypesToRun & kReadWriteTests)
+    if (gtestTypesToRun & kReadWriteTests)
     {
         addressModes = addressModes_rw;
     }
@@ -61,39 +86,45 @@ int test_read_image_type( cl_device_id device, cl_context context, cl_command_qu
         addressModes = addressModes_ro;
     }
 
-#if defined( __APPLE__ )
+#if defined(__APPLE__)
     // According to the OpenCL specification, we do not guarantee the precision
     // of operations for linear filtering on the GPU.  We do not test linear
     // filtering for the CL_RGB CL_UNORM_INT_101010 image format; however, we
     // test it internally for a set of other image formats.
-    if ((gDeviceType == CL_DEVICE_TYPE_GPU) &&
-        (imageSampler->filter_mode == CL_FILTER_LINEAR) &&
-        (format->image_channel_order == CL_RGB) &&
-        (format->image_channel_data_type == CL_UNORM_INT_101010))
+    if ((gDeviceType == CL_DEVICE_TYPE_GPU)
+        && (imageSampler->filter_mode == CL_FILTER_LINEAR)
+        && (format->image_channel_order == CL_RGB)
+        && (format->image_channel_data_type == CL_UNORM_INT_101010))
     {
-        log_info("--- Skipping CL_RGB CL_UNORM_INT_101010 format with CL_FILTER_LINEAR on GPU.\n");
+        log_info("--- Skipping CL_RGB CL_UNORM_INT_101010 format with "
+                 "CL_FILTER_LINEAR on GPU.\n");
         return 0;
     }
 #endif
 
-    for( int adMode = 0; addressModes[ adMode ] != (cl_addressing_mode)-1; adMode++ )
+    for (int adMode = 0; addressModes[adMode] != (cl_addressing_mode)-1;
+         adMode++)
     {
-        imageSampler->addressing_mode = addressModes[ adMode ];
+        imageSampler->addressing_mode = addressModes[adMode];
 
-        if( (addressModes[ adMode ] == CL_ADDRESS_REPEAT || addressModes[ adMode ] == CL_ADDRESS_MIRRORED_REPEAT) && !( imageSampler->normalized_coords ) )
+        if ((addressModes[adMode] == CL_ADDRESS_REPEAT
+             || addressModes[adMode] == CL_ADDRESS_MIRRORED_REPEAT)
+            && !(imageSampler->normalized_coords))
             continue; // Repeat doesn't make sense for non-normalized coords
 
         // Use this run if we were told to only run a certain filter mode
-        if( gAddressModeToUse != (cl_addressing_mode)-1 && imageSampler->addressing_mode != gAddressModeToUse )
+        if (gAddressModeToUse != (cl_addressing_mode)-1
+            && imageSampler->addressing_mode != gAddressModeToUse)
             continue;
 
         /*
          Remove redundant check to see if workaround still necessary
-         // Check added in because this case was leaking through causing a crash on CPU
-         if( ! imageSampler->normalized_coords && imageSampler->addressing_mode == CL_ADDRESS_REPEAT )
-         continue;       //repeat mode requires normalized coordinates
+         // Check added in because this case was leaking through causing a crash
+         on CPU if( ! imageSampler->normalized_coords &&
+         imageSampler->addressing_mode == CL_ADDRESS_REPEAT ) continue; //repeat
+         mode requires normalized coordinates
          */
-        print_read_header( format, imageSampler, false );
+        print_read_header(format, imageSampler, false);
 
         gTestCount++;
 
@@ -101,27 +132,37 @@ int test_read_image_type( cl_device_id device, cl_context context, cl_command_qu
         switch (imageType)
         {
             case CL_MEM_OBJECT_IMAGE1D:
-                retCode = test_read_image_set_1D( device, context, queue, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_1D(device, context, queue, format,
+                                                 imageSampler, floatCoords,
+                                                 outputType);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                retCode = test_read_image_set_1D_array( device, context, queue, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_1D_array(device, context, queue,
+                                                       format, imageSampler,
+                                                       floatCoords, outputType);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                retCode = test_read_image_set_2D( device, context, queue, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_2D(device, context, queue, format,
+                                                 imageSampler, floatCoords,
+                                                 outputType);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                retCode = test_read_image_set_2D_array( device, context, queue, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_2D_array(device, context, queue,
+                                                       format, imageSampler,
+                                                       floatCoords, outputType);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                retCode = test_read_image_set_3D( device, context, queue, format, imageSampler, floatCoords, outputType );
+                retCode = test_read_image_set_3D(device, context, queue, format,
+                                                 imageSampler, floatCoords,
+                                                 outputType);
                 break;
         }
-        if( retCode != 0 )
+        if (retCode != 0)
         {
             gFailCount++;
-            log_error( "FAILED: " );
-            print_read_header( format, imageSampler, true );
-            log_info( "\n" );
+            log_error("FAILED: ");
+            print_read_header(format, imageSampler, true);
+            log_info("\n");
         }
         ret |= retCode;
     }
@@ -129,8 +170,12 @@ int test_read_image_type( cl_device_id device, cl_context context, cl_command_qu
     return ret;
 }
 
-int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
-                            image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
+int test_read_image_formats(cl_device_id device, cl_context context,
+                            cl_command_queue queue, cl_image_format *formatList,
+                            bool *filterFlags, unsigned int numFormats,
+                            image_sampler_data *imageSampler,
+                            ExplicitType outputType,
+                            cl_mem_object_type imageType)
 {
     int ret = 0;
     bool flipFlop[2] = { false, true };
@@ -138,41 +183,52 @@ int test_read_image_formats( cl_device_id device, cl_context context, cl_command
 
 
     // Use this run if we were told to only run a certain filter mode
-    if( gFilterModeToUse != (cl_filter_mode)-1 && imageSampler->filter_mode != gFilterModeToUse )
+    if (gFilterModeToUse != (cl_filter_mode)-1
+        && imageSampler->filter_mode != gFilterModeToUse)
         return 0;
 
     // Test normalized/non-normalized
-    for( normalizedIdx = 0; normalizedIdx < 2; normalizedIdx++ )
+    for (normalizedIdx = 0; normalizedIdx < 2; normalizedIdx++)
     {
-        imageSampler->normalized_coords = flipFlop[ normalizedIdx ];
-        if( gNormalizedModeToUse != 7 && gNormalizedModeToUse != (int)imageSampler->normalized_coords )
+        imageSampler->normalized_coords = flipFlop[normalizedIdx];
+        if (gNormalizedModeToUse != 7
+            && gNormalizedModeToUse != (int)imageSampler->normalized_coords)
             continue;
 
-        for( floatCoordIdx = 0; floatCoordIdx < 2; floatCoordIdx++ )
+        for (floatCoordIdx = 0; floatCoordIdx < 2; floatCoordIdx++)
         {
-            // Checks added in because this case was leaking through causing a crash on CPU
-            if( !flipFlop[ floatCoordIdx ] )
-                if( imageSampler->filter_mode != CL_FILTER_NEAREST      ||  // integer coords can only be used with nearest
-                   flipFlop[ normalizedIdx ])                               // Normalized integer coords makes no sense (they'd all be zero)
+            // Checks added in because this case was leaking through causing a
+            // crash on CPU
+            if (!flipFlop[floatCoordIdx])
+                if (imageSampler->filter_mode != CL_FILTER_NEAREST
+                    || // integer coords can only be used with nearest
+                    flipFlop[normalizedIdx]) // Normalized integer coords makes
+                                             // no sense (they'd all be zero)
                     continue;
 
-            if( flipFlop[ floatCoordIdx ] && (gtestTypesToRun & kReadWriteTests))
+            if (flipFlop[floatCoordIdx] && (gtestTypesToRun & kReadWriteTests))
                 // sampler-less read in read_write tests run only integer coord
                 continue;
 
 
-            log_info( "read_image (%s coords, %s results) *****************************\n",
-                     flipFlop[ floatCoordIdx ] ? ( imageSampler->normalized_coords ? "normalized float" : "unnormalized float" ) : "integer",
-                     get_explicit_type_name( outputType ) );
+            log_info("read_image (%s coords, %s results) "
+                     "*****************************\n",
+                     flipFlop[floatCoordIdx] ? (imageSampler->normalized_coords
+                                                    ? "normalized float"
+                                                    : "unnormalized float")
+                                             : "integer",
+                     get_explicit_type_name(outputType));
 
-            for( unsigned int i = 0; i < numFormats; i++ )
+            for (unsigned int i = 0; i < numFormats; i++)
             {
-                if( filterFlags[i] )
-                    continue;
+                if (filterFlags[i]) continue;
 
-                cl_image_format &imageFormat = formatList[ i ];
+                cl_image_format &imageFormat = formatList[i];
 
-                ret |= test_read_image_type( device, context, queue, &imageFormat, flipFlop[ floatCoordIdx ], imageSampler, outputType, imageType );
+                ret |=
+                    test_read_image_type(device, context, queue, &imageFormat,
+                                         flipFlop[floatCoordIdx], imageSampler,
+                                         outputType, imageType);
             }
         }
     }
@@ -180,51 +236,65 @@ int test_read_image_formats( cl_device_id device, cl_context context, cl_command
 }
 
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, test_format_set_fn formatTestFn, cl_mem_object_type imageType )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, test_format_set_fn formatTestFn,
+                   cl_mem_object_type imageType)
 {
     int ret = 0;
     static int printedFormatList = -1;
 
 
-    if ( (imageType == CL_MEM_OBJECT_IMAGE3D) && (formatTestFn == test_write_image_formats) )
+    if ((imageType == CL_MEM_OBJECT_IMAGE3D)
+        && (formatTestFn == test_write_image_formats))
     {
-        if ( 0 == is_extension_available( device, "cl_khr_3d_image_writes" ))
+        if (0 == is_extension_available(device, "cl_khr_3d_image_writes"))
         {
-            log_info( "-----------------------------------------------------\n" );
-            log_info( "This device does not support cl_khr_3d_image_writes.\nSkipping 3d image write test. \n" );
-            log_info( "-----------------------------------------------------\n\n" );
+            log_info("-----------------------------------------------------\n");
+            log_info(
+                "This device does not support "
+                "cl_khr_3d_image_writes.\nSkipping 3d image write test. \n");
+            log_info(
+                "-----------------------------------------------------\n\n");
             return 0;
         }
     }
 
-    if ( gTestMipmaps )
+    if (gTestMipmaps)
     {
-        if ( 0 == is_extension_available( device, "cl_khr_mipmap_image" ))
+        if (0 == is_extension_available(device, "cl_khr_mipmap_image"))
         {
-            log_info( "-----------------------------------------------------\n" );
-            log_info( "This device does not support cl_khr_mipmap_image.\nSkipping mipmapped image test. \n" );
-            log_info( "-----------------------------------------------------\n\n" );
+            log_info("-----------------------------------------------------\n");
+            log_info("This device does not support "
+                     "cl_khr_mipmap_image.\nSkipping mipmapped image test. \n");
+            log_info(
+                "-----------------------------------------------------\n\n");
             return 0;
         }
-        if ( ( 0 == is_extension_available( device, "cl_khr_mipmap_image_writes" )) && (formatTestFn == test_write_image_formats))
+        if ((0 == is_extension_available(device, "cl_khr_mipmap_image_writes"))
+            && (formatTestFn == test_write_image_formats))
         {
-            log_info( "-----------------------------------------------------\n" );
-            log_info( "This device does not support cl_khr_mipmap_image_writes.\nSkipping mipmapped image write test. \n" );
-            log_info( "-----------------------------------------------------\n\n" );
+            log_info("-----------------------------------------------------\n");
+            log_info("This device does not support "
+                     "cl_khr_mipmap_image_writes.\nSkipping mipmapped image "
+                     "write test. \n");
+            log_info(
+                "-----------------------------------------------------\n\n");
             return 0;
         }
     }
 
-    int version_check = (get_device_cl_version(device) < Version(1,2));
-    if (version_check != 0) {
-      switch (imageType) {
-        case CL_MEM_OBJECT_IMAGE1D:
-          test_missing_feature(version_check, "image_1D");
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-          test_missing_feature(version_check, "image_1D_array");
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-          test_missing_feature(version_check, "image_2D_array");
-      }
+    int version_check = (get_device_cl_version(device) < Version(1, 2));
+    if (version_check != 0)
+    {
+        switch (imageType)
+        {
+            case CL_MEM_OBJECT_IMAGE1D:
+                test_missing_feature(version_check, "image_1D");
+            case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+                test_missing_feature(version_check, "image_1D_array");
+            case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+                test_missing_feature(version_check, "image_2D_array");
+        }
     }
 
     // Grab the list of supported image formats for integer reads
@@ -236,9 +306,9 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     // The flag for creating image will be set explicitly in test functions
     cl_mem_flags flags;
     const char *flagNames;
-    if( formatTestFn == test_read_image_formats )
+    if (formatTestFn == test_read_image_formats)
     {
-        if(gtestTypesToRun & kReadTests)
+        if (gtestTypesToRun & kReadTests)
         {
             flags = CL_MEM_READ_ONLY;
             flagNames = "read";
@@ -251,7 +321,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     }
     else
     {
-        if(gtestTypesToRun & kWriteTests)
+        if (gtestTypesToRun & kWriteTests)
         {
             flags = CL_MEM_WRITE_ONLY;
             flagNames = "write";
@@ -263,33 +333,40 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
         }
     }
 
-    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
+    if (get_format_list(context, imageType, formatList, numFormats, flags))
         return -1;
     BufferOwningPtr<cl_image_format> formatListBuf(formatList);
 
 
-    filterFlags = new bool[ numFormats ];
-    if( filterFlags == NULL )
+    filterFlags = new bool[numFormats];
+    if (filterFlags == NULL)
     {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
+        log_error("ERROR: Out of memory allocating filter flags list!\n");
         return -1;
     }
     BufferOwningPtr<bool> filterFlagsBuf(filterFlags);
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
+    memset(filterFlags, 0, sizeof(bool) * numFormats);
 
-    // First time through, we'll go ahead and print the formats supported, regardless of type
-    int test = imageType | (formatTestFn == test_read_image_formats ? (1 << 16) : (1 << 17));
-    if( printedFormatList != test )
+    // First time through, we'll go ahead and print the formats supported,
+    // regardless of type
+    int test = imageType
+        | (formatTestFn == test_read_image_formats ? (1 << 16) : (1 << 17));
+    if (printedFormatList != test)
     {
-        log_info( "---- Supported %s %s formats for this device ---- \n", convert_image_type_to_string(imageType), flagNames );
-        for( unsigned int f = 0; f < numFormats; f++ )
+        log_info("---- Supported %s %s formats for this device ---- \n",
+                 convert_image_type_to_string(imageType), flagNames);
+        for (unsigned int f = 0; f < numFormats; f++)
         {
-            if ( IsChannelOrderSupported( formatList[ f ].image_channel_order ) && IsChannelTypeSupported( formatList[ f ].image_channel_data_type ) )
-                log_info( "  %-7s %-24s %d\n", GetChannelOrderName( formatList[ f ].image_channel_order ),
-                        GetChannelTypeName( formatList[ f ].image_channel_data_type ),
-                        (int)get_format_channel_count( &formatList[ f ] ) );
+            if (IsChannelOrderSupported(formatList[f].image_channel_order)
+                && IsChannelTypeSupported(
+                    formatList[f].image_channel_data_type))
+                log_info(
+                    "  %-7s %-24s %d\n",
+                    GetChannelOrderName(formatList[f].image_channel_order),
+                    GetChannelTypeName(formatList[f].image_channel_data_type),
+                    (int)get_format_channel_count(&formatList[f]));
         }
-        log_info( "------------------------------------------- \n" );
+        log_info("------------------------------------------- \n");
         printedFormatList = test;
     }
 


### PR DESCRIPTION
Fixes #872 

Currently the image streams test will fail if a device does not support `cl_khr_3d_image_writes`, but this extension is only required for OpenCL 2.x devices and is not required for OpenCL 1.x or OpenCL 3.0 devices.  So, rather than failing the test if 3D image writes are unsupported, we can simply skip these test cases instead.

Note that there is already a check that `cl_khr_3d_image_writes` is supported for OpenCL 2.x devices in `test_min_max_device_version`, so we don't need to add any similar checks here.