### PR TITLE
compiler: Modify the IL check code to check for an empty string

### DIFF
--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -265,7 +265,7 @@ public:
         Version version = get_device_cl_version(device);
         std::string sILVersion = get_device_il_version_string(device);
         if ((version >= Version(2, 1) && version < Version(3, 0))
-            || (version >= Version(3, 0) && sILVersion.length() != 1))
+            || (version >= Version(3, 0) && !sILVersion.empty()))
         {
             m_CreateProgramWithIL = clCreateProgramWithIL;
             m_enabled = true;


### PR DESCRIPTION
The called function (get_device_info_string) subtracts 1 from
length before returning it. Hence, to check for an empty string
(that the spec requires the implementation to return when
CL_DEVICE_IL_VERSION is not supported) the check should be modified
to check for empty and not length == 1