### PR TITLE
Add a binary compile mode CSV

### DIFF
--- a/test_conformance/opencl_conformance_tests_full_binary.csv
+++ b/test_conformance/opencl_conformance_tests_full_binary.csv
@@ -1,0 +1,107 @@
+#
+# OpenCL Conformance Test Suite (full version)
+#
+
+# #########################################
+# Basic Information on the compute device
+# #########################################
+Compute Info,computeinfo/test_computeinfo
+
+# #########################################
+# Basic operation tests
+# #########################################
+Basic,basic/test_basic --compilation-mode binary --compilation-cache-path .
+API,api/test_api --compilation-mode binary --compilation-cache-path .
+Compiler,compiler/test_compiler --compilation-mode binary --compilation-cache-path .
+
+# #########################################
+# Common mathematical functions
+# #########################################
+Common Functions,commonfns/test_commonfns --compilation-mode binary --compilation-cache-path .
+Geometric Functions,geometrics/test_geometrics --compilation-mode binary --compilation-cache-path .
+Relationals,relationals/test_relationals --compilation-mode binary --compilation-cache-path .
+
+# #########################################
+# General operation
+# #########################################
+Thread Dimensions,thread_dimensions/test_thread_dimensions full* --compilation-mode binary --compilation-cache-path .
+Multiple Device/Context,multiple_device_context/test_multiples --compilation-mode binary --compilation-cache-path .
+Atomics,atomics/test_atomics --compilation-mode binary --compilation-cache-path .
+Profiling,profiling/test_profiling --compilation-mode binary --compilation-cache-path .
+Events,events/test_events --compilation-mode binary --compilation-cache-path .
+Allocations (single maximum),allocations/test_allocations single 5 all --compilation-mode binary --compilation-cache-path .
+Allocations (total maximum),allocations/test_allocations multiple 5 all --compilation-mode binary --compilation-cache-path .
+Vectors, vectors/test_vectors --compilation-mode binary --compilation-cache-path .
+Printf,printf/test_printf --compilation-mode binary --compilation-cache-path .
+Device Partitioning,device_partition/test_device_partition --compilation-mode binary --compilation-cache-path .
+
+# #########################################
+# Buffers and images
+# #########################################
+Images (API Info),images/clGetInfo/test_cl_get_info
+Buffers,buffers/test_buffers --compilation-mode binary --compilation-cache-path .
+Images (Kernel Methods),images/kernel_image_methods/test_kernel_image_methods --compilation-mode binary --compilation-cache-path .
+Images (Kernel),images/kernel_read_write/test_image_streams CL_FILTER_NEAREST --compilation-mode binary --compilation-cache-path .
+Images (Kernel pitch),images/kernel_read_write/test_image_streams use_pitches CL_FILTER_NEAREST --compilation-mode binary --compilation-cache-path .
+Images (Kernel max size),images/kernel_read_write/test_image_streams max_images CL_FILTER_NEAREST --compilation-mode binary --compilation-cache-path .
+Images (clCopyImage),images/clCopyImage/test_cl_copy_images
+Images (clCopyImage small),images/clCopyImage/test_cl_copy_images small_images
+Images (clCopyImage max size),images/clCopyImage/test_cl_copy_images max_images
+Images (clReadWriteImage),images/clReadWriteImage/test_cl_read_write_images
+Images (clReadWriteImage pitch),images/clReadWriteImage/test_cl_read_write_images use_pitches
+Images (clReadWriteImage max size),images/clReadWriteImage/test_cl_read_write_images max_images
+Images (clFillImage),images/clFillImage/test_cl_fill_images
+Images (clFillImage pitch),images/clFillImage/test_cl_fill_images use_pitches
+Images (clFillImage max size),images/clFillImage/test_cl_fill_images max_images
+Images (Samplerless),images/samplerlessReads/test_samplerless_reads --compilation-mode binary --compilation-cache-path .
+Images (Samplerless pitch),images/samplerlessReads/test_samplerless_reads use_pitches --compilation-mode binary --compilation-cache-path .
+Images (Samplerless max size),images/samplerlessReads/test_samplerless_reads max_images --compilation-mode binary --compilation-cache-path .
+Mem (Host Flags),mem_host_flags/test_mem_host_flags
+
+# #########################################
+# CPU is required to pass linear and normalized image filtering
+# #########################################
+CL_DEVICE_TYPE_CPU, Images (Kernel CL_FILTER_LINEAR),images/kernel_read_write/test_image_streams CL_FILTER_LINEAR --compilation-mode binary --compilation-cache-path .
+CL_DEVICE_TYPE_CPU, Images (Kernel CL_FILTER_LINEAR pitch),images/kernel_read_write/test_image_streams use_pitches CL_FILTER_LINEAR --compilation-mode binary --compilation-cache-path .
+CL_DEVICE_TYPE_CPU, Images (Kernel CL_FILTER_LINEAR max size),images/kernel_read_write/test_image_streams max_images CL_FILTER_LINEAR --compilation-mode binary --compilation-cache-path .
+
+# #########################################
+# OpenGL/CL interaction
+# #########################################
+OpenCL-GL Sharing,gl/test_gl --compilation-mode binary --compilation-cache-path .
+
+# #########################################
+# Thorough math and conversions tests
+# #########################################
+Select,select/test_select --compilation-mode binary --compilation-cache-path .
+Conversions,conversions/test_conversions --compilation-mode binary --compilation-cache-path .
+Contractions,contractions/test_contractions --compilation-mode binary --compilation-cache-path .
+Math,math_brute_force/test_bruteforce --compilation-mode binary --compilation-cache-path .
+Integer Ops,integer_ops/test_integer_ops --compilation-mode binary --compilation-cache-path .
+Half Ops,half/test_half --compilation-mode binary --compilation-cache-path .
+
+#####################################
+# OpenCL 2.0 tests
+#####################################
+C11 Atomics,c11_atomics/test_c11_atomics --compilation-mode binary --compilation-cache-path .
+Execution Model,device_execution/test_device_execution --compilation-mode binary --compilation-cache-path .
+Generic Address Space,generic_address_space/test_generic_address_space --compilation-mode binary --compilation-cache-path .
+Non Uniform Work Groups,non_uniform_work_group/test_non_uniform_work_group --compilation-mode binary --compilation-cache-path .
+Pipes,pipes/test_pipes --compilation-mode binary --compilation-cache-path .
+SVM,SVM/test_svm --compilation-mode binary --compilation-cache-path .
+Workgroups,workgroups/test_workgroups --compilation-mode binary --compilation-cache-path .
+
+#####################################
+# OpenCL 2.1 tests
+#####################################
+Device timer,device_timer/test_device_timer
+SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+
+#########################################
+# Extensions
+#########################################
+SPIR,spir/test_spir
+Mipmaps (Kernel),images/kernel_read_write/test_image_streams test_mipmaps CL_FILTER_NEAREST --compilation-mode binary --compilation-cache-path .
+Mipmaps (clCopyImage),images/clCopyImage/test_cl_copy_images test_mipmaps --compilation-mode binary --compilation-cache-path .
+Mipmaps (clReadWriteImage),images/clReadWriteImage/test_cl_read_write_images test_mipmaps --compilation-mode binary --compilation-cache-path .
+Subgroups,subgroups/test_subgroups --compilation-mode binary --compilation-cache-path .


### PR DESCRIPTION
This is identical to the SPIR-V spreadsheet, except spir-v mode is replaced by
binary mode.