### PR TITLE
Implement Negative Test for Platform Layer Functions

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -68,6 +68,7 @@ const char *IGetErrorString(int clErrorCode)
         case CL_INVALID_SAMPLER: return "CL_INVALID_SAMPLER";
         case CL_INVALID_BINARY: return "CL_INVALID_BINARY";
         case CL_INVALID_BUILD_OPTIONS: return "CL_INVALID_BUILD_OPTIONS";
+        case CL_INVALID_PLATFORM: return "CL_INVALID_PLATFORM";
         case CL_INVALID_PROGRAM: return "CL_INVALID_PROGRAM";
         case CL_INVALID_PROGRAM_EXECUTABLE:
             return "CL_INVALID_PROGRAM_EXECUTABLE";

--- a/test_common/harness/errorHelpers.h
+++ b/test_common/harness/errorHelpers.h
@@ -124,6 +124,17 @@ static int vlog_win32(const char *format, ...);
             return retValue;                                                   \
         }                                                                      \
     }
+#define test_failure_error_ret_file_line(errCode, expectedErrCode, msg,        \
+                                         retValue, file, line)                 \
+    {                                                                          \
+        if (errCode != expectedErrCode)                                        \
+        {                                                                      \
+            log_error("ERROR: %s! (Got %s, expected %s from %s:%d)\n", msg,    \
+                      IGetErrorString(errCode),                                \
+                      IGetErrorString(expectedErrCode), file, line);           \
+            return retValue;                                                   \
+        }                                                                      \
+    }
 #define print_failure_error(errCode, expectedErrCode, msg)                     \
     log_error("ERROR: %s! (Got %s, expected %s from %s:%d)\n", msg,            \
               IGetErrorString(errCode), IGetErrorString(expectedErrCode),      \

--- a/test_common/harness/errorHelpers.h
+++ b/test_common/harness/errorHelpers.h
@@ -124,17 +124,6 @@ static int vlog_win32(const char *format, ...);
             return retValue;                                                   \
         }                                                                      \
     }
-#define test_failure_error_ret_file_line(errCode, expectedErrCode, msg,        \
-                                         retValue, file, line)                 \
-    {                                                                          \
-        if (errCode != expectedErrCode)                                        \
-        {                                                                      \
-            log_error("ERROR: %s! (Got %s, expected %s from %s:%d)\n", msg,    \
-                      IGetErrorString(errCode),                                \
-                      IGetErrorString(expectedErrCode), file, line);           \
-            return retValue;                                                   \
-        }                                                                      \
-    }
 #define print_failure_error(errCode, expectedErrCode, msg)                     \
     log_error("ERROR: %s! (Got %s, expected %s from %s:%d)\n", msg,            \
               IGetErrorString(errCode), IGetErrorString(expectedErrCode),      \

--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -1161,6 +1161,15 @@ test_status check_spirv_compilation_readiness(cl_device_id device)
     return TEST_PASS;
 }
 
