### PR TITLE
Add async_build test to list of tests to skip during offline compilat…

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -744,6 +744,7 @@ const char *subtests_to_skip_with_offline_compiler[] = {
     "simple_link_with_callback",
     "simple_static_compile_only",
     "two_file_link",
+    "async_build",
 };
 
 int check_functions_for_offline_compiler(const char *subtestname, cl_device_id device)


### PR DESCRIPTION
…ion mode

The test attempts to build a program from source containing invalid code, to
provoke a build failure. In offline compilation mode, this causes the offline
compiler to give an error, failing the test.

Signed-off-by: Einar Hov <einar.hov@arm.com>