### PR TITLE
Fix compilation issues for conforming_version.cpp

### DIFF
--- a/test_conformance/computeinfo/conforming_version.cpp
+++ b/test_conformance/computeinfo/conforming_version.cpp
@@ -21,7 +21,7 @@
 int test_conformance_version(cl_device_id deviceID, cl_context context,
                              cl_command_queue ignoreQueue, int num_elements)
 {
-    auto version_string{ get_device_info_string(
+    std::string version_string{ get_device_info_string(
         deviceID, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED) };
 
     // Latest conformance version passed should match vYYYY-MM-DD-XX, where XX


### PR DESCRIPTION
Previously this file used the auto keyword to
declare a string. This can cause compilation
issues when used in a later function.

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>