### PR TITLE
samplerlessReads: Release Image to stop Memory Leak

### DIFF
--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -173,6 +173,8 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
     clReleaseSampler(actualSampler);
     clReleaseMemObject(results);
+    clReleaseMemObject(read_only_image);
+
     if(gTestReadWrite)
     {
         clReleaseMemObject(read_write_image);


### PR DESCRIPTION
A previously created Image was not being released leading to a
memory leak.

Signed-off-by: Chetankumar Mistry <chetan.mistry@arm.com>