### PR TITLE
Minor fixes for CL_UNORM_SHORT_565, CL_UNORM_SHORT_555

### DIFF
--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -1579,4 +1579,3 @@ int filter_rounding_errors(int forceCorrectlyRoundedWrites,
 
     return 1;
 }
-

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -1544,3 +1544,39 @@ int test_read_image(cl_context context, cl_command_queue queue,
 
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
+
+void filter_undefined_bits(image_descriptor *imageInfo, char *resultPtr)
+{
+    // mask off the top bit (bit 15) if the image format is (CL_UNORM_SHORT_555,
+    // CL_RGB). (Note: OpenCL says: the top bit is undefined meaning it can be
+    // either 0 or 1.)
+    if (imageInfo->format->image_channel_data_type == CL_UNORM_SHORT_555)
+    {
+        cl_ushort *temp = (cl_ushort *)resultPtr;
+        temp[0] &= 0x7fff;
+    }
+}
+
+int filter_rounding_errors(int forceCorrectlyRoundedWrites,
+                           image_descriptor *imageInfo, float *errors)
+{
+    // We are allowed 0.6 absolute error vs. infinitely precise for some
+    // normalized formats
+    if (0 == forceCorrectlyRoundedWrites
+        && (imageInfo->format->image_channel_data_type == CL_UNORM_INT8
+            || imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010
+            || imageInfo->format->image_channel_data_type == CL_UNORM_INT16
+            || imageInfo->format->image_channel_data_type == CL_SNORM_INT8
+            || imageInfo->format->image_channel_data_type == CL_SNORM_INT16
+            || imageInfo->format->image_channel_data_type == CL_UNORM_SHORT_555
+            || imageInfo->format->image_channel_data_type
+                == CL_UNORM_SHORT_565))
+    {
+        if (!(fabsf(errors[0]) > 0.6f) && !(fabsf(errors[1]) > 0.6f)
+            && !(fabsf(errors[2]) > 0.6f) && !(fabsf(errors[3]) > 0.6f))
+            return 0;
+    }
+
+    return 1;
+}
+

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -229,3 +229,9 @@ int determine_validation_error_offset(
     }
     return 0;
 }
