### PR TITLE
Use glFinish to replace glFlush

### DIFF
--- a/test_conformance/gl/test_buffers.cpp
+++ b/test_conformance/gl/test_buffers.cpp
@@ -184,7 +184,7 @@ int test_buffer_kernel(cl_context context, cl_command_queue queue, ExplicitType 
     glBufferData( GL_ARRAY_BUFFER, bufferSize, outDataGL, GL_STATIC_DRAW );
 
     glBindBuffer( GL_ARRAY_BUFFER, 0 );
-    glFlush();
+    glFinish();
 
 
     /* Generate some streams. The first and last ones are GL, middle one just vanilla CL */

--- a/test_conformance/gl/test_image_methods.cpp
+++ b/test_conformance/gl/test_image_methods.cpp
@@ -287,10 +287,10 @@ int test_image_format_methods( cl_device_id device, cl_context context, cl_comma
     error = clSetKernelArg( kernel, 1, sizeof( outDataBuffer ), &outDataBuffer );
     test_error( error, "Unable to set kernel argument" );
 
-  // Flush and Acquire.
-  glFlush();
-  error = (*clEnqueueAcquireGLObjects_ptr)( queue, 1, &image, 0, NULL, NULL);
-  test_error( error, "Unable to acquire GL obejcts");
+    // Finish and Acquire.
+    glFinish();
+    error = (*clEnqueueAcquireGLObjects_ptr)(queue, 1, &image, 0, NULL, NULL);
+    test_error(error, "Unable to acquire GL obejcts");
 
     size_t threads[1] = { 1 }, localThreads[1] = { 1 };
 


### PR DESCRIPTION
In OpenCL spec 1.1:
"Prior to calling clEnqueueAcquireGLObjects, the application must ensure that any pending GL
operations which access the objects specified in mem_objects have completed. This may be
accomplished portably by issuing and waiting for completion of a glFinish command on all GL
contexts with pending references to these objects."

Without this change, there were data errors in a busy GPU or faster CPU.

Signed-off-by: Alex Xie <AlexBin.Xie@amd.com>