### PR TITLE
add a new test to verify reported image formats

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -3462,150 +3462,199 @@ bool find_format( cl_image_format *formatList, unsigned int numFormats, cl_image
     return false;
 }
 
-void build_required_image_formats(cl_mem_flags flags,
-                                  cl_mem_object_type image_type,
-                                  cl_device_id device,
-                                  std::vector<cl_image_format>& formatsToSupport)
+void build_required_image_formats(
+    cl_mem_flags flags, cl_mem_object_type image_type, cl_device_id device,
+    std::vector<cl_image_format> &formatsToSupport)
 {
-	Version version = get_device_cl_version(device);
+    formatsToSupport.clear();
 
-	formatsToSupport.clear();
+    // Minimum list of supported image formats for reading or writing (embedded
+    // profile)
+    static std::vector<cl_image_format> embeddedProfile_readOrWrite{
+        // clang-format off
+        { CL_RGBA, CL_UNORM_INT8 },
+        { CL_RGBA, CL_UNORM_INT16 },
+        { CL_RGBA, CL_SIGNED_INT8 },
+        { CL_RGBA, CL_SIGNED_INT16 },
+        { CL_RGBA, CL_SIGNED_INT32 },
+        { CL_RGBA, CL_UNSIGNED_INT8 },
+        { CL_RGBA, CL_UNSIGNED_INT16 },
+        { CL_RGBA, CL_UNSIGNED_INT32 },
+        { CL_RGBA, CL_HALF_FLOAT },
+        { CL_RGBA, CL_FLOAT },
+        // clang-format on
+    };
 
-	// Required embedded formats.
-	static std::vector<cl_image_format> embeddedProfReadOrWriteFormats
-	{
-		{ CL_RGBA, CL_UNORM_INT8 },
-		{ CL_RGBA, CL_UNORM_INT16 },
-		{ CL_RGBA, CL_SIGNED_INT8 },
-		{ CL_RGBA, CL_SIGNED_INT16 },
-		{ CL_RGBA, CL_SIGNED_INT32 },
-		{ CL_RGBA, CL_UNSIGNED_INT8 },
-		{ CL_RGBA, CL_UNSIGNED_INT16 },
-		{ CL_RGBA, CL_UNSIGNED_INT32 },
-		{ CL_RGBA, CL_HALF_FLOAT },
-		{ CL_RGBA, CL_FLOAT },
-	};
+    // Minimum list of required image formats for reading or writing
+    // num_channels, for all image types.
+    static std::vector<cl_image_format> fullProfile_readOrWrite{
+        // clang-format off
+        { CL_RGBA, CL_UNORM_INT8 },
+        { CL_RGBA, CL_UNORM_INT16 },
+        { CL_RGBA, CL_SIGNED_INT8 },
+        { CL_RGBA, CL_SIGNED_INT16 },
+        { CL_RGBA, CL_SIGNED_INT32 },
+        { CL_RGBA, CL_UNSIGNED_INT8 },
+        { CL_RGBA, CL_UNSIGNED_INT16 },
+        { CL_RGBA, CL_UNSIGNED_INT32 },
+        { CL_RGBA, CL_HALF_FLOAT },
+        { CL_RGBA, CL_FLOAT },
+        { CL_BGRA, CL_UNORM_INT8 },
+        // clang-format on
+    };
 
-	/*
-		Required full profile formats.
-		This array does not contain any full profile
-		formats that have restrictions on when they
-		are required.
-	*/
-	static std::vector<cl_image_format> fullProfReadOrWriteFormats
-	{
-		{ CL_RGBA, CL_UNORM_INT8 },
-		{ CL_RGBA, CL_UNORM_INT16 },
-		{ CL_RGBA, CL_SIGNED_INT8 },
-		{ CL_RGBA, CL_SIGNED_INT16 },
-		{ CL_RGBA, CL_SIGNED_INT32 },
-		{ CL_RGBA, CL_UNSIGNED_INT8 },
-		{ CL_RGBA, CL_UNSIGNED_INT16 },
-		{ CL_RGBA, CL_UNSIGNED_INT32 },
-		{ CL_RGBA, CL_HALF_FLOAT },
-		{ CL_RGBA, CL_FLOAT },
-		{ CL_BGRA, CL_UNORM_INT8 },
-	};
+    // Minimum list of supported image formats for reading or writing
+    // (OpenCL 2.0, 2.1, or 2.2), for all image types.
+    static std::vector<cl_image_format> fullProfile_2x_readOrWrite{
+        // clang-format off
+        { CL_R, CL_UNORM_INT8 },
+        { CL_R, CL_UNORM_INT16 },
+        { CL_R, CL_SNORM_INT8 },
+        { CL_R, CL_SNORM_INT16 },
+        { CL_R, CL_SIGNED_INT8 },
+        { CL_R, CL_SIGNED_INT16 },
+        { CL_R, CL_SIGNED_INT32 },
+        { CL_R, CL_UNSIGNED_INT8 },
+        { CL_R, CL_UNSIGNED_INT16 },
+        { CL_R, CL_UNSIGNED_INT32 },
+        { CL_R, CL_HALF_FLOAT },
+        { CL_R, CL_FLOAT },
+        { CL_RG, CL_UNORM_INT8 },
+        { CL_RG, CL_UNORM_INT16 },
+        { CL_RG, CL_SNORM_INT8 },
+        { CL_RG, CL_SNORM_INT16 },
+        { CL_RG, CL_SIGNED_INT8 },
+        { CL_RG, CL_SIGNED_INT16 },
+        { CL_RG, CL_SIGNED_INT32 },
+        { CL_RG, CL_UNSIGNED_INT8 },
+        { CL_RG, CL_UNSIGNED_INT16 },
+        { CL_RG, CL_UNSIGNED_INT32 },
+        { CL_RG, CL_HALF_FLOAT },
+        { CL_RG, CL_FLOAT },
+        { CL_RGBA, CL_UNORM_INT8 },
+        { CL_RGBA, CL_UNORM_INT16 },
+        { CL_RGBA, CL_SNORM_INT8 },
+        { CL_RGBA, CL_SNORM_INT16 },
+        { CL_RGBA, CL_SIGNED_INT8 },
+        { CL_RGBA, CL_SIGNED_INT16 },
+        { CL_RGBA, CL_SIGNED_INT32 },
+        { CL_RGBA, CL_UNSIGNED_INT8 },
+        { CL_RGBA, CL_UNSIGNED_INT16 },
+        { CL_RGBA, CL_UNSIGNED_INT32 },
+        { CL_RGBA, CL_HALF_FLOAT },
+        { CL_RGBA, CL_FLOAT },
+        { CL_BGRA, CL_UNORM_INT8 },
+        // clang-format on
+    };
 
-	/*
-		Required full profile formats specifically for 2.x.
-		This array does not contain any full profile
-		formats that have restrictions on when they
-		are required.
-	*/
-	static std::vector<cl_image_format> fullProf2XReadOrWriteFormats
-	{
-		{ CL_R, CL_UNORM_INT8 },
-		{ CL_R, CL_UNORM_INT16 },
-		{ CL_R, CL_SNORM_INT8 },
-		{ CL_R, CL_SNORM_INT16 },
-		{ CL_R, CL_SIGNED_INT8 },
-		{ CL_R, CL_SIGNED_INT16 },
-		{ CL_R, CL_SIGNED_INT32 },
-		{ CL_R, CL_UNSIGNED_INT8 },
-		{ CL_R, CL_UNSIGNED_INT16 },
-		{ CL_R, CL_UNSIGNED_INT32 },
-		{ CL_R, CL_HALF_FLOAT },
-		{ CL_R, CL_FLOAT },
-		{ CL_RG, CL_UNORM_INT8 },
-		{ CL_RG, CL_UNORM_INT16 },
-		{ CL_RG, CL_SNORM_INT8 },
-		{ CL_RG, CL_SNORM_INT16 },
-		{ CL_RG, CL_SIGNED_INT8 },
-		{ CL_RG, CL_SIGNED_INT16 },
-		{ CL_RG, CL_SIGNED_INT32 },
-		{ CL_RG, CL_UNSIGNED_INT8 },
-		{ CL_RG, CL_UNSIGNED_INT16 },
-		{ CL_RG, CL_UNSIGNED_INT32 },
-		{ CL_RG, CL_HALF_FLOAT },
-		{ CL_RG, CL_FLOAT },
-		{ CL_RGBA, CL_SNORM_INT8 },
-		{ CL_RGBA, CL_SNORM_INT16 },
-	};
+    // Conditional addition to the 2x readOrWrite table:
+    // Support for the CL_DEPTH image channel order is required only for 2D
+    // images and 2D image arrays.
+    static std::vector<cl_image_format> fullProfile_2x_readOrWrite_Depth{
+        // clang-format off
+        { CL_DEPTH, CL_UNORM_INT16 },
+        { CL_DEPTH, CL_FLOAT },
+        // clang-format on
+    };
 
-	/*
-		Required full profile formats for CL_DEPTH
-		(specifically 2.x).
-		There are cases whereby the format isn't required.
-	*/
-	static std::vector<cl_image_format> fullProf2XReadOrWriteDepthFormats
-	{
-		{ CL_DEPTH, CL_UNORM_INT16 },
-		{ CL_DEPTH, CL_FLOAT },
-	};
+    // Conditional addition to the 2x readOrWrite table:
+    // Support for reading from the CL_sRGBA image channel order is optional for
+    // 1D image buffers. Support for writing to the CL_sRGBA image channel order
+    // is optional for all image types.
+    static std::vector<cl_image_format> fullProfile_2x_readOrWrite_srgb{
+        { CL_sRGBA, CL_UNORM_INT8 },
+    };
 
-	/*
-		Required full profile formats for CL_sRGB
-		(specifically 2.x).
-		There are cases whereby the format isn't required.
-	*/
-	static std::vector<cl_image_format> fullProf2XSRGBFormats
-	{
-		{ CL_sRGBA, CL_UNORM_INT8 },
-	};
+    // Minimum list of required image formats for reading and writing.
+    static std::vector<cl_image_format> fullProfile_readAndWrite{
+        // clang-format off
+        { CL_R, CL_UNORM_INT8 },
+        { CL_R, CL_SIGNED_INT8 },
+        { CL_R, CL_SIGNED_INT16 },
+        { CL_R, CL_SIGNED_INT32 },
+        { CL_R, CL_UNSIGNED_INT8 },
+        { CL_R, CL_UNSIGNED_INT16 },
+        { CL_R, CL_UNSIGNED_INT32 },
+        { CL_R, CL_HALF_FLOAT },
+        { CL_R, CL_FLOAT },
+        { CL_RGBA, CL_UNORM_INT8 },
+        { CL_RGBA, CL_SIGNED_INT8 },
+        { CL_RGBA, CL_SIGNED_INT16 },
+        { CL_RGBA, CL_SIGNED_INT32 },
+        { CL_RGBA, CL_UNSIGNED_INT8 },
+        { CL_RGBA, CL_UNSIGNED_INT16 },
+        { CL_RGBA, CL_UNSIGNED_INT32 },
+        { CL_RGBA, CL_HALF_FLOAT },
+        { CL_RGBA, CL_FLOAT },
+        // clang-format on
+    };
 
-	// Embedded profile
-	if (gIsEmbedded)
-	{
-		copy(embeddedProfReadOrWriteFormats.begin(),
-		     embeddedProfReadOrWriteFormats.end(),
-		     back_inserter(formatsToSupport));
-	}
-	// Full profile
-	else
-	{
-		copy(fullProfReadOrWriteFormats.begin(),
-		     fullProfReadOrWriteFormats.end(),
-		     back_inserter(formatsToSupport));
-	}
+    // Embedded profile
+    if (gIsEmbedded)
+    {
+        copy(embeddedProfile_readOrWrite.begin(),
+             embeddedProfile_readOrWrite.end(),
+             back_inserter(formatsToSupport));
+    }
+    // Full profile
+    else
+    {
+        Version version = get_device_cl_version(device);
+        if (version < Version(2, 0) || version >= Version(3, 0))
+        {
+            // Full profile, OpenCL 1.2 or 3.0.
+            if (flags & CL_MEM_KERNEL_READ_AND_WRITE)
+            {
+                // Note: assumes that read-write images are supported!
+                copy(fullProfile_readAndWrite.begin(),
+                     fullProfile_readAndWrite.end(),
+                     back_inserter(formatsToSupport));
+            }
+            else
+            {
+                copy(fullProfile_readOrWrite.begin(),
+                     fullProfile_readOrWrite.end(),
+                     back_inserter(formatsToSupport));
+            }
+        }
+        else
+        {
+            // Full profile, OpenCL 2.0, 2.1, 2.2.
+            if (flags & CL_MEM_KERNEL_READ_AND_WRITE)
+            {
+                copy(fullProfile_readAndWrite.begin(),
+                     fullProfile_readAndWrite.end(),
+                     back_inserter(formatsToSupport));
+            }
+            else
+            {
+                copy(fullProfile_2x_readOrWrite.begin(),
+                     fullProfile_2x_readOrWrite.end(),
+                     back_inserter(formatsToSupport));
 
-	// Full profile, OpenCL 2.0, 2.1, 2.2
-	if (!gIsEmbedded && version >= Version(2, 0) && version <= Version(2, 2))
-	{
-		copy(fullProf2XReadOrWriteFormats.begin(),
-		     fullProf2XReadOrWriteFormats.end(),
-		     back_inserter(formatsToSupport));
+                // Support for the CL_DEPTH image channel order is required only
+                // for 2D images and 2D image arrays.
+                if (image_type == CL_MEM_OBJECT_IMAGE2D
+                    || image_type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
+                {
+                    copy(fullProfile_2x_readOrWrite_Depth.begin(),
+                         fullProfile_2x_readOrWrite_Depth.end(),
+                         back_inserter(formatsToSupport));
+                }
 
-		// Depth images are only required for 2DArray and 2D images
-		if (image_type == CL_MEM_OBJECT_IMAGE2D_ARRAY || image_type == CL_MEM_OBJECT_IMAGE2D)
-		{
-			copy(fullProf2XReadOrWriteDepthFormats.begin(),
-			     fullProf2XReadOrWriteDepthFormats.end(),
-			     back_inserter(formatsToSupport));
-		}
-
-		// sRGB is not required for 1DImage Buffers
-		if (image_type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
-		{
-			// sRGB is only required for reading
-			if (flags == CL_MEM_READ_ONLY)
-			{
-				copy(fullProf2XSRGBFormats.begin(),
-				     fullProf2XSRGBFormats.end(),
-				     back_inserter(formatsToSupport));
-			}
-		}
-	}
+                // Support for reading from the CL_sRGBA image channel order is
+                // optional for 1D image buffers. Support for writing to the
+                // CL_sRGBA image channel order is optional for all image types.
+                if (image_type != CL_MEM_OBJECT_IMAGE1D_BUFFER
+                    && flags == CL_MEM_READ_ONLY)
+                {
+                    copy(fullProfile_2x_readOrWrite_srgb.begin(),
+                         fullProfile_2x_readOrWrite_srgb.end(),
+                         back_inserter(formatsToSupport));
+                }
+            }
+        }
+    }
 }
 
 bool is_image_format_required(cl_image_format format,
@@ -3733,4 +3782,18 @@ size_t compute_mip_level_offset( image_descriptor * imageInfo , size_t lod)
 
   }
   return retOffset;
+}
+
+const char *convert_image_type_to_string(cl_mem_object_type image_type)
+{
+    switch (image_type)
+    {
+        case CL_MEM_OBJECT_IMAGE1D: return "1D";
+        case CL_MEM_OBJECT_IMAGE2D: return "2D";
+        case CL_MEM_OBJECT_IMAGE3D: return "3D";
+        case CL_MEM_OBJECT_IMAGE1D_ARRAY: return "1D array";
+        case CL_MEM_OBJECT_IMAGE2D_ARRAY: return "2D array";
+        case CL_MEM_OBJECT_IMAGE1D_BUFFER: return "1D image buffer";
+        default: return "unrecognized object type";
+    }
 }

--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -653,4 +653,7 @@ static int inline is_half_zero( cl_ushort half ){ return ( half & 0x7fff ) == 0;
 
 extern double sRGBmap(float fc);
 
+extern const char *convert_image_type_to_string(cl_mem_object_type imageType);
+
+
 #endif // _imageHelpers_h

--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -23,6 +23,7 @@ set(${MODULE_NAME}_SOURCES
          test_kernel_arg_info_compatibility.cpp
          test_null_buffer_arg.cpp
          test_mem_object_info.cpp
+         test_min_image_formats.cpp
          test_queue.cpp
          test_queue_hint.cpp
          test_queue_properties.cpp

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -142,6 +142,8 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(consistency_subgroups, Version(3, 0)),
     ADD_TEST_VERSION(consistency_prog_ctor_dtor, Version(3, 0)),
     ADD_TEST_VERSION(consistency_3d_image_writes, Version(3, 0)),
+
+    ADD_TEST(min_image_formats),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -186,3 +186,6 @@ extern int test_consistency_3d_image_writes(cl_device_id deviceID,
                                             cl_context context,
                                             cl_command_queue queue,
                                             int num_elements);
+
+extern int test_min_image_formats(cl_device_id deviceID, cl_context context,
+                                  cl_command_queue queue, int num_elements);

--- a/test_conformance/api/test_min_image_formats.cpp
+++ b/test_conformance/api/test_min_image_formats.cpp
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2017 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "testBase.h"
+
+int test_min_image_formats(cl_device_id device, cl_context context,
+                           cl_command_queue queue, int num_elements)
+{
+    int missingFormats = 0;
+
+    cl_int error = CL_SUCCESS;
+
+    Version version = get_device_cl_version(device);
+
+    cl_bool supports_images = CL_FALSE;
+    error = clGetDeviceInfo(device, CL_DEVICE_IMAGE_SUPPORT,
+                            sizeof(supports_images), &supports_images, NULL);
+    test_error(error, "clGetDeviceInfo for CL_DEVICE_IMAGE_SUPPORT failed");
+
+    if (supports_images == CL_FALSE)
+    {
+        log_info("No image support on current device - skipped\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    const cl_mem_object_type image_types[] = {
+        CL_MEM_OBJECT_IMAGE1D,       CL_MEM_OBJECT_IMAGE1D_BUFFER,
+        CL_MEM_OBJECT_IMAGE2D,       CL_MEM_OBJECT_IMAGE3D,
+        CL_MEM_OBJECT_IMAGE1D_ARRAY, CL_MEM_OBJECT_IMAGE2D_ARRAY,
+    };
+    const cl_mem_flags mem_flags[] = {
+        CL_MEM_READ_ONLY,
+        CL_MEM_WRITE_ONLY,
+        CL_MEM_KERNEL_READ_AND_WRITE,
+    };
+
+    cl_bool supports_read_write_images = CL_FALSE;
+    if (version >= Version(3, 0))
+    {
+        cl_uint maxReadWriteImageArgs = 0;
+        error = clGetDeviceInfo(device, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS,
+                                sizeof(maxReadWriteImageArgs),
+                                &maxReadWriteImageArgs, NULL);
+        test_error(error,
+                   "Unable to query "
+                   "CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS");
+
+        // read-write images are supported if MAX_READ_WRITE_IMAGE_ARGS is
+        // nonzero
+        supports_read_write_images =
+            maxReadWriteImageArgs != 0 ? CL_TRUE : CL_FALSE;
+    }
+    else if (version >= Version(2, 0))
+    {
+        // read-write images are required for OpenCL 2.x
+        supports_read_write_images = CL_TRUE;
+    }
+
+    int supports_3D_image_writes =
+        is_extension_available(device, "cl_khr_3d_image_writes");
+
+    for (int t = 0; t < ARRAY_SIZE(image_types); t++)
+    {
+        const cl_mem_object_type type = image_types[t];
+        log_info("    testing %s...\n", convert_image_type_to_string(type));
+        for (int f = 0; f < ARRAY_SIZE(mem_flags); f++)
+        {
+            const cl_mem_flags flags = mem_flags[f];
+            const char* testTypeString = flags == CL_MEM_READ_ONLY
+                ? "read-only"
+                : flags == CL_MEM_WRITE_ONLY
+                    ? "write only"
+                    : flags == CL_MEM_KERNEL_READ_AND_WRITE ? "read and write"
+                                                            : "unknown???";
+
+            if (flags == CL_MEM_KERNEL_READ_AND_WRITE
+                && !supports_read_write_images)
+            {
+                continue;
+            }
+
+            if (type == CL_MEM_OBJECT_IMAGE3D && flags != CL_MEM_READ_ONLY
+                && !supports_3D_image_writes)
+            {
+                continue;
+            }
+
+            cl_uint numImageFormats = 0;
+            error = clGetSupportedImageFormats(context, flags, type, 0, NULL,
+                                               &numImageFormats);
+            test_error(error, "Unable to query number of image formats");
+
+            std::vector<cl_image_format> supportedFormats(numImageFormats);
+            if (numImageFormats != 0)
+            {
+                error = clGetSupportedImageFormats(
+                    context, flags, type, supportedFormats.size(),
+                    supportedFormats.data(), NULL);
+                test_error(error, "Unable to query image formats");
+            }
+
+            std::vector<cl_image_format> requiredFormats;
+            build_required_image_formats(flags, type, device, requiredFormats);
+
+            for (auto& format : requiredFormats)
+            {
+                if (!find_format(supportedFormats.data(),
+                                 supportedFormats.size(), &format))
+                {
+                    log_error(
+                        "Missing required %s format %s + %s.\n", testTypeString,
+                        GetChannelOrderName(format.image_channel_order),
+                        GetChannelTypeName(format.image_channel_data_type));
+                    ++missingFormats;
+                }
+            }
+        }
+    }
+
+    return missingFormats == 0 ? TEST_PASS : TEST_FAIL;
+}

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -34,30 +34,6 @@ extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_i
 extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
 extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
 
-static bool check_minimum_supported(cl_image_format *formatList,
-                                    unsigned int numFormats,
-                                    cl_mem_flags flags,
-                                    cl_mem_object_type image_type,
-                                    cl_device_id device)
-{
-	bool passed = true;
-	Version version = get_device_cl_version(device);
-	std::vector<cl_image_format> formatsToSupport;
-	build_required_image_formats(flags, image_type, device, formatsToSupport);
-
-	for (auto &format: formatsToSupport)
-	{
-		if( !find_format( formatList, numFormats, &format ) )
-		{
-			log_error( "ERROR: Format required by OpenCL %s is not supported: ", version.to_string().c_str() );
-			print_header( &format, true );
-			passed = false;
-		}
-	}
-
-	return passed;
-}
-
 int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type image_type, cl_mem_flags flags )
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(image_type), flags == CL_MEM_READ_ONLY ? "read" : "write" );
@@ -73,17 +49,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
         return -1;
 
     BufferOwningPtr<cl_image_format> formatListBuf(formatList);
-
-    if ((image_type == CL_MEM_OBJECT_IMAGE3D) && (flags != CL_MEM_READ_ONLY)) {
-        log_info("No requirement for 3D write in OpenCL 1.2. Not checking formats.\n");
-    } else {
-        log_info("Checking for required OpenCL 1.2 formats.\n");
-        if (check_minimum_supported( formatList, numFormats, flags, image_type, device ) == false) {
-            ret++;
-        } else {
-            log_info("All required formats present.\n");
-        }
-    }
 
     filterFlags = new bool[ numFormats ];
     BufferOwningPtr<bool> filterFlagsBuf(filterFlags);

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -58,20 +58,6 @@ std::array<ImageTestTypes, 3> imageTestTypes = { {
     { kTestFloat, kFloat, floatFormats, "float" },
 } };
 
-const char *convert_image_type_to_string(cl_mem_object_type image_type)
-{
-    switch (image_type)
-    {
-        case CL_MEM_OBJECT_IMAGE1D: return "1D";
-        case CL_MEM_OBJECT_IMAGE2D: return "2D";
-        case CL_MEM_OBJECT_IMAGE3D: return "3D";
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY: return "1D array";
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY: return "2D array";
-        case CL_MEM_OBJECT_IMAGE1D_BUFFER: return "1D image buffer";
-        default: return "unrecognized object type";
-    }
-}
-
 int filter_formats(cl_image_format *formatList, bool *filterFlags,
                    unsigned int formatCount,
                    cl_channel_type *channelDataTypesToFilter,

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -40,7 +40,6 @@ struct ImageTestTypes
 
 extern std::array<ImageTestTypes, 3> imageTestTypes;
 
-const char *convert_image_type_to_string(cl_mem_object_type imageType);
 int filter_formats(cl_image_format *formatList, bool *filterFlags,
                    unsigned int formatCount,
                    cl_channel_type *channelDataTypesToFilter,


### PR DESCRIPTION
Fixes #639 

This PR separates the checks for required image formats into a dedicated test and adds checks for required read-and-write image formats.

I think I got this right, but it would be helpful to verify that these checks are correct in the following scenarios:

1. Embedded profile implementation.
2. OpenCL 1.2 implementation, especially without 3D image write support.
3. OpenCL 3.0 implementation without read-write image support.

Thanks!