### PR TITLE
Optionally Skip `progvar` Tests

### DIFF
--- a/test_conformance/basic/test_progvar.cpp
+++ b/test_conformance/basic/test_progvar.cpp
@@ -1510,6 +1510,29 @@ static int l_user_type( cl_device_id device, cl_context context, cl_command_queu
     return err;
 }
 
+// Determines whether its valid to skip this test based on the driver version
+// and the features it optionally supports.
+// Whether the test should be skipped is writen into the out paramter skip.
+// The check returns an error code for the clDeviceInfo query.
+static cl_int should_skip(cl_device_id device, cl_bool& skip)
+{
+    // Assume we can't skip to begin with.
+    skip = CL_FALSE;
+
+    // Progvar tests are already skipped for OpenCL < 2.0, so here we only need
+    // to test for 3.0 since that is when program scope global variables become
+    // optional.
+    if (get_device_cl_version(device) >= Version(3, 0))
+    {
+        size_t max_global_variable_size{};
+        test_error(clGetDeviceInfo(device, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE,
+                                   sizeof(max_global_variable_size),
+                                   &max_global_variable_size, nullptr),
+                   "clGetDeviceInfo failed");
+        skip = (max_global_variable_size != 0) ? CL_FALSE : CL_TRUE;
+    }
+    return CL_SUCCESS;
+}
 
 ////////////////////
 // Global functions
@@ -1518,6 +1541,18 @@ static int l_user_type( cl_device_id device, cl_context context, cl_command_queu
 // Test support for variables at program scope. Miscellaneous
 int test_progvar_prog_scope_misc(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
+    cl_bool skip{ CL_FALSE };
+    auto error = should_skip(device, skip);
+    if (CL_SUCCESS != error)
+    {
+        return TEST_FAIL;
+    }
+    if (skip)
+    {
+        log_info("Skipping progvar_prog_scope_misc since it is optionally not "
+                 "supported on this device\n");
+        return TEST_SKIPPED_ITSELF;
+    }
     size_t max_size = 0;
     size_t pref_size = 0;
 
@@ -1537,6 +1572,19 @@ int test_progvar_prog_scope_misc(cl_device_id device, cl_context context, cl_com
 // Test support for variables at program scope. Unitialized data
 int test_progvar_prog_scope_uninit(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
+    cl_bool skip{ CL_FALSE };
+    auto error = should_skip(device, skip);
+    if (CL_SUCCESS != error)
+    {
+        return TEST_FAIL;
+    }
+    if (skip)
+    {
+        log_info(
+            "Skipping progvar_prog_scope_uninit since it is optionally not "
+            "supported on this device\n");
+        return TEST_SKIPPED_ITSELF;
+    }
     size_t max_size = 0;
     size_t pref_size = 0;
 
@@ -1553,6 +1601,18 @@ int test_progvar_prog_scope_uninit(cl_device_id device, cl_context context, cl_c
 // Test support for variables at program scope. Initialized data.
 int test_progvar_prog_scope_init(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
+    cl_bool skip{ CL_FALSE };
+    auto error = should_skip(device, skip);
+    if (CL_SUCCESS != error)
+    {
+        return TEST_FAIL;
+    }
+    if (skip)
+    {
+        log_info("Skipping progvar_prog_scope_init since it is optionally not "
+                 "supported on this device\n");
+        return TEST_SKIPPED_ITSELF;
+    }
     size_t max_size = 0;
     size_t pref_size = 0;
 
@@ -1570,6 +1630,18 @@ int test_progvar_prog_scope_init(cl_device_id device, cl_context context, cl_com
 // A simple test for support of static variables inside a kernel.
 int test_progvar_func_scope(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {
+    cl_bool skip{ CL_FALSE };
+    auto error = should_skip(device, skip);
+    if (CL_SUCCESS != error)
+    {
+        return TEST_FAIL;
+    }
+    if (skip)
+    {
+        log_info("Skipping progvar_func_scope since it is optionally not "
+                 "supported on this device\n");
+        return TEST_SKIPPED_ITSELF;
+    }
     size_t max_size = 0;
     size_t pref_size = 0;
 


### PR DESCRIPTION
* Optionally skip the proram scope globa variable tests on OpenCL-3.0
devices that optionally do not support programscope global variables.