### PR TITLE
Add more relaxed math conformance tests

### DIFF
--- a/test_conformance/math_brute_force/FunctionList.cpp
+++ b/test_conformance/math_brute_force/FunctionList.cpp
@@ -135,13 +135,13 @@ extern const vtbl _mad_tbl;             // float mad( float, float, float )
 #endif // FUNCTION_LIST_ULPS_ONLY
 
 const Func functionList[] = {
-    ENTRY(acos, 4.0f, 4.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(acos, 4.0f, 4.0f, 4096.0f, FTZ_OFF, unaryF, 4096.0f),
     ENTRY(acosh, 4.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY(acospi, 5.0f, 5.0f, FTZ_OFF, unaryF),
-    ENTRY(asin, 4.0f, 4.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(asin, 4.0f, 4.0f, 4096.0f, FTZ_OFF, unaryF, 4096.0f),
     ENTRY(asinh, 4.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY(asinpi, 5.0f, 5.0f, FTZ_OFF, unaryF),
-    ENTRY(atan, 5.0f, 5.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(atan, 5.0f, 5.0f, 4096.0f, FTZ_OFF, unaryF, 4096.0f),
     ENTRY(atanh, 5.0f, 5.0f, FTZ_OFF, unaryF),
     ENTRY(atanpi, 5.0f, 5.0f, FTZ_OFF, unaryF),
     ENTRY(atan2, 6.0f, 6.0f, FTZ_OFF, binaryF),
@@ -152,7 +152,8 @@ const Func functionList[] = {
     ENTRY_EXT(cos, 4.0f, 4.0f, 0.00048828125f, FTZ_OFF, unaryF,
               0.00048828125f), // relaxed ulp 2^-11
     ENTRY(cosh, 4.0f, 4.0f, FTZ_OFF, unaryF),
-    ENTRY(cospi, 4.0f, 4.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(cospi, 4.0f, 4.0f, 0.00048828125f, FTZ_OFF, unaryF,
+              0.00048828125f), // relaxed ulp 2^-11
     //                                  ENTRY( erfc,                  16.0f,
     //                                  16.0f,         FTZ_OFF,     unaryF),
     //                                  //disabled for 1.0 due to lack of
@@ -202,7 +203,8 @@ const Func functionList[] = {
               4.76837158203125e-7f), // relaxed ulp 2^-21
     ENTRY_EXT(log2, 3.0f, 4.0f, 4.76837158203125e-7f, FTZ_OFF, unaryF,
               4.76837158203125e-7f), // relaxed ulp 2^-21
-    ENTRY(log10, 3.0f, 4.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(log10, 3.0f, 4.0f, 4.76837158203125e-7f, FTZ_OFF, unaryF,
+              4.76837158203125e-7f), // relaxed ulp 2^-21
     ENTRY(log1p, 2.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY(logb, 0.0f, 0.0f, FTZ_OFF, unaryF),
     ENTRY_EXT(mad, INFINITY, INFINITY, INFINITY, FTZ_OFF, mad_function,
@@ -233,7 +235,8 @@ const Func functionList[] = {
     ENTRY_EXT(sincos, 4.0f, 4.0f, 0.00048828125f, FTZ_OFF, unaryF_two_results,
               0.00048828125f), // relaxed ulp 2^-11
     ENTRY(sinh, 4.0f, 4.0f, FTZ_OFF, unaryF),
-    ENTRY(sinpi, 4.0f, 4.0f, FTZ_OFF, unaryF),
+    ENTRY_EXT(sinpi, 4.0f, 4.0f, 0.00048828125f, FTZ_OFF, unaryF,
+              0.00048828125f), // relaxed ulp 2^-11
     { "sqrt",
       "sqrt",
       { (void*)reference_sqrt },

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -124,6 +124,8 @@ double reference_cospi( double x)
     return reference_sin( x * M_PI );
 }
 
+double reference_relaxed_cospi(double x) { return reference_cospi(x); }
+
 double reference_relaxed_divide( double x, double y ) { return (float)(((float) x ) / ( (float) y )); }
 
 double reference_divide( double x, double y ) { return x / y; }
@@ -719,6 +721,8 @@ double reference_sinpi( double x)
     return reference_sin( r * M_PI );
 }
 
+double reference_relaxed_sinpi(double x) { return reference_sinpi(x); }
+
 double reference_tanpi( double x)
 {
     // set aside the sign  (allows us to preserve sign of -0)
@@ -1199,6 +1203,8 @@ double reference_atanh( double x )
 
     return signed_half * reference_log1p(2.0 * x / (1-x));
 }
+
+double reference_relaxed_atan(double x) { return reference_atan(x); }
 
 double reference_relaxed_exp2( double x )
 {
@@ -5263,6 +5269,8 @@ long double reference_acosl(long double x)
     return head + ((y + tail) - x);
 }
 
+double reference_relaxed_acos(double x) { return reference_acos(x); }
+
 double reference_log10(double x)
 {
     if( x == 0.0 )
@@ -5279,6 +5287,8 @@ double reference_log10(double x)
     __log2_ep(&logxHi, &logxLo, x);
     return logxHi*log2Hi;
 }
+
+double reference_relaxed_log10(double x) { return reference_log10(x); }
 
 long double reference_log10l(long double x)
 {
@@ -5409,6 +5419,8 @@ double reference_asin(double x)
 {
     return asin( x );
 }
+
+double reference_relaxed_asin(double x) { return reference_asin(x); }
 
 double reference_fabs(double x)
 {

--- a/test_conformance/math_brute_force/reference_math.h
+++ b/test_conformance/math_brute_force/reference_math.h
@@ -117,10 +117,15 @@ double reference_assignment( double x );
 int    reference_not( double x );
 // -- for testing fast-relaxed
 
+double reference_relaxed_acos(double);
+double reference_relaxed_asin(double);
+double reference_relaxed_atan(double);
 double reference_relaxed_mad( double, double, double );
 double reference_relaxed_divide( double x, double y );
 double reference_relaxed_sin( double x );
+double reference_relaxed_sinpi(double x);
 double reference_relaxed_cos( double x );
+double reference_relaxed_cospi(double x);
 double reference_relaxed_sincos( double x, double * y);
 double reference_relaxed_tan( double x );
 double reference_relaxed_exp( double x );
@@ -128,6 +133,7 @@ double reference_relaxed_exp2( double x );
 double reference_relaxed_exp10( double x );
 double reference_relaxed_log( double x );
 double reference_relaxed_log2( double x );
+double reference_relaxed_log10(double x);
 double reference_relaxed_pow( double x, double y);
 double reference_relaxed_reciprocal( double x );
 

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -629,6 +629,15 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
                         fail = ! (fabsf(abs_error) <= ulps);
                         use_abs_error = 1;
                     }
+                    if (strcmp(fname, "sinpi") == 0
+                        || strcmp(fname, "cospi") == 0)
+                    {
+                        if (s[j] >= -1.0 && s[j] <= 1.0)
+                        {
+                            fail = !(fabsf(abs_error) <= ulps);
+                            use_abs_error = 1;
+                        }
+                    }
 
                     if ( strcmp(fname, "reciprocal") == 0 )
                     {
@@ -663,7 +672,8 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
                         }
                         // Else fast math derived implementation does not require ULP verification
                     }
-                    if ( strcmp(fname,"log") == 0 || strcmp(fname,"log2") == 0 )
+                    if (strcmp(fname, "log") == 0 || strcmp(fname, "log2") == 0
+                        || strcmp(fname, "log10") == 0)
                     {
                         if( s[j] >= 0.5 && s[j] <= 2 )
                         {
@@ -674,7 +684,6 @@ static cl_int TestFloat( cl_uint job_id, cl_uint thread_id, void *data )
                             ulps = gIsEmbedded ? job->f->float_embedded_ulps : job->f->float_ulps;
                             fail = ! (fabsf(err) <= ulps);
                         }
-
                     }
 
 


### PR DESCRIPTION
* Add relaxed tests for functions (in an implementation that uses
  derived functions) that define an absolute ULP precision requirement,
  but were not tested in the current conformance suite
  * acos
  * asin
  * atan
  * cospi
  * sinpi
  * log10

I've tested these changes (via clvk) on an AMD, Arm, Nvidia and Qualcomm gpu. 