### PR TITLE
Skip compiler unload/reload tests if compiler is not available

### DIFF
--- a/test_conformance/compiler/procs.h
+++ b/test_conformance/compiler/procs.h
@@ -19,6 +19,25 @@
 #include "harness/mt19937.h"
 #include "harness/typeWrappers.h"
 
+// This is a macro rather than a function to be able to use and act like the
+// existing test_error macro.
+//
+// Not all compiler tests need to use this macro, only those that don't use the
+// test harness compiler helpers.
+#define check_compiler_available(DEVICE)                                       \
+    {                                                                          \
+        cl_bool compilerAvailable = CL_FALSE;                                  \
+        cl_int error = clGetDeviceInfo((DEVICE), CL_DEVICE_COMPILER_AVAILABLE, \
+                                       sizeof(compilerAvailable),              \
+                                       &compilerAvailable, NULL);              \
+        test_error(error, "Unable to query CL_DEVICE_COMPILER_AVAILABLE");     \
+        if (compilerAvailable == CL_FALSE)                                     \
+        {                                                                      \
+            log_info("Skipping test - no compiler is available.\n");           \
+            return TEST_SKIPPED_ITSELF;                                        \
+        }                                                                      \
+    }
+
 extern int test_load_program_source(cl_device_id deviceID, cl_context context,
                                     cl_command_queue queue, int num_elements);
 extern int test_load_multistring_source(cl_device_id deviceID,

--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -732,7 +732,7 @@ int test_features_macro(cl_device_id deviceID, cl_context context,
     // also "may not".
     check_compiler_available(deviceID);
 
-    cl_int error = CL_SUCCESS;
+    int error = TEST_PASS;
     cl_bool supported = CL_FALSE;
     std::string test_macro_name = "";
     std::vector<std::string> supported_features_vec;

--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -724,21 +724,15 @@ int test_consistency_c_features_list(cl_device_id deviceID,
 int test_features_macro(cl_device_id deviceID, cl_context context,
                         cl_command_queue queue, int num_elements)
 {
-    cl_bool compilerAvailable = CL_FALSE;
-    cl_int error =
-        clGetDeviceInfo(deviceID, CL_DEVICE_COMPILER_AVAILABLE,
-                        sizeof(compilerAvailable), &compilerAvailable, NULL);
-    test_error(error, "Unable to query CL_DEVICE_COMPILER_AVAILABLE");
-    if (compilerAvailable == CL_FALSE)
-    {
-        // Note: Not checking that the feature array is empty because the
-        // specification says "For devices that do not support compilation from
-        // OpenCL C source, this query may return an empty array."  It "may"
-        // return an empty array implies that an implementation also "may not".
-        log_info("Skipping test - no compiler is available.\n");
-        return TEST_SKIPPED_ITSELF;
-    }
 
+    // Note: Not checking that the feature array is empty for the compiler not
+    // available case because the specification says "For devices that do not
+    // support compilation from OpenCL C source, this query may return an empty
+    // array."  It "may" return an empty array implies that an implementation
+    // also "may not".
+    check_compiler_available(deviceID);
+
+    cl_int error = CL_SUCCESS;
     cl_bool supported = CL_FALSE;
     std::string test_macro_name = "";
     std::vector<std::string> supported_features_vec;

--- a/test_conformance/compiler/test_opencl_c_versions.cpp
+++ b/test_conformance/compiler/test_opencl_c_versions.cpp
@@ -289,15 +289,7 @@ static int test_CL_DEVICE_OPENCL_C_VERSION_versions(cl_device_id device,
 int test_opencl_c_versions(cl_device_id device, cl_context context,
                            cl_command_queue queue, int num_elements)
 {
-    cl_bool compilerAvailable = CL_FALSE;
-    cl_int error =
-        clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
-                        sizeof(compilerAvailable), &compilerAvailable, NULL);
-    if (compilerAvailable == CL_FALSE)
-    {
-        log_info("Skipping test - no compiler is available.\n");
-        return TEST_SKIPPED_ITSELF;
-    }
+    check_compiler_available(device);
 
     const Version version = get_device_cl_version(device);
 

--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -409,6 +409,8 @@ int test_unload_invalid(cl_device_id, cl_context, cl_command_queue, int)
 int test_unload_repeated(cl_device_id device, cl_context context,
                          cl_command_queue, int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
     try
     {
@@ -438,6 +440,8 @@ int test_unload_repeated(cl_device_id device, cl_context context,
 int test_unload_compile_unload_link(cl_device_id device, cl_context context,
                                     cl_command_queue, int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
     try
     {
@@ -468,6 +472,8 @@ int test_unload_build_unload_create_kernel(cl_device_id device,
                                            cl_context context, cl_command_queue,
                                            int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
     try
     {
@@ -497,6 +503,8 @@ int test_unload_build_unload_create_kernel(cl_device_id device,
 int test_unload_link_different(cl_device_id device, cl_context context,
                                cl_command_queue, int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
 
     static const char *sources_1[] = { "unsigned int a() { return 42; }" };
@@ -645,6 +653,8 @@ int test_unload_build_threaded(cl_device_id device, cl_context context,
 {
     using clock = std::chrono::steady_clock;
 
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
 
     const auto end = clock::now() + std::chrono::seconds(5);
@@ -732,6 +742,8 @@ int test_unload_build_threaded(cl_device_id device, cl_context context,
 int test_unload_build_info(cl_device_id device, cl_context context,
                            cl_command_queue, int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
 
     static const char *sources[] = { write_kernel_source };
@@ -893,6 +905,8 @@ int test_unload_build_info(cl_device_id device, cl_context context,
 int test_unload_program_binaries(cl_device_id device, cl_context context,
                                  cl_command_queue, int)
 {
+    check_compiler_available(device);
+
     const cl_platform_id platform = device_platform(device);
 
     static const char *sources[] = { write_kernel_source };


### PR DESCRIPTION
Note that tests that use the compiler helper functions but won't work without a
compiler are in the `subtests_to_skip_with_offline_compiler` list.  I didn't do
that here because they tests directly use `clBuildProgram` etc directly,
because they're specifically testing it's behaviour in edge-cases.