### PR TITLE
Use std::vector for format lists in images suite

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -3571,8 +3571,8 @@ cl_float CoordWalker::Get(size_t idx, size_t el)
 }
 
 
-void print_read_header(const cl_image_format *format, image_sampler_data *sampler,
-                       bool err, int t)
+void print_read_header(const cl_image_format *format,
+                       image_sampler_data *sampler, bool err, int t)
 {
     const char *addressMode = NULL;
     const char *normalizedNames[2] = { "UNNORMALIZED", "NORMALIZED" };

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -269,7 +269,7 @@ int is_format_signed(const cl_image_format *format)
     }
 }
 
-uint32_t get_pixel_size(cl_image_format *format)
+uint32_t get_pixel_size(const cl_image_format *format)
 {
     switch (format->image_channel_data_type)
     {
@@ -330,7 +330,7 @@ uint32_t next_power_of_two(uint32_t v)
     return v;
 }
 
-uint32_t get_pixel_alignment(cl_image_format *format)
+uint32_t get_pixel_alignment(const cl_image_format *format)
 {
     return next_power_of_two(get_pixel_size(format));
 }
@@ -533,7 +533,7 @@ bool is_sRGBA_order(cl_channel_order image_channel_order)
 
 // Format helpers
 
-int has_alpha(cl_image_format *format)
+int has_alpha(const cl_image_format *format)
 {
     switch (format->image_channel_order)
     {
@@ -586,7 +586,7 @@ void get_max_sizes(
     size_t maxWidth, size_t maxHeight, size_t maxDepth, size_t maxArraySize,
     const cl_ulong maxIndividualAllocSize, // CL_DEVICE_MAX_MEM_ALLOC_SIZE
     const cl_ulong maxTotalAllocSize, // CL_DEVICE_GLOBAL_MEM_SIZE
-    cl_mem_object_type image_type, cl_image_format *format,
+    cl_mem_object_type image_type, const cl_image_format *format,
     int usingMaxPixelSizeBuffer)
 {
 
@@ -797,7 +797,7 @@ void get_max_sizes(
     }
 }
 
-float get_max_absolute_error(cl_image_format *format,
+float get_max_absolute_error(const cl_image_format *format,
                              image_sampler_data *sampler)
 {
     if (sampler->filter_mode == CL_FILTER_NEAREST) return 0.0f;
@@ -816,7 +816,7 @@ float get_max_absolute_error(cl_image_format *format,
     }
 }
 
-float get_max_relative_error(cl_image_format *format,
+float get_max_relative_error(const cl_image_format *format,
                              image_sampler_data *sampler, int is3D,
                              int isLinearFilter)
 {
@@ -899,7 +899,7 @@ float get_max_relative_error(cl_image_format *format,
     return maxError;
 }
 
-size_t get_format_max_int(cl_image_format *format)
+size_t get_format_max_int(const cl_image_format *format)
 {
     switch (format->image_channel_data_type)
     {
@@ -932,7 +932,7 @@ size_t get_format_max_int(cl_image_format *format)
     }
 }
 
-int get_format_min_int(cl_image_format *format)
+int get_format_min_int(const cl_image_format *format)
 {
     switch (format->image_channel_data_type)
     {
@@ -1247,7 +1247,7 @@ void read_image_pixel_float(void *imageData, image_descriptor *imageInfo, int x,
         return;
     }
 
-    cl_image_format *format = imageInfo->format;
+    const cl_image_format *format = imageInfo->format;
 
     unsigned int i;
     float tempData[4];
@@ -3571,7 +3571,7 @@ cl_float CoordWalker::Get(size_t idx, size_t el)
 }
 
 
-void print_read_header(cl_image_format *format, image_sampler_data *sampler,
+void print_read_header(const cl_image_format *format, image_sampler_data *sampler,
                        bool err, int t)
 {
     const char *addressMode = NULL;
@@ -3638,7 +3638,7 @@ void print_read_header(cl_image_format *format, image_sampler_data *sampler,
     }
 }
 
-void print_write_header(cl_image_format *format, bool err = false)
+void print_write_header(const cl_image_format *format, bool err = false)
 {
     if (err)
         log_error("[%-7s %-24s %d]\n",
@@ -3653,7 +3653,7 @@ void print_write_header(cl_image_format *format, bool err = false)
 }
 
 
-void print_header(cl_image_format *format, bool err = false)
+void print_header(const cl_image_format *format, bool err = false)
 {
     if (err)
     {

--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -76,11 +76,11 @@ int round_to_even(float v);
 #define CONVERT_UINT(v, max, max_val)                                          \
     (v < 0 ? 0 : (v > max ? max_val : round_to_even(v)))
 
-extern void print_read_header(cl_image_format *format,
+extern void print_read_header(const cl_image_format *format,
                               image_sampler_data *sampler, bool err = false,
                               int t = 0);
-extern void print_write_header(cl_image_format *format, bool err);
-extern void print_header(cl_image_format *format, bool err);
+extern void print_write_header(const cl_image_format *format, bool err);
+extern void print_header(const cl_image_format *format, bool err);
 extern bool find_format(cl_image_format *formatList, unsigned int numFormats,
                         cl_image_format *formatToFind);
 extern bool is_image_format_required(cl_image_format format, cl_mem_flags flags,
@@ -98,7 +98,7 @@ extern uint32_t get_channel_order_channel_count(cl_channel_order order);
 cl_channel_type get_channel_type_from_name(const char *name);
 cl_channel_order get_channel_order_from_name(const char *name);
 extern int is_format_signed(const cl_image_format *format);
-extern uint32_t get_pixel_size(cl_image_format *format);
+extern uint32_t get_pixel_size(const cl_image_format *format);
 
 /* Helper to get any ol image format as long as it is 8-bits-per-channel */
 extern int get_8_bit_image_format(cl_context context,
@@ -123,7 +123,7 @@ typedef struct
     size_t rowPitch;
     size_t slicePitch;
     size_t arraySize;
-    cl_image_format *format;
+    const cl_image_format *format;
     cl_mem buffer;
     cl_mem_object_type type;
     cl_uint num_mip_levels;
@@ -139,9 +139,9 @@ void get_max_sizes(size_t *numberOfSizes, const int maxNumberOfSizes,
                    size_t maxDepth, size_t maxArraySize,
                    const cl_ulong maxIndividualAllocSize,
                    const cl_ulong maxTotalAllocSize,
-                   cl_mem_object_type image_type, cl_image_format *format,
+                   cl_mem_object_type image_type, const cl_image_format *format,
                    int usingMaxPixelSize = 0);
-extern size_t get_format_max_int(cl_image_format *format);
+extern size_t get_format_max_int(const cl_image_format *format);
 
 extern cl_ulong get_image_size(image_descriptor const *imageInfo);
 extern cl_ulong get_image_size_mb(image_descriptor const *imageInfo);
@@ -173,7 +173,7 @@ extern void copy_image_data(image_descriptor *srcImageInfo,
                             void *destImageValues, const size_t sourcePos[],
                             const size_t destPos[], const size_t regionSize[]);
 
-int has_alpha(cl_image_format *format);
+int has_alpha(const cl_image_format *format);
 
 extern bool is_sRGBA_order(cl_channel_order image_channel_order);
 
@@ -240,7 +240,7 @@ void read_image_pixel(void *imageData, image_descriptor *imageInfo, int x,
         return;
     }
 
-    cl_image_format *format = imageInfo->format;
+    const cl_image_format *format = imageInfo->format;
 
     unsigned int i;
     T tempData[4];
@@ -662,9 +662,9 @@ extern char *create_random_image_data(ExplicitType dataType,
 
 extern void get_sampler_kernel_code(image_sampler_data *imageSampler,
                                     char *outLine);
-extern float get_max_absolute_error(cl_image_format *format,
+extern float get_max_absolute_error(const cl_image_format *format,
                                     image_sampler_data *sampler);
-extern float get_max_relative_error(cl_image_format *format,
+extern float get_max_relative_error(const cl_image_format *format,
                                     image_sampler_data *sampler, int is3D,
                                     int isLinearFilter);
 

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -105,25 +105,15 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     int ret = 0;
 
     // Grab the list of supported image formats for integer reads
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
-    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
+    std::vector<cl_image_format> formatList;
+    if( get_format_list( context, imageType, formatList, flags ) )
         return -1;
 
-    filterFlags = new bool[ numFormats ];
-    if( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
-
-    filter_formats(formatList, filterFlags, numFormats, NULL);
+    std::vector<bool> filterFlags(formatList.size(), false);
+    filter_formats(formatList, filterFlags, nullptr);
 
     // Run the format list
-    for( unsigned int i = 0; i < numFormats; i++ )
+    for( unsigned int i = 0; i < formatList.size(); i++ )
     {
         int test_return = 0;
         if( filterFlags[i] )
@@ -167,9 +157,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
         ret += test_return;
     }
-
-    delete filterFlags;
-    delete formatList;
 
     return ret;
 }

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -106,14 +106,13 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     // Grab the list of supported image formats for integer reads
     std::vector<cl_image_format> formatList;
-    if( get_format_list( context, imageType, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
     filter_formats(formatList, filterFlags, nullptr);
 
     // Run the format list
-    for( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
         int test_return = 0;
         if( filterFlags[i] )

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -69,26 +69,16 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     int ret = 0;
 
     // Grab the list of supported image formats
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
-    if ( get_format_list( context, imageType, formatList, numFormats, flags ) )
+    std::vector<cl_image_format> formatList;
+    if ( get_format_list( context, imageType, formatList, flags ) )
         return -1;
-
-    filterFlags = new bool[ numFormats ];
-    if ( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
 
     for (auto test : imageTestTypes)
     {
         if (gTypesToTest & test.type)
         {
-            if (filter_formats(formatList, filterFlags, numFormats,
+            std::vector<bool> filterFlags(formatList.size(), false);
+            if (filter_formats(formatList, filterFlags,
                                test.channelTypes)
                 == 0)
             {
@@ -97,7 +87,7 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
             else
             {
                 // Run the format list
-                for (unsigned int i = 0; i < numFormats; i++)
+                for (unsigned int i = 0; i < formatList.size(); i++)
                 {
                     if (filterFlags[i])
                     {
@@ -124,9 +114,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
             }
         }
     }
-
-    delete[] filterFlags;
-    delete[] formatList;
 
     return ret;
 }

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -70,17 +70,14 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     // Grab the list of supported image formats
     std::vector<cl_image_format> formatList;
-    if ( get_format_list( context, imageType, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     for (auto test : imageTestTypes)
     {
         if (gTypesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
-            if (filter_formats(formatList, filterFlags,
-                               test.channelTypes)
-                == 0)
+            if (filter_formats(formatList, filterFlags, test.channelTypes) == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);
             }

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -29,28 +29,15 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
     int ret = 0;
 
     // Grab the list of supported image formats for integer reads
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
-    if ( get_format_list( context, image_type, formatList, numFormats, flags ) )
+    std::vector<cl_image_format> formatList;
+    if ( get_format_list( context, image_type, formatList, flags ) )
         return -1;
 
-    BufferOwningPtr<cl_image_format> formatListBuf(formatList);
-
-    filterFlags = new bool[ numFormats ];
-    BufferOwningPtr<bool> filterFlagsBuf(filterFlags);
-
-    if( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
-    filter_formats( formatList, filterFlags, numFormats, 0 );
+    std::vector<bool> filterFlags(formatList.size(), false);
+    filter_formats( formatList, filterFlags, nullptr );
 
     // Run the format list
-    for( unsigned int i = 0; i < numFormats; i++ )
+    for( unsigned int i = 0; i < formatList.size(); i++ )
     {
         int test_return = 0;
         if( filterFlags[i] )

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -30,14 +30,13 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
 
     // Grab the list of supported image formats for integer reads
     std::vector<cl_image_format> formatList;
-    if ( get_format_list( context, image_type, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, image_type, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats( formatList, filterFlags, nullptr );
+    filter_formats(formatList, filterFlags, nullptr);
 
     // Run the format list
-    for( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
         int test_return = 0;
         if( filterFlags[i] )

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -40,11 +40,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     int ret = 0;
 
-    // Grab the list of supported image formats for integer reads
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
   if ( gTestMipmaps )
   {
     if ( 0 == is_extension_available( device, "cl_khr_mipmap_image" ))
@@ -56,20 +51,16 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     }
   }
 
-    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
+    // Grab the list of supported image formats for integer reads
+    std::vector<cl_image_format> formatList;
+    if ( get_format_list( context, imageType, formatList, flags ) )
         return -1;
 
-    filterFlags = new bool[ numFormats ];
-    if( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
-    filter_formats( formatList, filterFlags, numFormats, 0 );
+    std::vector<bool> filterFlags(formatList.size(), false);
+    filter_formats( formatList, filterFlags, nullptr );
 
     // Run the format list
-    for( unsigned int i = 0; i < numFormats; i++ )
+    for( unsigned int i = 0; i < formatList.size(); i++ )
     {
         int test_return = 0;
         if( filterFlags[i] )
@@ -115,9 +106,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
         ret += test_return;
     }
-
-    delete[] filterFlags;
-    delete[] formatList;
 
     return ret;
 }

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -40,41 +40,43 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     int ret = 0;
 
-  if ( gTestMipmaps )
-  {
-    if ( 0 == is_extension_available( device, "cl_khr_mipmap_image" ))
+    if (gTestMipmaps)
     {
-      log_info( "-----------------------------------------------------\n" );
-      log_info( "This device does not support cl_khr_mipmap_image.\nSkipping mipmapped image test. \n" );
-      log_info( "-----------------------------------------------------\n\n" );
-      return 0;
+        if (0 == is_extension_available(device, "cl_khr_mipmap_image"))
+        {
+            log_info("-----------------------------------------------------\n");
+            log_info("This device does not support "
+                     "cl_khr_mipmap_image.\nSkipping mipmapped image test. \n");
+            log_info(
+                "-----------------------------------------------------\n\n");
+            return 0;
+        }
     }
-  }
 
     // Grab the list of supported image formats for integer reads
     std::vector<cl_image_format> formatList;
-    if ( get_format_list( context, imageType, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats( formatList, filterFlags, nullptr );
+    filter_formats(formatList, filterFlags, nullptr);
 
     // Run the format list
-    for( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
         int test_return = 0;
-        if( filterFlags[i] )
+        if (filterFlags[i])
         {
-            log_info( "NOT RUNNING: " );
-            print_header( &formatList[ i ], false );
+            log_info("NOT RUNNING: ");
+            print_header(&formatList[i], false);
             continue;
         }
 
-        print_header( &formatList[ i ], false );
+        print_header(&formatList[i], false);
 
         gTestCount++;
 
-        switch (imageType) {
+        switch (imageType)
+        {
             case CL_MEM_OBJECT_IMAGE1D:
                 test_return = test_read_image_set_1D(device, context, queue,
                                                      &formatList[i], flags);
@@ -97,11 +99,12 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
                 break;
         }
 
-        if (test_return) {
+        if (test_return)
+        {
             gFailCount++;
-            log_error( "FAILED: " );
-            print_header( &formatList[ i ], true );
-            log_info( "\n" );
+            log_error("FAILED: ");
+            print_header(&formatList[i], true);
+            log_info("\n");
         }
 
         ret += test_return;

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -58,13 +58,13 @@ std::array<ImageTestTypes, 3> imageTestTypes = { {
     { kTestFloat, kFloat, floatFormats, "float" },
 } };
 
-int filter_formats(cl_image_format *formatList, bool *filterFlags,
-                   unsigned int formatCount,
+int filter_formats(const std::vector<cl_image_format> &formatList,
+                   std::vector<bool> &filterFlags,
                    cl_channel_type *channelDataTypesToFilter,
                    bool testMipmaps /*=false*/)
 {
     int numSupported = 0;
-    for (unsigned int j = 0; j < formatCount; j++)
+    for (unsigned int j = 0; j < formatList.size(); j++)
     {
         // If this format has been previously filtered, remove the filter
         if (filterFlags[j]) filterFlags[j] = false;
@@ -129,18 +129,18 @@ int filter_formats(cl_image_format *formatList, bool *filterFlags,
 }
 
 int get_format_list(cl_context context, cl_mem_object_type imageType,
-                    cl_image_format *&outFormatList,
-                    unsigned int &outFormatCount, cl_mem_flags flags)
+                    std::vector<cl_image_format> &outFormatList,
+                    cl_mem_flags flags)
 {
+    cl_uint formatCount;
     int error = clGetSupportedImageFormats(context, flags, imageType, 0, NULL,
-                                           &outFormatCount);
+                                           &formatCount);
     test_error(error, "Unable to get count of supported image formats");
 
-    outFormatList =
-        (outFormatCount > 0) ? new cl_image_format[outFormatCount] : NULL;
+    outFormatList.resize(formatCount);
 
-    error = clGetSupportedImageFormats(context, flags, imageType,
-                                       outFormatCount, outFormatList, NULL);
+    error = clGetSupportedImageFormats(context, flags, imageType, formatCount,
+                                       outFormatList.data(), NULL);
     test_error(error, "Unable to get list of supported image formats");
     return 0;
 }

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -22,6 +22,7 @@
 #include "harness/conversions.h"
 
 #include <array>
+#include <vector>
 
 extern cl_channel_type gChannelTypeToUse;
 extern cl_channel_order gChannelOrderToUse;
@@ -40,13 +41,13 @@ struct ImageTestTypes
 
 extern std::array<ImageTestTypes, 3> imageTestTypes;
 
-int filter_formats(cl_image_format *formatList, bool *filterFlags,
-                   unsigned int formatCount,
+int filter_formats(const std::vector<cl_image_format> &formatList,
+                   std::vector<bool> &filterFlags,
                    cl_channel_type *channelDataTypesToFilter,
                    bool testMipmaps = false);
 int get_format_list(cl_context context, cl_mem_object_type imageType,
-                    cl_image_format *&outFormatList,
-                    unsigned int &outFormatCount, cl_mem_flags flags);
+                    std::vector<cl_image_format> &outFormatList,
+                    cl_mem_flags flags);
 size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d);
 
 #endif // IMAGES_COMMON_H

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -43,14 +43,13 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     // Grab the list of supported image formats for integer reads
     std::vector<cl_image_format> formatList;
-    if( get_format_list( context, imageType, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats( formatList, filterFlags, nullptr );
+    filter_formats(formatList, filterFlags, nullptr);
 
     // Run the format list
-    for( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
         int test_return = 0;
         if( filterFlags[i] )

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -42,24 +42,15 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     int ret = 0;
 
     // Grab the list of supported image formats for integer reads
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
-    if( get_format_list( context, imageType, formatList, numFormats, flags ) )
+    std::vector<cl_image_format> formatList;
+    if( get_format_list( context, imageType, formatList, flags ) )
         return -1;
 
-    filterFlags = new bool[ numFormats ];
-    if( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
-    filter_formats( formatList, filterFlags, numFormats, 0 );
+    std::vector<bool> filterFlags(formatList.size(), false);
+    filter_formats( formatList, filterFlags, nullptr );
 
     // Run the format list
-    for( unsigned int i = 0; i < numFormats; i++ )
+    for( unsigned int i = 0; i < formatList.size(); i++ )
     {
         int test_return = 0;
         if( filterFlags[i] )
@@ -105,9 +96,6 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
         ret += test_return;
     }
-
-    delete filterFlags;
-    delete formatList;
 
     return ret;
 }

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1562,8 +1562,11 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                        bool floatCoords, ExplicitType outputType )
+int test_read_image_set_2D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler, bool floatCoords,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1562,7 +1562,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                         bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -24,34 +24,34 @@ extern int gtestTypesToRun;
 
 extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format,
+                                  const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format,
+                                  const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format,
+                                  const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType);
 extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
-                                        cl_image_format *format,
+                                        const cl_image_format *format,
                                         image_sampler_data *imageSampler,
                                         bool floatCoords,
                                         ExplicitType outputType);
 extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
-                                        cl_image_format *format,
+                                        const cl_image_format *format,
                                         image_sampler_data *imageSampler,
                                         bool floatCoords,
                                         ExplicitType outputType);
 
 int test_read_image_type(cl_device_id device, cl_context context,
-                         cl_command_queue queue, cl_image_format *format,
+                         cl_command_queue queue, const cl_image_format *format,
                          bool floatCoords, image_sampler_data *imageSampler,
                          ExplicitType outputType, cl_mem_object_type imageType)
 {
@@ -164,8 +164,8 @@ int test_read_image_type(cl_device_id device, cl_context context,
 }
 
 int test_read_image_formats(cl_device_id device, cl_context context,
-                            cl_command_queue queue, cl_image_format *formatList,
-                            bool *filterFlags, unsigned int numFormats,
+                            cl_command_queue queue, const std::vector<cl_image_format> &formatList,
+                            const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
                             cl_mem_object_type imageType)
@@ -212,11 +212,11 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                                              : "integer",
                      get_explicit_type_name(outputType));
 
-            for (unsigned int i = 0; i < numFormats; i++)
+            for (unsigned int i = 0; i < formatList.size(); i++)
             {
                 if (filterFlags[i]) continue;
 
-                cl_image_format &imageFormat = formatList[i];
+                const cl_image_format &imageFormat = formatList[i];
 
                 ret |=
                     test_read_image_type(device, context, queue, &imageFormat,
@@ -290,11 +290,6 @@ int test_image_set(cl_device_id device, cl_context context,
         }
     }
 
-    // Grab the list of supported image formats for integer reads
-    cl_image_format *formatList;
-    bool *filterFlags;
-    unsigned int numFormats;
-
     // This flag is only for querying the list of supported formats
     // The flag for creating image will be set explicitly in test functions
     cl_mem_flags flags;
@@ -326,19 +321,10 @@ int test_image_set(cl_device_id device, cl_context context,
         }
     }
 
-    if (get_format_list(context, imageType, formatList, numFormats, flags))
+    // Grab the list of supported image formats for integer reads
+    std::vector<cl_image_format> formatList;
+    if ( get_format_list( context, imageType, formatList, flags ) )
         return -1;
-    BufferOwningPtr<cl_image_format> formatListBuf(formatList);
-
-
-    filterFlags = new bool[numFormats];
-    if (filterFlags == NULL)
-    {
-        log_error("ERROR: Out of memory allocating filter flags list!\n");
-        return -1;
-    }
-    BufferOwningPtr<bool> filterFlagsBuf(filterFlags);
-    memset(filterFlags, 0, sizeof(bool) * numFormats);
 
     // First time through, we'll go ahead and print the formats supported,
     // regardless of type
@@ -348,7 +334,7 @@ int test_image_set(cl_device_id device, cl_context context,
     {
         log_info("---- Supported %s %s formats for this device ---- \n",
                  convert_image_type_to_string(imageType), flagNames);
-        for (unsigned int f = 0; f < numFormats; f++)
+        for (unsigned int f = 0; f < formatList.size(); f++)
         {
             if (IsChannelOrderSupported(formatList[f].image_channel_order)
                 && IsChannelTypeSupported(
@@ -369,7 +355,8 @@ int test_image_set(cl_device_id device, cl_context context,
     {
         if (gTypesToTest & test.type)
         {
-            if (filter_formats(formatList, filterFlags, numFormats,
+            std::vector<bool> filterFlags(formatList.size(), false);
+            if (filter_formats(formatList, filterFlags,
                                test.channelTypes, gTestMipmaps)
                 == 0)
             {
@@ -379,7 +366,7 @@ int test_image_set(cl_device_id device, cl_context context,
             {
                 imageSampler.filter_mode = CL_FILTER_NEAREST;
                 ret += formatTestFn(device, context, queue, formatList,
-                                    filterFlags, numFormats, &imageSampler,
+                                    filterFlags, &imageSampler,
                                     test.explicitType, imageType);
 
                 // Linear filtering is only supported with floats
@@ -387,7 +374,7 @@ int test_image_set(cl_device_id device, cl_context context,
                 {
                     imageSampler.filter_mode = CL_FILTER_LINEAR;
                     ret += formatTestFn(device, context, queue, formatList,
-                                        filterFlags, numFormats, &imageSampler,
+                                        filterFlags, &imageSampler,
                                         test.explicitType, imageType);
                 }
             }

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -164,7 +164,8 @@ int test_read_image_type(cl_device_id device, cl_context context,
 }
 
 int test_read_image_formats(cl_device_id device, cl_context context,
-                            cl_command_queue queue, const std::vector<cl_image_format> &formatList,
+                            cl_command_queue queue,
+                            const std::vector<cl_image_format> &formatList,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
@@ -323,8 +324,7 @@ int test_image_set(cl_device_id device, cl_context context,
 
     // Grab the list of supported image formats for integer reads
     std::vector<cl_image_format> formatList;
-    if ( get_format_list( context, imageType, formatList, flags ) )
-        return -1;
+    if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     // First time through, we'll go ahead and print the formats supported,
     // regardless of type
@@ -356,8 +356,8 @@ int test_image_set(cl_device_id device, cl_context context,
         if (gTypesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
-            if (filter_formats(formatList, filterFlags,
-                               test.channelTypes, gTestMipmaps)
+            if (filter_formats(formatList, filterFlags, test.channelTypes,
+                               gTestMipmaps)
                 == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -985,7 +985,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                         bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -985,8 +985,11 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                        bool floatCoords, ExplicitType outputType )
+int test_read_image_set_1D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler, bool floatCoords,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -1094,8 +1094,11 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                                 bool floatCoords, ExplicitType outputType )
+int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 const cl_image_format *format,
+                                 image_sampler_data *imageSampler,
+                                 bool floatCoords, ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -1094,7 +1094,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                                  bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -1301,8 +1301,11 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                           bool floatCoords, ExplicitType outputType )
+int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 const cl_image_format *format,
+                                 image_sampler_data *imageSampler,
+                                 bool floatCoords, ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -1301,7 +1301,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                            bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -1158,7 +1158,7 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                            bool floatCoords, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -1158,8 +1158,11 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                           bool floatCoords, ExplicitType outputType )
+int test_read_image_set_3D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler, bool floatCoords,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -521,7 +521,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
     return totalErrors;
 }
 
-int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -521,7 +521,10 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
     return totalErrors;
 }
 
-int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_set(cl_device_id device, cl_context context,
+                            cl_command_queue queue,
+                            const cl_image_format *format,
+                            ExplicitType inputType, MTdata d)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -542,7 +542,10 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_array_set(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  ExplicitType inputType, MTdata d)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -542,7 +542,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -568,7 +568,10 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_2D_array_set(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  ExplicitType inputType, MTdata d)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -568,7 +568,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 }
 
 
-int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -576,7 +576,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 }
 
 
-int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -576,7 +576,10 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 }
 
 
-int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_3D_set(cl_device_id device, cl_context context,
+                            cl_command_queue queue,
+                            const cl_image_format *format,
+                            ExplicitType inputType, MTdata d)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -23,10 +23,24 @@ extern bool gTestImage2DFromBuffer;
 extern cl_mem_flags gMemFlagsToUse;
 extern int gtestTypesToRun;
 
-extern int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_1D_set(cl_device_id device, cl_context context,
+                                   cl_command_queue queue,
+                                   const cl_image_format *format,
+                                   ExplicitType inputType, MTdata d);
+extern int test_write_image_3D_set(cl_device_id device, cl_context context,
+                                   cl_command_queue queue,
+                                   const cl_image_format *format,
+                                   ExplicitType inputType, MTdata d);
+extern int test_write_image_1D_array_set(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         const cl_image_format *format,
+                                         ExplicitType inputType, MTdata d);
+extern int test_write_image_2D_array_set(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         const cl_image_format *format,
+                                         ExplicitType inputType, MTdata d);
 
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
@@ -595,7 +609,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 }
 
 
-int test_write_image_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_set(cl_device_id device, cl_context context,
+                         cl_command_queue queue, const cl_image_format *format,
+                         ExplicitType inputType, MTdata d)
 {
     char programSrc[10240];
     const char *ptr;
@@ -797,8 +813,13 @@ int test_write_image_set( cl_device_id device, cl_context context, cl_command_qu
     return 0;
 }
 
-int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
-                             image_sampler_data *imageSampler, ExplicitType inputType, cl_mem_object_type imageType )
+int test_write_image_formats(cl_device_id device, cl_context context,
+                             cl_command_queue queue,
+                             const std::vector<cl_image_format> &formatList,
+                             const std::vector<bool> &filterFlags,
+                             image_sampler_data *imageSampler,
+                             ExplicitType inputType,
+                             cl_mem_object_type imageType)
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
         // No need to run for linear filters
@@ -811,9 +832,9 @@ int test_write_image_formats( cl_device_id device, cl_context context, cl_comman
 
     RandomSeed seed( gRandomSeed );
 
-    for( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
-        const cl_image_format &imageFormat = formatList[ i ];
+        const cl_image_format &imageFormat = formatList[i];
 
         if( filterFlags[ i ] )
             continue;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -23,10 +23,10 @@ extern bool gTestImage2DFromBuffer;
 extern cl_mem_flags gMemFlagsToUse;
 extern int gtestTypesToRun;
 
-extern int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
-extern int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_1D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_3D_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_1D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
+extern int test_write_image_2D_array_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d );
 
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
@@ -595,7 +595,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 }
 
 
-int test_write_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType inputType, MTdata d )
+int test_write_image_set( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, ExplicitType inputType, MTdata d )
 {
     char programSrc[10240];
     const char *ptr;
@@ -797,7 +797,7 @@ int test_write_image_set( cl_device_id device, cl_context context, cl_command_qu
     return 0;
 }
 
-int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
                              image_sampler_data *imageSampler, ExplicitType inputType, cl_mem_object_type imageType )
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
@@ -811,9 +811,9 @@ int test_write_image_formats( cl_device_id device, cl_context context, cl_comman
 
     RandomSeed seed( gRandomSeed );
 
-    for( unsigned int i = 0; i < numFormats; i++ )
+    for( unsigned int i = 0; i < formatList.size(); i++ )
     {
-        cl_image_format &imageFormat = formatList[ i ];
+        const cl_image_format &imageFormat = formatList[ i ];
 
         if( filterFlags[ i ] )
             continue;

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -176,7 +176,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -176,8 +176,11 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                            ExplicitType outputType )
+int test_read_image_set_2D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -19,14 +19,14 @@
 extern int gTypesToTest;
 extern bool gTestReadWrite;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
 
-int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
+int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
                           image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -68,7 +68,7 @@ int test_read_image_type( cl_device_id device, cl_context context, cl_command_qu
     return ret;
 }
 
-int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
                              image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
 {
     int ret = 0;
@@ -76,12 +76,12 @@ int test_read_image_formats( cl_device_id device, cl_context context, cl_command
     log_info( "read_image (%s coords, %s results) *****************************\n",
               "integer", get_explicit_type_name( outputType ) );
 
-    for ( unsigned int i = 0; i < numFormats; i++ )
+    for ( unsigned int i = 0; i < formatList.size(); i++ )
     {
         if ( filterFlags[i] )
             continue;
 
-        cl_image_format &imageFormat = formatList[ i ];
+        const cl_image_format &imageFormat = formatList[ i ];
 
         ret |= test_read_image_type( device, context, queue, &imageFormat, imageSampler, outputType, imageType );
     }
@@ -95,78 +95,51 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     static int printedFormatList = -1;
 
     // Grab the list of supported image formats
-    cl_image_format *formatList;
-    unsigned int numFormats;
+    std::vector<cl_image_format> formatList;
 
     if (gTestReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
 
-    cl_image_format *readOnlyFormats;
-    unsigned int numReadOnlyFormats;
-
-    if (get_format_list(context, imageType, readOnlyFormats, numReadOnlyFormats,
+    std::vector<cl_image_format> readOnlyFormats;
+    if (get_format_list(context, imageType, readOnlyFormats,
                         CL_MEM_READ_ONLY))
         return -1;
 
     if (gTestReadWrite)
     {
-        cl_image_format *readWriteFormats;
-        unsigned int numReadWriteFormats;
-
+        std::vector<cl_image_format> readWriteFormats;
         if (get_format_list(context, imageType, readWriteFormats,
-                            numReadWriteFormats, CL_MEM_KERNEL_READ_AND_WRITE))
+                            CL_MEM_KERNEL_READ_AND_WRITE))
             return -1;
 
-        numFormats = numReadOnlyFormats;
-        formatList = new cl_image_format[numFormats];
-        unsigned int k = 0;
-
         // Keep only intersecting formats with read only and read write flags
-        for (unsigned int i = 0; i < numReadOnlyFormats; i++)
+        for (unsigned int i = 0; i < readOnlyFormats.size(); i++)
         {
-            for (unsigned int j = 0; j < numReadWriteFormats; j++)
+            for (unsigned int j = 0; j < readWriteFormats.size(); j++)
             {
                 if (readOnlyFormats[i].image_channel_data_type
                         == readWriteFormats[j].image_channel_data_type
                     && readOnlyFormats[i].image_channel_order
                         == readWriteFormats[j].image_channel_order)
                 {
-                    formatList[k].image_channel_data_type =
-                        readOnlyFormats[i].image_channel_data_type;
-                    formatList[k].image_channel_order =
-                        readOnlyFormats[i].image_channel_order;
-                    k++;
+                    formatList.push_back(readOnlyFormats[i]);
                     break;
                 }
             }
         }
-
-        numFormats = k;
-
-        delete[] readOnlyFormats;
-        delete[] readWriteFormats;
     }
     else
     {
-        numFormats = numReadOnlyFormats;
         formatList = readOnlyFormats;
     }
-
-    bool *filterFlags = new bool[numFormats];
-    if ( filterFlags == NULL )
-    {
-        log_error( "ERROR: Out of memory allocating filter flags list!\n" );
-        return -1;
-    }
-    memset( filterFlags, 0, sizeof( bool ) * numFormats );
 
     // First time through, we'll go ahead and print the formats supported, regardless of type
     if ( printedFormatList != (int)imageType )
     {
         log_info( "---- Supported %s read formats for this device ---- \n", convert_image_type_to_string(imageType) );
-        for ( unsigned int f = 0; f < numFormats; f++ )
+        for ( unsigned int f = 0; f < formatList.size(); f++ )
             log_info( "  %-7s %-24s %d\n", GetChannelOrderName( formatList[ f ].image_channel_order ),
                       GetChannelTypeName( formatList[ f ].image_channel_data_type ),
                       (int)get_format_channel_count( &formatList[ f ] ) );
@@ -180,7 +153,8 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     {
         if (gTypesToTest & test.type)
         {
-            if (filter_formats(formatList, filterFlags, numFormats,
+            std::vector<bool> filterFlags(formatList.size(), false);
+            if (filter_formats(formatList, filterFlags,
                                test.channelTypes)
                 == 0)
             {
@@ -190,14 +164,11 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
             {
                 imageSampler.filter_mode = CL_FILTER_NEAREST;
                 ret += test_read_image_formats(
-                    device, context, queue, formatList, filterFlags, numFormats,
+                    device, context, queue, formatList, filterFlags,
                     &imageSampler, test.explicitType, imageType);
             }
         }
     }
-
-    delete[] filterFlags;
-    delete[] formatList;
 
     return ret;
 }

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -19,15 +19,42 @@
 extern int gTypesToTest;
 extern bool gTestReadWrite;
 
-extern int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
-extern int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler, ExplicitType outputType );
+extern int test_read_image_set_1D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  ExplicitType outputType);
+extern int test_read_image_set_1D_buffer(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         const cl_image_format *format,
+                                         image_sampler_data *imageSampler,
+                                         ExplicitType outputType);
+extern int test_read_image_set_2D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  ExplicitType outputType);
+extern int test_read_image_set_3D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  ExplicitType outputType);
+extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        const cl_image_format *format,
+                                        image_sampler_data *imageSampler,
+                                        ExplicitType outputType);
+extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        const cl_image_format *format,
+                                        image_sampler_data *imageSampler,
+                                        ExplicitType outputType);
 
-int test_read_image_type( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
-                          image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
+int test_read_image_type(cl_device_id device, cl_context context,
+                         cl_command_queue queue, const cl_image_format *format,
+                         image_sampler_data *imageSampler,
+                         ExplicitType outputType, cl_mem_object_type imageType)
 {
     int ret = 0;
     imageSampler->addressing_mode = CL_ADDRESS_NONE;
@@ -68,20 +95,25 @@ int test_read_image_type( cl_device_id device, cl_context context, cl_command_qu
     return ret;
 }
 
-int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue, const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
-                             image_sampler_data *imageSampler, ExplicitType outputType, cl_mem_object_type imageType )
+int test_read_image_formats(cl_device_id device, cl_context context,
+                            cl_command_queue queue,
+                            const std::vector<cl_image_format> &formatList,
+                            const std::vector<bool> &filterFlags,
+                            image_sampler_data *imageSampler,
+                            ExplicitType outputType,
+                            cl_mem_object_type imageType)
 {
     int ret = 0;
     imageSampler->normalized_coords = false;
     log_info( "read_image (%s coords, %s results) *****************************\n",
               "integer", get_explicit_type_name( outputType ) );
 
-    for ( unsigned int i = 0; i < formatList.size(); i++ )
+    for (unsigned int i = 0; i < formatList.size(); i++)
     {
         if ( filterFlags[i] )
             continue;
 
-        const cl_image_format &imageFormat = formatList[ i ];
+        const cl_image_format &imageFormat = formatList[i];
 
         ret |= test_read_image_type( device, context, queue, &imageFormat, imageSampler, outputType, imageType );
     }
@@ -103,8 +135,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     }
 
     std::vector<cl_image_format> readOnlyFormats;
-    if (get_format_list(context, imageType, readOnlyFormats,
-                        CL_MEM_READ_ONLY))
+    if (get_format_list(context, imageType, readOnlyFormats, CL_MEM_READ_ONLY))
         return -1;
 
     if (gTestReadWrite)
@@ -139,7 +170,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     if ( printedFormatList != (int)imageType )
     {
         log_info( "---- Supported %s read formats for this device ---- \n", convert_image_type_to_string(imageType) );
-        for ( unsigned int f = 0; f < formatList.size(); f++ )
+        for (unsigned int f = 0; f < formatList.size(); f++)
             log_info( "  %-7s %-24s %d\n", GetChannelOrderName( formatList[ f ].image_channel_order ),
                       GetChannelTypeName( formatList[ f ].image_channel_data_type ),
                       (int)get_format_channel_count( &formatList[ f ] ) );
@@ -154,9 +185,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
         if (gTypesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
-            if (filter_formats(formatList, filterFlags,
-                               test.channelTypes)
-                == 0)
+            if (filter_formats(formatList, filterFlags, test.channelTypes) == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);
             }

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -177,7 +177,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -177,8 +177,11 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                            ExplicitType outputType )
+int test_read_image_set_1D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -175,7 +175,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     return 0;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -175,8 +175,11 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     return 0;
 }
 
-int test_read_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                            ExplicitType outputType )
+int test_read_image_set_1D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 const cl_image_format *format,
+                                 image_sampler_data *imageSampler,
+                                 ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -160,7 +160,7 @@ int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_ke
     return 0;
 }
 
-int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, image_sampler_data *imageSampler,
+int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
                             ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -160,8 +160,11 @@ int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_ke
     return 0;
 }
 
-int test_read_image_set_1D_buffer( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format, image_sampler_data *imageSampler,
-                            ExplicitType outputType )
+int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  const cl_image_format *format,
+                                  image_sampler_data *imageSampler,
+                                  ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -161,8 +161,11 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     return 0;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
-                                  image_sampler_data *imageSampler, ExplicitType outputType )
+int test_read_image_set_2D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 const cl_image_format *format,
+                                 image_sampler_data *imageSampler,
+                                 ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -161,7 +161,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     return 0;
 }
 
-int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
+int test_read_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
                                   image_sampler_data *imageSampler, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -164,8 +164,11 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
-                            image_sampler_data *imageSampler, ExplicitType outputType )
+int test_read_image_set_3D(cl_device_id device, cl_context context,
+                           cl_command_queue queue,
+                           const cl_image_format *format,
+                           image_sampler_data *imageSampler,
+                           ExplicitType outputType)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -164,7 +164,7 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     return 0;
 }
 
-int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format,
+int test_read_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, const cl_image_format *format,
                             image_sampler_data *imageSampler, ExplicitType outputType )
 {
     char programSrc[10240];

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -65,16 +65,16 @@ enum TestTypes
 };
 
 typedef int (*test_format_set_fn)( cl_device_id device, cl_context context, cl_command_queue queue,
-  cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
 
 extern int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
-  cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
 extern int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
-  cl_image_format *formatList, bool *filterFlags, unsigned int numFormats,
+  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
   image_sampler_data *imageSampler, ExplicitType outputType,
   cl_mem_object_type imageType );
 

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -64,19 +64,22 @@ enum TestTypes
     kAllTests = ( kReadTests | kWriteTests | kReadWriteTests )
 };
 
-typedef int (*test_format_set_fn)( cl_device_id device, cl_context context, cl_command_queue queue,
-  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
-  image_sampler_data *imageSampler, ExplicitType outputType,
-  cl_mem_object_type imageType );
+typedef int (*test_format_set_fn)(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const std::vector<cl_image_format> &formatList,
+    const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
+    ExplicitType outputType, cl_mem_object_type imageType);
 
-extern int test_read_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
-  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
-  image_sampler_data *imageSampler, ExplicitType outputType,
-  cl_mem_object_type imageType );
-extern int test_write_image_formats( cl_device_id device, cl_context context, cl_command_queue queue,
-  const std::vector<cl_image_format> &formatList, const std::vector<bool> &filterFlags,
-  image_sampler_data *imageSampler, ExplicitType outputType,
-  cl_mem_object_type imageType );
+extern int test_read_image_formats(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const std::vector<cl_image_format> &formatList,
+    const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
+    ExplicitType outputType, cl_mem_object_type imageType);
+extern int test_write_image_formats(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const std::vector<cl_image_format> &formatList,
+    const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
+    ExplicitType outputType, cl_mem_object_type imageType);
 
 #endif // _testBase_h
 


### PR DESCRIPTION
Avoids memory deallocation issues and generally simplifies the code.

There's a fair bit of churn due to adding lots of `const` qualifiers to function parameters, but it's largely mechanical. The first commit contains the changes, the second is just formatting; I'd recommend reviewing just the first.

Fixes #723 