### PR TITLE
Reduce difference between files

### DIFF
--- a/test_conformance/math_brute_force/binary.cpp
+++ b/test_conformance/math_brute_force/binary.cpp
@@ -634,6 +634,7 @@ static int TestFunc_Float_Float_Float_common(const Func *f, MTdata d,
     vlog("\n");
 
 exit:
+    // Release
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)
     {
         clReleaseProgram(test_info.programs[i]);

--- a/test_conformance/math_brute_force/binaryOperator.cpp
+++ b/test_conformance/math_brute_force/binaryOperator.cpp
@@ -567,7 +567,6 @@ int TestFunc_Float_Float_Float_Operator(const Func *f, MTdata d,
             return error;
         }
 
-
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
         {
@@ -633,6 +632,7 @@ int TestFunc_Float_Float_Float_Operator(const Func *f, MTdata d,
     vlog("\n");
 
 exit:
+    // Release
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)
     {
         clReleaseProgram(test_info.programs[i]);
@@ -1147,7 +1147,6 @@ exit:
     return error;
 }
 
-
 // A table of more difficult cases to get right
 static const double specialValuesDouble[] = {
     -NAN,
@@ -1437,13 +1436,13 @@ int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata d,
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer ***\n", error);
             return error;
         }
+
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer2, CL_FALSE, 0,
                                           BUFFER_SIZE, gIn2, 0, NULL, NULL)))
         {
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer2 ***\n", error);
             return error;
         }
-
 
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)

--- a/test_conformance/math_brute_force/binary_i.cpp
+++ b/test_conformance/math_brute_force/binary_i.cpp
@@ -513,24 +513,23 @@ int TestFunc_Float_Float_Int(const Func *f, MTdata d, bool relaxedMode)
     }
 
     // Run the kernels
-    error = ThreadPool_Do(TestFloat, test_info.jobCount, &test_info);
-
-
-    // Accumulate the arithmetic errors
-    for (i = 0; i < test_info.threadCount; i++)
-    {
-        if (test_info.tinfo[i].maxError > maxError)
-        {
-            maxError = test_info.tinfo[i].maxError;
-            maxErrorVal = test_info.tinfo[i].maxErrorValue;
-            maxErrorVal2 = test_info.tinfo[i].maxErrorValue2;
-        }
-    }
-
-    if (error) goto exit;
-
     if (!gSkipCorrectnessTesting)
     {
+        error = ThreadPool_Do(TestFloat, test_info.jobCount, &test_info);
+
+        // Accumulate the arithmetic errors
+        for (i = 0; i < test_info.threadCount; i++)
+        {
+            if (test_info.tinfo[i].maxError > maxError)
+            {
+                maxError = test_info.tinfo[i].maxError;
+                maxErrorVal = test_info.tinfo[i].maxErrorValue;
+                maxErrorVal2 = test_info.tinfo[i].maxErrorValue2;
+            }
+        }
+
+        if (error) goto exit;
+
         if (gWimpyMode)
             vlog("Wimp pass");
         else
@@ -561,7 +560,6 @@ int TestFunc_Float_Float_Int(const Func *f, MTdata d, bool relaxedMode)
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer2 ***\n", error);
             return error;
         }
-
 
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
@@ -628,6 +626,7 @@ int TestFunc_Float_Float_Int(const Func *f, MTdata d, bool relaxedMode)
     vlog("\n");
 
 exit:
