### PR TITLE
Use the right flags when creating images (#328)

### DIFF
--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -16,11 +16,23 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
+extern int test_read_image_set_1D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format, cl_mem_flags flags);
+extern int test_read_image_set_2D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format, cl_mem_flags flags);
+extern int test_read_image_set_3D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format, cl_mem_flags flags);
+extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        cl_mem_flags flags);
+extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        cl_mem_flags flags);
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
 {
@@ -73,19 +85,24 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
         switch (imageType) {
             case CL_MEM_OBJECT_IMAGE1D:
-                test_return = test_read_image_set_1D( device, context, queue, &formatList[ i ] );
+                test_return = test_read_image_set_1D(device, context, queue,
+                                                     &formatList[i], flags);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                test_return = test_read_image_set_2D( device, context, queue, &formatList[ i ] );
+                test_return = test_read_image_set_2D(device, context, queue,
+                                                     &formatList[i], flags);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                test_return = test_read_image_set_3D( device,context, queue,  &formatList[ i ] );
+                test_return = test_read_image_set_3D(device, context, queue,
+                                                     &formatList[i], flags);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                test_return = test_read_image_set_1D_array( device, context, queue, &formatList[ i ] );
+                test_return = test_read_image_set_1D_array(
+                    device, context, queue, &formatList[i], flags);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                test_return = test_read_image_set_2D_array( device, context, queue, &formatList[ i ] );
+                test_return = test_read_image_set_2D_array(
+                    device, context, queue, &formatList[i], flags);
                 break;
         }
 

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_read_image_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_read_image_1D(cl_context context, cl_command_queue queue,
+                       image_descriptor *imageInfo, MTdata d,
+                       cl_mem_flags flags)
 {
     int error;
 
@@ -34,12 +36,14 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, image_descri
     // Construct testing sources
   if(!gTestMipmaps)
   {
-    image = create_image_1d( context, (cl_mem_flags)(CL_MEM_READ_ONLY), imageInfo->format, imageInfo->width, 0, NULL, NULL, &error );
-    if( image == NULL )
-    {
-      log_error( "ERROR: Unable to create 1D image of size %d (%s)", (int)imageInfo->width, IGetErrorString( error ) );
-      return -1;
-    }
+      image = create_image_1d(context, flags, imageInfo->format,
+                              imageInfo->width, 0, NULL, NULL, &error);
+      if (image == NULL)
+      {
+          log_error("ERROR: Unable to create 1D image of size %d (%s)",
+                    (int)imageInfo->width, IGetErrorString(error));
+          return -1;
+      }
   }
   else
   {
@@ -48,7 +52,8 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, image_descri
     image_desc.image_width = imageInfo->width;
     image_desc.num_mip_levels = imageInfo->num_mip_levels;
 
-    image = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
+    image = clCreateImage(context, flags, imageInfo->format, &image_desc, NULL,
+                          &error);
     if( error != CL_SUCCESS )
     {
       log_error( "ERROR: Unable to create %d level mipmapped 1D image of size %d x %d (pitch %d ) (%s)",(int)imageInfo->num_mip_levels, (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->rowPitch, IGetErrorString( error ) );
@@ -158,7 +163,9 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, image_descri
     return 0;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_read_image_set_1D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags flags)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -192,7 +199,8 @@ int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_
             if( gDebugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int ret = test_read_image_1D( context, queue, &imageInfo, seed );
+            int ret =
+                test_read_image_1D(context, queue, &imageInfo, seed, flags);
             if( ret )
                 return -1;
         }
@@ -216,7 +224,7 @@ int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_
             log_info("Testing %d\n", (int)imageInfo.width);
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)maxWidth );
-            if( test_read_image_1D( context, queue, &imageInfo, seed ) )
+            if (test_read_image_1D(context, queue, &imageInfo, seed, flags))
                 return -1;
         }
     }
