### PR TITLE
Skip Compiler Unload Tests in Binary Mode

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -745,6 +745,13 @@ const char *subtests_to_skip_with_offline_compiler[] = {
     "simple_static_compile_only",
     "two_file_link",
     "async_build",
+    "unload_repeated",
+    "unload_compile_unload_link",
+    "unload_build_unload_create_kernel",
+    "unload_link_different",
+    "unload_build_threaded",
+    "unload_build_info",
+    "unload_program_binaries",
 };
 
 int check_functions_for_offline_compiler(const char *subtestname, cl_device_id device)


### PR DESCRIPTION
The following tests make calls to `clCompileProgram` or
`clBuildProgram` and therefore require a compiler in the runtime:
  * `unload_repeated`
  * `unload_compile_unload_link`
  * `unload_build_unload_create_kernel`
  * `unload_link_different↩`
  * `unload_build_threaded`
  * `unload_build_info`
  * `unload_program_binaries`

Skip these tests if no compiler is present in the runtime.