### PR TITLE
Use delete[] to deallocate after new[]

### DIFF
--- a/test_conformance/mem_host_flags/C_host_memory_block.h
+++ b/test_conformance/mem_host_flags/C_host_memory_block.h
@@ -69,14 +69,14 @@ C_host_memory_block<T>::C_host_memory_block()
 template < class T>
 C_host_memory_block<T>::~C_host_memory_block()
 {
-  if (pData!=NULL) delete pData;
+  if (pData!=NULL) delete[] pData;
   num_elements = 0;
 }
 
 template < class T >
 void C_host_memory_block<T>::Init(int num_elem, T & value)
 {
-  if (pData!=NULL) delete pData;
+  if (pData!=NULL) delete[] pData;
   pData= new T [num_elem];
   for (int i=0; i<num_elem; i++)
     pData[i] = value;
@@ -87,7 +87,7 @@ void C_host_memory_block<T>::Init(int num_elem, T & value)
 template < class T >
 void C_host_memory_block<T>::Init(int num_elem)
 {
-  if (pData!=NULL) delete pData;
+  if (pData!=NULL) delete[] pData;
   pData = new T [num_elem];
   for (int i=0; i<num_elem; i++)
     pData[i]= (T) i;

--- a/test_conformance/mem_host_flags/C_host_memory_block.h
+++ b/test_conformance/mem_host_flags/C_host_memory_block.h
@@ -69,31 +69,28 @@ C_host_memory_block<T>::C_host_memory_block()
 template < class T>
 C_host_memory_block<T>::~C_host_memory_block()
 {
-  if (pData!=NULL) delete[] pData;
-  num_elements = 0;
+    if (pData != NULL) delete[] pData;
+    num_elements = 0;
 }
 
 template < class T >
 void C_host_memory_block<T>::Init(int num_elem, T & value)
 {
-  if (pData!=NULL) delete[] pData;
-  pData= new T [num_elem];
-  for (int i=0; i<num_elem; i++)
-    pData[i] = value;
+    if (pData != NULL) delete[] pData;
+    pData = new T[num_elem];
+    for (int i = 0; i < num_elem; i++) pData[i] = value;
 
-  num_elements= num_elem;
+    num_elements = num_elem;
 }
 
 template < class T >
 void C_host_memory_block<T>::Init(int num_elem)
 {
-  if (pData!=NULL) delete[] pData;
-  pData = new T [num_elem];
-  for (int i=0; i<num_elem; i++)
-    pData[i]= (T) i;
+    if (pData != NULL) delete[] pData;
+    pData = new T[num_elem];
+    for (int i = 0; i < num_elem; i++) pData[i] = (T)i;
 
-  num_elements = num_elem;
-
+    num_elements = num_elem;
 }
 template < class T >
 void  C_host_memory_block<T>::Set_to_zero()


### PR DESCRIPTION
Fixes ASan issues flagged in the mem_host_flags suite.

First commit is the trivial change, second is just formatting.