### PR TITLE
fix gles build error

### DIFF
--- a/test_common/gles/gl_headers.h
+++ b/test_common/gles/gl_headers.h
@@ -42,17 +42,17 @@
 
 #ifndef GL_ES_VERSION_3_0
 #define glTexImage3D                 glTexImage3DOES
-#define GL_RGBA32F                   GL_RGBA32F_EXT
+#define GL_RGBA32F GL_RGBA32F_EXT
 //#define GL_TEXTURE_3D                GL_TEXTURE_3D_OES
-#define GL_READ_ONLY                 GL_BUFFER_ACCESS_OES
-#define GL_HALF_FLOAT_ARB            GL_HALF_FLOAT_OES
-#define GL_BGRA                      GL_BGRA_EXT
-#define glMapBufferRange             glMapBufferRangeEXT
-#define glUnmapBuffer                glUnmapBufferOES
+#define GL_READ_ONLY GL_BUFFER_ACCESS_OES
+#define GL_HALF_FLOAT_ARB GL_HALF_FLOAT_OES
+#define GL_BGRA GL_BGRA_EXT
+#define glMapBufferRange glMapBufferRangeEXT
+#define glUnmapBuffer glUnmapBufferOES
 #else
 //#define GL_HALF_FLOAT_OES            GL_HALF_FLOAT
 //#define GL_RGBA8_OES                 GL_RGBA8
-#define GL_HALF_FLOAT_ARB            GL_HALF_FLOAT
+#define GL_HALF_FLOAT_ARB GL_HALF_FLOAT
 #endif
 
 #define glutGetProcAddress           eglGetProcAddress
@@ -65,7 +65,7 @@
 #define GL_DEPTH_ATTACHMENT_EXT      GL_DEPTH_ATTACHMENT
 
 #define GL_RGBA32F_ARB               GL_RGBA
-#define GL_BGRA                      GL_BGRA_EXT
+#define GL_BGRA GL_BGRA_EXT
 
 typedef unsigned short GLhalf;
 

--- a/test_common/gles/gl_headers.h
+++ b/test_common/gles/gl_headers.h
@@ -27,7 +27,6 @@
 #endif
 
 #include <GLES2/gl2ext.h>
-#include <GLES2/gl2extQCOM.h>
 
 // Some macros to minimize the changes in the tests from GL to GLES2
 #define glGenRenderbuffersEXT        glGenRenderbuffers
@@ -40,21 +39,33 @@
 #define glDeleteFramebuffersEXT      glDeleteFramebuffers
 #define glBindFramebufferEXT         glBindFramebuffer
 #define glFramebufferRenderbufferEXT glFramebufferRenderbuffer
+
+#ifndef GL_ES_VERSION_3_0
 #define glTexImage3D                 glTexImage3DOES
+#define GL_RGBA32F                   GL_RGBA32F_EXT
+//#define GL_TEXTURE_3D                GL_TEXTURE_3D_OES
+#define GL_READ_ONLY                 GL_BUFFER_ACCESS_OES
+#define GL_HALF_FLOAT_ARB            GL_HALF_FLOAT_OES
+#define GL_BGRA                      GL_BGRA_EXT
+#define glMapBufferRange             glMapBufferRangeEXT
+#define glUnmapBuffer                glUnmapBufferOES
+#else
+//#define GL_HALF_FLOAT_OES            GL_HALF_FLOAT
+//#define GL_RGBA8_OES                 GL_RGBA8
+#define GL_HALF_FLOAT_ARB            GL_HALF_FLOAT
+#endif
+
 #define glutGetProcAddress           eglGetProcAddress
 
 #define GL_FRAMEBUFFER_EXT           GL_FRAMEBUFFER
 #define GL_FRAMEBUFFER_COMPLETE_EXT  GL_FRAMEBUFFER_COMPLETE
 #define GL_RENDERBUFFER_INTERNAL_FORMAT_EXT GL_RENDERBUFFER_INTERNAL_FORMAT
 #define GL_RENDERBUFFER_EXT          GL_RENDERBUFFER
-#define GL_COLOR_ATTACHMENT0_EXT     GL_COLOR_ATTACHMENT0
+//#define GL_COLOR_ATTACHMENT0_EXT     GL_COLOR_ATTACHMENT0
 #define GL_DEPTH_ATTACHMENT_EXT      GL_DEPTH_ATTACHMENT
