### PR TITLE
Regroup vtbl definitions to one translation unit

### DIFF
--- a/test_conformance/math_brute_force/binary.cpp
+++ b/test_conformance/math_brute_force/binary.cpp
@@ -13,25 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_Float_Float_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double_Double_Double(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Float_Float_Float_nextafter(const Func *f, MTdata,
-                                         bool relaxedMode);
-int TestFunc_Double_Double_Double_nextafter(const Func *f, MTdata,
-                                            bool relaxedMode);
-
-extern const vtbl _binary = { "binary", TestFunc_Float_Float_Float,
-                              TestFunc_Double_Double_Double };
-
-extern const vtbl _binary_nextafter = {
-    "binary_nextafter", TestFunc_Float_Float_Float_nextafter,
-    TestFunc_Double_Double_Double_nextafter
-};
 
 const float twoToMinus126 = MAKE_HEX_FLOAT(0x1p-126f, 1, -126);
 const double twoToMinus1022 = MAKE_HEX_DOUBLE(0x1p-1022, 1, -1022);

--- a/test_conformance/math_brute_force/binary_i.cpp
+++ b/test_conformance/math_brute_force/binary_i.cpp
@@ -13,18 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <limits.h>
 #include <string.h>
-
-int TestFunc_Float_Float_Int(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double_Double_Int(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _binary_i = { "binary_i", TestFunc_Float_Float_Int,
-                                TestFunc_Double_Double_Int };
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/binary_operator.cpp
+++ b/test_conformance/math_brute_force/binary_operator.cpp
@@ -13,19 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_Float_Float_Float_Operator(const Func *f, MTdata,
-                                        bool relaxedMode);
-int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata,
-                                           bool relaxedMode);
-
-extern const vtbl _binary_operator = { "binaryOperator",
-                                       TestFunc_Float_Float_Float_Operator,
-                                       TestFunc_Double_Double_Double_Operator };
 
 static int BuildKernel(const char *name, const char *operator_symbol,
                        int vectorSize, cl_uint kernel_count, cl_kernel *k,

--- a/test_conformance/math_brute_force/binary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i.cpp
@@ -13,19 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <limits.h>
 #include <string.h>
-
-int TestFunc_FloatI_Float_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_DoubleI_Double_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _binary_two_results_i = { "binary_two_results_i",
-                                            TestFunc_FloatI_Float_Float,
-                                            TestFunc_DoubleI_Double_Double };
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -13,8 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
 #include "reference_math.h"
+#include "test_functions.h"
 
 #define FTZ_ON 1
 #define FTZ_OFF 0
@@ -102,23 +104,89 @@
             _embedded_ulp, INFINITY, INFINITY, _rmode, RELAXED_OFF, _type      \
     }
 
-extern const vtbl _unary; // float foo( float )
-extern const vtbl _unary_u; // float foo( uint ),  double foo( ulong )
-extern const vtbl _i_unary; // int foo( float )
-extern const vtbl _macro_unary; // int foo( float ),  returns {0,1} for scalar,
-                                // { 0, -1 } for vector
-extern const vtbl _binary; // float foo( float, float )
-extern const vtbl _binary_nextafter; // float foo( float, float ), special
-                                     // handling for nextafter
-extern const vtbl _binary_operator; // float .op. float
-extern const vtbl _macro_binary; // int foo( float, float ), returns {0,1} for
-                                 // scalar, { 0, -1 } for vector
-extern const vtbl _binary_i; // float foo( float, int )
-extern const vtbl _ternary; // float foo( float, float, float )
-extern const vtbl _unary_two_results; // float foo( float, float * )
-extern const vtbl _unary_two_results_i; // float foo( float, int * )
-extern const vtbl _binary_two_results_i; // float foo( float, float, int * )
-extern const vtbl _mad_tbl; // float mad( float, float, float )
+static constexpr vtbl _unary = {
+    "unary",
+    TestFunc_Float_Float,
+    TestFunc_Double_Double,
+};
+
+static constexpr vtbl _i_unary = {
+    "i_unary",
+    TestFunc_Int_Float,
+    TestFunc_Int_Double,
+};
+
+static constexpr vtbl _unary_u = {
+    "unary_u",
+    TestFunc_Float_UInt,
+    TestFunc_Double_ULong,
+};
+
+static constexpr vtbl _macro_unary = {
+    "macro_unary",
+    TestMacro_Int_Float,
+    TestMacro_Int_Double,
+};
+
+static constexpr vtbl _binary = {
+    "binary",
+    TestFunc_Float_Float_Float,
+    TestFunc_Double_Double_Double,
+};
+
+static constexpr vtbl _binary_nextafter = {
+    "binary_nextafter",
+    TestFunc_Float_Float_Float_nextafter,
+    TestFunc_Double_Double_Double_nextafter,
+};
+
+static constexpr vtbl _binary_operator = {
+    "binaryOperator",
+    TestFunc_Float_Float_Float_Operator,
+    TestFunc_Double_Double_Double_Operator,
+};
+
+static constexpr vtbl _binary_i = {
+    "binary_i",
+    TestFunc_Float_Float_Int,
+    TestFunc_Double_Double_Int,
+};
+
+static constexpr vtbl _macro_binary = {
+    "macro_binary",
+    TestMacro_Int_Float_Float,
+    TestMacro_Int_Double_Double,
+};
+
+static constexpr vtbl _ternary = {
+    "ternary",
+    TestFunc_Float_Float_Float_Float,
+    TestFunc_Double_Double_Double_Double,
+};
+
+static constexpr vtbl _unary_two_results = {
+    "unary_two_results",
+    TestFunc_Float2_Float,
+    TestFunc_Double2_Double,
+};
+
+static constexpr vtbl _unary_two_results_i = {
+    "unary_two_results_i",
+    TestFunc_FloatI_Float,
+    TestFunc_DoubleI_Double,
+};
+
+static constexpr vtbl _binary_two_results_i = {
+    "binary_two_results_i",
+    TestFunc_FloatI_Float_Float,
+    TestFunc_DoubleI_Double_Double,
+};
+
+static constexpr vtbl _mad_tbl = {
+    "ternary",
+    TestFunc_mad_Float,
+    TestFunc_mad_Double,
+};
 
 #define unaryF &_unary
 #define i_unaryF &_i_unary

--- a/test_conformance/math_brute_force/i_unary.cpp
+++ b/test_conformance/math_brute_force/i_unary.cpp
@@ -13,18 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_Int_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Int_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _i_unary = { "i_unary", TestFunc_Int_Float,
-                               TestFunc_Int_Double };
-
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/macro_binary.cpp
+++ b/test_conformance/math_brute_force/macro_binary.cpp
@@ -13,17 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestMacro_Int_Float_Float(const Func *f, MTdata, bool relaxedMode);
-int TestMacro_Int_Double_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _macro_binary = { "macro_binary", TestMacro_Int_Float_Float,
-                                    TestMacro_Int_Double_Double };
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/macro_unary.cpp
+++ b/test_conformance/math_brute_force/macro_unary.cpp
@@ -13,17 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestMacro_Int_Float(const Func *f, MTdata, bool relaxedMode);
-int TestMacro_Int_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _macro_unary = { "macro_unary", TestMacro_Int_Float,
-                                   TestMacro_Int_Double };
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/mad.cpp
+++ b/test_conformance/math_brute_force/mad.cpp
@@ -13,16 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_mad(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_mad_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _mad_tbl = { "ternary", TestFunc_mad, TestFunc_mad_Double };
-
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)
@@ -235,7 +231,7 @@ static cl_int BuildKernel_DoubleFn(cl_uint job_id, cl_uint thread_id UNUSED,
                              info->programs + i, info->relaxedMode);
 }
 
-int TestFunc_mad(const Func *f, MTdata d, bool relaxedMode)
+int TestFunc_mad_Float(const Func *f, MTdata d, bool relaxedMode)
 {
     uint64_t i;
     uint32_t j, k;

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
 #include "sleep.h"
 #include "utility.h"

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "harness/compat.h"
 #include "reference_math.h"
 #include <limits.h>

--- a/test_conformance/math_brute_force/sleep.cpp
+++ b/test_conformance/math_brute_force/sleep.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "sleep.h"
 #include "utility.h"
 

--- a/test_conformance/math_brute_force/ternary.cpp
+++ b/test_conformance/math_brute_force/ternary.cpp
@@ -13,20 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
 
 #define CORRECTLY_ROUNDED 0
 #define FLUSHED 1
-
-int TestFunc_Float_Float_Float_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double_Double_Double_Double(const Func *f, MTdata,
-                                         bool relaxedMode);
-
-extern const vtbl _ternary = { "ternary", TestFunc_Float_Float_Float_Float,
-                               TestFunc_Double_Double_Double_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/test_functions.h
+++ b/test_conformance/math_brute_force/test_functions.h
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2021 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_FUNCTIONS_H
+#define TEST_FUNCTIONS_H
+
+#include "function_list.h"
+
+// float foo(float)
+int TestFunc_Float_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double)
+int TestFunc_Double_Double(const Func *f, MTdata, bool relaxedMode);
+
+// int foo(float)
+int TestFunc_Int_Float(const Func *f, MTdata, bool relaxedMode);
+
+// int foo(double)
+int TestFunc_Int_Double(const Func *f, MTdata, bool relaxedMode);
+
+// float foo(uint)
+int TestFunc_Float_UInt(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(ulong)
+int TestFunc_Double_ULong(const Func *f, MTdata, bool relaxedMode);
+
+// Returns {0, 1} for scalar and {0, -1} for vector.
+// int foo(float)
+int TestMacro_Int_Float(const Func *f, MTdata, bool relaxedMode);
+
+// Returns {0, 1} for scalar and {0, -1} for vector.
+// int foo(double)
+int TestMacro_Int_Double(const Func *f, MTdata, bool relaxedMode);
+
+// float foo(float, float)
+int TestFunc_Float_Float_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, double)
+int TestFunc_Double_Double_Double(const Func *f, MTdata, bool relaxedMode);
+
+// Special handling for nextafter.
+// float foo(float, float)
+int TestFunc_Float_Float_Float_nextafter(const Func *f, MTdata,
+                                         bool relaxedMode);
+
+// Special handling for nextafter.
+// double foo(double, double)
+int TestFunc_Double_Double_Double_nextafter(const Func *f, MTdata,
+                                            bool relaxedMode);
+
+// float op float
+int TestFunc_Float_Float_Float_Operator(const Func *f, MTdata,
+                                        bool relaxedMode);
+
+// double op double
+int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata,
+                                           bool relaxedMode);
+
+// float foo(float, int)
+int TestFunc_Float_Float_Int(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, int)
+int TestFunc_Double_Double_Int(const Func *f, MTdata, bool relaxedMode);
+
+// Returns {0, 1} for scalar and {0, -1} for vector.
+// int foo(float, float)
+int TestMacro_Int_Float_Float(const Func *f, MTdata, bool relaxedMode);
+
+// Returns {0, 1} for scalar and {0, -1} for vector.
+// int foo(double, double)
+int TestMacro_Int_Double_Double(const Func *f, MTdata, bool relaxedMode);
+
+// float foo(float, float, float)
+int TestFunc_Float_Float_Float_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, double, double)
+int TestFunc_Double_Double_Double_Double(const Func *f, MTdata,
+                                         bool relaxedMode);
+
+// float foo(float, float*)
+int TestFunc_Float2_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, double*)
+int TestFunc_Double2_Double(const Func *f, MTdata, bool relaxedMode);
+
+// float foo(float, int*)
+int TestFunc_FloatI_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, int*)
+int TestFunc_DoubleI_Double(const Func *f, MTdata, bool relaxedMode);
+
+// float foo(float, float, int*)
+int TestFunc_FloatI_Float_Float(const Func *f, MTdata, bool relaxedMode);
+
+// double foo(double, double, int*)
+int TestFunc_DoubleI_Double_Double(const Func *f, MTdata, bool relaxedMode);
+
+// Special handling for mad.
+// float mad(float, float, float)
+int TestFunc_mad_Float(const Func *f, MTdata, bool relaxedMode);
+
+// Special handling for mad.
+// double mad(double, double, double)
+int TestFunc_mad_Double(const Func *f, MTdata, bool relaxedMode);
+
+#endif

