### PR TITLE
Automatically Select Latest `-cl-std` for `pragma unroll` Test

### DIFF
--- a/test_conformance/compiler/test_pragma_unroll.cpp
+++ b/test_conformance/compiler/test_pragma_unroll.cpp
@@ -258,9 +258,13 @@ int test_pragma_unroll(cl_device_id deviceID, cl_context context, cl_command_que
   for (size_t kernelIdx = 0; kernelIdx < KERNEL_NUM; ++kernelIdx) {
     clProgramWrapper program;
     clKernelWrapper kernel;
-    if( create_single_kernel_helper_with_build_options( context, &program, &kernel, 1, (const char **)&pragma_unroll_kernels[kernelIdx], "pragma_unroll", "-cl-std=CL2.0" ) ) {
-      log_error("The program we attempted to compile was: \n%s\n", pragma_unroll_kernels[kernelIdx]);
-      return -1;
+    if (create_single_kernel_helper(
+            context, &program, &kernel, 1,
+            (const char **)&pragma_unroll_kernels[kernelIdx], "pragma_unroll"))
+    {
+        log_error("The program we attempted to compile was: \n%s\n",
+                  pragma_unroll_kernels[kernelIdx]);
+        return -1;
     }
 
     clMemWrapper buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, ELEMENT_NUM * sizeof(cl_uint), NULL, &error);


### PR DESCRIPTION
* Stop assuming `-cl-std=CL2.0` for the `pragma unroll` test. This
allows us to run this test for OpenCL-3.0 drivers which optionally do
not support OpenCL C 2.0. Use the CTS framework to automatically select
the latest OpenCL C supported by the driver.