### PR TITLE
API Feature Consistency Test, Part 1

### DIFF
--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_NAME API)
 
 set(${MODULE_NAME}_SOURCES
          main.cpp
+         test_api_consistency.cpp
          test_bool.cpp
          test_retain.cpp
          test_retain_program.cpp

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -128,6 +128,7 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(consistency_svm, Version(3, 0)),
     ADD_TEST_VERSION(consistency_memory_model, Version(3, 0)),
     ADD_TEST_VERSION(consistency_device_enqueue, Version(3, 0)),
+    ADD_TEST_VERSION(consistency_pipes, Version(3, 0)),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -126,6 +126,8 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(image_properties_queries, Version(3, 0)),
 
     ADD_TEST_VERSION(consistency_svm, Version(3, 0)),
+    ADD_TEST_VERSION(consistency_memory_model, Version(3, 0)),
+    ADD_TEST_VERSION(consistency_device_enqueue, Version(3, 0)),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -123,7 +123,9 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(clone_kernel, Version(2, 1)),
     ADD_TEST_VERSION(zero_sized_enqueue, Version(2, 1)),
     ADD_TEST_VERSION(buffer_properties_queries, Version(3, 0)),
-    ADD_TEST_VERSION(image_properties_queries, Version(3, 0))
+    ADD_TEST_VERSION(image_properties_queries, Version(3, 0)),
+
+    ADD_TEST_VERSION(consistency_svm, Version(3, 0)),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -131,3 +131,5 @@ extern int test_image_properties_queries(cl_device_id deviceID,
                                          int num_elements);
 
 extern int      test_consistency_svm( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );
+extern int      test_consistency_memory_model( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );
+extern int      test_consistency_device_enqueue( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,239 +18,85 @@
 #include "harness/typeWrappers.h"
 #include "harness/clImageHelper.h"
 #include "harness/imageHelpers.h"
-extern float calculate_ulperror(float a, float b);
+extern float    calculate_ulperror(float a, float b);
 
-extern int test_load_single_kernel(cl_device_id deviceID, cl_context context,
-                                   cl_command_queue queue, int num_elements);
-extern int test_load_two_kernels(cl_device_id deviceID, cl_context context,
-                                 cl_command_queue queue, int num_elements);
-extern int test_load_two_kernels_in_one(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_load_two_kernels_manually(cl_device_id deviceID,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
-extern int test_get_program_info_kernel_names(cl_device_id deviceID,
-                                              cl_context context,
-                                              cl_command_queue queue,
-                                              int num_elements);
-extern int test_create_kernels_in_program(cl_device_id deviceID,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
-extern int test_enqueue_task(cl_device_id deviceID, cl_context context,
-                             cl_command_queue queue, int num_elements);
-extern int test_repeated_setup_cleanup(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
+extern int        test_load_single_kernel(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_load_two_kernels(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_load_two_kernels_in_one(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_load_two_kernels_manually(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_get_program_info_kernel_names( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_create_kernels_in_program(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_enqueue_task(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_repeated_setup_cleanup(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_bool_type(cl_device_id deviceID, cl_context context,
-                          cl_command_queue queue, int num_elements);
-extern int test_platform_extensions(cl_device_id deviceID, cl_context context,
-                                    cl_command_queue queue, int num_elements);
-extern int test_get_platform_info(cl_device_id deviceID, cl_context context,
-                                  cl_command_queue queue, int num_elements);
-extern int test_get_sampler_info(cl_device_id deviceID, cl_context context,
-                                 cl_command_queue queue, int num_elements);
-extern int test_get_sampler_info_compatibility(cl_device_id deviceID,
-                                               cl_context context,
-                                               cl_command_queue queue,
-                                               int num_elements);
-extern int test_get_command_queue_info(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_get_command_queue_info_compatibility(cl_device_id deviceID,
-                                                     cl_context context,
-                                                     cl_command_queue queue,
-                                                     int num_elements);
-extern int test_get_context_info(cl_device_id deviceID, cl_context context,
-                                 cl_command_queue queue, int num_elements);
-extern int test_get_device_info(cl_device_id deviceID, cl_context context,
-                                cl_command_queue queue, int num_elements);
-extern int test_kernel_required_group_size(cl_device_id deviceID,
-                                           cl_context context,
-                                           cl_command_queue queue,
-                                           int num_elements);
+extern int        test_bool_type(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_platform_extensions(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_platform_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_sampler_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_sampler_info_compatibility(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_command_queue_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_command_queue_info_compatibility(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_context_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_get_device_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_kernel_required_group_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_binary_get(cl_device_id deviceID, cl_context context,
-                           cl_command_queue queue, int num_elements);
-extern int test_binary_create(cl_device_id deviceID, cl_context context,
-                              cl_command_queue queue, int num_elements);
+extern int        test_binary_get(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_binary_create(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_release_kernel_order(cl_device_id deviceID, cl_context context,
-                                     cl_command_queue queue, int num_elements);
-extern int test_release_during_execute(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
+extern int        test_release_kernel_order(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_release_during_execute(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_get_kernel_info(cl_device_id deviceID, cl_context context,
-                                cl_command_queue queue, int num_elements);
-extern int test_execute_kernel_local_sizes(cl_device_id deviceID,
-                                           cl_context context,
-                                           cl_command_queue queue,
-                                           int num_elements);
-extern int test_set_kernel_arg_by_index(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_set_kernel_arg_struct(cl_device_id deviceID, cl_context context,
-                                      cl_command_queue queue, int num_elements);
-extern int test_set_kernel_arg_constant(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_set_kernel_arg_struct_array(cl_device_id deviceID,
-                                            cl_context context,
-                                            cl_command_queue queue,
-                                            int num_elements);
-extern int test_kernel_global_constant(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
+extern int        test_get_kernel_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_execute_kernel_local_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_set_kernel_arg_by_index(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_set_kernel_arg_struct(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_set_kernel_arg_constant(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_set_kernel_arg_struct_array(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_kernel_global_constant(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_min_max_thread_dimensions(cl_device_id deviceID,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
-extern int test_min_max_work_items_sizes(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_work_group_size(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_min_max_read_image_args(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_min_max_write_image_args(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_mem_alloc_size(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_image_2d_width(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_image_2d_height(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_min_max_image_3d_width(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_image_3d_height(cl_device_id deviceID,
-                                        cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_min_max_image_3d_depth(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_image_array_size(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_image_buffer_size(cl_device_id deviceID,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
-extern int test_min_max_parameter_size(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_samplers(cl_device_id deviceID, cl_context context,
-                                 cl_command_queue queue, int num_elements);
-extern int test_min_max_constant_buffer_size(cl_device_id deviceID,
-                                             cl_context context,
-                                             cl_command_queue queue,
-                                             int num_elements);
-extern int test_min_max_constant_args(cl_device_id deviceID, cl_context context,
-                                      cl_command_queue queue, int num_elements);
-extern int test_min_max_compute_units(cl_device_id deviceID, cl_context context,
-                                      cl_command_queue queue, int num_elements);
-extern int test_min_max_address_bits(cl_device_id deviceID, cl_context context,
-                                     cl_command_queue queue, int num_elements);
-extern int test_min_max_single_fp_config(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_double_fp_config(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_local_mem_size(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_kernel_preferred_work_group_size_multiple(
-    cl_device_id deviceID, cl_context context, cl_command_queue queue,
-    int num_elements);
-extern int test_min_max_execution_capabilities(cl_device_id deviceID,
-                                               cl_context context,
-                                               cl_command_queue queue,
-                                               int num_elements);
-extern int test_min_max_queue_properties(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_min_max_device_version(cl_device_id deviceID,
-                                       cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_min_max_language_version(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
+extern int        test_min_max_thread_dimensions(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_work_items_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_work_group_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_read_image_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_write_image_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_image_2d_width(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_image_2d_height(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_image_3d_width(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_image_3d_height(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_min_max_image_array_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_min_max_image_buffer_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_parameter_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_samplers(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_constant_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_compute_units(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_address_bits(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_single_fp_config(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_min_max_double_fp_config(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_local_mem_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_kernel_preferred_work_group_size_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_execution_capabilities(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_queue_properties(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_device_version(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_min_max_language_version(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_native_kernel(cl_device_id device, cl_context context,
-                              cl_command_queue queue, int n_elems);
+extern int        test_native_kernel(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems );
 
-extern int test_create_context_from_type(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
+extern int      test_create_context_from_type(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_get_platform_ids(cl_device_id deviceID, cl_context context,
-                                 cl_command_queue queue, int num_elements);
+extern int      test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_kernel_arg_changes(cl_device_id deviceID, cl_context context,
-                                   cl_command_queue queue, int num_elements);
-extern int test_kernel_arg_multi_setup_random(cl_device_id deviceID,
-                                              cl_context context,
-                                              cl_command_queue queue,
-                                              int num_elements);
+extern int        test_kernel_arg_changes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_kernel_arg_multi_setup_random(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
-extern int test_retain_queue_single(cl_device_id deviceID, cl_context context,
-                                    cl_command_queue queue, int num_elements);
-extern int test_retain_queue_multiple(cl_device_id deviceID, cl_context context,
-                                      cl_command_queue queue, int num_elements);
-extern int test_retain_mem_object_single(cl_device_id deviceID,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_retain_mem_object_multiple(cl_device_id deviceID,
-                                           cl_context context,
-                                           cl_command_queue queue,
-                                           int num_elements);
-extern int test_retain_mem_object_set_kernel_arg(cl_device_id deviceID,
-                                                 cl_context context,
-                                                 cl_command_queue queue,
-                                                 int num_elements);
-extern int test_min_data_type_align_size_alignment(cl_device_id device,
-                                                   cl_context context,
-                                                   cl_command_queue queue,
-                                                   int n_elems);
+extern int        test_retain_queue_single(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_retain_queue_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_retain_mem_object_single(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_retain_mem_object_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int        test_retain_mem_object_set_kernel_arg(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int      test_min_data_type_align_size_alignment(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems );
 
 extern int test_context_destructor_callback(cl_device_id deviceID,
                                             cl_context context,

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -129,3 +129,5 @@ extern int test_image_properties_queries(cl_device_id deviceID,
                                          cl_context context,
                                          cl_command_queue queue,
                                          int num_elements);
+
+extern int      test_consistency_svm( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,85 +18,239 @@
 #include "harness/typeWrappers.h"
 #include "harness/clImageHelper.h"
 #include "harness/imageHelpers.h"
-extern float    calculate_ulperror(float a, float b);
+extern float calculate_ulperror(float a, float b);
 
-extern int        test_load_single_kernel(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_load_two_kernels(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_load_two_kernels_in_one(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_load_two_kernels_manually(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_get_program_info_kernel_names( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_create_kernels_in_program(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_enqueue_task(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_repeated_setup_cleanup(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_load_single_kernel(cl_device_id deviceID, cl_context context,
+                                   cl_command_queue queue, int num_elements);
+extern int test_load_two_kernels(cl_device_id deviceID, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_load_two_kernels_in_one(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_load_two_kernels_manually(cl_device_id deviceID,
+                                          cl_context context,
+                                          cl_command_queue queue,
+                                          int num_elements);
+extern int test_get_program_info_kernel_names(cl_device_id deviceID,
+                                              cl_context context,
+                                              cl_command_queue queue,
+                                              int num_elements);
+extern int test_create_kernels_in_program(cl_device_id deviceID,
+                                          cl_context context,
+                                          cl_command_queue queue,
+                                          int num_elements);
+extern int test_enqueue_task(cl_device_id deviceID, cl_context context,
+                             cl_command_queue queue, int num_elements);
+extern int test_repeated_setup_cleanup(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
 
-extern int        test_bool_type(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_platform_extensions(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_platform_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_sampler_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_sampler_info_compatibility(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_command_queue_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_command_queue_info_compatibility(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_context_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_get_device_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_kernel_required_group_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_bool_type(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue, int num_elements);
+extern int test_platform_extensions(cl_device_id deviceID, cl_context context,
+                                    cl_command_queue queue, int num_elements);
+extern int test_get_platform_info(cl_device_id deviceID, cl_context context,
+                                  cl_command_queue queue, int num_elements);
+extern int test_get_sampler_info(cl_device_id deviceID, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_get_sampler_info_compatibility(cl_device_id deviceID,
+                                               cl_context context,
+                                               cl_command_queue queue,
+                                               int num_elements);
+extern int test_get_command_queue_info(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_get_command_queue_info_compatibility(cl_device_id deviceID,
+                                                     cl_context context,
+                                                     cl_command_queue queue,
+                                                     int num_elements);
+extern int test_get_context_info(cl_device_id deviceID, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_get_device_info(cl_device_id deviceID, cl_context context,
+                                cl_command_queue queue, int num_elements);
+extern int test_kernel_required_group_size(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
 
-extern int        test_binary_get(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_binary_create(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_binary_get(cl_device_id deviceID, cl_context context,
+                           cl_command_queue queue, int num_elements);
+extern int test_binary_create(cl_device_id deviceID, cl_context context,
+                              cl_command_queue queue, int num_elements);
 
-extern int        test_release_kernel_order(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_release_during_execute(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_release_kernel_order(cl_device_id deviceID, cl_context context,
+                                     cl_command_queue queue, int num_elements);
+extern int test_release_during_execute(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
 
-extern int        test_get_kernel_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_execute_kernel_local_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_set_kernel_arg_by_index(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_set_kernel_arg_struct(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_set_kernel_arg_constant(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_set_kernel_arg_struct_array(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_kernel_global_constant(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_get_kernel_info(cl_device_id deviceID, cl_context context,
+                                cl_command_queue queue, int num_elements);
+extern int test_execute_kernel_local_sizes(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
+extern int test_set_kernel_arg_by_index(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_set_kernel_arg_struct(cl_device_id deviceID, cl_context context,
+                                      cl_command_queue queue, int num_elements);
+extern int test_set_kernel_arg_constant(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_set_kernel_arg_struct_array(cl_device_id deviceID,
+                                            cl_context context,
+                                            cl_command_queue queue,
+                                            int num_elements);
+extern int test_kernel_global_constant(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
 
-extern int        test_min_max_thread_dimensions(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_work_items_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_work_group_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_read_image_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_write_image_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_image_2d_width(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_image_2d_height(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_image_3d_width(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_image_3d_height(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_min_max_image_array_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_min_max_image_buffer_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_parameter_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_samplers(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_constant_args(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_compute_units(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_address_bits(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_single_fp_config(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_min_max_double_fp_config(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_local_mem_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_kernel_preferred_work_group_size_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_execution_capabilities(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_queue_properties(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_device_version(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_min_max_language_version(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_min_max_thread_dimensions(cl_device_id deviceID,
+                                          cl_context context,
+                                          cl_command_queue queue,
+                                          int num_elements);
+extern int test_min_max_work_items_sizes(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_work_group_size(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_min_max_read_image_args(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_min_max_write_image_args(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_mem_alloc_size(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_image_2d_width(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_image_2d_height(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_min_max_image_3d_width(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_image_3d_height(cl_device_id deviceID,
+                                        cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_min_max_image_3d_depth(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_image_array_size(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_image_buffer_size(cl_device_id deviceID,
+                                          cl_context context,
+                                          cl_command_queue queue,
+                                          int num_elements);
+extern int test_min_max_parameter_size(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_samplers(cl_device_id deviceID, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_min_max_constant_buffer_size(cl_device_id deviceID,
+                                             cl_context context,
+                                             cl_command_queue queue,
+                                             int num_elements);
+extern int test_min_max_constant_args(cl_device_id deviceID, cl_context context,
+                                      cl_command_queue queue, int num_elements);
+extern int test_min_max_compute_units(cl_device_id deviceID, cl_context context,
+                                      cl_command_queue queue, int num_elements);
+extern int test_min_max_address_bits(cl_device_id deviceID, cl_context context,
+                                     cl_command_queue queue, int num_elements);
+extern int test_min_max_single_fp_config(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_double_fp_config(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_local_mem_size(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_kernel_preferred_work_group_size_multiple(
+    cl_device_id deviceID, cl_context context, cl_command_queue queue,
+    int num_elements);
+extern int test_min_max_execution_capabilities(cl_device_id deviceID,
+                                               cl_context context,
+                                               cl_command_queue queue,
+                                               int num_elements);
+extern int test_min_max_queue_properties(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_min_max_device_version(cl_device_id deviceID,
+                                       cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_min_max_language_version(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
 
-extern int        test_native_kernel(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems );
+extern int test_native_kernel(cl_device_id device, cl_context context,
+                              cl_command_queue queue, int n_elems);
 
-extern int      test_create_context_from_type(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_create_context_from_type(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
 
-extern int      test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_get_platform_ids(cl_device_id deviceID, cl_context context,
+                                 cl_command_queue queue, int num_elements);
 
-extern int        test_kernel_arg_changes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_kernel_arg_multi_setup_random(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_kernel_arg_changes(cl_device_id deviceID, cl_context context,
+                                   cl_command_queue queue, int num_elements);
+extern int test_kernel_arg_multi_setup_random(cl_device_id deviceID,
+                                              cl_context context,
+                                              cl_command_queue queue,
+                                              int num_elements);
 
-extern int        test_retain_queue_single(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_retain_queue_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_retain_mem_object_single(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_retain_mem_object_multiple(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int        test_retain_mem_object_set_kernel_arg(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
-extern int      test_min_data_type_align_size_alignment(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems );
+extern int test_retain_queue_single(cl_device_id deviceID, cl_context context,
+                                    cl_command_queue queue, int num_elements);
+extern int test_retain_queue_multiple(cl_device_id deviceID, cl_context context,
+                                      cl_command_queue queue, int num_elements);
+extern int test_retain_mem_object_single(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_retain_mem_object_multiple(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
+extern int test_retain_mem_object_set_kernel_arg(cl_device_id deviceID,
+                                                 cl_context context,
+                                                 cl_command_queue queue,
+                                                 int num_elements);
+extern int test_min_data_type_align_size_alignment(cl_device_id device,
+                                                   cl_context context,
+                                                   cl_command_queue queue,
+                                                   int n_elems);
 
 extern int test_context_destructor_callback(cl_device_id deviceID,
                                             cl_context context,
@@ -130,6 +284,15 @@ extern int test_image_properties_queries(cl_device_id deviceID,
                                          cl_command_queue queue,
                                          int num_elements);
 
-extern int      test_consistency_svm( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );
-extern int      test_consistency_memory_model( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );
-extern int      test_consistency_device_enqueue( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements );
+extern int test_consistency_svm(cl_device_id deviceID, cl_context context,
+                                cl_command_queue queue, int num_elements);
+extern int test_consistency_memory_model(cl_device_id deviceID,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_consistency_device_enqueue(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
+extern int test_consistency_pipes(cl_device_id deviceID, cl_context context,
+                                  cl_command_queue queue, int num_elements);

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "testBase.h"
+#include "harness/testHarness.h"
+
+const char* test_kernel = R"CLC(
+__kernel void test(__global int* dst) {
+    dst[0] = 0;
+}
+)CLC";
+
+int test_consistency_svm(cl_device_id deviceID, cl_context context,
+                         cl_command_queue queue, int num_elements)
+{
+    // clGetDeviceInfo, passing CL_​DEVICE_​SVM_​CAPABILITIES:
+    // May return 0, indicating that device does not support Shared Virtual
+    // Memory.
+    int error;
+
+    const size_t allocSize = 16;
+    clMemWrapper mem;
+    clProgramWrapper program;
+    clKernelWrapper kernel;
+
+    cl_device_svm_capabilities svmCaps = 0;
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES,
+                            sizeof(svmCaps), &svmCaps, NULL);
+    test_error(error, "Unable to query CL_DEVICE_SVM_CAPABILITIES");
+
+    if (svmCaps == 0)
+    {
+        mem =
+            clCreateBuffer(context, CL_MEM_READ_WRITE, allocSize, NULL, &error);
+        test_error(error, "Unable to create test buffer");
+
+        error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                            &test_kernel, "test");
+        test_error(error, "Unable to create test kernel");
+
+        // clGetMemObjectInfo, passing CL_MEM_USES_SVM_POINTER
+        // Returns CL_​FALSE if no devices in the context associated with
+        // memobj support Shared Virtual Memory.
+        cl_bool usesSVMPointer;
+        error =
+            clGetMemObjectInfo(mem, CL_MEM_USES_SVM_POINTER,
+                               sizeof(usesSVMPointer), &usesSVMPointer, NULL);
+        test_error(error,
+                   "Unable to query CL_​MEM_​USES_​SVM_​POINTER");
+
+        // Check that the SVM APIs can be called.
+        // It's OK if they return an error.
+        void* ptr0;
+        ptr0 = clSVMAlloc(context, CL_MEM_READ_WRITE, allocSize, 0);
+
+        void* ptr1;
+        ptr1 = clSVMAlloc(context, CL_MEM_READ_WRITE, allocSize, 0);
+
+        cl_uint pattern = 0xAAAAAAAA;
+        clEnqueueSVMMemFill(queue, ptr0, &pattern, sizeof(pattern), allocSize,
+                            0, NULL, NULL);
+        clEnqueueSVMMemcpy(queue, CL_TRUE, ptr1, ptr0, allocSize, 0, NULL,
+                           NULL);
+
+        clEnqueueSVMMap(queue, CL_TRUE, CL_MAP_READ, ptr1, allocSize, 0, NULL,
+                        NULL);
+        clEnqueueSVMUnmap(queue, ptr1, 0, NULL, NULL);
+
+        error = clFinish(queue);
+        test_error(error, "Error calling clFinish after SVM operations");
+
+        clSVMFree(context, ptr0);
+        clEnqueueSVMFree(queue, 1, &ptr1, NULL, NULL, 0, NULL, NULL);
+
+        error = clFinish(queue);
+        test_error(error, "Error calling clFinish after SVM free");
+    }
+
+    return TEST_PASS;
+}

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -121,7 +121,8 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         // supported.
         cl_uint bogus = 0xDEADBEEF;
         clSVMFree(context, &bogus);
-        error = clEnqueueSVMFree(queue, 1, &bogus, NULL, NULL, 0, NULL, NULL);
+        void* pBogus = &bogus;
+        error = clEnqueueSVMFree(queue, 1, &pBogus, NULL, NULL, 0, NULL, NULL);
         test_failure_error(
             error, CL_INVALID_OPERATION,
             "CL_DEVICE_SVM_CAPABILITIES returned 0 but "

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -42,6 +42,8 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
 
     if (svmCaps == 0)
     {
+        // Test setup:
+
         mem =
             clCreateBuffer(context, CL_MEM_READ_WRITE, allocSize, NULL, &error);
         test_error(error, "Unable to create test buffer");
@@ -110,8 +112,9 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
             "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
             "clEnqueueSVMUnmap did not return CL_INVALID_OPERATION");
 
-        error = clFinish(queue);
-        test_error(error, "Error calling clFinish after SVM operations");
+        // If the enqueue calls above did not return errors, a clFinish would be
+        // needed here to ensure the SVM operations are complete before freeing
+        // the SVM pointers.
 
         clSVMFree(context, ptr0);
         error = clEnqueueSVMFree(queue, 1, &ptr1, NULL, NULL, 0, NULL, NULL);
@@ -120,8 +123,8 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
             "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
             "clEnqueueSVMFree did not return CL_INVALID_OPERATION");
 
-        error = clFinish(queue);
-        test_error(error, "Error calling clFinish after SVM free");
+        // If the enqueue calls above did not return errors, a clFinish should
+        // be included here to ensure the enqueued SVM free is complete.
 
         // clSetKernelArgSVMPointer, clSetKernelExecInfo
         // Returns CL_INVALID_OPERATION if no devices in the context associated

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -58,6 +58,12 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
             clGetMemObjectInfo(mem, CL_MEM_USES_SVM_POINTER,
                                sizeof(usesSVMPointer), &usesSVMPointer, NULL);
         test_error(error, "Unable to query CL_MEM_USES_SVM_POINTER");
+        if (usesSVMPointer != CL_FALSE)
+        {
+            log_error("CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+                      "CL_MEM_USES_SVM_POINTER did not return CL_FALSE\n");
+            return TEST_FAIL;
+        }
 
         // Check that the SVM APIs can be called.
 
@@ -79,53 +85,40 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         cl_uint pattern = 0xAAAAAAAA;
         error = clEnqueueSVMMemFill(queue, ptr0, &pattern, sizeof(pattern),
                                     allocSize, 0, NULL, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error(
-                "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                "clEnqueueSVMMemFill did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but clEnqueueSVMMemFill did "
+            "not return CL_INVALID_OPERATION");
 
         error = clEnqueueSVMMemcpy(queue, CL_TRUE, ptr1, ptr0, allocSize, 0,
                                    NULL, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error(
-                "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                "clEnqueueSVMMemcpy did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clEnqueueSVMMemcpy did not return CL_INVALID_OPERATION");
 
         error = clEnqueueSVMMap(queue, CL_TRUE, CL_MAP_READ, ptr1, allocSize, 0,
                                 NULL, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error("CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                      "clEnqueueSVMMap did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clEnqueueSVMMap did not return CL_INVALID_OPERATION");
 
         error = clEnqueueSVMUnmap(queue, ptr1, 0, NULL, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error(
-                "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                "clEnqueueSVMUnmap did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clEnqueueSVMUnmap did not return CL_INVALID_OPERATION");
 
         error = clFinish(queue);
         test_error(error, "Error calling clFinish after SVM operations");
 
         clSVMFree(context, ptr0);
         error = clEnqueueSVMFree(queue, 1, &ptr1, NULL, NULL, 0, NULL, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error("CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                      "clEnqueueSVMFree did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clEnqueueSVMFree did not return CL_INVALID_OPERATION");
 
         error = clFinish(queue);
         test_error(error, "Error calling clFinish after SVM free");
@@ -135,23 +128,17 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         // with kernel support Shared Virtual Memory.
 
         error = clSetKernelArgSVMPointer(kernel, 0, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error("CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                      "clSetKernelArgSVMPointer did not return "
-                      "CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clSetKernelArgSVMPointer did not return CL_INVALID_OPERATION");
 
         error =
             clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_SVM_PTRS, 0, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error(
-                "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
-                "clSetKernelExecInfo did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_SVM_CAPABILITIES returned 0 but "
+            "clSetKernelExecInfo did not return CL_INVALID_OPERATION");
     }
 
     return TEST_PASS;
@@ -341,13 +328,10 @@ int test_consistency_device_enqueue(cl_device_id deviceID, cl_context context,
         // Returns CL_INVALID_OPERATION if device does not support On-Device
         // Queues.
         error = clSetDefaultDeviceCommandQueue(context, deviceID, NULL);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES returned 0 but "
-                      "clSetDefaultDeviceCommandQueue did not return "
-                      "CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(error, CL_INVALID_OPERATION,
+                           "CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES returned 0 "
+                           "but clSetDefaultDeviceCommandQueue did not return "
+                           "CL_INVALID_OPERATION");
     }
     else
     {
@@ -357,14 +341,12 @@ int test_consistency_device_enqueue(cl_device_id deviceID, cl_context context,
             // Returns CL_INVALID_OPERATION if device does not support a
             // replaceable default On-Device Queue.
             error = clSetDefaultDeviceCommandQueue(context, deviceID, NULL);
-            if (error != CL_INVALID_OPERATION)
-            {
-                log_error("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES did not "
-                          "include CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT but "
-                          "clSetDefaultDeviceCommandQueue did not return "
-                          "CL_INVALID_OPERATION\n");
-                return TEST_FAIL;
-            }
+            test_failure_error(
+                error, CL_INVALID_OPERATION,
+                "CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES did not "
+                "include CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT but "
+                "clSetDefaultDeviceCommandQueue did not return "
+                "CL_INVALID_OPERATION");
         }
 
         // If CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT is set,
@@ -460,23 +442,19 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
         // clCreatePipe
         // Returns CL_INVALID_OPERATION if no devices in context support Pipes.
         clMemWrapper mem = clCreatePipe(context, 0, 0, 0, NULL, &error);
-        if (error != CL_INVALID_OPERATION)
-        {
-            log_error("CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-                      "clCreatePipe did not return CL_INVALID_OPERATION\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_OPERATION,
+            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
+            "clCreatePipe did not return CL_INVALID_OPERATION");
 
         // clGetPipeInfo
         // Returns CL_INVALID_MEM_OBJECT since pipe cannot be a valid pipe
         // object.
         error = clGetPipeInfo(mem, CL_PIPE_PACKET_SIZE, sizeof(u), &u, NULL);
-        if (error != CL_INVALID_MEM_OBJECT)
-        {
-            log_error("CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-                      "clGetPipeInfo did not return CL_INVALID_MEM_OBJECT\n");
-            return TEST_FAIL;
-        }
+        test_failure_error(
+            error, CL_INVALID_MEM_OBJECT,
+            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
+            "clGetPipeInfo did not return CL_INVALID_MEM_OBJECT");
     }
     else
     {

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -116,8 +116,12 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         // needed here to ensure the SVM operations are complete before freeing
         // the SVM pointers.
 
-        clSVMFree(context, ptr0);
-        error = clEnqueueSVMFree(queue, 1, &ptr1, NULL, NULL, 0, NULL, NULL);
+        // These calls to free SVM purposefully passes a bogus pointer to the
+        // free function to better test that it they are a NOP when SVM is not
+        // supported.
+        cl_uint bogus = 0xDEADBEEF;
+        clSVMFree(context, &bogus);
+        error = clEnqueueSVMFree(queue, 1, &bogus, NULL, NULL, 0, NULL, NULL);
         test_failure_error(
             error, CL_INVALID_OPERATION,
             "CL_DEVICE_SVM_CAPABILITIES returned 0 but "

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -119,10 +119,9 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         // These calls to free SVM purposefully passes a bogus pointer to the
         // free function to better test that it they are a NOP when SVM is not
         // supported.
-        cl_uint bogus = 0xDEADBEEF;
-        clSVMFree(context, &bogus);
-        void* pBogus = &bogus;
-        error = clEnqueueSVMFree(queue, 1, &pBogus, NULL, NULL, 0, NULL, NULL);
+        void* bogus = (void*)0xDEADBEEF;
+        clSVMFree(context, bogus);
+        error = clEnqueueSVMFree(queue, 1, &bogus, NULL, NULL, 0, NULL, NULL);
         test_failure_error(
             error, CL_INVALID_OPERATION,
             "CL_DEVICE_SVM_CAPABILITIES returned 0 but "

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -441,7 +441,8 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
 
         // clCreatePipe
         // Returns CL_INVALID_OPERATION if no devices in context support Pipes.
-        clMemWrapper mem = clCreatePipe(context, 0, 0, 0, NULL, &error);
+        clMemWrapper mem =
+            clCreatePipe(context, CL_MEM_HOST_NO_ACCESS, 4, 4, NULL, &error);
         test_failure_error(error, CL_INVALID_OPERATION,
                            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
                            "clCreatePipe did not return CL_INVALID_OPERATION");

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -25,7 +25,7 @@ __kernel void test(__global int* dst) {
 int test_consistency_svm(cl_device_id deviceID, cl_context context,
                          cl_command_queue queue, int num_elements)
 {
-    // clGetDeviceInfo, passing CL_​DEVICE_​SVM_​CAPABILITIES:
+    // clGetDeviceInfo, passing CL_DEVICE_SVM_CAPABILITIES:
     // May return 0, indicating that device does not support Shared Virtual
     // Memory.
     int error;
@@ -51,14 +51,13 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
         test_error(error, "Unable to create test kernel");
 
         // clGetMemObjectInfo, passing CL_MEM_USES_SVM_POINTER
-        // Returns CL_​FALSE if no devices in the context associated with
+        // Returns CL_FALSE if no devices in the context associated with
         // memobj support Shared Virtual Memory.
         cl_bool usesSVMPointer;
         error =
             clGetMemObjectInfo(mem, CL_MEM_USES_SVM_POINTER,
                                sizeof(usesSVMPointer), &usesSVMPointer, NULL);
-        test_error(error,
-                   "Unable to query CL_​MEM_​USES_​SVM_​POINTER");
+        test_error(error, "Unable to query CL_MEM_USES_SVM_POINTER");
 
         // Check that the SVM APIs can be called.
         // It's OK if they return an error.
@@ -86,6 +85,223 @@ int test_consistency_svm(cl_device_id deviceID, cl_context context,
 
         error = clFinish(queue);
         test_error(error, "Error calling clFinish after SVM free");
+    }
+
+    return TEST_PASS;
+}
+
+static int check_atomic_capabilities(cl_device_atomic_capabilities atomicCaps, cl_device_atomic_capabilities requiredCaps)
+{
+    if ((atomicCaps & requiredCaps) != requiredCaps)
+    {
+        log_error("Atomic capabilities %llx is missing support for at least "
+                  "one required capability %llx!\n",
+                  atomicCaps, requiredCaps);
+        return TEST_FAIL;
+    }
+
+    if ((atomicCaps & CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES) != 0
+        && (atomicCaps & CL_DEVICE_ATOMIC_SCOPE_DEVICE) == 0)
+    {
+        // It isn't an error to support ALL_DEVICES atomics but not DEVICE
+        // atomics, but it is strange.
+        log_info("Check: ATOMIC_SCOPE_ALL_DEVICES is supported, but "
+                 "ATOMIC_SCOPE_DEVICE is not?\n");
+    }
+
+    if ((atomicCaps & CL_DEVICE_ATOMIC_SCOPE_DEVICE) != 0
+        && (atomicCaps & CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP) == 0)
+    {
+        // It isn't an error to support DEVICE atomics but not WORK_GROUP
+        // atomics, but it is strange.
+        log_info("Check: ATOMIC_SCOPE_DEVICE is supported, but "
+                 "ATOMIC_SCOPE_WORK_GROPU is not?\n");
+    }
+
+    return TEST_PASS;
+}
+
+int test_consistency_memory_model(cl_device_id deviceID, cl_context context,
+                                  cl_command_queue queue, int num_elements)
+{
+    int error;
+    cl_device_atomic_capabilities atomicCaps = 0;
+
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES,
+                            sizeof(atomicCaps), &atomicCaps, NULL);
+    test_error(error, "Unable to query CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES");
+
+    error = check_atomic_capabilities(atomicCaps,
+                                      CL_DEVICE_ATOMIC_ORDER_RELAXED
+                                          | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP);
+    if (error == TEST_FAIL)
+    {
+        log_error("Checks failed for CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES\n");
+        return error;
+    }
+
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES,
+                            sizeof(atomicCaps), &atomicCaps, NULL);
+    test_error(error, "Unable to query CL_DEVICE_ATOMIC_FENCE_CAPABILITIES");
+
+    error = check_atomic_capabilities(atomicCaps,
+                                      CL_DEVICE_ATOMIC_ORDER_RELAXED
+                                          | CL_DEVICE_ATOMIC_ORDER_ACQ_REL
+                                          | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP);
+    if (error == TEST_FAIL)
+    {
+        log_error("Checks failed for CL_DEVICE_ATOMIC_FENCE_CAPABILITIES\n");
+        return error;
+    }
+
+    return TEST_PASS;
+}
+
+int test_consistency_device_enqueue(cl_device_id deviceID, cl_context context,
+                                    cl_command_queue queue, int num_elements)
+{
+    // clGetDeviceInfo, passing CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES
+    // May return 0, indicating that device does not support Device-Side Enqueue
+    // and On-Device Queues.
+    int error;
+
+    cl_device_device_enqueue_capabilities dseCaps = 0;
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES,
+                            sizeof(dseCaps), &dseCaps, NULL);
+    test_error(error, "Unable to query CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES");
+
+    if (dseCaps == 0)
+    {
+        // clGetDeviceInfo, passing CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES
+        // Returns 0 if device does not support Device-Side Enqueue and
+        // On-Device Queues.
+
+        cl_command_queue_properties devQueueProps = 0;
+        error = clGetDeviceInfo(deviceID, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES,
+                                sizeof(devQueueProps), &devQueueProps, NULL);
+        test_error(error,
+                   "Unable to query CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES");
+        if (devQueueProps != 0)
+        {
+            // It isn't an error to return nonzero device queue properties, but
+            // it is strange.
+            log_info("Check: DEVICE_ENQUEUE_CAPABILITIES is zero, but "
+                     "QUEUE_ON_DEVICE_PROPERTIES is nonzero?\n");
+        }
+
+        // clGetDeviceInfo, passing
+        // CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE,
+        // CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE,
+        // CL_DEVICE_MAX_ON_DEVICE_QUEUES, or
+        // CL_DEVICE_MAX_ON_DEVICE_EVENTS
+        // Returns 0 if device does not support Device-Side Enqueue and
+        // On-Device Queues.
+
+        cl_uint u = 0;
+
+        error =
+            clGetDeviceInfo(deviceID, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE,
+                            sizeof(u), &u, NULL);
+        test_error(error,
+                   "Unable to query CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE");
+        if (u != 0)
+        {
+            // It isn't an error to return a nonzero preferred device queue
+            // size, but it is strange.
+            log_info("Check: DEVICE_ENQUEUE_CAPABILITIES is zero, but "
+                     "​QUEUE_ON_DEVICE_PREFERRED_SIZE is nonzero?\n");
+        }
+
+        error = clGetDeviceInfo(deviceID, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE,
+                                sizeof(u), &u, NULL);
+        test_error(error, "Unable to query CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE");
+        if (u != 0)
+        {
+            // It isn't an error to return a nonzero preferred device queue
+            // size, but it is strange.
+            log_info("Check: DEVICE_ENQUEUE_CAPABILITIES is zero, but "
+                     "QUEUE_ON_DEVICE_MAX_SIZE is nonzero?\n");
+        }
+
+        error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_ON_DEVICE_QUEUES,
+                                sizeof(u), &u, NULL);
+        test_error(error, "Unable to query CL_DEVICE_MAX_ON_DEVICE_QUEUES");
+        if (u != 0)
+        {
+            // It isn't an error to return a nonzero maximum number of on-device
+            // queues, but it is strange.
+            log_info("Check: DEVICE_ENQUEUE_CAPABILITIES is zero, but "
+                     "MAX_ON_DEVICE_QUEUES is nonzero?\n");
+        }
+
+        error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_ON_DEVICE_EVENTS,
+                                sizeof(u), &u, NULL);
+        test_error(error, "Unable to query CL_DEVICE_MAX_ON_DEVICE_EVENTS");
+        if (u != 0)
+        {
+            // It isn't an error to return a nonzero maximum number of on-device
+            // events, but it is strange.
+            log_info("Check: DEVICE_ENQUEUE_CAPABILITIES is zero, but "
+                     "MAX_ON_DEVICE_EVENTS is nonzero?\n");
+        }
+
+        // clGetCommandQueueInfo, passing CL_QUEUE_SIZE or
+        // CL_QUEUE_DEVICE_DEFAULT Returns 0 or NULL if the device associated
+        // with command_queue does not support On-Device Queues.
+
+        error =
+            clGetCommandQueueInfo(queue, CL_QUEUE_SIZE, sizeof(u), &u, NULL);
+        test_error(error, "Unable to query CL_QUEUE_SIZE");
+
+        cl_command_queue q = NULL;
+        error = clGetCommandQueueInfo(queue, CL_QUEUE_DEVICE_DEFAULT, sizeof(q),
+                                      &q, NULL);
+        test_error(error, "Unable to query CL_QUEUE_DEVICE_DEFAULT");
+
+        // Check that clSetDefaultDeviceCommandQueue can be called.
+        // It's OK if it returns an error, and in fact it should, since NULL is
+        // not a valid device queue.
+        clSetDefaultDeviceCommandQueue(context, deviceID, NULL);
+    }
+    else
+    {
+        if ((dseCaps & CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT) == 0)
+        {
+            // Check that clSetDefaultDeviceCommandQueue can be called.
+            // It's OK if it returns an error, and in fact it should, since NULL
+            // is not a valid device queue.
+            clSetDefaultDeviceCommandQueue(context, deviceID, NULL);
+        }
+
+        // If CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT is set,
+        // CL_DEVICE_QUEUE_SUPPORTED must also be set.
+        if ((dseCaps & CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT) != 0
+            && (dseCaps & CL_DEVICE_QUEUE_SUPPORTED) == 0)
+        {
+            log_error("DEVICE_QUEUE_REPLACEABLE_DEFAULT is set but "
+                      "DEVICE_QUEUE_SUPPORTED is not set\n");
+            return TEST_FAIL;
+        }
+
+        // Devices that set CL_DEVICE_QUEUE_SUPPORTED must also return CL_TRUE
+        // for CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.
+        if ((dseCaps & CL_DEVICE_QUEUE_SUPPORTED) != 0)
+        {
+            cl_bool b;
+            error = clGetDeviceInfo(deviceID,
+                                    CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT,
+                                    sizeof(b), &b, NULL);
+            test_error(
+                error,
+                "Unable to query CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT");
+            if (b != CL_TRUE)
+            {
+                log_error("DEVICE_QUEUE_SUPPORTED is set but "
+                          "CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT returned "
+                          "CL_FALSE\n");
+                return TEST_FAIL;
+            }
+        }
     }
 
     return TEST_PASS;

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -442,10 +442,9 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
         // clCreatePipe
         // Returns CL_INVALID_OPERATION if no devices in context support Pipes.
         clMemWrapper mem = clCreatePipe(context, 0, 0, 0, NULL, &error);
-        test_failure_error(
-            error, CL_INVALID_OPERATION,
-            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-            "clCreatePipe did not return CL_INVALID_OPERATION");
+        test_failure_error(error, CL_INVALID_OPERATION,
+                           "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
+                           "clCreatePipe did not return CL_INVALID_OPERATION");
 
         // clGetPipeInfo
         // Returns CL_INVALID_MEM_OBJECT since pipe cannot be a valid pipe


### PR DESCRIPTION
This is the start of an "API Feature Consistency" test.  It is designed to ensure that when an optional OpenCL 3.0 API feature is not supported that other queries and APIs related to the feature can be called even if they return an error, and that when an optional OpenCL 3.0 API feature is supported, any other required features are also supported.

I've modeled this test very heavily on [Appendix H](https://bashbaug.github.io/OpenCL-Docs/html/OpenCL_API.html#opencl-3.0-backwards-compatibility) in the OpenCL 3.0 spec.  So far I have added API consistency tests for SVM, the memory consistency model, device-side enqueue, and pipes.

I am mostly looking for high-level feedback on the overall approach before adding additional API feature consistency checks.  I think most of the remaining checks are shorter, so if this looks good, I'll get everything else added in Part 2.

One note: I haven't checked any OpenCL C features in these tests, since I'm assuming this will be covered by a different test (#762?).  I think that's the right thing to do, but if I should add checks for OpenCL C features here also, please do let me know.  Thanks!