### PR TITLE
Fix incorrect use of kernel parameter

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i.cpp
@@ -132,7 +132,7 @@ static int BuildKernelDouble(const char *name, int vectorSize, cl_kernel *k,
                         "   size_t i = get_global_id(0);\n"
                         "   out[i] = ",
                         name,
-                        "( in1[i], in2[i], out2[i] );\n"
+                        "( in1[i], in2[i], out2 + i );\n"
                         "}\n" };
 
     const char *c3[] = {


### PR DESCRIPTION
This issue was introduced in 8ad1088a (Reduce difference between files in math_brute_force (#1138), 2021-02-10).

Cf https://github.com/KhronosGroup/OpenCL-CTS/pull/1166#issuecomment-781143569
CC @gwawiork 