### PR TITLE
Reduce number of compilations in buffer suite

### DIFF
--- a/test_conformance/buffers/test_buffer_fill.cpp
+++ b/test_conformance/buffers/test_buffer_fill.cpp
@@ -696,7 +696,7 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
     void        *outptr;
     TestStruct  *inptr;
     TestStruct  *hostptr;
-    TestStruct  *pattern;
+    TestStruct pattern;
     clProgramWrapper program;
     clKernelWrapper kernel;
     clEventWrapper event[2];
@@ -724,9 +724,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
         if (err)
         {
             log_error(" Error creating program for struct\n");
-            free((void *)pattern);
-            align_free((void *)inptr);
-            align_free((void *)hostptr);
             free_mtdata(d);
             return -1;
         }
@@ -741,9 +738,8 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             log_info("Testing random fill from offset %d for %d elements: \n",
                      (int)offset_elements, (int)fill_elements);
 
-            pattern = (TestStruct *)malloc(ptrSize);
-            pattern->a = (cl_int)genrand_int32(d);
-            pattern->b = (cl_float)get_random_float(-FLT_MAX, FLT_MAX, d);
+            pattern.a = (cl_int)genrand_int32(d);
+            pattern.b = (cl_float)get_random_float(-FLT_MAX, FLT_MAX, d);
 
             inptr = (TestStruct *)align_malloc(ptrSize * num_elements,
                                                min_alignment);
@@ -754,8 +750,8 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             }
             for (j = offset_elements; j < offset_elements + fill_elements; j++)
             {
-                inptr[j].a = pattern->a;
-                inptr[j].b = pattern->b;
+                inptr[j].a = pattern.a;
+                inptr[j].b = pattern.b;
             }
             for (j = offset_elements + fill_elements; j < (size_t)num_elements;
                  j++)