+    // Release
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)
     {
         clReleaseProgram(test_info.programs[i]);
@@ -1205,24 +1204,22 @@ int TestFunc_Double_Double_Int(const Func *f, MTdata d, bool relaxedMode)
 
     // Run the kernels
     if (!gSkipCorrectnessTesting)
+    {
         error = ThreadPool_Do(TestDouble, test_info.jobCount, &test_info);
 
-
-    // Accumulate the arithmetic errors
-    for (i = 0; i < test_info.threadCount; i++)
-    {
-        if (test_info.tinfo[i].maxError > maxError)
+        // Accumulate the arithmetic errors
+        for (i = 0; i < test_info.threadCount; i++)
         {
-            maxError = test_info.tinfo[i].maxError;
-            maxErrorVal = test_info.tinfo[i].maxErrorValue;
-            maxErrorVal2 = test_info.tinfo[i].maxErrorValue2;
+            if (test_info.tinfo[i].maxError > maxError)
+            {
+                maxError = test_info.tinfo[i].maxError;
+                maxErrorVal = test_info.tinfo[i].maxErrorValue;
+                maxErrorVal2 = test_info.tinfo[i].maxErrorValue2;
+            }
         }
-    }
 
-    if (error) goto exit;
+        if (error) goto exit;
 
-    if (!gSkipCorrectnessTesting)
-    {
         if (gWimpyMode)
             vlog("Wimp pass");
         else

--- a/test_conformance/math_brute_force/macro_binary.cpp
+++ b/test_conformance/math_brute_force/macro_binary.cpp
@@ -526,7 +526,6 @@ int TestMacro_Int_Float_Float(const Func *f, MTdata d, bool relaxedMode)
             return error;
         }
 
-
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
         {
@@ -590,6 +589,7 @@ int TestMacro_Int_Float_Float(const Func *f, MTdata d, bool relaxedMode)
     vlog("\n");
 
 exit:
+    // Release
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)
     {
         clReleaseProgram(test_info.programs[i]);
@@ -934,7 +934,6 @@ exit:
     return error;
 }
 
-
 // A table of more difficult cases to get right
 static const double specialValuesDouble[] = {
     -NAN,
@@ -1207,13 +1206,13 @@ int TestMacro_Int_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer ***\n", error);
             return error;
         }
+
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer2, CL_FALSE, 0,
                                           BUFFER_SIZE, gIn2, 0, NULL, NULL)))
         {
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer2 ***\n", error);
             return error;
         }
-
 
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)

--- a/test_conformance/math_brute_force/macro_unary.cpp
+++ b/test_conformance/math_brute_force/macro_unary.cpp
@@ -441,6 +441,7 @@ int TestMacro_Int_Float(const Func *f, MTdata d, bool relaxedMode)
     vlog("\n");
 
 exit:
+    // Release
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)
     {
         clReleaseProgram(test_info.programs[i]);
@@ -507,7 +508,7 @@ static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *data)
     // Get that moving
     if ((error = clFlush(tinfo->tQueue))) vlog("clFlush failed\n");
 
-    // Write the new values to the input array
+    // Init input array
     cl_uint *p = (cl_uint *)gIn + thread_id * buffer_elements;
     for (j = 0; j < buffer_elements; j++) p[j] = base + j * scale;
 

--- a/test_conformance/math_brute_force/mad.cpp
+++ b/test_conformance/math_brute_force/mad.cpp
@@ -676,25 +676,27 @@ int TestFunc_mad_Double(const Func *f, MTdata d, bool relaxedMode)
             p2[j] = DoubleFromUInt32(genrand_int32(d));
             p3[j] = DoubleFromUInt32(genrand_int32(d));
         }
+
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer, CL_FALSE, 0,
                                           bufferSize, gIn, 0, NULL, NULL)))
         {
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer ***\n", error);
             return error;
         }
+
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer2, CL_FALSE, 0,
                                           bufferSize, gIn2, 0, NULL, NULL)))
         {
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer2 ***\n", error);
             return error;
         }
+
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer3, CL_FALSE, 0,
                                           bufferSize, gIn3, 0, NULL, NULL)))
         {
             vlog_error("\n*** Error %d in clEnqueueWriteBuffer3 ***\n", error);
             return error;
         }
-
 
         // Run the kernels
         for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -629,7 +629,7 @@ static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *data)
             return error;
         }
 
-        // Run the kernel
+        // run the kernel
         size_t vectorCount =
             (buffer_elements + sizeValues[j] - 1) / sizeValues[j];
         cl_kernel kernel = job->k[j][thread_id]; // each worker thread has its


### PR DESCRIPTION
Another fairly trivial change for math_brute_force that will allow us to reduce code duplication in the long run.

---

Moves `if (!gSkipCorrectnessTesting)` in binary_i.cpp to follow structure of binary.cpp, unary.cpp, macro_unary.cpp and macro_binary.cpp.

Other non-semantic changes include adding/removing new lines and updating comments.
