### PR TITLE
Dynamically select `-cl-std` Build Option for `get_(global|local)_lin…

### DIFF
--- a/test_conformance/basic/test_get_linear_ids.cpp
+++ b/test_conformance/basic/test_get_linear_ids.cpp
@@ -59,7 +59,8 @@ test_get_linear_ids(cl_device_id device, cl_context context, cl_command_queue qu
 
 
     // Create the kernel
-    error = create_single_kernel_helper_with_build_options(context, &program, &kernel, 1, linear_ids_source, "test_linear_ids", "-cl-std=CL2.0");
+    error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                        linear_ids_source, "test_linear_ids");
     if (error)
         return error;
 

--- a/test_conformance/basic/test_global_linear_id.cpp
+++ b/test_conformance/basic/test_global_linear_id.cpp
@@ -80,9 +80,13 @@ test_global_linear_id(cl_device_id device, cl_context context, cl_command_queue 
     streams = clCreateBuffer(context, (cl_mem_flags)(CL_MEM_READ_WRITE), length*sizeof(int), NULL, &err);
     test_error( err, "clCreateBuffer failed.");
 
-    err = create_single_kernel_helper_with_build_options(context, &program[0], &kernel[0], 1, &global_linear_id_1d_code, "test_global_linear_id_1d", "-cl-std=CL2.0");
+    err = create_single_kernel_helper(context, &program[0], &kernel[0], 1,
+                                      &global_linear_id_1d_code,
+                                      "test_global_linear_id_1d");
     test_error( err, "create_single_kernel_helper failed");
-    err = create_single_kernel_helper_with_build_options(context, &program[1], &kernel[1], 1, &global_linear_id_2d_code, "test_global_linear_id_2d", "-cl-std=CL2.0");
+    err = create_single_kernel_helper(context, &program[1], &kernel[1], 1,
+                                      &global_linear_id_2d_code,
+                                      "test_global_linear_id_2d");
     test_error( err, "create_single_kernel_helper failed");
 
     err  = clSetKernelArg(kernel[0], 0, sizeof streams, &streams);

--- a/test_conformance/basic/test_local_linear_id.cpp
+++ b/test_conformance/basic/test_local_linear_id.cpp
@@ -81,9 +81,13 @@ test_local_linear_id(cl_device_id device, cl_context context, cl_command_queue q
     streams = clCreateBuffer(context, (cl_mem_flags)(CL_MEM_READ_WRITE), length*sizeof(int), NULL, &err);
     test_error( err, "clCreateBuffer failed.");
 
-    err = create_single_kernel_helper_with_build_options(context, &program[0], &kernel[0], 1, &local_linear_id_1d_code, "test_local_linear_id_1d", "-cl-std=CL2.0");
+    err = create_single_kernel_helper(context, &program[0], &kernel[0], 1,
+                                      &local_linear_id_1d_code,
+                                      "test_local_linear_id_1d");
     test_error( err, "create_single_kernel_helper failed");
-    err = create_single_kernel_helper_with_build_options(context, &program[1], &kernel[1], 1, &local_linear_id_2d_code, "test_local_linear_id_2d", "-cl-std=CL2.0");
+    err = create_single_kernel_helper(context, &program[1], &kernel[1], 1,
+                                      &local_linear_id_2d_code,
+                                      "test_local_linear_id_2d");
     test_error( err, "create_single_kernel_helper failed");
 
     err  = clSetKernelArg(kernel[0], 0, sizeof streams, &streams);


### PR DESCRIPTION
…ear_id`

* Dynamically select the build option `-cl-std` for the
`get_(global|local)_linear_id()` builtin based on the device version
of the driver. Either `CL2.0` or `CL3.0` depending on the driver version,
there is no need to consider earlier OpenCLC versions since this
builtin didn't exist before OpenCLC 2.0.