@@ -774,7 +770,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 buffers[0] = clCreateBuffer(context, flag_set[src_flag_id],  ptrSize * num_elements, NULL, &err);
             if ( err ){
                 print_error(err, " clCreateBuffer failed\n" );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -784,7 +779,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
                 err = clEnqueueWriteBuffer(queue, buffers[0], CL_FALSE, 0, ptrSize * num_elements, hostptr, 0, NULL, NULL);
                 if ( err != CL_SUCCESS ){
                     print_error(err, " clEnqueueWriteBuffer failed\n" );
-                    free( (void *)pattern );
                     align_free( (void *)inptr );
                     align_free( (void *)hostptr );
                     free_mtdata(d);
@@ -797,23 +791,21 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             if ( ! buffers[1] || err){
                 print_error(err, " clCreateBuffer failed\n" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
                 return -1;
             }
 
-            err = clEnqueueFillBuffer(queue, buffers[0], pattern, ptrSize,
-                                      ptrSize * offset_elements, ptrSize * fill_elements,
-                                      0, NULL, &(event[0]));
+            err = clEnqueueFillBuffer(
+                queue, buffers[0], &pattern, ptrSize, ptrSize * offset_elements,
+                ptrSize * fill_elements, 0, NULL, &(event[0]));
             /* uncomment for test debugging
              err = clEnqueueWriteBuffer(queue, buffers[0], CL_FALSE, 0, ptrSize * num_elements, inptr, 0, NULL, &(event[0]));
              */
             if ( err != CL_SUCCESS ){
                 print_error( err, " clEnqueueFillBuffer failed" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -825,7 +817,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             if ( err != CL_SUCCESS ){
                 print_error( err, " clSetKernelArg failed" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -836,7 +827,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             if ( err != CL_SUCCESS ){
                 print_error( err, "clWaitForEvents() failed" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -848,7 +838,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             if ( err != CL_SUCCESS ){
                 print_error( err, " clEnqueueNDRangeKernel failed" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -859,7 +848,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             if ( err != CL_SUCCESS ){
                 print_error( err, " clEnqueueReadBuffer failed" );
                 align_free( outptr );
-                free( (void *)pattern );
                 align_free( (void *)inptr );
                 align_free( (void *)hostptr );
                 free_mtdata(d);
@@ -881,7 +869,6 @@ int test_buffer_fill_struct( cl_device_id deviceID, cl_context context, cl_comma
             }
             // cleanup
             align_free( outptr );
-            free((void *)pattern);
             align_free((void *)inptr);
             align_free((void *)hostptr);
         } // src cl_mem_flag

--- a/test_conformance/buffers/test_buffer_map.cpp
+++ b/test_conformance/buffers/test_buffer_map.cpp
@@ -588,7 +588,6 @@ static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_c
         if (err)
         {
             log_error(" Error creating program for %s\n", type);
-            align_free(outptr[i]);
             return -1;
         }
 

--- a/test_conformance/buffers/test_buffer_map.cpp
+++ b/test_conformance/buffers/test_buffer_map.cpp
@@ -554,10 +554,10 @@ static int verify_read_struct( void *ptr, int n )
 static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements, size_t size, char *type, int loops,
                                  const char *kernelCode[], const char *kernelName[], int (*fn)(void *,int) )
 {
-    cl_mem      buffers[5];
+    clMemWrapper buffers[5];
     void        *outptr[5];
-    cl_program  program[5];
-    cl_kernel   kernel[5];
+    clProgramWrapper program[5];
+    clKernelWrapper kernel[5];
     size_t      threads[3], localThreads[3];
     cl_int      err;
     int         i;
@@ -580,10 +580,21 @@ static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_c
     if (! gHasLong && strstr(type,"long"))
         return 0;
 
-    for (src_flag_id=0; src_flag_id < NUM_FLAGS; src_flag_id++) {
-        log_info("Testing with cl_mem_flags src: %s\n", flag_set_names[src_flag_id]);
+    for (i = 0; i < loops; i++)
+    {
 
-        for ( i = 0; i < loops; i++ ){
+        err = create_single_kernel_helper(context, &program[i], &kernel[i], 1,
+                                          &kernelCode[i], kernelName[i]);
+        if (err)
+        {
+            log_error(" Error creating program for %s\n", type);
+            align_free(outptr[i]);
+            return -1;
+        }
+
+        for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
+        {
+
             outptr[i] = align_malloc( ptrSizes[i] * num_elements, min_alignment);
             if ( ! outptr[i] ){
                 log_error( " unable to allocate %d bytes of memory\n", (int)ptrSizes[i] * num_elements );
@@ -602,20 +613,9 @@ static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_c
                 return -1;
             }
 
-            err = create_single_kernel_helper(context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i] );
-            if ( err ){
-                log_error( " Error creating program for %s\n", type );
-                clReleaseMemObject( buffers[i] );
-                align_free( outptr[i] );
-                return -1;
-            }
-
             err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&buffers[i] );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clSetKernelArg failed\n" );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
-                clReleaseMemObject( buffers[i] );
                 align_free( outptr[i] );
                 return -1;
             }
@@ -628,9 +628,6 @@ static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_c
             err = clEnqueueNDRangeKernel( queue, kernel[i], 1, NULL, threads, localThreads, 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueNDRangeKernel failed\n" );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
-                clReleaseMemObject( buffers[i] );
                 align_free( outptr[i] );
                 return -1;
             }
@@ -638,28 +635,22 @@ static int test_buffer_map_read( cl_device_id deviceID, cl_context context, cl_c
             mappedPtr = clEnqueueMapBuffer(queue, buffers[i], CL_TRUE, CL_MAP_READ, 0, ptrSizes[i]*num_elements, 0, NULL, NULL, &err);
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueMapBuffer failed" );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
-                clReleaseMemObject( buffers[i] );
                 align_free( outptr[i] );
                 return -1;
             }
 
             if (fn(mappedPtr, num_elements*(1<<i))){
-                log_error(" %s%d test failed\n", type, 1<<i);
+                log_error(" %s%d test failed. cl_mem_flags src: %s\n", type,
+                          1 << i, flag_set_names[src_flag_id]);
                 total_errors++;
             }
             else{
-                log_info(" %s%d test passed\n", type, 1<<i);
+                log_info(" %s%d test passed. cl_mem_flags src: %s\n", type,
+                         1 << i, flag_set_names[src_flag_id]);
             }
 
             err = clEnqueueUnmapMemObject(queue, buffers[i], mappedPtr, 0, NULL, NULL);
             test_error(err, "clEnqueueUnmapMemObject failed");
-
-            // cleanup
-            clReleaseKernel( kernel[i] );
-            clReleaseProgram( program[i] );
-            clReleaseMemObject( buffers[i] );
 
             // If we are using the outptr[i] as backing via USE_HOST_PTR we need to make sure we are done before freeing.
             if ((flag_set[src_flag_id] & CL_MEM_USE_HOST_PTR)) {

--- a/test_conformance/buffers/test_buffer_read.cpp
+++ b/test_conformance/buffers/test_buffer_read.cpp
@@ -621,11 +621,11 @@ static int verify_read_struct(TestStruct *outptr, int n)
 int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements, size_t size, char *type, int loops,
                       const char *kernelCode[], const char *kernelName[], int (*fn)(void *,int) )
 {
-    cl_mem      buffers[5];
+    clMemWrapper buffers[5];
     void        *outptr[5];
     void        *inptr[5];
-    cl_program  program[5];
-    cl_kernel   kernel[5];
+    clProgramWrapper program[5];
+    clKernelWrapper kernel[5];
     size_t      global_work_size[3];
     cl_int      err;
     int         i;
@@ -650,10 +650,23 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
         return CL_SUCCESS;
     }
 
-    for (src_flag_id=0; src_flag_id < NUM_FLAGS; src_flag_id++) {
-        log_info("Testing with cl_mem_flags src: %s\n", flag_set_names[src_flag_id]);
+    for (i = 0; i < loops; i++)
+    {
 
-        for ( i = 0; i < loops; i++ ){
+        err = create_single_kernel_helper(context, &program[i], &kernel[i], 1,
+                                          &kernelCode[i], kernelName[i]);
+        if (err)
+        {
+            log_error("Creating program for %s\n", type);
+            print_error(err, " Error creating program ");
+            align_free(outptr[i]);
+            align_free(inptr[i]);
+            return -1;
+        }
+
+        for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
+        {
+
             outptr[i] = align_malloc( ptrSizes[i] * num_elements, min_alignment);
             if ( ! outptr[i] ){
                 log_error( " unable to allocate %d bytes for outptr\n", (int)( ptrSizes[i] * num_elements ) );
@@ -677,22 +690,9 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
                 return -1;
             }
 
-            err = create_single_kernel_helper(  context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i] );
-            if ( err ){
-                log_error("Creating program for %s\n", type);
-                print_error(err,  " Error creating program " );
-                clReleaseMemObject(buffers[i]);
-                align_free( outptr[i] );
-                align_free( inptr[i] );
-                return -1;
-            }
-
             err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&buffers[i] );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clSetKernelArg failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -701,9 +701,6 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
             err = clEnqueueNDRangeKernel( queue, kernel[i], 1, NULL, global_work_size, NULL, 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueNDRangeKernel failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -712,28 +709,24 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
             err = clEnqueueReadBuffer( queue, buffers[i], CL_TRUE, 0, ptrSizes[i]*num_elements, outptr[i], 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueReadBuffer failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
             }
 
             if (fn(outptr[i], num_elements*(1<<i))){
-                log_error( " %s%d test failed\n", type, 1<<i );
+                log_error(" %s%d test failed. cl_mem_flags src: %s\n", type,
+                          1 << i, flag_set_names[src_flag_id]);
                 total_errors++;
             }
             else{
-                log_info( " %s%d test passed\n", type, 1<<i );
+                log_info(" %s%d test passed. cl_mem_flags src: %s\n", type,
+                         1 << i, flag_set_names[src_flag_id]);
             }
 
             err = clEnqueueReadBuffer( queue, buffers[i], CL_TRUE, 0, ptrSizes[i]*num_elements, inptr[i], 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueReadBuffer failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -749,9 +742,6 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
 
 
             // cleanup
-            clReleaseMemObject( buffers[i] );
-            clReleaseKernel( kernel[i] );
-            clReleaseProgram( program[i] );
             align_free( outptr[i] );
             align_free( inptr[i] );
         }
@@ -764,10 +754,10 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
 int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements, size_t size, char *type, int loops,
                             const char *kernelCode[], const char *kernelName[], int (*fn)(void *,int) )
 {
-    cl_mem      buffers[5];
-    cl_program  program[5];
-    cl_kernel   kernel[5];
-    cl_event    event;
+    clMemWrapper buffers[5];
+    clProgramWrapper program[5];
+    clKernelWrapper kernel[5];
+    clEventWrapper event;
     void        *outptr[5];
     void        *inptr[5];
     size_t      global_work_size[3];
@@ -795,10 +785,22 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
         return CL_SUCCESS;
     }
 
-    for (src_flag_id=0; src_flag_id < NUM_FLAGS; src_flag_id++) {
-        log_info("Testing with cl_mem_flags src: %s\n", flag_set_names[src_flag_id]);
+    for (i = 0; i < loops; i++)
+    {
 
-        for ( i = 0; i < loops; i++ ){
+        err = create_single_kernel_helper(context, &program[i], &kernel[i], 1,
+                                          &kernelCode[i], kernelName[i]);
+        if (err)
+        {
+            log_error(" Error creating program for %s\n", type);
+            align_free(outptr[i]);
+            align_free(inptr[i]);
+            return -1;
+        }
+
+        for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
+        {
+
             outptr[i] = align_malloc(ptrSizes[i] * num_elements, min_alignment);
             if ( ! outptr[i] ){
                 log_error( " unable to allocate %d bytes for outptr\n", (int)(ptrSizes[i] * num_elements) );
@@ -824,21 +826,9 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
                 return -1;
             }
 
-            err = create_single_kernel_helper( context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i]);
-            if ( err ){
-                log_error( " Error creating program for %s\n", type );
-                clReleaseMemObject( buffers[i] );
-                align_free( outptr[i] );
-                align_free( inptr[i] );
-                return -1;
-            }
-
             err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&buffers[i] );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clSetKernelArg failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -847,9 +837,6 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
             err = clEnqueueNDRangeKernel( queue, kernel[i], 1, NULL, global_work_size, NULL, 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueNDRangeKernel failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -865,9 +852,6 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
 #endif
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueReadBuffer failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -875,27 +859,22 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
             err = clWaitForEvents(1, &event );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clWaitForEvents() failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
             }
 
             if ( fn(outptr[i], num_elements*(1<<i)) ){
-                log_error( " %s%d test failed\n", type, 1<<i );
+                log_error(" %s%d test failed. cl_mem_flags src: %s\n", type,
+                          1 << i, flag_set_names[src_flag_id]);
                 total_errors++;
             }
             else{
-                log_info( " %s%d test passed\n", type, 1<<i );
+                log_info(" %s%d test passed. cl_mem_flags src: %s\n", type,
+                         1 << i, flag_set_names[src_flag_id]);
             }
 
             // cleanup
-            clReleaseEvent( event );
-            clReleaseMemObject( buffers[i] );
-            clReleaseKernel( kernel[i] );
-            clReleaseProgram( program[i] );
             align_free( outptr[i] );
             align_free( inptr[i] );
         }
@@ -910,10 +889,10 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
 int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements, size_t size, char *type, int loops,
                                     const char *kernelCode[], const char *kernelName[], int (*fn)(void *,int) )
 {
-    cl_mem      buffers[5];
-    cl_program  program[5];
-    cl_kernel   kernel[5];
-    cl_event    event;
+    clMemWrapper buffers[5];
+    clProgramWrapper program[5];
+    clKernelWrapper kernel[5];
+    clEventWrapper event;
     void        *outptr[5], *inptr[5];
     size_t      global_work_size[3];
     cl_int      err;
@@ -940,10 +919,22 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
         return CL_SUCCESS;
     }
 
-    for (src_flag_id=0; src_flag_id < NUM_FLAGS; src_flag_id++) {
-        log_info("Testing with cl_mem_flags src: %s\n", flag_set_names[src_flag_id]);
+    for (i = 0; i < loops; i++)
+    {
 
-        for ( i = 0; i < loops; i++ ){
+        err = create_single_kernel_helper(context, &program[i], &kernel[i], 1,
+                                          &kernelCode[i], kernelName[i]);
+        if (err)
+        {
+            log_error(" Error creating program for %s\n", type);
+            align_free(outptr[i]);
+            align_free(inptr[i]);
+            return -1;
+        }
+
+        for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
+        {
+
             outptr[i] = align_malloc(ptrSizes[i] * num_elements, min_alignment);
             if ( ! outptr[i] ){
                 log_error( " unable to allocate %d bytes for outptr\n", (int)(ptrSizes[i] * num_elements) );
@@ -968,21 +959,9 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
                 return -1;
             }
 
-            err = create_single_kernel_helper(  context, &program[i], &kernel[i], 1, &kernelCode[i], kernelName[i] );
-            if ( err ){
-                log_error( " Error creating program for %s\n", type );
-                clReleaseMemObject( buffers[i] );
-                align_free( outptr[i] );
-                align_free( inptr[i] );
-                return -1;
-            }
-
             err = clSetKernelArg( kernel[i], 0, sizeof( cl_mem ), (void *)&buffers[i] );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clSetKernelArgs failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -991,9 +970,6 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
             err = clEnqueueNDRangeKernel( queue, kernel[i], 1, NULL, global_work_size, NULL, 0, NULL, NULL );
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueNDRangeKernel failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -1009,9 +985,6 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
 #endif
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueReadBuffer failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
@@ -1019,9 +992,6 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
             err = clEnqueueBarrierWithWaitList(queue, 0, NULL, NULL);
             if ( err != CL_SUCCESS ){
                 print_error( err, "clEnqueueBarrierWithWaitList() failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 return -1;
             }
@@ -1029,27 +999,22 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
             err = clWaitForEvents(1, &event);
             if ( err != CL_SUCCESS ){
                 print_error( err, "clWaitForEvents() failed" );
-                clReleaseMemObject( buffers[i] );
-                clReleaseKernel( kernel[i] );
-                clReleaseProgram( program[i] );
                 align_free( outptr[i] );
                 align_free( inptr[i] );
                 return -1;
             }
 
             if ( fn(outptr[i], num_elements*(1<<i)) ){
-                log_error(" %s%d test failed\n", type, 1<<i);
+                log_error(" %s%d test failed. cl_mem_flags src: %s\n", type,
+                          1 << i, flag_set_names[src_flag_id]);
                 total_errors++;
             }
             else{
-                log_info(" %s%d test passed\n", type, 1<<i);
+                log_info(" %s%d test passed. cl_mem_flags src: %s\n", type,
+                         1 << i, flag_set_names[src_flag_id]);
             }
 
             // cleanup
-            clReleaseEvent( event );
-            clReleaseMemObject( buffers[i] );
-            clReleaseKernel( kernel[i] );
-            clReleaseProgram( program[i] );
             align_free( outptr[i] );
             align_free( inptr[i] );
         }

--- a/test_conformance/buffers/test_buffer_read.cpp
+++ b/test_conformance/buffers/test_buffer_read.cpp
@@ -659,8 +659,6 @@ int test_buffer_read( cl_device_id deviceID, cl_context context, cl_command_queu
         {
             log_error("Creating program for %s\n", type);
             print_error(err, " Error creating program ");
-            align_free(outptr[i]);
-            align_free(inptr[i]);
             return -1;
         }
 
@@ -793,8 +791,6 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
         if (err)
         {
             log_error(" Error creating program for %s\n", type);
-            align_free(outptr[i]);
-            align_free(inptr[i]);
             return -1;
         }
 
@@ -927,8 +923,6 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
         if (err)
         {
             log_error(" Error creating program for %s\n", type);
-            align_free(outptr[i]);
-            align_free(inptr[i]);
             return -1;
         }
 

--- a/test_conformance/buffers/test_buffer_write.cpp
+++ b/test_conformance/buffers/test_buffer_write.cpp
@@ -652,7 +652,6 @@ int test_buffer_write( cl_device_id deviceID, cl_context context, cl_command_que
                                           &kernelCode[i], kernelName[i]);
         if (err)
         {
-            align_free(outptr[i]);
             log_error(" Error creating program for %s\n", type);
             return -1;
         }
@@ -810,7 +809,6 @@ int test_buffer_write_struct( cl_device_id deviceID, cl_context context, cl_comm
                                           "read_write_struct");
         if (err)
         {
-            align_free(outptr[i]);
             log_error(" Error creating program for struct\n");
             free_mtdata(d);
             return -1;


### PR DESCRIPTION
Extracts program and kernel compilation from mem_flags loop
as they were being recompiled unnecessarily.

Fixes #1020

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>