### PR TITLE
Remove unnecessary scope

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i.cpp
@@ -504,163 +504,150 @@ int TestFunc_FloatI_Float_Float(const Func *f, MTdata d, bool relaxedMode)
                     && (q[j] & 0x7fffffff) > 0x7f800000 && t2[j] == q2[j])
                     continue;
 
-                // if( t[j] != q[j] || t2[j] != q2[j] )
+                float test = ((float *)q)[j];
+                int correct2 = INT_MIN;
+                double correct = f->func.f_ffpI(s[j], s2[j], &correct2);
+                float err = Ulp_Error(test, correct);
+                int64_t iErr;
+
+                // in case of remquo, we only care about the sign and last
+                // seven bits of integer as per the spec.
+                if (testingRemquo)
+                    iErr = (long long)(q2[j] & 0x0000007f)
+                        - (long long)(correct2 & 0x0000007f);
+                else
+                    iErr = (long long)q2[j] - (long long)correct2;
+
+                // For remquo, if y = 0, x is infinite, or either is NaN
+                // then the standard either neglects to say what is returned
+                // in iptr or leaves it undefined or implementation defined.
+                int iptrUndefined = fabs(((float *)gIn)[j]) == INFINITY
+                    || ((float *)gIn2)[j] == 0.0f || isnan(((float *)gIn2)[j])
+                    || isnan(((float *)gIn)[j]);
+                if (iptrUndefined) iErr = 0;
+
+                int fail = !(fabsf(err) <= float_ulps && iErr == 0);
+                if (ftz && fail)
                 {
-                    float test = ((float *)q)[j];
-                    int correct2 = INT_MIN;
-                    double correct = f->func.f_ffpI(s[j], s2[j], &correct2);
-                    float err = Ulp_Error(test, correct);
-                    int64_t iErr;
-
-                    // in case of remquo, we only care about the sign and last
-                    // seven bits of integer as per the spec.
-                    if (testingRemquo)
-                        iErr = (long long)(q2[j] & 0x0000007f)
-                            - (long long)(correct2 & 0x0000007f);
-                    else
-                        iErr = (long long)q2[j] - (long long)correct2;
-
-                    // For remquo, if y = 0, x is infinite, or either is NaN
-                    // then the standard either neglects to say what is returned
-                    // in iptr or leaves it undefined or implementation defined.
-                    int iptrUndefined = fabs(((float *)gIn)[j]) == INFINITY
-                        || ((float *)gIn2)[j] == 0.0f
-                        || isnan(((float *)gIn2)[j])
-                        || isnan(((float *)gIn)[j]);
-                    if (iptrUndefined) iErr = 0;
-
-                    int fail = !(fabsf(err) <= float_ulps && iErr == 0);
-                    if (ftz && fail)
+                    // retry per section 6.5.3.2
+                    if (IsFloatResultSubnormal(correct, float_ulps))
                     {
-                        // retry per section 6.5.3.2
-                        if (IsFloatResultSubnormal(correct, float_ulps))
+                        fail = fail && !(test == 0.0f && iErr == 0);
+                        if (!fail) err = 0.0f;
+                    }
+
+                    // retry per section 6.5.3.3
+                    if (IsFloatSubnormal(s[j]))
+                    {
+                        int correct3i, correct4i;
+                        double correct3 =
+                            f->func.f_ffpI(0.0, s2[j], &correct3i);
+                        double correct4 =
+                            f->func.f_ffpI(-0.0, s2[j], &correct4i);
+                        float err2 = Ulp_Error(test, correct3);
+                        float err3 = Ulp_Error(test, correct4);
+                        int64_t iErr3 = (long long)q2[j] - (long long)correct3i;
+                        int64_t iErr4 = (long long)q2[j] - (long long)correct4i;
+                        fail = fail
+                            && ((!(fabsf(err2) <= float_ulps && iErr3 == 0))
+                                && (!(fabsf(err3) <= float_ulps
+                                      && iErr4 == 0)));
+                        if (fabsf(err2) < fabsf(err)) err = err2;
+                        if (fabsf(err3) < fabsf(err)) err = err3;
+                        if (llabs(iErr3) < llabs(iErr)) iErr = iErr3;
+                        if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
+
+                        // retry per section 6.5.3.4
+                        if (IsFloatResultSubnormal(correct2, float_ulps)
+                            || IsFloatResultSubnormal(correct3, float_ulps))
                         {
-                            fail = fail && !(test == 0.0f && iErr == 0);
+                            fail = fail
+                                && !(test == 0.0f
+                                     && (iErr3 == 0 || iErr4 == 0));
                             if (!fail) err = 0.0f;
                         }
 
-                        // retry per section 6.5.3.3
-                        if (IsFloatSubnormal(s[j]))
+                        // try with both args as zero
+                        if (IsFloatSubnormal(s2[j]))
                         {
-                            int correct3i, correct4i;
-                            double correct3 =
-                                f->func.f_ffpI(0.0, s2[j], &correct3i);
-                            double correct4 =
-                                f->func.f_ffpI(-0.0, s2[j], &correct4i);
-                            float err2 = Ulp_Error(test, correct3);
-                            float err3 = Ulp_Error(test, correct4);
-                            int64_t iErr3 =
-                                (long long)q2[j] - (long long)correct3i;
-                            int64_t iErr4 =
-                                (long long)q2[j] - (long long)correct4i;
+                            int correct7i, correct8i;
+                            correct3 = f->func.f_ffpI(0.0, 0.0, &correct3i);
+                            correct4 = f->func.f_ffpI(-0.0, 0.0, &correct4i);
+                            double correct7 =
+                                f->func.f_ffpI(0.0, -0.0, &correct7i);
+                            double correct8 =
+                                f->func.f_ffpI(-0.0, -0.0, &correct8i);
+                            err2 = Ulp_Error(test, correct3);
+                            err3 = Ulp_Error(test, correct4);
+                            float err4 = Ulp_Error(test, correct7);
+                            float err5 = Ulp_Error(test, correct8);
+                            iErr3 = (long long)q2[j] - (long long)correct3i;
+                            iErr4 = (long long)q2[j] - (long long)correct4i;
+                            int64_t iErr7 =
+                                (long long)q2[j] - (long long)correct7i;
+                            int64_t iErr8 =
+                                (long long)q2[j] - (long long)correct8i;
                             fail = fail
                                 && ((!(fabsf(err2) <= float_ulps && iErr3 == 0))
                                     && (!(fabsf(err3) <= float_ulps
-                                          && iErr4 == 0)));
+                                          && iErr4 == 0))
+                                    && (!(fabsf(err4) <= float_ulps
+                                          && iErr7 == 0))
+                                    && (!(fabsf(err5) <= float_ulps
+                                          && iErr8 == 0)));
                             if (fabsf(err2) < fabsf(err)) err = err2;
                             if (fabsf(err3) < fabsf(err)) err = err3;
