### PR TITLE
switch back to CL_INVALID_MEM_OBJECT for clGetPipeInfo

### DIFF
--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -424,8 +424,8 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
         error =
             clGetPipeInfo(not_a_pipe, CL_PIPE_PACKET_SIZE, sizeof(u), &u, NULL);
         test_failure_error(error, CL_INVALID_MEM_OBJECT,
-                          "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-                          "clGetPipeInfo did not return CL_INVALID_OPERATION");
+                           "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
+                           "clGetPipeInfo did not return CL_INVALID_OPERATION");
     }
     else
     {

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -423,9 +423,10 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
 
         error =
             clGetPipeInfo(not_a_pipe, CL_PIPE_PACKET_SIZE, sizeof(u), &u, NULL);
-        test_failure_error(error, CL_INVALID_MEM_OBJECT,
-                           "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-                           "clGetPipeInfo did not return CL_INVALID_MEM_OBJECT");
+        test_failure_error(
+            error, CL_INVALID_MEM_OBJECT,
+            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but clGetPipeInfo did "
+            "not return CL_INVALID_MEM_OBJECT");
     }
     else
     {

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -415,15 +415,15 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
                            "clCreatePipe did not return CL_INVALID_OPERATION");
 
         // clGetPipeInfo
-        // Returns CL_INVALID_OPERATION if no devices in the context associated
-        // with pipe support Pipes.
+        // Returns CL_INVALID_MEM_OBJECT since pipe cannot be a valid pipe
+        // object.
         clMemWrapper not_a_pipe =
             clCreateBuffer(context, CL_MEM_READ_WRITE, 4, NULL, &error);
         test_error(error, "Unable to create non-pipe buffer");
 
         error =
             clGetPipeInfo(not_a_pipe, CL_PIPE_PACKET_SIZE, sizeof(u), &u, NULL);
-        test_assert_error(error == CL_INVALID_OPERATION,
+        test_failure_error(error, CL_INVALID_MEM_OBJECT,
                           "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
                           "clGetPipeInfo did not return CL_INVALID_OPERATION");
     }

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -425,7 +425,7 @@ int test_consistency_pipes(cl_device_id deviceID, cl_context context,
             clGetPipeInfo(not_a_pipe, CL_PIPE_PACKET_SIZE, sizeof(u), &u, NULL);
         test_failure_error(error, CL_INVALID_MEM_OBJECT,
                            "CL_DEVICE_PIPE_SUPPORT returned CL_FALSE but "
-                           "clGetPipeInfo did not return CL_INVALID_OPERATION");
+                           "clGetPipeInfo did not return CL_INVALID_MEM_OBJECT");
     }
     else
     {


### PR DESCRIPTION
Fixes #945.

This PR aligns the CTS feature consistency test with the spec changes in KhronosGroup/OpenCL-Docs#418, which originally specified that `clGetPipeInfo` should return `CL_INVALID_MEM_OBJECT` if pipes are not supported, but recently switched back to `CL_INVALID_MEM_OBJECT` for this case.