### PR TITLE
Make functions local to translation unit

### DIFF
--- a/test_conformance/math_brute_force/binary.cpp
+++ b/test_conformance/math_brute_force/binary.cpp
@@ -24,10 +24,6 @@ int TestFunc_Float_Float_Float_nextafter(const Func *f, MTdata,
                                          bool relaxedMode);
 int TestFunc_Double_Double_Double_nextafter(const Func *f, MTdata,
                                             bool relaxedMode);
-int TestFunc_Float_Float_Float_common(const Func *f, MTdata, int isNextafter,
-                                      bool relaxedMode);
-int TestFunc_Double_Double_Double_common(const Func *f, MTdata, int isNextafter,
-                                         bool relaxedMode);
 
 const float twoToMinus126 = MAKE_HEX_FLOAT(0x1p-126f, 1, -126);
 const double twoToMinus1022 = MAKE_HEX_DOUBLE(0x1p-1022, 1, -1022);
@@ -40,8 +36,6 @@ extern const vtbl _binary_nextafter = {
     TestFunc_Double_Double_Double_nextafter
 };
 
-static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
-                       cl_kernel *k, cl_program *p, bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
@@ -331,8 +325,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -341,8 +333,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {
@@ -394,8 +384,8 @@ typedef struct TestInfo
 
 static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *p);
 
