### PR TITLE
Fix kernel compilation issue in c11 atomics.

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -883,7 +883,8 @@ std::string CBasicTest<HostAtomicType, HostDataType>::KernelCode(cl_uint maxNumD
                 if(atomic_fetch_add_explicit(&finishedThreads, 1,
                                            memory_order_relaxed,
                                            memory_scope_work_group)
-                   == get_global_size(0)-1) // last finished thread)";
+                   == get_global_size(0)-1) // last finished thread
+                   )";
     code +=
         "    for(uint dstItemIdx = 0; dstItemIdx < numDestItems; dstItemIdx++)\n";
     if(aTypeName == "atomic_flag")


### PR DESCRIPTION
The code generated placed the next valid line on the end of a previous comment.