### PR TITLE
Ensure basic/test_basic/kernel_preprocessor_macros checks the OpenCL C version correctly for 3.0 onwards.

### DIFF
--- a/test_common/harness/kernelHelpers.h
+++ b/test_common/harness/kernelHelpers.h
@@ -175,13 +175,20 @@ cl_device_fp_config get_default_rounding_mode( cl_device_id device );
 /* Prints out the standard device header for all tests given the device to print for */
 extern int printDeviceHeader( cl_device_id device );
 
+// Execute the CL_DEVICE_OPENCL_C_VERSION query and return the OpenCL C version
+// is supported by the device.
+Version get_device_cl_c_version(cl_device_id device);
+
 // Gets the latest (potentially non-backward compatible) OpenCL C version
 // supported by the device.
-Version get_device_cl_c_version(cl_device_id device);
+Version get_device_latest_cl_c_version(cl_device_id device);
 
 // Gets the maximum universally supported OpenCL C version in a context, i.e.
 // the OpenCL C version supported by all devices in a context.
 Version get_max_OpenCL_C_for_context(cl_context context);
+
+// Checks whether a particular OpenCL C version is supported by the device.
+bool device_supports_cl_c_version(cl_device_id device, Version version);
 
 // Poll fn every interval_ms until timeout_ms or it returns true
 bool poll_until(unsigned timeout_ms, unsigned interval_ms,

--- a/test_conformance/basic/test_preprocessors.cpp
+++ b/test_conformance/basic/test_preprocessors.cpp
@@ -213,33 +213,15 @@ int test_kernel_preprocessor_macros(cl_device_id deviceID, cl_context context, c
 
     // The OpenCL version reported by the macro reports the feature level supported by the compiler. Since
     // this doesn't directly match any property we can query, we just check to see if it's a sane value
-    char versionBuffer[ 128 ];
-    error = clGetDeviceInfo( deviceID, CL_DEVICE_VERSION, sizeof( versionBuffer ), versionBuffer, NULL );
-    test_error( error, "Unable to get device's version to validate against" );
-
-    // We need to parse to get the version number to compare against
-    char *p1, *p2, *p3;
-    for( p1 = versionBuffer; ( *p1 != 0 ) && !isdigit( *p1 ); p1++ )
-        ;
-    for( p2 = p1; ( *p2 != 0 ) && ( *p2 != '.' ); p2++ )
-        ;
-    for( p3 = p2; ( *p3 != 0 ) && ( *p3 != ' ' ); p3++ )
-        ;
-
-    if( p2 == p3 )
+    auto device_cl_version = get_device_cl_version(deviceID);
+    int device_cl_version_int = device_cl_version.to_int() * 10;
+    if ((results[2] < 100) || (results[2] > device_cl_version_int))
     {
-        log_error( "ERROR: Unable to verify OpenCL version string (platform string is incorrect format)\n" );
-        return -1;
-    }
-    *p2 = 0;
-    *p3 = 0;
-    int major = atoi( p1 );
-    int minor = atoi( p2 + 1 );
-    int realVersion = ( major * 100 ) + ( minor * 10 );
-    if( ( results[ 2 ] < 100 ) || ( results[ 2 ] > realVersion ) )
-    {
-        log_error( "ERROR: Kernel preprocessor __OPENCL_VERSION__ does not make sense w.r.t. device's version string! "
-                  "(preprocessor states %d, real version is %d (%d.%d))\n", results[ 2 ], realVersion, major, minor );
+        log_error("ERROR: Kernel preprocessor __OPENCL_VERSION__ does not make "
+                  "sense w.r.t. device's version string! "
+                  "(preprocessor states %d, CL_DEVICE_VERSION is %d (%s))\n",
+                  results[2], device_cl_version_int,
+                  device_cl_version.to_string().c_str());
         return -1;
     }
 
@@ -250,33 +232,29 @@ int test_kernel_preprocessor_macros(cl_device_id deviceID, cl_context context, c
         return -1;
     }
 
-    // The OpenCL C version reported by the macro reports the OpenCL C supported by the compiler for this OpenCL device.
-    char cVersionBuffer[ 128 ];
-    error = clGetDeviceInfo( deviceID, CL_DEVICE_OPENCL_C_VERSION, sizeof( cVersionBuffer ), cVersionBuffer, NULL );
-    test_error( error, "Unable to get device's OpenCL C version to validate against" );
-
-    // We need to parse to get the version number to compare against
-    for( p1 = cVersionBuffer; ( *p1 != 0 ) && !isdigit( *p1 ); p1++ )
-        ;
-    for( p2 = p1; ( *p2 != 0 ) && ( *p2 != '.' ); p2++ )
-        ;
-    for( p3 = p2; ( *p3 != 0 ) && ( *p3 != ' ' ); p3++ )
-        ;
-
-    if( p2 == p3 )
+    // The OpenCL C version reported by the macro reports the OpenCL C version
+    // specified to the compiler. We need to see whether it is supported.
+    int cl_c_major_version = results[3] / 100;
+    int cl_c_minor_version = (results[3] / 10) % 10;
+    if ((results[3] < 100)
+        || (!device_supports_cl_c_version(
+            deviceID, Version{ cl_c_major_version, cl_c_minor_version })))
     {
-        log_error( "ERROR: Unable to verify OpenCL C version string (platform string is incorrect format)\n" );
-        return -1;
-    }
-    *p2 = 0;
-    *p3 = 0;
-    major = atoi( p1 );
-    minor = atoi( p2 + 1 );
-    realVersion = ( major * 100 ) + ( minor * 10 );
-    if( ( results[ 3 ] < 100 ) || ( results[ 3 ] > realVersion ) )
-    {
-        log_error( "ERROR: Kernel preprocessor __OPENCL_C_VERSION__ does not make sense w.r.t. device's version string! "
-                  "(preprocessor states %d, real version is %d (%d.%d))\n", results[ 2 ], realVersion, major, minor );
+        auto device_version = get_device_cl_c_version(deviceID);
+        log_error(
+            "ERROR: Kernel preprocessor __OPENCL_C_VERSION__ does not make "
+            "sense w.r.t. device's version string! "
+            "(preprocessor states %d, CL_DEVICE_OPENCL_C_VERSION is %d (%s))\n",
+            results[3], device_version.to_int() * 10,
+            device_version.to_string().c_str());
+        log_error("This means that CL_DEVICE_OPENCL_C_VERSION < "
+                  "__OPENCL_C_VERSION__");
+        if (device_cl_version >= Version{ 3, 0 })
+        {
+            log_error(", and __OPENCL_C_VERSION__ does not appear in "
+                      "CL_DEVICE_OPENCL_C_ALL_VERSIONS");
+        }
+        log_error("\n");
         return -1;
     }
 


### PR DESCRIPTION
Currently, it fails if `__OPENCL_C_VERSION__` is greater than the version reported by `CL_DEVICE_OPENCL_C_VERSION`.

However (as of the 3.0 provisional spec), it's possible to have an OpenCL 3.0 device which reports 1.2 as the highest backwards-compatible version (from querying `CL_DEVICE_OPENCL_C_VERSION`), but supports 3.0 according to `CL_DEVICE_OPENCL_C_ALL_VERSIONS`.

In that case, this test should only fail if `__OPENCL_C_VERSION__ > CL_DEVICE_OPENCL_C_VERSION` _and_ `__OPENCL_C_VERSION__` is not in the list returned by `CL_DEVICE_OPENCL_C_ALL_VERSIONS`.

I took the liberty of refactoring some of the test to make use of some helper functions in `kernelHelpers.h`.