### PR TITLE
Change Behaviour of C11 Atomic Tests for OpenCL-3.0

### DIFF
--- a/test_common/harness/errorHelpers.h
+++ b/test_common/harness/errorHelpers.h
@@ -62,7 +62,15 @@
         return TEST_FAIL;                                                      \
     }
 #define test_error(errCode,msg)    test_error_ret(errCode,msg,errCode)
-#define test_error_ret(errCode,msg,retValue)    { if( errCode != CL_SUCCESS ) { print_error( errCode, msg ); return retValue ; } }
+#define test_error_ret(errCode, msg, retValue)                                 \
+    {                                                                          \
+        auto errCodeResult = errCode;                                          \
+        if (errCodeResult != CL_SUCCESS)                                       \
+        {                                                                      \
+            print_error(errCodeResult, msg);                                   \
+            return retValue;                                                   \
+        }                                                                      \
+    }
 #define print_error(errCode,msg)    log_error( "ERROR: %s! (%s from %s:%d)\n", msg, IGetErrorString( errCode ), __FILE__, __LINE__ );
 
 #define test_missing_feature(errCode, msg) test_missing_feature_ret(errCode, msg, errCode)

--- a/test_conformance/c11_atomics/common.cpp
+++ b/test_conformance/c11_atomics/common.cpp
@@ -206,3 +206,77 @@ template<> cl_long AtomicTypeExtendedInfo<cl_long>::MaxValue() {return CL_LONG_M
 template<> cl_ulong AtomicTypeExtendedInfo<cl_ulong>::MaxValue() {return CL_ULONG_MAX;}
 template<> cl_float AtomicTypeExtendedInfo<cl_float>::MaxValue() {return CL_FLT_MAX;}
 template<> cl_double AtomicTypeExtendedInfo<cl_double>::MaxValue() {return CL_DBL_MAX;}
+
+cl_int getSupportedMemoryOrdersAndScopes(
+    cl_device_id device, std::vector<TExplicitMemoryOrderType> &memoryOrders,
+    std::vector<TExplicitMemoryScopeType> &memoryScopes)
+{
+    // The CL_DEVICE_ATOMIC_MEMORY_CAPABILITES is missing before 3.0, but since
+    // all orderings and scopes are required for 2.X devices and this test is
+    // skipped before 2.0 we can safely return all orderings and scopes if the
+    // device is 2.X. Query device for the supported orders.
+    if (get_device_cl_version(device) < Version{ 3, 0 })
+    {
+        memoryOrders.push_back(MEMORY_ORDER_EMPTY);
+        memoryOrders.push_back(MEMORY_ORDER_RELAXED);
+        memoryOrders.push_back(MEMORY_ORDER_ACQUIRE);
+        memoryOrders.push_back(MEMORY_ORDER_RELEASE);
+        memoryOrders.push_back(MEMORY_ORDER_ACQ_REL);
+        memoryOrders.push_back(MEMORY_ORDER_SEQ_CST);
+        memoryScopes.push_back(MEMORY_SCOPE_EMPTY);
+        memoryScopes.push_back(MEMORY_SCOPE_WORK_GROUP);
+        memoryScopes.push_back(MEMORY_SCOPE_DEVICE);
+        memoryScopes.push_back(MEMORY_SCOPE_ALL_SVM_DEVICES);
+        return CL_SUCCESS;
+    }
+
+    // For a 3.0 device we can query the supported orderings and scopes
+    // directly.
+    cl_device_atomic_capabilities atomic_capabilities{};
+    test_error(
+        clGetDeviceInfo(device, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES,
+                        sizeof(atomic_capabilities), &atomic_capabilities,
+                        nullptr),
+        "clGetDeviceInfo failed for CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES\n");
+
+    // Provided we succeeded, we can start filling the vectors.
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_ORDER_RELAXED)
+    {
+        memoryOrders.push_back(MEMORY_ORDER_RELAXED);
+    }
+
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_ORDER_ACQ_REL)
+    {
+        memoryOrders.push_back(MEMORY_ORDER_ACQUIRE);
+        memoryOrders.push_back(MEMORY_ORDER_RELEASE);
+        memoryOrders.push_back(MEMORY_ORDER_ACQ_REL);
+    }
+
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_ORDER_SEQ_CST)
+    {
+        // The functions not ending in explicit have the same semantics as the
+        // corresponding explicit function with memory_order_seq_cst for the
+        // memory_order argument.
+        memoryOrders.push_back(MEMORY_ORDER_EMPTY);
+        memoryOrders.push_back(MEMORY_ORDER_SEQ_CST);
+    }
+
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP)
+    {
+        memoryScopes.push_back(MEMORY_SCOPE_WORK_GROUP);
+    }
+
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_SCOPE_DEVICE)
+    {
+        // The functions that do not have memory_scope argument have the same
+        // semantics as the corresponding functions with the memory_scope
+        // argument set to memory_scope_device.
+        memoryScopes.push_back(MEMORY_SCOPE_EMPTY);
+        memoryScopes.push_back(MEMORY_SCOPE_DEVICE);
+    }
+    if (atomic_capabilities & CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES)
+    {
+        memoryScopes.push_back(MEMORY_SCOPE_ALL_SVM_DEVICES);
+    }
+    return CL_SUCCESS;
+}

--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -159,6 +159,32 @@ test_status InitCL(cl_device_id device) {
                 "Minimum atomic memory capabilities unsupported by device\n");
             return TEST_FAIL;
         }
+
+        // Disable program scope global variable testing in the case that it is
+        // not supported on an OpenCL-3.0 driver.
+        size_t max_global_variable_size{};
+        test_error_ret(clGetDeviceInfo(device,
+                                       CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE,
+                                       sizeof(max_global_variable_size),
+                                       &max_global_variable_size, nullptr),
+                       "Unable to get max global variable size\n", TEST_FAIL);
+        if (0 == max_global_variable_size)
+        {
+            gNoGlobalVariables = true;
+        }
+
+        // Disable generic address space testing in the case that it is not
+        // supported on an OpenCL-3.0 driver.
+        cl_bool generic_address_space_support{};
+        test_error_ret(
+            clGetDeviceInfo(device, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT,
+                            sizeof(generic_address_space_support),
+                            &generic_address_space_support, nullptr),
+            "Unable to get generic address space support\n", TEST_FAIL);
+        if (CL_FALSE == generic_address_space_support)
+        {
+            gNoGenericAddressSpace = true;
+        }
     }
     else
     {


### PR DESCRIPTION
* Change setup code in `KernelCode()` to use `_explicit` builtin
variants that are common to both OpenCL-2.X and OpenCL-3.0.

* Only test optional supported builtin variants (`_explicit` signature
 memory_order/scope) for OpenCL-3.0.

* Disable program scope global variable and generic address space tests
for a OpenCL-3.0 driver which does not optionally support these
features.