### PR TITLE
Fix implicit int->float warning inside kernel

### DIFF
--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -46,7 +46,7 @@ const char *options_test_kernel[] = {
 "__kernel void sample_test(__global float *src, __global int *dst)\n"
 "{\n"
 "    size_t tid = get_global_id(0);\n"
-"    dst[tid] = src[tid];\n"
+"    dst[tid] = (int)src[tid];\n"
 "}\n" };
 
 const char *optimization_options[] = {

--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -43,11 +43,12 @@ const char *include_test_kernel[] = {
 "}\n" };
 
 const char *options_test_kernel[] = {
-"__kernel void sample_test(__global float *src, __global int *dst)\n"
-"{\n"
-"    size_t tid = get_global_id(0);\n"
-"    dst[tid] = (int)src[tid];\n"
-"}\n" };
+    "__kernel void sample_test(__global float *src, __global int *dst)\n"
+    "{\n"
+    "    size_t tid = get_global_id(0);\n"
+    "    dst[tid] = (int)src[tid];\n"
+    "}\n"
+};
 
 const char *optimization_options[] = {
     "-cl-single-precision-constant",


### PR DESCRIPTION
This kernel is used to test various compiler options including `-Werror`. Some compilers produce a warning about the implicit conversion which results in this test failing when `-Werror` is used.

This first commit contains the trivial change. The second is just formatting.