### PR TITLE
Remove unused code in kernel_image_methods

### DIFF
--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -13,23 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../harness/compat.h"
-#include "../harness/parseParameters.h"
 
 #include <stdio.h>
 #include <string.h>
-
-#if !defined(_WIN32)
-#include <unistd.h>
-#include <sys/time.h>
-#endif
-
 #include "../testBase.h"
+#include "../harness/compat.h"
+#include "../harness/parseParameters.h"
 
 bool gDebugTrace;
 bool gTestSmallImages;
 bool gTestMaxImages;
-int  gTypesToTest;
 bool gDeviceLt20 = false;
 
 cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
@@ -38,8 +31,6 @@ cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
 extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
 
 static void printUsage( const char *execName );
-
-#define MAX_ALLOWED_STD_DEVIATION_IN_MB        8.0
 
 int test_1D(cl_device_id device, cl_context context, cl_command_queue queue, int num_elements)
 {

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -15,10 +15,7 @@
 //
 #include "../testBase.h"
 
-#define MAX_ERR 0.005f
-#define MAX_HALF_LINEAR_ERR 0.3f
-
-extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
+extern bool gDeviceLt20;
 
 struct image_kernel_data
 {

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -15,10 +15,7 @@
 //
 #include "../testBase.h"
 
-#define MAX_ERR 0.005f
-#define MAX_HALF_LINEAR_ERR 0.3f
-
-extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
+extern bool gDeviceLt20;
 
 struct image_kernel_data
 {

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -15,10 +15,7 @@
 //
 #include "../testBase.h"
 
-#define MAX_ERR 0.005f
-#define MAX_HALF_LINEAR_ERR 0.3f
-
-extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
+extern bool gDeviceLt20;
 
 struct image_kernel_data
 {

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -15,10 +15,7 @@
 //
 #include "../testBase.h"
 
-#define MAX_ERR 0.005f
-#define MAX_HALF_LINEAR_ERR 0.3f
-
-extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
+extern bool gDeviceLt20;
 
 struct image_kernel_data
 {

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -15,11 +15,6 @@
 //
 #include "../testBase.h"
 
-#define MAX_ERR 0.005f
-#define MAX_HALF_LINEAR_ERR 0.3f
-
-extern bool            gDebugTrace, gTestSmallImages, gTestMaxImages, gDeviceLt20;
-
 extern int test_get_image_info_single( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d );
 
 int test_get_image_info_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -16,14 +16,7 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern cl_filter_mode     gFilterModeToUse;
-extern cl_addressing_mode gAddressModeToUse;
-extern int                gTypesToTest;
-extern int                gNormalizedModeToUse;
-extern cl_channel_type      gChannelTypeToUse;
 extern bool gDeviceLt20;
-
-extern bool gDebugTrace;
 
 extern int test_get_image_info_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );
 extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format );


### PR DESCRIPTION
These declarations either aren't used or aren't needed, as testBase.h
already declares them.

Signed-off-by: Radek Szymanski <radek.szymanski@arm.com>