### PR TITLE
Fix memory leak of test_basic (#943)

### DIFF
--- a/test_conformance/basic/test_async_strided_copy.cpp
+++ b/test_conformance/basic/test_async_strided_copy.cpp
@@ -215,6 +215,8 @@ int test_strided_copy(cl_device_id deviceID, cl_context context, cl_command_queu
                 sprintf(values + strlen( values), "%2x ", outchar[j]);
             sprintf(values + strlen(values), "]");
             log_error("%s\n", values);
+            free(inBuffer);
+            free(outBuffer);
             return -1;
         }
     }


### PR DESCRIPTION
Fix issue https://github.com/KhronosGroup/OpenCL-CTS/issues/943.

Free buffer while verify failed.

Signed-off-by: Qinyu.Tang <qinyu.tang@verisilicon.com>