### PR TITLE
Fail gracefully in CL_MEM_PROPERTIES tests when unexpectedly getting zero-size return

### DIFF
--- a/test_conformance/api/test_mem_object_properties_queries.cpp
+++ b/test_conformance/api/test_mem_object_properties_queries.cpp
@@ -92,9 +92,17 @@ int create_object_and_check_properties(cl_context context,
                "clGetMemObjectInfo failed asking for CL_MEM_PROPERTIES.");
 
     // verify set_size 0 returned
-    if (test_case.properties.size() == 0 && set_size == 0)
+    if (set_size == 0)
     {
-        return TEST_PASS;
+        if (test_case.properties.size() == 0)
+        {
+            return TEST_PASS;
+        }
+        else
+        {
+            log_error("ERROR: Expected non-zero size!\n");
+            return TEST_FAIL;
+        }
     }
 
     cl_uint number_of_props = set_size / sizeof(cl_mem_properties);


### PR DESCRIPTION


Signed-off-by: Kévin Petit <kpet@free.fr>