### PR TITLE
Remove compiler options that are specific to Apple

### DIFF
--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -61,10 +61,6 @@ const char *optimization_options[] = {
     "-cl-fast-relaxed-math",
     "-w",
     "-Werror",
-#if defined( __APPLE__ )
-    "-cl-opt-enable",
-    "-cl-auto-vectorize-enable"
-#endif
     };
 
 cl_int get_result_from_program( cl_context context, cl_command_queue queue, cl_program program, cl_int *outValue )


### PR DESCRIPTION
These are causing test failures for non-Apple implementations of
OpenCL running on macOS.