+cl_platform_id getPlatformFromDevice(cl_device_id deviceID)
+{
+    cl_platform_id platform = nullptr;
+    cl_int err = clGetDeviceInfo(deviceID, CL_DEVICE_PLATFORM, sizeof(platform),
+                                 &platform, nullptr);
+    ASSERT_SUCCESS(err, "clGetDeviceInfo");
+    return platform;
+}
+
 void PrintArch(void)
 {
     vlog("sizeof( void*) = %ld\n", sizeof(void *));

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -178,21 +178,6 @@ extern int gHasLong; // This is set to 1 if the device suppots long and ulong
                      // types in OpenCL C.
 extern bool gCoreILProgram;
 
-#define negative_test(func, expected, msg, ...)                                \
-    (TEST_FAIL                                                                 \
-     == run_negative_test(func, expected, msg, __FILE__, __LINE__,             \
-                          __VA_ARGS__))
-
-template <typename Func, typename Error, typename... Args>
-static test_status run_negative_test(Func function, Error expected,
-                                     const char *msg, const char *file,
-                                     unsigned int line, Args... args)
-{
-    cl_int err = function(args...);
-    test_failure_error_ret_file_line(err, expected, msg, TEST_FAIL, file, line);
-    return TEST_PASS;
-}
-
 extern cl_platform_id getPlatformFromDevice(cl_device_id deviceID);
 
 #if !defined(__APPLE__)

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -178,6 +178,23 @@ extern int gHasLong; // This is set to 1 if the device suppots long and ulong
                      // types in OpenCL C.
 extern bool gCoreILProgram;
 
+#define negative_test(func, expected, msg, ...)                                \
+    (TEST_FAIL                                                                 \
+     == run_negative_test(func, expected, msg, __FILE__, __LINE__,             \
+                          __VA_ARGS__))
+
+template <typename Func, typename Error, typename... Args>
+static test_status run_negative_test(Func function, Error expected,
+                                     const char *msg, const char *file,
+                                     unsigned int line, Args... args)
+{
+    cl_int err = function(args...);
+    test_failure_error_ret_file_line(err, expected, msg, TEST_FAIL, file, line);
+    return TEST_PASS;
+}
+
+extern cl_platform_id getPlatformFromDevice(cl_device_id deviceID);
+
 #if !defined(__APPLE__)
 void memset_pattern4(void *, const void *, size_t);
 #endif

--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_NAME API)
 
 set(${MODULE_NAME}_SOURCES
          main.cpp
+         negative_platform.cpp
          test_api_consistency.cpp
          test_bool.cpp
          test_retain.cpp

--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -146,6 +146,8 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(consistency_3d_image_writes, Version(3, 0)),
 
     ADD_TEST(min_image_formats),
+    ADD_TEST(negative_get_platform_info),
+    ADD_TEST(negative_get_platform_ids),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/negative_platform.cpp
+++ b/test_conformance/api/negative_platform.cpp
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testBase.h"
+#include "harness/errorHelpers.h"
+#include "harness/testHarness.h"
+
+int test_negative_get_platform_ids(cl_device_id deviceID, cl_context context,
+                                   cl_command_queue queue, int num_elements)
+{
+
+    cl_platform_id platform;
+    bool failed_tests = negative_test(
+        clGetPlatformIDs, CL_INVALID_VALUE,
+        "clGetPlatformIDs should return CL_INVALID_VALUE when: \"num_entries "
+        "is equal to zero and platforms is not NULL\"",
+        0, &platform, nullptr);
+
+    failed_tests |=
+        negative_test(clGetPlatformIDs, CL_INVALID_VALUE,
+                      "clGetPlatformIDs should return CL_INVALID_VALUE "
+                      "when: \"both num_platforms and"
+                      "platforms are NULL\"",
+                      1, nullptr, nullptr);
+
+    return failed_tests ? TEST_FAIL : TEST_PASS;
+}
+
+int test_negative_get_platform_info(cl_device_id deviceID, cl_context context,
+                                    cl_command_queue queue, int num_elements)
+{
+    cl_platform_id platform = getPlatformFromDevice(deviceID);
+
+    bool failed_tests = negative_test(
+        clGetPlatformInfo, CL_INVALID_PLATFORM,
+        "clGetPlatformInfo should return CL_INVALID_PLATFORM  when: \"platform "
+        "is "
+        "not a valid platform\" using a nullptr",
+        nullptr, CL_PLATFORM_VERSION, sizeof(char*), nullptr, nullptr);
+
+    failed_tests |= negative_test(
+        clGetPlatformInfo, CL_INVALID_PLATFORM,
+        "clGetPlatformInfo should return CL_INVALID_PLATFORM when: \"platform "
+        "is not a valid platform\" using a valid object which is NOT a "
+        "platform",
+        reinterpret_cast<cl_platform_id>(deviceID), CL_PLATFORM_VERSION,
+        sizeof(char*), nullptr, nullptr);
+
+    constexpr cl_platform_info INVALID_PARAM_VALUE = 0;
+    failed_tests |=
+        negative_test(clGetPlatformInfo, CL_INVALID_VALUE,
+                      "clGetPlatformInfo should return CL_INVALID_VALUE when: "
+                      "\"param_name is not one of the supported values\"",
+                      platform, INVALID_PARAM_VALUE, 0, nullptr, nullptr);
+
+    char* version;
+    failed_tests |= negative_test(
+        clGetPlatformInfo, CL_INVALID_VALUE,
+        "clGetPlatformInfo should return CL_INVALID_VALUE when: \"size "
+        "in bytes specified"
+        "by param_value_size is < size of return type and "
+        "param_value is not a NULL value\"",
+        platform, CL_PLATFORM_VERSION, 0, &version, nullptr);
+    return failed_tests ? TEST_FAIL : TEST_PASS;
+}

--- a/test_conformance/api/negative_platform.cpp
+++ b/test_conformance/api/negative_platform.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2021 The Khronos Group Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,28 +15,26 @@
 //
 
 #include "testBase.h"
-#include "harness/errorHelpers.h"
-#include "harness/testHarness.h"
 
 int test_negative_get_platform_ids(cl_device_id deviceID, cl_context context,
                                    cl_command_queue queue, int num_elements)
 {
-
     cl_platform_id platform;
-    bool failed_tests = negative_test(
-        clGetPlatformIDs, CL_INVALID_VALUE,
+    cl_int err = clGetPlatformIDs(0, &platform, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_VALUE,
         "clGetPlatformIDs should return CL_INVALID_VALUE when: \"num_entries "
         "is equal to zero and platforms is not NULL\"",
-        0, &platform, nullptr);
+        TEST_FAIL);
 
-    failed_tests |=
-        negative_test(clGetPlatformIDs, CL_INVALID_VALUE,
-                      "clGetPlatformIDs should return CL_INVALID_VALUE "
-                      "when: \"both num_platforms and"
-                      "platforms are NULL\"",
-                      1, nullptr, nullptr);
+    err = clGetPlatformIDs(1, nullptr, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_VALUE,
+        "clGetPlatformIDs should return CL_INVALID_VALUE when: \"both "
+        "num_platforms and platforms are NULL\"",
+        TEST_FAIL);
 
-    return failed_tests ? TEST_FAIL : TEST_PASS;
+    return TEST_PASS;
 }
 
 int test_negative_get_platform_info(cl_device_id deviceID, cl_context context,
@@ -44,35 +42,41 @@ int test_negative_get_platform_info(cl_device_id deviceID, cl_context context,
 {
     cl_platform_id platform = getPlatformFromDevice(deviceID);
 
-    bool failed_tests = negative_test(
-        clGetPlatformInfo, CL_INVALID_PLATFORM,
+    cl_int err = clGetPlatformInfo(nullptr, CL_PLATFORM_VERSION, sizeof(char*),
+                                   nullptr, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_PLATFORM,
         "clGetPlatformInfo should return CL_INVALID_PLATFORM  when: \"platform "
-        "is "
-        "not a valid platform\" using a nullptr",
-        nullptr, CL_PLATFORM_VERSION, sizeof(char*), nullptr, nullptr);
+        "is not a valid platform\" using a nullptr",
+        TEST_FAIL);
 
-    failed_tests |= negative_test(
-        clGetPlatformInfo, CL_INVALID_PLATFORM,
-        "clGetPlatformInfo should return CL_INVALID_PLATFORM when: \"platform "
+    err =
+        clGetPlatformInfo(reinterpret_cast<cl_platform_id>(deviceID),
+                          CL_PLATFORM_VERSION, sizeof(char*), nullptr, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_PLATFORM,
+        "clGetPlatformInfo should return CL_INVALID_PLATFORM  when: \"platform "
         "is not a valid platform\" using a valid object which is NOT a "
         "platform",
-        reinterpret_cast<cl_platform_id>(deviceID), CL_PLATFORM_VERSION,
-        sizeof(char*), nullptr, nullptr);
+        TEST_FAIL);
 
     constexpr cl_platform_info INVALID_PARAM_VALUE = 0;
-    failed_tests |=
-        negative_test(clGetPlatformInfo, CL_INVALID_VALUE,
-                      "clGetPlatformInfo should return CL_INVALID_VALUE when: "
-                      "\"param_name is not one of the supported values\"",
-                      platform, INVALID_PARAM_VALUE, 0, nullptr, nullptr);
+    err = clGetPlatformInfo(platform, INVALID_PARAM_VALUE, 0, nullptr, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_VALUE,
+        "clGetPlatformInfo should return CL_INVALID_VALUE when: \"param_name "
+        "is not one of the supported values\"",
+        TEST_FAIL);
 
     char* version;
-    failed_tests |= negative_test(
-        clGetPlatformInfo, CL_INVALID_VALUE,
-        "clGetPlatformInfo should return CL_INVALID_VALUE when: \"size "
-        "in bytes specified"
-        "by param_value_size is < size of return type and "
+    err =
+        clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, &version, nullptr);
+    test_failure_error_ret(
+        err, CL_INVALID_VALUE,
+        "clGetPlatformInfo should return CL_INVALID_VALUE when: \"size in "
+        "bytes specified by param_value_size is < size of return type and "
         "param_value is not a NULL value\"",
-        platform, CL_PLATFORM_VERSION, 0, &version, nullptr);
-    return failed_tests ? TEST_FAIL : TEST_PASS;
+        TEST_FAIL);
+
+    return TEST_PASS;
 }

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -195,3 +195,11 @@ extern int test_consistency_3d_image_writes(cl_device_id deviceID,
 
 extern int test_min_image_formats(cl_device_id deviceID, cl_context context,
                                   cl_command_queue queue, int num_elements);
+extern int test_negative_get_platform_info(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
+extern int test_negative_get_platform_ids(cl_device_id deviceID,
+                                          cl_context context,
+                                          cl_command_queue queue,
+                                          int num_elements);


### PR DESCRIPTION
This change introduces a negative test for clGetPlatformInfo
as well as changes to the Harness to help with
other negative tests.

Signed-off-by: Chetankumar Mistry <chetan.mistry@arm.com>