### PR TITLE
Skip `features_macro` Test in Offline Mode

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -745,6 +745,7 @@ const char *subtests_to_skip_with_offline_compiler[] = {
     "unload_build_threaded",
     "unload_build_info",
     "unload_program_binaries",
+    "features_macro",
 };
 
 int check_functions_for_offline_compiler(const char *subtestname,


### PR DESCRIPTION
- [x] Skip the `features_macro` test in offline mode since it makes
calls to `create_single_kernel_helper_create_program` and fails when the
call doesn't return `CL_SUCCESS` which will happen when the offline
compiler fails to compile the kernel which is deliberately supposed to
fail compilation in this test.