### PR TITLE
Only include sys/sysctl.h on for Apple

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -34,7 +34,7 @@
 #include <unistd.h>
 #endif
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif
 

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -19,7 +19,7 @@
 #include "harness/testHarness.h"
 #include "harness/kernelHelpers.h"
 #include "harness/parseParameters.h"
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif
 

--- a/test_conformance/half/main.cpp
+++ b/test_conformance/half/main.cpp
@@ -19,7 +19,7 @@
 
 #if !defined (_WIN32)
 #include <sys/resource.h>
-#if !defined(__ANDROID__)
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif
 #include <libgen.h>

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -20,7 +20,7 @@
 #include <memory>
 
 #if ! defined( _WIN32)
-#if ! defined( __ANDROID__ )
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif
 #include <unistd.h>

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -20,7 +20,7 @@
 #include <time.h>
 #include <string.h>
 #if ! defined( _WIN32)
-#if ! defined( __ANDROID__ )
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif
 #endif


### PR DESCRIPTION
glibc deprecated that header in version 2.30, and removed it in 2.32.