@@ -252,7 +260,8 @@ int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_
 
             if( gDebugTrace )
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret = test_read_image_1D( context, queue, &imageInfo, seed );
+            int ret =
+                test_read_image_1D(context, queue, &imageInfo, seed, flags);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_read_image_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_read_image_1D_array(cl_context context, cl_command_queue queue,
+                             image_descriptor *imageInfo, MTdata d,
+                             cl_mem_flags flags)
 {
     int error;
 
@@ -35,7 +37,9 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, image_
     // Construct testing sources
     if(!gTestMipmaps)
     {
-        image = create_image_1d_array( context, (cl_mem_flags)(CL_MEM_READ_ONLY), imageInfo->format, imageInfo->width, imageInfo->arraySize, 0, 0, NULL, &error );
+        image = create_image_1d_array(context, flags, imageInfo->format,
+                                      imageInfo->width, imageInfo->arraySize, 0,
+                                      0, NULL, &error);
         if( image == NULL )
         {
             log_error( "ERROR: Unable to create 1D image array of size %d x %d (%s)", (int)imageInfo->width, (int)imageInfo->arraySize, IGetErrorString( error ) );
@@ -50,7 +54,8 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, image_
         image_desc.image_array_size = imageInfo->arraySize;
         image_desc.num_mip_levels = imageInfo->num_mip_levels;
 
-        image = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
+        image = clCreateImage(context, flags, imageInfo->format, &image_desc,
+                              NULL, &error);
         if( error != CL_SUCCESS )
         {
             log_error( "ERROR: Unable to create %d level mipmapped 1D image of width %d and array size %d (pitch %d ) (%s)",(int)imageInfo->num_mip_levels, (int)imageInfo->width, (int)imageInfo->arraySize, (int)imageInfo->rowPitch, IGetErrorString( error ) );
@@ -164,7 +169,9 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, image_
     return 0;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 cl_image_format *format, cl_mem_flags flags)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -201,7 +208,8 @@ int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_co
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_read_image_1D_array( context, queue, &imageInfo, seed );
+                int ret = test_read_image_1D_array(context, queue, &imageInfo,
+                                                   seed, flags);
                 if( ret )
                     return -1;
             }
@@ -228,7 +236,8 @@ int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_co
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.arraySize);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxArraySize );
-            if( test_read_image_1D_array( context, queue, &imageInfo, seed ) )
+            if (test_read_image_1D_array(context, queue, &imageInfo, seed,
+                                         flags))
                 return -1;
         }
     }
@@ -266,7 +275,8 @@ int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_co
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int ret = test_read_image_1D_array( context, queue, &imageInfo, seed );
+            int ret = test_read_image_1D_array(context, queue, &imageInfo, seed,
+                                               flags);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_read_image_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_read_image_2D(cl_context context, cl_command_queue queue,
+                       image_descriptor *imageInfo, MTdata d,
+                       cl_mem_flags flags)
 {
     int error;
 
@@ -35,7 +37,9 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, image_descri
     // Construct testing sources
     if(!gTestMipmaps)
     {
-        image = create_image_2d( context, (cl_mem_flags)(CL_MEM_READ_ONLY), imageInfo->format, imageInfo->width, imageInfo->height, 0, NULL, &error );
+        image =
+            create_image_2d(context, flags, imageInfo->format, imageInfo->width,
+                            imageInfo->height, 0, NULL, &error);
         if( image == NULL )
         {
             log_error( "ERROR: Unable to create 2D image of size %d x %d (%s)", (int)imageInfo->width, (int)imageInfo->height, IGetErrorString( error ) );
@@ -50,7 +54,8 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, image_descri
         image_desc.image_height = imageInfo->height;
         image_desc.num_mip_levels = imageInfo->num_mip_levels;
 
-        image = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
+        image = clCreateImage(context, flags, imageInfo->format, &image_desc,
+                              NULL, &error);
         if( error != CL_SUCCESS )
         {
             log_error( "ERROR: Unable to create %d level mipmapped 2D image of size %d x %d (pitch %d ) (%s)",(int)imageInfo->num_mip_levels, (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->rowPitch, IGetErrorString( error ) );
@@ -167,7 +172,9 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, image_descri
     return 0;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_read_image_set_2D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags flags)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -203,7 +210,8 @@ int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_
                 if( gDebugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_read_image_2D( context, queue, &imageInfo, seed );
+                int ret =
+                    test_read_image_2D(context, queue, &imageInfo, seed, flags);
                 if( ret )
                     return -1;
             }
@@ -229,7 +237,7 @@ int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.height);
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxHeight );
-            if( test_read_image_2D( context, queue, &imageInfo, seed ) )
+            if (test_read_image_2D(context, queue, &imageInfo, seed, flags))
                 return -1;
         }
     }
