### PR TITLE
Fix build_with_il on devices older than 2.1

### DIFF
--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -262,13 +262,20 @@ public:
                   const cl_device_id device)
         : build_base{ context, device }
     {
+        /* Disable build_with_il if neither core nor extension functionality is
+         * available */
+        m_enabled = false;
+
         Version version = get_device_cl_version(device);
-        std::string sILVersion = get_device_il_version_string(device);
-        if ((version >= Version(2, 1) && version < Version(3, 0))
-            || (version >= Version(3, 0) && !sILVersion.empty()))
+        if (version >= Version(2, 1))
         {
+            std::string sILVersion = get_device_il_version_string(device);
+            if (version < Version(3, 0) || !sILVersion.empty())
+            {
+                m_enabled = true;
+            }
+
             m_CreateProgramWithIL = clCreateProgramWithIL;
-            m_enabled = true;
         }
         else if (is_extension_available(device, "cl_khr_il_program"))
         {
@@ -281,12 +288,6 @@ public:
                                           "function address is nullptr");
             }
             m_enabled = true;
-        }
-        else
-        {
-            /* Disable build_with_il if neither core nor extension functionality
-             * is available */
-            m_enabled = false;
         }
 
         cl_uint address_bits{};


### PR DESCRIPTION
The `get_device_il_version_string()` function throws an exception if the
device does not support the `CL_DEVICE_IL_VERSION` query, so don't call
this unless the version is recent enough.