### PR TITLE
Release clMemObj on reasignment

### DIFF
--- a/test_common/harness/typeWrappers.h
+++ b/test_common/harness/typeWrappers.h
@@ -120,6 +120,7 @@ public:
 
     clMemWrapper &operator=(const cl_mem &rhs)
     {
+        if (mMem != NULL) clReleaseMemObject(mMem);
         mMem = rhs;
         return *this;
     }


### PR DESCRIPTION
This change fixes a bug introduced in PR #1082.

Signed-off-by: Sebastian Luzynski <sebastian.jozef.luzynski@intel.com>