@@ -265,7 +273,8 @@ int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_read_image_2D( context, queue, &imageInfo, seed );
+            int ret =
+                test_read_image_2D(context, queue, &imageInfo, seed, flags);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_read_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_read_image_2D_array(cl_context context, cl_command_queue queue,
+                             image_descriptor *imageInfo, MTdata d,
+                             cl_mem_flags flags)
 {
     int error;
 
@@ -35,7 +37,9 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, image_
     // Construct testing sources
     if(!gTestMipmaps)
     {
-        image = create_image_2d_array( context, (cl_mem_flags)(CL_MEM_READ_ONLY), imageInfo->format, imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, NULL, &error );
+        image = create_image_2d_array(context, flags, imageInfo->format,
+                                      imageInfo->width, imageInfo->height,
+                                      imageInfo->arraySize, 0, 0, NULL, &error);
         if( image == NULL )
         {
             log_error( "ERROR: Unable to create 2D image array of size %d x %d x %d (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize, IGetErrorString( error ) );
@@ -51,7 +55,8 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, image_
         image_desc.image_array_size = imageInfo->arraySize;
         image_desc.num_mip_levels = imageInfo->num_mip_levels;
 
-        image = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
+        image = clCreateImage(context, flags, imageInfo->format, &image_desc,
+                              NULL, &error);
         if( error != CL_SUCCESS )
         {
             log_error( "ERROR: Unable to create %d level mipmapped 3D image of size %d x %d x %d (pitch %d, %d ) (%s)",(int)imageInfo->num_mip_levels, (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );
@@ -142,7 +147,9 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, image_
     return 0;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 cl_image_format *format, cl_mem_flags flags)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -181,7 +188,8 @@ int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_co
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_read_image_2D_array( context, queue, &imageInfo, seed );
+                    int ret = test_read_image_2D_array(context, queue,
+                                                       &imageInfo, seed, flags);
                     if( ret )
                         return -1;
                 }
@@ -209,7 +217,8 @@ int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_co
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
             log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize);
-            if( test_read_image_2D_array( context, queue, &imageInfo, seed ) )
+            if (test_read_image_2D_array(context, queue, &imageInfo, seed,
+                                         flags))
                 return -1;
         }
     }
@@ -253,7 +262,8 @@ int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_co
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_read_image_2D_array( context, queue, &imageInfo, seed );
+            int ret = test_read_image_2D_array(context, queue, &imageInfo, seed,
+                                               flags);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_read_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_read_image_3D(cl_context context, cl_command_queue queue,
+                       image_descriptor *imageInfo, MTdata d,
+                       cl_mem_flags flags)
 {
     int error;
 
@@ -34,7 +36,9 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, image_descri
     // Construct testing sources
     if(!gTestMipmaps)
     {
-        image = create_image_3d( context, (cl_mem_flags)(CL_MEM_READ_ONLY), imageInfo->format, imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, NULL, &error );
+        image = create_image_3d(context, flags, imageInfo->format,
+                                imageInfo->width, imageInfo->height,
+                                imageInfo->depth, 0, 0, NULL, &error);
         if( image == NULL )
         {
             log_error( "ERROR: Unable to create 2D image of size %d x %d x %d (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, IGetErrorString( error ) );
@@ -50,7 +54,8 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, image_descri
         image_desc.image_depth = imageInfo->depth;
         image_desc.num_mip_levels = imageInfo->num_mip_levels;
 
-        image = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
+        image = clCreateImage(context, flags, imageInfo->format, &image_desc,
+                              NULL, &error);
         if( error != CL_SUCCESS )
         {
             log_error( "ERROR: Unable to create %d level mipmapped 3D image of size %d x %d x %d (pitch %d, %d ) (%s)",(int)imageInfo->num_mip_levels, (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );
@@ -147,7 +152,9 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, image_descri
     return 0;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_read_image_set_3D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags flags)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -186,7 +193,8 @@ int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_
 
                     if( gDebugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_read_image_3D( context, queue, &imageInfo, seed );
+                    int ret = test_read_image_3D(context, queue, &imageInfo,
+                                                 seed, flags);
                     if( ret )
                         return -1;
                 }
@@ -214,8 +222,8 @@ int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_
         imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
 
       log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth);
-      if( test_read_image_3D( context, queue, &imageInfo, seed ) )
-        return -1;
+      if (test_read_image_3D(context, queue, &imageInfo, seed, flags))
+          return -1;
     }
   }
     else
@@ -257,7 +265,8 @@ int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_
 
             if( gDebugTrace )
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_read_image_3D( context, queue, &imageInfo, seed );
+            int ret =
+                test_read_image_3D(context, queue, &imageInfo, seed, flags);
             if( ret )
                 return -1;
         }


### PR DESCRIPTION
Test was querying for supported images with CL_MEM_WRITE_ONLY flag, but
always used CL_MEM_READ_ONLY to create images.

Fixes issue #328

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>
Signed-off-by: James Morrissey <james.morrissey@arm.com>