### PR TITLE
Automatically Select `-cl-std` for Compiler Defines Test

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -335,7 +335,8 @@ int test_compiler_defines_for_extensions(cl_device_id device, cl_context context
 
     Version version = get_device_cl_version(device);
 
-    error = create_single_kernel_helper(context, &program, &kernel, 1, (const char **)&kernel_code, "test", version < Version(2,0) ? "" : "-cl-std=CL2.0");
+    error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                        (const char **)&kernel_code, "test");
     test_error(error, "create_single_kernel_helper failed");
 
     data = (cl_int*)malloc(sizeof(cl_int)*(num_not_supported_extensions+num_of_supported_extensions));


### PR DESCRIPTION
* Automatically select the `-cl-std` build option (stop assuming
`CL2.0`) in the `compiler_defines_for_extensions` test. This will allow
us to test `test_compiler_defines_for_extensions` with an OpenCL-3.0
driver that optionally might not support OpenCL C 2.0. Use the CTS
framework to automatically select the latest version of OpenCL C
supported by the device.