### PR TITLE
Fix floating point validation in write_image tests

### DIFF
--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1174,8 +1174,11 @@ bool validate_float_write_results( float *expected, float *actual, image_descrip
                 continue;
             if ( IsFloatSubnormal( expected[j] ) && actual[j] == 0.0f )
                 continue;
-            pass = false;
-            break;
+            if (expected[j] != actual[j])
+            {
+                pass = false;
+                break;
+            }
         }
     }
     return pass;
@@ -1193,8 +1196,11 @@ bool validate_half_write_results( cl_half *expected, cl_half *actual, image_desc
                 continue;
             if ( is_half_denorm( expected[j] ) && is_half_zero( actual[j] ) )
                 continue;
-            pass = false;
-            break;
+            if (expected[j] != actual[j])
+            {
+                pass = false;
+                break;
+            }
         }
     }
     return pass;


### PR DESCRIPTION
Fix validate_float/half_write_results so that when nan/inf is
encountered on a channel, the rest of the channel values are still
considered for correctness.

Signed-off-by: John Kesapides <john.kesapides@arm.com>
Signed-off-by: James Morrissey <james.morrissey@arm.com>