### PR TITLE
Fail feature macro compare if compiler has more features than runtime

### DIFF
--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -22,7 +22,7 @@ const char* macro_supported_source = R"(kernel void enabled(global int * buf) {
         int n = get_global_id(0);
         buf[n] = 0;
         #ifndef %s
-            ERROR;
+            #error Feature macro was not defined
         #endif
 })";
 
@@ -31,7 +31,7 @@ const char* macro_not_supported_source =
         int n = get_global_id(0);
         buf[n] = 0;
         #ifdef %s
-            ERROR;
+            #error Feature macro was defined
         #endif
 })";
 
@@ -686,9 +686,7 @@ int test_consistency_c_features_list(cl_device_id deviceID,
     sort(vec_to_cmp.begin(), vec_to_cmp.end());
     sort(vec_device_feature_names.begin(), vec_device_feature_names.end());
 
-    cl_bool result =
-        std::equal(vec_device_feature_names.begin(),
-                   vec_device_feature_names.end(), vec_to_cmp.begin());
+    cl_bool result = vec_device_feature_names == vec_to_cmp;
     if (result)
     {
         log_info("Comparison list of features - passed\n");

--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -686,8 +686,7 @@ int test_consistency_c_features_list(cl_device_id deviceID,
     sort(vec_to_cmp.begin(), vec_to_cmp.end());
     sort(vec_device_feature_names.begin(), vec_device_feature_names.end());
 
-    cl_bool result = vec_device_feature_names == vec_to_cmp;
-    if (result)
+    if (vec_device_feature_names == vec_to_cmp)
     {
         log_info("Comparison list of features - passed\n");
     }


### PR DESCRIPTION
Because a C++11 `std::equal` only iterates over the first container, and
matches with items in the second, if the second container contains more items
the check can still pass even though they're not identical.  Just use `==`
instead.

Fixes #979