### PR TITLE
Dynamically Select `-cl-std` Option

### DIFF
--- a/test_common/harness/kernelHelpers.h
+++ b/test_common/harness/kernelHelpers.h
@@ -173,4 +173,12 @@ cl_device_fp_config get_default_rounding_mode( cl_device_id device );
 /* Prints out the standard device header for all tests given the device to print for */
 extern int printDeviceHeader( cl_device_id device );
 
+// Gets the latest (potentially non-backward compatible) OpenCL C version
+// supported by the device.
+Version get_device_cl_c_version(cl_device_id device);
+
+// Gets the maximum universally supported OpenCL C version in a context, i.e.
+// the OpenCL C version supported by all devices in a context.
+Version get_max_OpenCL_C_for_context(cl_context context);
+
 #endif // _kernelHelpers_h

--- a/test_conformance/basic/test_sizeof.cpp
+++ b/test_conformance/basic/test_sizeof.cpp
@@ -49,13 +49,8 @@ cl_int get_type_size( cl_context context, cl_command_queue queue, const char *ty
     {
         sizeof_kernel_code[0] = "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n";
     }
-    bool deviceLt20 = false;
-    Version version = get_device_cl_version(device);
-    if (version < Version(2,0)) {
-        deviceLt20 = true;
-    }
-
-    cl_int err = create_single_kernel_helper_with_build_options(context, &p, &k, 4, sizeof_kernel_code, "test_sizeof", deviceLt20 ? "" : "-cl-std=CL2.0");
+    cl_int err = create_single_kernel_helper_with_build_options(
+        context, &p, &k, 4, sizeof_kernel_code, "test_sizeof", nullptr);
     if( err )
         return err;
 

--- a/test_conformance/basic/test_wg_barrier.cpp
+++ b/test_conformance/basic/test_wg_barrier.cpp
@@ -87,7 +87,9 @@ test_wg_barrier(cl_device_id device, cl_context context, cl_command_queue queue,
     size_t max_threadgroup_size = 0;
     MTdata d;
 
-    err = create_single_kernel_helper_with_build_options(context, &program, &kernel, 1, &wg_barrier_kernel_code, "compute_sum", "-cl-std=CL2.0" );
+    err = create_single_kernel_helper_with_build_options(
+        context, &program, &kernel, 1, &wg_barrier_kernel_code, "compute_sum",
+        nullptr);
     test_error(err, "Failed to build kernel/program.");
 
     err = clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE,


### PR DESCRIPTION
    * Dynamically select the `-cl-std` option on the basic `sizeof` and
    `wg_barrier` tests to be one of `CL1.X`, `CL2.0` or `CL3.0`.
    Use the most recent CL C standard supported on the device.