-#define GL_TEXTURE_3D                GL_TEXTURE_3D_OES
-#define GL_READ_ONLY                 GL_BUFFER_ACCESS_OES
 
-#define GL_HALF_FLOAT_ARB            GL_HALF_FLOAT_OES
-#define GL_BGRA                      GL_BGRA_EXT
 #define GL_RGBA32F_ARB               GL_RGBA
+#define GL_BGRA                      GL_BGRA_EXT
 
 typedef unsigned short GLhalf;
 

--- a/test_common/gles/gl_headers.h
+++ b/test_common/gles/gl_headers.h
@@ -24,6 +24,9 @@
 #include <GLES3/gl3.h>
 #else
 #include <GLES2/gl2.h>
+#define glTexImage3DOES glTexImage3D
+#define glUnmapBufferOES glUnmapBuffer
+#define glMapBufferRangeEXT glMapBufferRange
 #endif
 
 #include <GLES2/gl2ext.h>
@@ -41,17 +44,11 @@
 #define glFramebufferRenderbufferEXT glFramebufferRenderbuffer
 
 #ifndef GL_ES_VERSION_3_0
-#define glTexImage3D                 glTexImage3DOES
 #define GL_RGBA32F GL_RGBA32F_EXT
-//#define GL_TEXTURE_3D                GL_TEXTURE_3D_OES
 #define GL_READ_ONLY GL_BUFFER_ACCESS_OES
 #define GL_HALF_FLOAT_ARB GL_HALF_FLOAT_OES
 #define GL_BGRA GL_BGRA_EXT
-#define glMapBufferRange glMapBufferRangeEXT
-#define glUnmapBuffer glUnmapBufferOES
 #else
-//#define GL_HALF_FLOAT_OES            GL_HALF_FLOAT
-//#define GL_RGBA8_OES                 GL_RGBA8
 #define GL_HALF_FLOAT_ARB GL_HALF_FLOAT
 #endif
 
@@ -61,7 +58,6 @@
 #define GL_FRAMEBUFFER_COMPLETE_EXT  GL_FRAMEBUFFER_COMPLETE
 #define GL_RENDERBUFFER_INTERNAL_FORMAT_EXT GL_RENDERBUFFER_INTERNAL_FORMAT
 #define GL_RENDERBUFFER_EXT          GL_RENDERBUFFER
-//#define GL_COLOR_ATTACHMENT0_EXT     GL_COLOR_ATTACHMENT0
 #define GL_DEPTH_ATTACHMENT_EXT      GL_DEPTH_ATTACHMENT
 
 #define GL_RGBA32F_ARB               GL_RGBA

--- a/test_common/gles/helpers.cpp
+++ b/test_common/gles/helpers.cpp
@@ -16,6 +16,7 @@
 #include "helpers.h"
 
 #include "gl_headers.h"
+#include "CL/cl_half.h"
 
 #define CHECK_ERROR()\
     {GLint __error = glGetError(); if(__error) {log_error( "GL ERROR: %s!\n", gluErrorString( err ));}}

--- a/test_conformance/gles/CMakeLists.txt
+++ b/test_conformance/gles/CMakeLists.txt
@@ -15,8 +15,8 @@ set (${MODULE_NAME}_SOURCES
         ../../test_common/gles/helpers.cpp
     )
 
