### PR TITLE
Validate CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED

### DIFF
--- a/test_conformance/computeinfo/CMakeLists.txt
+++ b/test_conformance/computeinfo/CMakeLists.txt
@@ -4,6 +4,7 @@ set(${MODULE_NAME}_SOURCES
         main.cpp
         device_uuid.cpp
         extended_versioning.cpp
+        conforming_version.cpp
 )
 
 include(../CMakeCommon.txt)

--- a/test_conformance/computeinfo/conforming_version.cpp
+++ b/test_conformance/computeinfo/conforming_version.cpp
@@ -1,0 +1,37 @@
+
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <regex>
+#include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+
+int test_conformance_version(cl_device_id deviceID, cl_context context,
+                             cl_command_queue ignoreQueue, int num_elements)
+{
+    auto version_string{ get_device_info_string(
+        deviceID, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED) };
+
+    // Latest conformance version passed should match vYYYY-MM-DD-XX, where XX
+    // is a number
+    std::regex valid_format("^v\\d{4}-(((0)[1-9])|((1)[0-2]))-((0)[1-9]|[1-2]["
+                            "0-9]|(3)[0-1])-[0-9][0-9]$");
+    test_assert_error(
+        std::regex_match(version_string, valid_format),
+        "CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED does not return "
+        "valid format vYYYY-MM-DD-XX");
+
+    return TEST_PASS;
+}

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1422,10 +1422,14 @@ extern int test_extended_versioning(cl_device_id, cl_context, cl_command_queue,
                                     int);
 extern int test_device_uuid(cl_device_id, cl_context, cl_command_queue, int);
 
+extern int test_conformance_version(cl_device_id, cl_context, cl_command_queue,
+                                    int);
+
 test_definition test_list[] = {
     ADD_TEST(computeinfo),
     ADD_TEST(extended_versioning),
     ADD_TEST(device_uuid),
+    ADD_TEST_VERSION(conformance_version, Version(3, 0))
 };
 
 const int test_num = ARRAY_SIZE(test_list);


### PR DESCRIPTION
Adding test to validate value returned from clGetDeviceInfo with
CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED.

Fixes #993

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>