--- a/test_conformance/math_brute_force/unary.cpp
+++ b/test_conformance/math_brute_force/unary.cpp
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
@@ -21,12 +23,6 @@
 #if defined(__APPLE__)
 #include <sys/time.h>
 #endif
-
-int TestFunc_Float_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _unary = { "unary", TestFunc_Float_Float,
-                             TestFunc_Double_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/unary_two_results.cpp
+++ b/test_conformance/math_brute_force/unary_two_results.cpp
@@ -13,17 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_Float2_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double2_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _unary_two_results = { "unary_two_results",
-                                         TestFunc_Float2_Float,
-                                         TestFunc_Double2_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/unary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i.cpp
@@ -13,18 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <limits.h>
 #include <string.h>
-
-int TestFunc_FloatI_Float(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_DoubleI_Double(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _unary_two_results_i = { "unary_two_results_i",
-                                           TestFunc_FloatI_Float,
-                                           TestFunc_DoubleI_Double };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/unary_u.cpp
+++ b/test_conformance/math_brute_force/unary_u.cpp
@@ -13,16 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "function_list.h"
+#include "test_functions.h"
 #include "utility.h"
 
 #include <string.h>
-
-int TestFunc_Float_UInt(const Func *f, MTdata, bool relaxedMode);
-int TestFunc_Double_ULong(const Func *f, MTdata, bool relaxedMode);
-
-extern const vtbl _unary_u = { "unary_u", TestFunc_Float_UInt,
-                               TestFunc_Double_ULong };
 
 static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                        cl_program *p, bool relaxedMode)

--- a/test_conformance/math_brute_force/utility.cpp
+++ b/test_conformance/math_brute_force/utility.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 #include "utility.h"
 #include "function_list.h"
 


### PR DESCRIPTION
Move function declarations to a new header file, with relevant existing documentation.

---

This will allow further cleanups to be easier, such as splitting files to identify undesired differences between float and double versions of the tests.