+
+
+extern int filter_rounding_errors(int forceCorrectlyRoundedWrites,
+                                  image_descriptor *imageInfo, float *errors);
+extern void filter_undefined_bits(image_descriptor *imageInfo, char *resultPtr);
+

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -234,4 +234,3 @@ int determine_validation_error_offset(
 extern int filter_rounding_errors(int forceCorrectlyRoundedWrites,
                                   image_descriptor *imageInfo, float *errors);
 extern void filter_undefined_bits(image_descriptor *imageInfo, char *resultPtr);
-

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "test_common.h"
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -395,6 +396,8 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                     }
                     else
                     {
+                        filter_undefined_bits(imageInfo, resultPtr);
+
                         // Exact result passes every time
                         if( memcmp( resultBuffer, resultPtr, get_pixel_size( imageInfo->format ) ) != 0 )
                         {
@@ -403,21 +406,8 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                             float errors[4] = {NAN, NAN, NAN, NAN};
                             pack_image_pixel_error( (float *)imagePtr, imageInfo->format, resultBuffer, errors );
 
-                            // We are allowed 0.6 absolute error vs. infinitely precise for some normalized formats
-                            if( 0 == forceCorrectlyRoundedWrites    &&
-                               (
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT16 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT16
-                                ))
-                            {
-                                if( ! (fabsf( errors[0] ) > 0.6f) && ! (fabsf( errors[1] ) > 0.6f) &&
-                                   ! (fabsf( errors[2] ) > 0.6f) && ! (fabsf( errors[3] ) > 0.6f)  )
-                                    failure = 0;
-                            }
-
+                            failure = filter_rounding_errors(
+                                forceCorrectlyRoundedWrites, imageInfo, errors);
 
                             if( failure )
                             {
@@ -458,6 +448,56 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                         log_error( "    Actual:   0x%2.2x 0x%2.2x 0x%2.2x 0x%2.2x\n", ((cl_uchar*)resultPtr)[0], ((cl_uchar*)resultPtr)[1], ((cl_uchar*)resultPtr)[2], ((cl_uchar*)resultPtr)[3] );
                                         log_error( "    Error:    %f %f %f %f\n", errors[0], errors[1], errors[2], errors[3] );
                                         break;
+                                    case CL_UNORM_SHORT_565: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x3F,
+                                                  (ref_value[0] >> 11) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x3F,
+                                                  (test_value[0] >> 11) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
+                                    case CL_UNORM_SHORT_555: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x1F,
+                                                  (ref_value[0] >> 10) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x1F,
+                                                  (test_value[0] >> 10) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
                                     case CL_UNORM_INT16:
                                     case CL_SNORM_INT16:
                                     case CL_UNSIGNED_INT16:

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "test_common.h"
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -415,6 +416,9 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                     }
                     else
                     {
+
+                        filter_undefined_bits(imageInfo, resultPtr);
+
                         // Exact result passes every time
                         if( memcmp( resultBuffer, resultPtr, pixelSize ) != 0 )
                         {
@@ -423,21 +427,8 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                             float errors[4] = {NAN, NAN, NAN, NAN};
                             pack_image_pixel_error( (float *)imagePtr, imageInfo->format, resultBuffer, errors );
 
-                            // We are allowed 0.6 absolute error vs. infinitely precise for some normalized formats
-                            if( 0 == forceCorrectlyRoundedWrites    &&
-                               (
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT16 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT16
-                                ))
-                            {
-                                if( ! (fabsf( errors[0] ) > 0.6f) && ! (fabsf( errors[1] ) > 0.6f) &&
-                                   ! (fabsf( errors[2] ) > 0.6f) && ! (fabsf( errors[3] ) > 0.6f)  )
-                                    failure = 0;
-                            }
-
+                            failure = filter_rounding_errors(
+                                forceCorrectlyRoundedWrites, imageInfo, errors);
 
                             if( failure )
                             {
@@ -478,6 +469,56 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                         log_error( "    Actual:   0x%2.2x 0x%2.2x 0x%2.2x 0x%2.2x\n", ((cl_uchar*)resultPtr)[0], ((cl_uchar*)resultPtr)[1], ((cl_uchar*)resultPtr)[2], ((cl_uchar*)resultPtr)[3] );
                                         log_error( "    Error:    %f %f %f %f\n", errors[0], errors[1], errors[2], errors[3] );
                                         break;
+                                    case CL_UNORM_SHORT_565: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x3F,
+                                                  (ref_value[0] >> 11) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x3F,
+                                                  (test_value[0] >> 11) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
+                                    case CL_UNORM_SHORT_555: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x1F,
+                                                  (ref_value[0] >> 10) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x1F,
+                                                  (test_value[0] >> 10) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
                                     case CL_UNORM_INT16:
                                     case CL_SNORM_INT16:
                                     case CL_UNSIGNED_INT16:

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "test_common.h"
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -438,6 +439,9 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                         }
                         else
                         {
+
+                            filter_undefined_bits(imageInfo, resultPtr);
+
                             // Exact result passes every time
                             if( memcmp( resultBuffer, resultPtr, get_pixel_size( imageInfo->format ) ) != 0 )
                             {
@@ -446,21 +450,9 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                 float errors[4] = {NAN, NAN, NAN, NAN};
                                 pack_image_pixel_error( (float *)imagePtr, imageInfo->format, resultBuffer, errors );
 
-                                // We are allowed 0.6 absolute error vs. infinitely precise for some normalized formats
-                                if( 0 == forceCorrectlyRoundedWrites    &&
-                                   (
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT8 ||
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010 ||
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT16 ||
-                                    imageInfo->format->image_channel_data_type == CL_SNORM_INT8 ||
-                                    imageInfo->format->image_channel_data_type == CL_SNORM_INT16
-                                    ))
-                                {
-                                    if( ! (fabsf( errors[0] ) > 0.6f) && ! (fabsf( errors[1] ) > 0.6f) &&
-                                       ! (fabsf( errors[2] ) > 0.6f) && ! (fabsf( errors[3] ) > 0.6f)  )
-                                        failure = 0;
-                                }
-
+                                failure = filter_rounding_errors(
+                                    forceCorrectlyRoundedWrites, imageInfo,
+                                    errors);
 
                                 if( failure )
                                 {
@@ -501,6 +493,64 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                             log_error( "    Actual:   0x%2.2x 0x%2.2x 0x%2.2x 0x%2.2x\n", ((cl_uchar*)resultPtr)[0], ((cl_uchar*)resultPtr)[1], ((cl_uchar*)resultPtr)[2], ((cl_uchar*)resultPtr)[3] );
                                             log_error( "    Error:    %f %f %f %f\n", errors[0], errors[1], errors[2], errors[3] );
                                             break;
+                                        case CL_UNORM_SHORT_565: {
+                                            cl_uint *ref_value =
+                                                (cl_uint *)resultBuffer;
+                                            cl_uint *test_value =
+                                                (cl_uint *)resultPtr;
+
+                                            log_error(" Expected: 0x%2.2x "
+                                                      "Actual: 0x%2.2x \n",
+                                                      ref_value[0],
+                                                      test_value[0]);
+
+                                            log_error(
+                                                "    Expected: 0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                ref_value[0] & 0x1F,
+                                                (ref_value[0] >> 5) & 0x3F,
+                                                (ref_value[0] >> 11) & 0x1F);
+                                            log_error(
+                                                "    Actual:   0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                test_value[0] & 0x1F,
+                                                (test_value[0] >> 5) & 0x3F,
+                                                (test_value[0] >> 11) & 0x1F);
+                                            log_error(
+                                                "    Error:    %f %f %f %f\n",
+                                                errors[0], errors[1],
+                                                errors[2]);
+                                            break;
+                                        }
+                                        case CL_UNORM_SHORT_555: {
+                                            cl_uint *ref_value =
+                                                (cl_uint *)resultBuffer;
+                                            cl_uint *test_value =
+                                                (cl_uint *)resultPtr;
+
+                                            log_error(" Expected: 0x%2.2x "
+                                                      "Actual: 0x%2.2x \n",
+                                                      ref_value[0],
+                                                      test_value[0]);
+
+                                            log_error(
+                                                "    Expected: 0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                ref_value[0] & 0x1F,
+                                                (ref_value[0] >> 5) & 0x1F,
+                                                (ref_value[0] >> 10) & 0x1F);
+                                            log_error(
+                                                "    Actual:   0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                test_value[0] & 0x1F,
+                                                (test_value[0] >> 5) & 0x1F,
+                                                (test_value[0] >> 10) & 0x1F);
+                                            log_error(
+                                                "    Error:    %f %f %f %f\n",
+                                                errors[0], errors[1],
+                                                errors[2]);
+                                            break;
+                                        }
                                         case CL_UNORM_INT16:
                                         case CL_SNORM_INT16:
                                         case CL_UNSIGNED_INT16:

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "test_common.h"
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -445,6 +446,9 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                         }
                         else
                         {
+
+                            filter_undefined_bits(imageInfo, resultPtr);
+
                             // Exact result passes every time
                             if( memcmp( resultBuffer, resultPtr, get_pixel_size( imageInfo->format ) ) != 0 )
                             {
@@ -453,21 +457,9 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                 float errors[4] = {NAN, NAN, NAN, NAN};
                                 pack_image_pixel_error( (float *)imagePtr, imageInfo->format, resultBuffer, errors );
 
-                                // We are allowed 0.6 absolute error vs. infinitely precise for some normalized formats
-                                if( 0 == forceCorrectlyRoundedWrites    &&
-                                   (
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT8 ||
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010 ||
-                                    imageInfo->format->image_channel_data_type == CL_UNORM_INT16 ||
-                                    imageInfo->format->image_channel_data_type == CL_SNORM_INT8 ||
-                                    imageInfo->format->image_channel_data_type == CL_SNORM_INT16
-                                    ))
-                                {
-                                    if( ! (fabsf( errors[0] ) > 0.6f) && ! (fabsf( errors[1] ) > 0.6f) &&
-                                       ! (fabsf( errors[2] ) > 0.6f) && ! (fabsf( errors[3] ) > 0.6f)  )
-                                        failure = 0;
-                                }
-
+                                failure = filter_rounding_errors(
+                                    forceCorrectlyRoundedWrites, imageInfo,
+                                    errors);
 
                                 if( failure )
                                 {
@@ -508,6 +500,64 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                             log_error( "    Actual:   0x%2.2x 0x%2.2x 0x%2.2x 0x%2.2x\n", ((cl_uchar*)resultPtr)[0], ((cl_uchar*)resultPtr)[1], ((cl_uchar*)resultPtr)[2], ((cl_uchar*)resultPtr)[3] );
                                             log_error( "    Error:    %f %f %f %f\n", errors[0], errors[1], errors[2], errors[3] );
                                             break;
+                                        case CL_UNORM_SHORT_565: {
+                                            cl_uint *ref_value =
+                                                (cl_uint *)resultBuffer;
+                                            cl_uint *test_value =
+                                                (cl_uint *)resultPtr;
+
+                                            log_error(" Expected: 0x%2.2x "
+                                                      "Actual: 0x%2.2x \n",
+                                                      ref_value[0],
+                                                      test_value[0]);
+
+                                            log_error(
+                                                "    Expected: 0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                ref_value[0] & 0x1F,
+                                                (ref_value[0] >> 5) & 0x3F,
+                                                (ref_value[0] >> 11) & 0x1F);
+                                            log_error(
+                                                "    Actual:   0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                test_value[0] & 0x1F,
+                                                (test_value[0] >> 5) & 0x3F,
+                                                (test_value[0] >> 11) & 0x1F);
+                                            log_error(
+                                                "    Error:    %f %f %f %f\n",
+                                                errors[0], errors[1],
+                                                errors[2]);
+                                            break;
+                                        }
+                                        case CL_UNORM_SHORT_555: {
+                                            cl_uint *ref_value =
+                                                (cl_uint *)resultBuffer;
+                                            cl_uint *test_value =
+                                                (cl_uint *)resultPtr;
+
+                                            log_error(" Expected: 0x%2.2x "
+                                                      "Actual: 0x%2.2x \n",
+                                                      ref_value[0],
+                                                      test_value[0]);
+
+                                            log_error(
+                                                "    Expected: 0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                ref_value[0] & 0x1F,
+                                                (ref_value[0] >> 5) & 0x1F,
+                                                (ref_value[0] >> 10) & 0x1F);
+                                            log_error(
+                                                "    Actual:   0x%2.2x 0x%2.2x "
+                                                "0x%2.2x \n",
+                                                test_value[0] & 0x1F,
+                                                (test_value[0] >> 5) & 0x1F,
+                                                (test_value[0] >> 10) & 0x1F);
+                                            log_error(
+                                                "    Error:    %f %f %f %f\n",
+                                                errors[0], errors[1],
+                                                errors[2]);
+                                            break;
+                                        }
                                         case CL_UNORM_INT16:
                                         case CL_SNORM_INT16:
                                         case CL_UNSIGNED_INT16:

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "test_common.h"
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -477,6 +478,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     }
                     else
                     {
+
+                        filter_undefined_bits(imageInfo, resultPtr);
+
                         // Exact result passes every time
                         if( memcmp( resultBuffer, resultPtr, get_pixel_size( imageInfo->format ) ) != 0 )
                         {
@@ -485,21 +489,8 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                             float errors[4] = {NAN, NAN, NAN, NAN};
                             pack_image_pixel_error( (float *)imagePtr, imageInfo->format, resultBuffer, errors );
 
-                            // We are allowed 0.6 absolute error vs. infinitely precise for some normalized formats
-                            if( 0 == forceCorrectlyRoundedWrites    &&
-                               (
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT_101010 ||
-                                imageInfo->format->image_channel_data_type == CL_UNORM_INT16 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT8 ||
-                                imageInfo->format->image_channel_data_type == CL_SNORM_INT16
-                                ))
-                            {
-                                if( ! (fabsf( errors[0] ) > 0.6f) && ! (fabsf( errors[1] ) > 0.6f) &&
-                                   ! (fabsf( errors[2] ) > 0.6f) && ! (fabsf( errors[3] ) > 0.6f)  )
-                                    failure = 0;
-                            }
-
+                            failure = filter_rounding_errors(
+                                forceCorrectlyRoundedWrites, imageInfo, errors);
 
                             if( failure )
                             {
@@ -577,6 +568,57 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                         log_error( "    Actual:   %a %a %a %a\n", ((cl_float*)resultPtr)[0], ((cl_float*)resultPtr)[1], ((cl_float*)resultPtr)[2], ((cl_float*)resultPtr)[3] );
                                         log_error( "    Ulps:     %f %f %f %f\n", errors[0], errors[1], errors[2], errors[3] );
                                         break;
+                                    case CL_UNORM_SHORT_565: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x3F,
+                                                  (ref_value[0] >> 11) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x3F,
+                                                  (test_value[0] >> 11) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
+
+                                    case CL_UNORM_SHORT_555: {
+                                        cl_uint *ref_value =
+                                            (cl_uint *)resultBuffer;
+                                        cl_uint *test_value =
+                                            (cl_uint *)resultPtr;
+
+                                        log_error(" Expected: 0x%2.2x Actual: "
+                                                  "0x%2.2x \n",
+                                                  ref_value[0], test_value[0]);
+
+                                        log_error("    Expected: 0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  ref_value[0] & 0x1F,
+                                                  (ref_value[0] >> 5) & 0x1F,
+                                                  (ref_value[0] >> 10) & 0x1F);
+                                        log_error("    Actual:   0x%2.2x "
+                                                  "0x%2.2x 0x%2.2x \n",
+                                                  test_value[0] & 0x1F,
+                                                  (test_value[0] >> 5) & 0x1F,
+                                                  (test_value[0] >> 10) & 0x1F);
+                                        log_error("    Error:    %f %f %f %f\n",
+                                                  errors[0], errors[1],
+                                                  errors[2]);
+                                        break;
+                                    }
                                 }
 
                                 float *v = (float *)(char *)imagePtr;


### PR DESCRIPTION
* Fix verification for undefined bit
* Relax current infinitely precision requirement for these formats
  and move check in common function.
* Add proper debug output.

Signed-off-by: John Kesapides <john.kesapides@arm.com>