+                            if (fabsf(err4) < fabsf(err)) err = err4;
+                            if (fabsf(err5) < fabsf(err)) err = err5;
                             if (llabs(iErr3) < llabs(iErr)) iErr = iErr3;
                             if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
+                            if (llabs(iErr7) < llabs(iErr)) iErr = iErr7;
+                            if (llabs(iErr8) < llabs(iErr)) iErr = iErr8;
 
                             // retry per section 6.5.3.4
-                            if (IsFloatResultSubnormal(correct2, float_ulps)
-                                || IsFloatResultSubnormal(correct3, float_ulps))
+                            if (IsFloatResultSubnormal(correct3, float_ulps)
+                                || IsFloatResultSubnormal(correct4, float_ulps)
+                                || IsFloatResultSubnormal(correct7, float_ulps)
+                                || IsFloatResultSubnormal(correct8, float_ulps))
                             {
                                 fail = fail
                                     && !(test == 0.0f
-                                         && (iErr3 == 0 || iErr4 == 0));
-                                if (!fail) err = 0.0f;
-                            }
-
-                            // try with both args as zero
-                            if (IsFloatSubnormal(s2[j]))
-                            {
-                                int correct7i, correct8i;
-                                correct3 = f->func.f_ffpI(0.0, 0.0, &correct3i);
-                                correct4 =
-                                    f->func.f_ffpI(-0.0, 0.0, &correct4i);
-                                double correct7 =
-                                    f->func.f_ffpI(0.0, -0.0, &correct7i);
-                                double correct8 =
-                                    f->func.f_ffpI(-0.0, -0.0, &correct8i);
-                                err2 = Ulp_Error(test, correct3);
-                                err3 = Ulp_Error(test, correct4);
-                                float err4 = Ulp_Error(test, correct7);
-                                float err5 = Ulp_Error(test, correct8);
-                                iErr3 = (long long)q2[j] - (long long)correct3i;
-                                iErr4 = (long long)q2[j] - (long long)correct4i;
-                                int64_t iErr7 =
-                                    (long long)q2[j] - (long long)correct7i;
-                                int64_t iErr8 =
-                                    (long long)q2[j] - (long long)correct8i;
-                                fail = fail
-                                    && ((!(fabsf(err2) <= float_ulps
-                                           && iErr3 == 0))
-                                        && (!(fabsf(err3) <= float_ulps
-                                              && iErr4 == 0))
-                                        && (!(fabsf(err4) <= float_ulps
-                                              && iErr7 == 0))
-                                        && (!(fabsf(err5) <= float_ulps
-                                              && iErr8 == 0)));
-                                if (fabsf(err2) < fabsf(err)) err = err2;
-                                if (fabsf(err3) < fabsf(err)) err = err3;
-                                if (fabsf(err4) < fabsf(err)) err = err4;
-                                if (fabsf(err5) < fabsf(err)) err = err5;
-                                if (llabs(iErr3) < llabs(iErr)) iErr = iErr3;
-                                if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
-                                if (llabs(iErr7) < llabs(iErr)) iErr = iErr7;
-                                if (llabs(iErr8) < llabs(iErr)) iErr = iErr8;
-
-                                // retry per section 6.5.3.4
-                                if (IsFloatResultSubnormal(correct3, float_ulps)
-                                    || IsFloatResultSubnormal(correct4,
-                                                              float_ulps)
-                                    || IsFloatResultSubnormal(correct7,
-                                                              float_ulps)
-                                    || IsFloatResultSubnormal(correct8,
-                                                              float_ulps))
-                                {
-                                    fail = fail
-                                        && !(test == 0.0f
-                                             && (iErr3 == 0 || iErr4 == 0
-                                                 || iErr7 == 0 || iErr8 == 0));
-                                    if (!fail) err = 0.0f;
-                                }
-                            }
-                        }
-                        else if (IsFloatSubnormal(s2[j]))
-                        {
-                            int correct3i, correct4i;
-                            double correct3 =
-                                f->func.f_ffpI(s[j], 0.0, &correct3i);
-                            double correct4 =
-                                f->func.f_ffpI(s[j], -0.0, &correct4i);
-                            float err2 = Ulp_Error(test, correct3);
-                            float err3 = Ulp_Error(test, correct4);
-                            int64_t iErr3 =
-                                (long long)q2[j] - (long long)correct3i;
-                            int64_t iErr4 =
-                                (long long)q2[j] - (long long)correct4i;
-                            fail = fail
-                                && ((!(fabsf(err2) <= float_ulps && iErr3 == 0))
-                                    && (!(fabsf(err3) <= float_ulps
-                                          && iErr4 == 0)));
-                            if (fabsf(err2) < fabsf(err)) err = err2;
-                            if (fabsf(err3) < fabsf(err)) err = err3;
-                            if (llabs(iErr3) < llabs(iErr)) iErr = iErr3;
-                            if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
-
-                            // retry per section 6.5.3.4
-                            if (IsFloatResultSubnormal(correct2, float_ulps)
-                                || IsFloatResultSubnormal(correct3, float_ulps))
-                            {
-                                fail = fail
-                                    && !(test == 0.0f
-                                         && (iErr3 == 0 || iErr4 == 0));
+                                         && (iErr3 == 0 || iErr4 == 0
+                                             || iErr7 == 0 || iErr8 == 0));
                                 if (!fail) err = 0.0f;
                             }
                         }
                     }
