### PR TITLE
Fix error handling for test_half

### DIFF
--- a/test_conformance/half/Test_vLoadHalf.cpp
+++ b/test_conformance/half/Test_vLoadHalf.cpp
@@ -506,7 +506,7 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
                                        (aligned?"aligned":"unaligned"));
                             gFailCount++;
                             error = -1;
-                            break; // goto exit;
+                            goto exit;
                         }
                     }
                 }


### PR DESCRIPTION
For vLoadHalf test, the error was
not properly returned leading to
test success whereas it failed.