### PR TITLE
Don't require support for 3D image writes in tests that don't need it

### DIFF
--- a/test_common/harness/kernelHelpers.h
+++ b/test_common/harness/kernelHelpers.h
@@ -152,25 +152,28 @@ size_t get_min_alignment(cl_context context);
 /* Helper to obtain the default rounding mode for single precision computation. (Double is always CL_FP_ROUND_TO_NEAREST.) Returns 0 on error. */
 cl_device_fp_config get_default_rounding_mode( cl_device_id device );
 
-#define PASSIVE_REQUIRE_IMAGE_SUPPORT( device )    \
-    if( checkForImageSupport( device ) )    \
-    {    \
-        log_info( "\n\tNote: device does not support images. Skipping test...\n" );    \
-        return 0;    \
+#define PASSIVE_REQUIRE_IMAGE_SUPPORT(device)                                  \
+    if (checkForImageSupport(device))                                          \
+    {                                                                          \
+        log_info(                                                              \
+            "\n\tNote: device does not support images. Skipping test...\n");   \
+        return TEST_SKIPPED_ITSELF;                                            \
     }
 
-#define PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( device )    \
-    if( checkFor3DImageSupport( device ) )    \
-    {    \
-        log_info( "\n\tNote: device does not support 3D images. Skipping test...\n" );    \
-        return 0;    \
+#define PASSIVE_REQUIRE_3D_IMAGE_SUPPORT(device)                               \
+    if (checkFor3DImageSupport(device))                                        \
+    {                                                                          \
+        log_info("\n\tNote: device does not support 3D images. Skipping "      \
+                 "test...\n");                                                 \
+        return TEST_SKIPPED_ITSELF;                                            \
     }
 
-#define PASSIVE_REQUIRE_FP16_SUPPORT(device)                            \
-    if (!is_extension_available(device, "cl_khr_fp16"))                 \
-    {                                                                   \
-        log_info("\n\tNote: device does not support fp16. Skipping test...\n"); \
-        return 0;                                                       \
+#define PASSIVE_REQUIRE_FP16_SUPPORT(device)                                   \
+    if (!is_extension_available(device, "cl_khr_fp16"))                        \
+    {                                                                          \
+        log_info(                                                              \
+            "\n\tNote: device does not support fp16. Skipping test...\n");     \
+        return TEST_SKIPPED_ITSELF;                                            \
     }
 
 /* Prints out the standard device header for all tests given the device to print for */

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -692,7 +692,8 @@ int test_min_max_image_3d_width(cl_device_id deviceID, cl_context context, cl_co
     PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( deviceID )
 
     /* Just get any ol format to test with */
-    error = get_8_bit_image_format( context, CL_MEM_OBJECT_IMAGE3D, CL_MEM_READ_WRITE, 0, &image_format_desc );
+    error = get_8_bit_image_format(context, CL_MEM_OBJECT_IMAGE3D,
+                                   CL_MEM_READ_ONLY, 0, &image_format_desc);
     test_error( error, "Unable to obtain suitable image format to test with!" );
 
     /* Get the max 2d image width */
@@ -748,7 +749,8 @@ int test_min_max_image_3d_height(cl_device_id deviceID, cl_context context, cl_c
     PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( deviceID )
 
     /* Just get any ol format to test with */
-    error = get_8_bit_image_format( context, CL_MEM_OBJECT_IMAGE3D, CL_MEM_READ_WRITE, 0, &image_format_desc );
+    error = get_8_bit_image_format(context, CL_MEM_OBJECT_IMAGE3D,
+                                   CL_MEM_READ_ONLY, 0, &image_format_desc);
     test_error( error, "Unable to obtain suitable image format to test with!" );
 
     /* Get the max 2d image width */
@@ -805,7 +807,8 @@ int test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context, cl_co
     PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( deviceID )
 
     /* Just get any ol format to test with */
-    error = get_8_bit_image_format( context, CL_MEM_OBJECT_IMAGE3D, CL_MEM_READ_WRITE, 0, &image_format_desc );
+    error = get_8_bit_image_format(context, CL_MEM_OBJECT_IMAGE3D,
+                                   CL_MEM_READ_ONLY, 0, &image_format_desc);
     test_error( error, "Unable to obtain suitable image format to test with!" );
 
     /* Get the max 2d image width */

--- a/test_conformance/basic/test_arrayimagecopy3d.cpp
+++ b/test_conformance/basic/test_arrayimagecopy3d.cpp
@@ -39,7 +39,8 @@ int test_arrayimagecopy3d_single_format(cl_device_id device, cl_context context,
 
   log_info("Testing %s %s\n", GetChannelOrderName(format->image_channel_order), GetChannelTypeName(format->image_channel_data_type));
 
-  image = create_image_3d(context, (cl_mem_flags)(CL_MEM_READ_WRITE), format, img_width, img_height, img_depth, 0, 0, NULL, &err);
+  image = create_image_3d(context, CL_MEM_READ_ONLY, format, img_width,
+                          img_height, img_depth, 0, 0, NULL, &err);
   test_error(err, "create_image_3d failed");
 
   err = clGetImageInfo(image, CL_IMAGE_ELEMENT_SIZE, sizeof(size_t), &elem_size, NULL);
@@ -125,12 +126,15 @@ int test_arrayimagecopy3d(cl_device_id device, cl_context context, cl_command_qu
 
   PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( device )
 
-  err = clGetSupportedImageFormats(context, CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE3D, 0, NULL, &num_formats);
+  err = clGetSupportedImageFormats(
+      context, CL_MEM_READ_ONLY, CL_MEM_OBJECT_IMAGE3D, 0, NULL, &num_formats);
   test_error(err, "clGetSupportedImageFormats failed");
 
   formats = (cl_image_format *)malloc(num_formats * sizeof(cl_image_format));
 
-  err = clGetSupportedImageFormats(context, CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE3D, num_formats, formats, NULL);
+  err = clGetSupportedImageFormats(context, CL_MEM_READ_ONLY,
+                                   CL_MEM_OBJECT_IMAGE3D, num_formats, formats,
+                                   NULL);
   test_error(err, "clGetSupportedImageFormats failed");
 
   for (i = 0; i < num_formats; i++) {

--- a/test_conformance/basic/test_imagearraycopy3d.cpp
+++ b/test_conformance/basic/test_imagearraycopy3d.cpp
@@ -38,7 +38,8 @@ int test_imagearraycopy3d_single_format(cl_device_id device, cl_context context,
 
   log_info("Testing %s %s\n", GetChannelOrderName(format->image_channel_order), GetChannelTypeName(format->image_channel_data_type));
 
-  image = create_image_3d(context, (cl_mem_flags)(CL_MEM_READ_WRITE), format, img_width, img_height, img_depth, 0, 0, NULL, &err);
+  image = create_image_3d(context, CL_MEM_READ_ONLY, format, img_width,
+                          img_height, img_depth, 0, 0, NULL, &err);
   test_error(err, "create_image_3d failed");
 
   err = clGetImageInfo(image, CL_IMAGE_ELEMENT_SIZE, sizeof(size_t), &elem_size, NULL);
@@ -121,12 +122,15 @@ int test_imagearraycopy3d(cl_device_id device, cl_context context, cl_command_qu
 
   PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( device )
 
-  err = clGetSupportedImageFormats(context, CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE3D, 0, NULL, &num_formats);
+  err = clGetSupportedImageFormats(
+      context, CL_MEM_READ_ONLY, CL_MEM_OBJECT_IMAGE3D, 0, NULL, &num_formats);
   test_error(err, "clGetSupportedImageFormats failed");
 
   formats = (cl_image_format *)malloc(num_formats * sizeof(cl_image_format));
 
-  err = clGetSupportedImageFormats(context, CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE3D, num_formats, formats, NULL);
+  err = clGetSupportedImageFormats(context, CL_MEM_READ_ONLY,
+                                   CL_MEM_OBJECT_IMAGE3D, num_formats, formats,
+                                   NULL);
   test_error(err, "clGetSupportedImageFormats failed");
 
   for (i = 0; i < num_formats; i++) {


### PR DESCRIPTION
Also fix PASSIVE_REQUIRE_* macros to report tests as skipped instead of passed.

Signed-off-by: Kévin Petit <kpet@free.fr>