### PR TITLE
Fixes for kernel private memory size test

### DIFF
--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -10,6 +10,7 @@ set(${MODULE_NAME}_SOURCES
          test_queries_compatibility.cpp
          test_create_kernels.cpp
          test_kernels.cpp
+         test_kernel_private_memory_size.cpp
          test_api_min_max.cpp
          test_kernel_arg_changes.cpp
          test_kernel_arg_multi_setup.cpp

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -54,6 +54,7 @@ test_definition test_list[] = {
     ADD_TEST(get_kernel_arg_info_compatibility),
     ADD_TEST(create_kernels_in_program),
     ADD_TEST(get_kernel_info),
+    ADD_TEST(kernel_private_memory_size),
     ADD_TEST(execute_kernel_local_sizes),
     ADD_TEST(set_kernel_arg_by_index),
     ADD_TEST(set_kernel_arg_constant),

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -47,6 +47,10 @@ extern int        test_release_kernel_order(cl_device_id deviceID, cl_context co
 extern int        test_release_during_execute(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
 extern int        test_get_kernel_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_kernel_private_memory_size(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
 extern int        test_execute_kernel_local_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_set_kernel_arg_by_index(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_set_kernel_arg_struct(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);

--- a/test_conformance/api/test_kernel_private_memory_size.cpp
+++ b/test_conformance/api/test_kernel_private_memory_size.cpp
@@ -30,7 +30,7 @@ int test_kernel_private_memory_size(cl_device_id deviceID, cl_context context,
     clProgramWrapper program;
     clKernelWrapper kernel;
     cl_int err = create_single_kernel_helper(context, &program, &kernel, 1,
-                                             &kernels[i], "private_memory");
+                                             &TEST_KERNEL, "private_memory");
     test_error(err, "create_single_kernel_helper");
     cl_ulong size = CL_ULONG_MAX;
     err = clGetKernelWorkGroupInfo(kernel, deviceID, CL_KERNEL_PRIVATE_MEM_SIZE,

--- a/test_conformance/api/test_kernel_private_memory_size.cpp
+++ b/test_conformance/api/test_kernel_private_memory_size.cpp
@@ -22,8 +22,8 @@ int test_kernel_private_memory_size(cl_device_id deviceID, cl_context context,
                                     cl_command_queue queue, int num_elements)
 {
     const char* TEST_KERNEL =
-        R"(__kernel void private_memory( __global ulong *buffer ){
-         volatile __private ulong x[1];
+        R"(__kernel void private_memory( __global uint *buffer ){
+         volatile __private uint x[1];
          buffer[0] = x[0];
          })";
 


### PR DESCRIPTION
* Add the test source to `CMakeLists.txt`
* Register the test with the api suite
* Fix build error in host code
* Use `uint` instead of `ulong` (not all devices support 64-bit types)