### PR TITLE
Move TEST_SKIPPED_ITSELF to test_status in testHarness

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -482,6 +482,7 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
                 case TEST_PASS: break;
                 case TEST_FAIL: return fail_init_info(testNum);
                 case TEST_SKIP: return skip_init_info(testNum);
+                case TEST_SKIPPED_ITSELF: return skip_init_info(testNum);
             }
         }
     }
@@ -495,6 +496,7 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
             case TEST_PASS: break;
             case TEST_FAIL: return fail_init_info(testNum);
             case TEST_SKIP: return skip_init_info(testNum);
+            case TEST_SKIPPED_ITSELF: return skip_init_info(testNum);
         }
     }
 

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -80,6 +80,7 @@ typedef enum test_status
     TEST_PASS = 0,
     TEST_FAIL = 1,
     TEST_SKIP = 2,
+    TEST_SKIPPED_ITSELF = -100,
 } test_status;
 
 extern int gFailCount;

--- a/test_common/harness/threadTesting.h
+++ b/test_common/harness/threadTesting.h
@@ -22,8 +22,6 @@
 #include <CL/opencl.h>
 #endif
 
-#define TEST_SKIPPED_ITSELF -100
-
 typedef int (*basefn)(cl_device_id deviceID, cl_context context,
                       cl_command_queue queue, int num_elements);
 extern int test_threaded_function(basefn fnToTest, cl_device_id device,


### PR DESCRIPTION
TEST_SKIPPED_ITSELF was originally located in
threadTesting.h but this no longer makes sense.
This change moves the definition to the test_status
struct in testHarness so that it can be used in the same
way that test_status' can be used.

Signed-off-by: Chetankumar Mistry <chetan.mistry@arm.com>