+                    else if (IsFloatSubnormal(s2[j]))
+                    {
+                        int correct3i, correct4i;
+                        double correct3 = f->func.f_ffpI(s[j], 0.0, &correct3i);
+                        double correct4 =
+                            f->func.f_ffpI(s[j], -0.0, &correct4i);
+                        float err2 = Ulp_Error(test, correct3);
+                        float err3 = Ulp_Error(test, correct4);
+                        int64_t iErr3 = (long long)q2[j] - (long long)correct3i;
+                        int64_t iErr4 = (long long)q2[j] - (long long)correct4i;
+                        fail = fail
+                            && ((!(fabsf(err2) <= float_ulps && iErr3 == 0))
+                                && (!(fabsf(err3) <= float_ulps
+                                      && iErr4 == 0)));
+                        if (fabsf(err2) < fabsf(err)) err = err2;
+                        if (fabsf(err3) < fabsf(err)) err = err3;
+                        if (llabs(iErr3) < llabs(iErr)) iErr = iErr3;
+                        if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
+
+                        // retry per section 6.5.3.4
+                        if (IsFloatResultSubnormal(correct2, float_ulps)
+                            || IsFloatResultSubnormal(correct3, float_ulps))
+                        {
+                            fail = fail
+                                && !(test == 0.0f
+                                     && (iErr3 == 0 || iErr4 == 0));
+                            if (!fail) err = 0.0f;
+                        }
+                    }
+                }
                     if (fabsf(err) > maxError)
                     {
                         maxError = fabsf(err);
@@ -687,7 +674,6 @@ int TestFunc_FloatI_Float_Float(const Func *f, MTdata d, bool relaxedMode)
                         error = -1;
                         goto exit;
                     }
-                }
             }
         }
 


### PR DESCRIPTION
Reformat code using clang-format.
This is similar to https://github.com/KhronosGroup/OpenCL-CTS/pull/1117/commits/7a391f8b2d5f68876826b3b9dcb4f0c4d032f99b in #1117.