### PR TITLE
Return a non-zero exit-code when a sub-test fails

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -15,6 +15,7 @@
 //
 #include "testHarness.h"
 #include "compat.h"
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -637,6 +638,19 @@ int parseAndCallCommandLineTests( int argc, const char *argv[], cl_device_id dev
         {
             ret = saveResultsToJson( filename, argv[0], testList, selectedTestList, resultTestList, testNum );
         }
+    }
+
+    if (std::any_of(resultTestList, resultTestList + testNum,
+                    [](test_status result) {
+                        switch (result)
+                        {
+                            case TEST_PASS:
+                            case TEST_SKIP: return false;
+                            case TEST_FAIL: return true;
+                        };
+                    }))
+    {
+        ret = EXIT_FAILURE;
     }
 
     free( selectedTestList );


### PR DESCRIPTION
When running sub-tests explicitly on the command line and that sub-test
fails, the test harness returns `0` from `main()`. This is problematic
in automated testing environments as failed tests can be hidden.

This patch iterates over all the test results in the `resultTestList`
after all sub-tests have completed, if any of the tests failed a
non-zero value is returned from `parseAndCallCommandLineTests()` which
is then propagated up the call stack to `main()`.