### PR TITLE
Fix for test_conversions failure with Clang build on Linux #1057

### DIFF
--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -678,7 +678,8 @@ static void uint2short( void *out, void *in){ ((short*) out)[0] = ((cl_uint*) in
 static void uint2int( void *out, void *in){ ((cl_int*) out)[0] = ((cl_uint*) in)[0]; }
 static void uint2float( void *out, void *in)
 {
-    cl_uint l = ((cl_uint*) in)[0];
+    // Use volatile to prevent optimization by Clang compiler
+    volatile cl_uint l = ((cl_uint*) in)[0];
     ((float*) out)[0] = (l == 0 ? 0.0f : (float) l);        // Per IEEE-754-2008 5.4.1, 0's always convert to +0.0
 }
 static void uint2double( void *out, void *in)
@@ -791,7 +792,8 @@ static void ulong2double( void *out, void *in)
 #endif
     ((double*) out)[0] = (l == 0 ? 0.0 : (((cl_long)l < 0) ? result * 2.0 : result));
 #else
-    cl_ulong l = ((cl_ulong*) in)[0];
+    // Use volatile to prevent optimization by Clang compiler
+    volatile cl_ulong l = ((cl_ulong*) in)[0];
     ((double*) out)[0] = (l == 0 ? 0.0 : (double) l);      // Per IEEE-754-2008 5.4.1, 0's always convert to +0.0
 #endif
 }


### PR DESCRIPTION
    * Avoid optimization by using volatile qualifier
    * Fix both uint2float and ulong2double