-if(ANDROID)
-    list(APPEND CLConform_LIBRARIES GLESv2)
+if(ANDROID OR UNIX)
+    list(APPEND CLConform_LIBRARIES EGL GLESv2)
 elseif(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGLES3")
     list(APPEND CLConform_LIBRARIES libEGL libGLESv2 )

--- a/test_conformance/gles/main.cpp
+++ b/test_conformance/gles/main.cpp
@@ -62,8 +62,8 @@ TEST_FN_REDIRECTOR( renderbuffer_read )
 TEST_FN_REDIRECTOR( renderbuffer_write )
 TEST_FN_REDIRECTOR( renderbuffer_getinfo )
 
-#ifndef GL_ES_VERSION_2_0
-TEST_FN_REDIRECTOR( test_fence_sync )
+#ifdef GL_ES_VERSION_3_0
+TEST_FN_REDIRECTOR( fence_sync )
 #endif
 
 test_definition test_list[] = {
@@ -82,14 +82,17 @@ test_definition test_list[] = {
     TEST_FN_REDIRECT( renderbuffer_getinfo )
 };
 
-#ifndef GL_ES_VERSION_2_0
+#ifdef GL_ES_VERSION_3_0
 test_definition test_list32[] = {
     TEST_FN_REDIRECT( fence_sync )
 };
 #endif
 
 const int test_num = ARRAY_SIZE( test_list );
+
+#ifdef GL_ES_VERSION_3_0
 const int test_num32 = ARRAY_SIZE( test_list32 );
+#endif
 
 
 int main(int argc, const char *argv[])
@@ -113,9 +116,11 @@ int main(int argc, const char *argv[])
         for( int i = 0; i < test_num; i++ )
             log_info( "\t%s\n", test_list[i].name );
 
+#ifdef GL_ES_VERSION_3_0
         log_info( "Available 3.2 tests:\n" );
         for( int i = 0; i < test_num32; i++ )
             log_info( "\t%s\n", test_list32[i].name );
+#endif
 
     log_info( "Note: Any 3.2 test names must follow 2.1 test names on the command line." );
     log_info( "Use environment variables to specify desired device." );
@@ -141,12 +146,14 @@ int main(int argc, const char *argv[])
   // Check to see if any 2.x or 3.2 test names were specified on the command line.
   unsigned first_32_testname = 0;
 
+#ifdef GL_ES_VERSION_3_0
   for (int j=1; (j<argc) && (!first_32_testname); ++j)
     for (int i = 0; i < test_num32; ++i)
       if (strcmp(test_list32[i].name, argv[j]) == 0 ) {
         first_32_testname = j;
         break;
       }
+#endif
 
   // Create the environment for the test.
     GLEnvironment *glEnv = GLEnvironment::Instance();
@@ -322,7 +329,7 @@ int main(int argc, const char *argv[])
           error = -1;
           goto cleanup;
         }
-#ifdef GL_ES_VERSION_2_0
+#ifndef GLES3
         log_info("Cannot test OpenGL 3.2! This test was built for OpenGL ES 2.0\n");
         error = -1;
         goto cleanup;

--- a/test_conformance/gles/main.cpp
+++ b/test_conformance/gles/main.cpp
@@ -63,7 +63,7 @@ TEST_FN_REDIRECTOR( renderbuffer_write )
 TEST_FN_REDIRECTOR( renderbuffer_getinfo )
 
 #ifdef GL_ES_VERSION_3_0
-TEST_FN_REDIRECTOR( fence_sync )
+TEST_FN_REDIRECTOR(fence_sync)
 #endif
 
 test_definition test_list[] = {
@@ -122,8 +122,9 @@ int main(int argc, const char *argv[])
             log_info( "\t%s\n", test_list32[i].name );
 #endif
 
-    log_info( "Note: Any 3.2 test names must follow 2.1 test names on the command line." );
-    log_info( "Use environment variables to specify desired device." );
+        log_info("Note: Any 3.2 test names must follow 2.1 test names on the "
+                 "command line.");
+        log_info("Use environment variables to specify desired device.");
 
         return 0;
     }

--- a/test_conformance/gles/setup_egl.cpp
+++ b/test_conformance/gles/setup_egl.cpp
@@ -112,11 +112,18 @@ public:
         size_t dev_size;
         cl_int status;
 
-        status = clGetGLContextInfoKHR(properties,
-                                       CL_DEVICES_FOR_GL_CONTEXT_KHR,
-                                       sizeof(devices),
-                                       devices,
-                                       &dev_size);
+        clGetGLContextInfoKHR_fn GetGLContextInfo = (clGetGLContextInfoKHR_fn)clGetExtensionFunctionAddressForPlatform(
+                                                                                _platform, "clGetGLContextInfoKHR");
+        if (GetGLContextInfo == NULL) {
+            print_error(status, "clGetGLContextInfoKHR failed");
+            return NULL;
+        }
+
+        status = GetGLContextInfo(properties,
+                                  CL_DEVICES_FOR_GL_CONTEXT_KHR,
+                                  sizeof(devices),
+                                  devices,
+                                  &dev_size);
         if (status != CL_SUCCESS) {
             print_error(status, "clGetGLContextInfoKHR failed");
             return NULL;
@@ -124,11 +131,11 @@ public:
         dev_size /= sizeof(cl_device_id);
         log_info("GL _context supports %d compute devices\n", dev_size);
 
-        status = clGetGLContextInfoKHR(properties,
-                                       CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR,
-                                       sizeof(devices),
-                                       devices,
-                                       &dev_size);
+        status = GetGLContextInfo(properties,
+                                  CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR,
+                                  sizeof(devices),
+                                  devices,
+                                  &dev_size);
         if (status != CL_SUCCESS) {
             print_error(status, "clGetGLContextInfoKHR failed");
             return NULL;
@@ -164,7 +171,7 @@ public:
 
         // Check all devices, search for one that supports cl_khr_gl_sharing
         for (int i=0; i<(int)num_of_devices; i++) {
-            if (!is_extension_available(devices[i], "cl_khr_gl_sharing"){
+            if (!is_extension_available(devices[i], "cl_khr_gl_sharing")) {
                 log_info("Device %d of %d does not support required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
             } else {
                 log_info("Device %d of %d supports required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);

--- a/test_conformance/gles/setup_egl.cpp
+++ b/test_conformance/gles/setup_egl.cpp
@@ -112,18 +112,17 @@ public:
         size_t dev_size;
         cl_int status;
 
-        clGetGLContextInfoKHR_fn GetGLContextInfo = (clGetGLContextInfoKHR_fn)clGetExtensionFunctionAddressForPlatform(
-                                                                                _platform, "clGetGLContextInfoKHR");
-        if (GetGLContextInfo == NULL) {
+        clGetGLContextInfoKHR_fn GetGLContextInfo =
+            (clGetGLContextInfoKHR_fn)clGetExtensionFunctionAddressForPlatform(
+                _platform, "clGetGLContextInfoKHR");
+        if (GetGLContextInfo == NULL)
+        {
             print_error(status, "clGetGLContextInfoKHR failed");
             return NULL;
         }
 
-        status = GetGLContextInfo(properties,
-                                  CL_DEVICES_FOR_GL_CONTEXT_KHR,
-                                  sizeof(devices),
-                                  devices,
-                                  &dev_size);
+        status = GetGLContextInfo(properties, CL_DEVICES_FOR_GL_CONTEXT_KHR,
+                                  sizeof(devices), devices, &dev_size);
         if (status != CL_SUCCESS) {
             print_error(status, "clGetGLContextInfoKHR failed");
             return NULL;
@@ -131,11 +130,9 @@ public:
         dev_size /= sizeof(cl_device_id);
         log_info("GL _context supports %d compute devices\n", dev_size);
 
-        status = GetGLContextInfo(properties,
-                                  CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR,
-                                  sizeof(devices),
-                                  devices,
-                                  &dev_size);
+        status =
+            GetGLContextInfo(properties, CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR,
+                             sizeof(devices), devices, &dev_size);
         if (status != CL_SUCCESS) {
             print_error(status, "clGetGLContextInfoKHR failed");
             return NULL;
@@ -171,9 +168,12 @@ public:
 
         // Check all devices, search for one that supports cl_khr_gl_sharing
         for (int i=0; i<(int)num_of_devices; i++) {
-            if (!is_extension_available(devices[i], "cl_khr_gl_sharing")) {
+            if (!is_extension_available(devices[i], "cl_khr_gl_sharing"))
+            {
                 log_info("Device %d of %d does not support required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
-            } else {
+            }
+            else
+            {
                 log_info("Device %d of %d supports required extension cl_khr_gl_sharing.\n", i+1, num_of_devices);
                 interop_devices++;
             }

--- a/test_conformance/gles/test_fence_sync.cpp
+++ b/test_conformance/gles/test_fence_sync.cpp
@@ -297,7 +297,7 @@ public:
     virtual void * IRun( void )
     {
         cl_int error = run_cl_kernel( mKernel, mQueue, mStream0, mStream1, mRowIdx, mFenceEvent, mNumThreads );
-        return (void *)error;
+        return (void *)(intptr_t)error;
     }
 };
 


### PR DESCRIPTION
1. gles 3.x also define GL_ES_VERSION_2_0
2. ICD don't export clGetGLContextInfoKHR, should get extension function address
3. remove ' include gl2extQCOM.h '

reopen PR of #651 