### PR TITLE
added extended versioning tests for OpenCL 3.0

### DIFF
--- a/test_conformance/computeinfo/extended_versioning.cpp
+++ b/test_conformance/computeinfo/extended_versioning.cpp
@@ -243,7 +243,7 @@ static int test_extended_versioning_platform_version(cl_platform_id platform)
 
 /* Check that CL_DEVICE{,_OPENCL_C}_NUMERIC_VERSION_KHR return the same versions
  * as CL_DEVICE{,_OPENCL_C}_VERSION */
-static int test_extended_versioning_device_versions(int ext,
+static int test_extended_versioning_device_versions(bool ext,
                                                     cl_device_id deviceID)
 {
     log_info("Device versions:\n");
@@ -727,8 +727,8 @@ static_assert(CL_MAKE_VERSION(1, 2, 3) == CL_MAKE_VERSION_KHR(1, 2, 3),
 int test_extended_versioning(cl_device_id deviceID, cl_context context,
                              cl_command_queue ignoreQueue, int num_elements)
 {
-    int ext = is_extension_available(deviceID, "cl_khr_extended_versioning");
-    int core = get_device_cl_version(deviceID) >= Version(3, 0);
+    bool ext = is_extension_available(deviceID, "cl_khr_extended_versioning");
+    bool core = get_device_cl_version(deviceID) >= Version(3, 0);
 
     if (!ext && !core)
     {


### PR DESCRIPTION
Fixes #992 

Adds testing for "extended versioning" for OpenCL 3.0 implementations in addition to implementations supporting `cl_khr_extended_versioning`.

This test assumes (and verifies) that the core enums are equal to the extension enums, so it only tests the queries once.

The only difference between the core functionality and the extension functionality is `CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR`, which exists in the extension but was not promoted to a core feature, so this sub-test is skipped if the OpenCL 3.0 implementation does not also support `cl_khr_extended_versioning`.

Note that `CL_DEVICE_OPENCL_C_ALL_VERSIONS` is NOT tested by this test, but it is tested as part of `test_opencl_c_versions`.