-int TestFunc_Float_Float_Float_common(const Func *f, MTdata d, int isNextafter,
-                                      bool relaxedMode)
+static int TestFunc_Float_Float_Float_common(const Func *f, MTdata d,
+                                             int isNextafter, bool relaxedMode)
 {
     TestInfo test_info;
     cl_int error;
@@ -1336,8 +1326,9 @@ static size_t specialValuesDoubleCount =
 
 static cl_int TestDouble(cl_uint job_id, cl_uint thread_id, void *p);
 
-int TestFunc_Double_Double_Double_common(const Func *f, MTdata d,
-                                         int isNextafter, bool relaxedMode)
+static int TestFunc_Double_Double_Double_common(const Func *f, MTdata d,
+                                                int isNextafter,
+                                                bool relaxedMode)
 {
     TestInfo test_info;
     cl_int error;

--- a/test_conformance/math_brute_force/binaryOperator.cpp
+++ b/test_conformance/math_brute_force/binaryOperator.cpp
@@ -29,13 +29,6 @@ extern const vtbl _binary_operator = { "binaryOperator",
 
 static int BuildKernel(const char *name, const char *operator_symbol,
                        int vectorSize, cl_uint kernel_count, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, const char *operator_symbol,
-                             int vectorSize, cl_uint kernel_count, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
-
-static int BuildKernel(const char *name, const char *operator_symbol,
-                       int vectorSize, cl_uint kernel_count, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
 {
     const char *c[] = { "__kernel void ",
@@ -224,8 +217,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -234,8 +225,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {
@@ -282,8 +271,6 @@ typedef struct TestInfo
 
     // no special fields
 } TestInfo;
-
-static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *p);
 
 // A table of more difficult cases to get right
 static const float specialValuesFloat[] = {

--- a/test_conformance/math_brute_force/binary_i.cpp
+++ b/test_conformance/math_brute_force/binary_i.cpp
@@ -25,11 +25,6 @@ int TestFunc_Double_Double_Int(const Func *f, MTdata, bool relaxedMode);
 extern const vtbl _binary_i = { "binary_i", TestFunc_Float_Float_Int,
                                 TestFunc_Double_Double_Int };
 
-static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
-                       cl_kernel *k, cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize,
-                             cl_uint kernel_count, cl_kernel *k, cl_program *p,
-                             bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
@@ -215,8 +210,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -225,8 +218,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/binary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i.cpp
@@ -26,10 +26,6 @@ extern const vtbl _binary_two_results_i = { "binary_two_results_i",
                                             TestFunc_FloatI_Float_Float,
                                             TestFunc_DoubleI_Double_Double };
 
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
@@ -225,8 +221,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -235,8 +229,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/i_unary.cpp
+++ b/test_conformance/math_brute_force/i_unary.cpp
@@ -25,10 +25,6 @@ extern const vtbl _i_unary = { "i_unary", TestFunc_Int_Float,
                                TestFunc_Int_Double };
 
 
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
@@ -199,8 +195,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -209,8 +203,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/macro_binary.cpp
+++ b/test_conformance/math_brute_force/macro_binary.cpp
@@ -24,11 +24,6 @@ int TestMacro_Int_Double_Double(const Func *f, MTdata, bool relaxedMode);
 extern const vtbl _macro_binary = { "macro_binary", TestMacro_Int_Float_Float,
                                     TestMacro_Int_Double_Double };
 
-static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
-                       cl_kernel *k, cl_program *p);
-static int BuildKernelDouble(const char *name, int vectorSize,
-                             cl_uint kernel_count, cl_kernel *k, cl_program *p,
-                             bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
@@ -215,8 +210,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -225,8 +218,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/macro_unary.cpp
+++ b/test_conformance/math_brute_force/macro_unary.cpp
@@ -24,11 +24,6 @@ int TestMacro_Int_Double(const Func *f, MTdata, bool relaxedMode);
 extern const vtbl _macro_unary = { "macro_unary", TestMacro_Int_Float,
                                    TestMacro_Int_Double };
 
-static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
-                       cl_kernel *k, cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize,
-                             cl_uint kernel_count, cl_kernel *k, cl_program *p,
-                             bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
@@ -203,8 +198,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -213,8 +206,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/mad.cpp
+++ b/test_conformance/math_brute_force/mad.cpp
@@ -23,10 +23,6 @@ int TestFunc_mad_Double(const Func *f, MTdata, bool relaxedMode);
 
 extern const vtbl _mad_tbl = { "ternary", TestFunc_mad, TestFunc_mad_Double };
 
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
@@ -216,8 +212,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -226,8 +220,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/ternary.cpp
+++ b/test_conformance/math_brute_force/ternary.cpp
@@ -29,10 +29,6 @@ extern const vtbl _ternary = { "ternary", TestFunc_Float_Float_Float_Float,
                                TestFunc_Double_Double_Double_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
 {
     const char *c[] = { "__kernel void math_kernel",
@@ -222,8 +218,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -232,8 +226,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -29,12 +29,6 @@ extern const vtbl _unary = { "unary", TestFunc_Float_Float,
                              TestFunc_Double_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
-                       cl_kernel *k, cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize,
-                             cl_uint kernel_count, cl_kernel *k, cl_program *p,
-                             bool relaxedMode);
-
-static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
 {
     const char *c[] = { "__kernel void math_kernel",
@@ -207,8 +201,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -217,8 +209,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->kernels[i], info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -26,10 +26,6 @@ extern const vtbl _unary_two_results = { "unary_two_results",
                                          TestFunc_Double2_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
 {
     const char *c[] = { "__kernel void math_kernel",
@@ -209,8 +205,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -219,8 +213,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {

--- a/test_conformance/math_brute_force/unary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i.cpp
@@ -27,11 +27,6 @@ extern const vtbl _unary_two_results_i = { "unary_two_results_i",
                                            TestFunc_DoubleI_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
-
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
 {
     const char *c[] = { "__kernel void math_kernel",
@@ -209,8 +204,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -220,8 +213,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
 }
 
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -230,8 +221,7 @@ static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                              info->programs + i, info->relaxedMode);
 }
 
-cl_ulong abs_cl_long(cl_long i);
-cl_ulong abs_cl_long(cl_long i)
+static cl_ulong abs_cl_long(cl_long i)
 {
     cl_long mask = i >> 63;
     return (i ^ mask) - mask;

--- a/test_conformance/math_brute_force/unary_u.cpp
+++ b/test_conformance/math_brute_force/unary_u.cpp
@@ -24,12 +24,6 @@ int TestFunc_Double_ULong(const Func *f, MTdata, bool relaxedMode);
 extern const vtbl _unary_u = { "unary_u", TestFunc_Float_UInt,
                                TestFunc_Double_ULong };
 
-
-static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
-                       cl_program *p, bool relaxedMode);
-static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
-                             cl_program *p, bool relaxedMode);
-
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
 {
@@ -199,8 +193,6 @@ typedef struct BuildKernelInfo
 } BuildKernelInfo;
 
 static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                  void *p);
-static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                   void *p)
 {
     BuildKernelInfo *info = (BuildKernelInfo *)p;
@@ -209,8 +201,6 @@ static cl_int BuildKernel_FloatFn(cl_uint job_id, cl_uint thread_id UNUSED,
                        info->programs + i, info->relaxedMode);
 }
 
-static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
-                                   void *p);
 static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                                    void *p)
 {


### PR DESCRIPTION
Remove unnecessary declarations.