### PR TITLE
Align with updated conformance process

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -54,8 +54,6 @@ cl_uint gReSeed = 0;
 int     gFlushDenormsToZero = 0;
 int     gInfNanSupport = 1;
 int     gIsEmbedded = 0;
-int     gIsOpenCL_C_1_0_Device = 0;
-int     gIsOpenCL_1_0_Device = 0;
 int     gHasLong = 1;
 bool gCoreILProgram = true;
 
@@ -401,27 +399,6 @@ int runTestHarnessWithCheck( int argc, const char *argv[], int testNum, test_def
         // check the extensions list to see if ulong and long are supported
         if( !is_extension_available(device, "cles_khr_int64" ))
             gHasLong = 0;
-    }
-
-    if( getenv( "OPENCL_1_0_DEVICE" ) )
-    {
-        char c_version[1024];
-        gIsOpenCL_1_0_Device = 1;
-        memset( c_version, 0, sizeof( c_version ) );
-
-        if( (err = clGetDeviceInfo( device, CL_DEVICE_OPENCL_C_VERSION, sizeof(c_version), c_version, NULL )) )
-        {
-            log_error( "FAILURE: unable to get CL_DEVICE_OPENCL_C_VERSION on 1.0 device. (%d)\n", err );
-            return EXIT_FAILURE;
-        }
-
-        if( 0 == strncmp( c_version, "OpenCL C 1.0 ", strlen( "OpenCL C 1.0 " ) ) )
-        {
-            gIsOpenCL_C_1_0_Device = 1;
-            log_info( "Device is a OpenCL C 1.0 device\n" );
-        }
-        else
-            log_info( "Device is a OpenCL 1.0 device, but supports OpenCL C 1.1\n" );
     }
 
     cl_uint device_address_bits = 0;

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -147,7 +147,6 @@ extern int      gFlushDenormsToZero;    // This is set to 1 if the device does n
 extern int      gInfNanSupport;         // This is set to 1 if the device supports infinities and NaNs
 extern int        gIsEmbedded;            // This is set to 1 if the device is an embedded device
 extern int        gHasLong;               // This is set to 1 if the device suppots long and ulong types in OpenCL C.
-extern int      gIsOpenCL_C_1_0_Device; // This is set to 1 if the device supports only OpenCL C 1.0.
 extern bool gCoreILProgram;
 
 #if ! defined( __APPLE__ )

--- a/test_conformance/submission_details_template.txt
+++ b/test_conformance/submission_details_template.txt
@@ -13,8 +13,7 @@
 
 ##############################################################################
 #
-# Submission information (mostly section 7 and F.5 of Conformance Process 
-# Document) that needs to be copied onto the web submission form.
+# Submission information that needs to be copied onto the web submission form
 #
 ##############################################################################
 
@@ -74,14 +73,18 @@ Platform Version:
 
 ##############################################################################
 #
-# Further submission information (mostly section 7 of Conformance Process
-# Document).
+# Further submission information
 #
 ##############################################################################
 
-# git tag of the tests used from GitHub (ex: vYYYY-MM-DD-XX)
+# git tag of the tests used from GitHub (e.g. vYYYY-MM-DD-XX)
 # 
 Tests version:
+
+# Implementations that support cl_khr_icd are required to use a loader to run
+# the tests and document the loader that was used.
+#
+Loader used:
 
 # Date of "Khronos Conformance Process" that this submission
 # adheres to (as shown in the change history at the start of the document).
@@ -94,35 +97,9 @@ Conformance Process Document date:
 #
 OpenCL Conformance Process Attachment date:
 
-##############################################################################
+# The conformance process document makes allowances for skipping specific tests
+# in some situations. A list of tests that were skipped in accordance to these
+# rules along with the justification must be documented here.
 #
-# Tested device configuration
-#
-##############################################################################
-
-# Max compute units (CL_DEVICE_MAX_COMPUTE_UNITS)
-CL_DEVICE_MAX_COMPUTE_UNITS:
-
-# Max memory allocation size (CL_DEVICE_MAX_MEM_ALLOC_SIZE)
-CL_DEVICE_MAX_MEM_ALLOC_SIZE:
-
-# Image support (CL_DEVICE_IMAGE_SUPPORT), 1/0
-CL_DEVICE_IMAGE_SUPPORT:
-
-# Global memory size (CL_DEVICE_GLOBAL_MEM_SIZE)
-CL_DEVICE_GLOBAL_MEM_SIZE:
-
-# Max constant buffer size (CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE)
-CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE:
-
-# Local memory size (CL_DEVICE_LOCAL_MEM_SIZE)
-CL_DEVICE_LOCAL_MEM_SIZE:
-
-
-##############################################################################
-#
-# Extension Queries
-#
-##############################################################################
-# Show the list of supported extensions per device tested, each extension string on a separate line.
+List of skipped tests in accordance with conformance process:
 


### PR DESCRIPTION
- Remove the requirement to detail values for device queries and list
  extensions in the submission template. They are printed by computeinfo.
- Require that tests skipped in accordance with the conformance
  process be listed in the submission template.
- Remove support for OPENCL_1_0_DEVICE. This variable doesn't control
  anything anymore and the updated conformance process no longer refers
  to it.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>