### PR TITLE
Fix build warning/error introduced by 8d443029

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -721,7 +721,8 @@ int parseAndCallCommandLineTests(int argc, const char *argv[],
                         {
                             case TEST_PASS:
                             case TEST_SKIP: return false;
-                            case TEST_FAIL: return true;
+                            case TEST_FAIL:
+                            default: return true;
                         };
                     }))
     {


### PR DESCRIPTION
"control reaches end of non-void function"

Signed-off-by: Kevin Petit <kevin.petit@arm.com>