### PR TITLE
Limit buffers sizes to leave some memory for the platform

### DIFF
--- a/test_common/harness/deviceInfo.cpp
+++ b/test_common/harness/deviceInfo.cpp
@@ -132,3 +132,42 @@ size_t get_max_param_size(cl_device_id device)
     }
     return ret;
 }
+
+static cl_ulong get_device_info_max_size(cl_device_id device,
+                                         cl_device_info info,
+                                         unsigned int divisor)
+{
+    cl_ulong max_size;
+
+    if (divisor == 0)
+    {
+        throw std::runtime_error("Allocation divisor should not be 0\n");
+    }
+
+    if (clGetDeviceInfo(device, info, sizeof(max_size), &max_size, NULL)
+        != CL_SUCCESS)
+    {
+        throw std::runtime_error("clGetDeviceInfo failed\n");
+    }
+    return max_size / divisor;
+}
+
+cl_ulong get_device_info_max_mem_alloc_size(cl_device_id device,
+                                            unsigned int divisor)
+{
+    return get_device_info_max_size(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+                                    divisor);
+}
+
+cl_ulong get_device_info_global_mem_size(cl_device_id device,
+                                         unsigned int divisor)
+{
+    return get_device_info_max_size(device, CL_DEVICE_GLOBAL_MEM_SIZE, divisor);
+}
+
+cl_ulong get_device_info_max_constant_buffer_size(cl_device_id device,
+                                                  unsigned int divisor)
+{
+    return get_device_info_max_size(device, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,
+                                    divisor);
+}

--- a/test_common/harness/deviceInfo.h
+++ b/test_common/harness/deviceInfo.h
@@ -51,4 +51,16 @@ std::string get_device_name(cl_device_id device);
 // Returns the maximum size in bytes for Kernel Parameters
 size_t get_max_param_size(cl_device_id device);
 
+/* We need to use a portion of available alloc size,
+ * divide it to leave some memory for the platform. */
+#define MAX_DEVICE_MEMORY_SIZE_DIVISOR (2)
+
+/* Get max allocation size. */
+cl_ulong get_device_info_max_mem_alloc_size(cl_device_id device,
+                                            unsigned int divisor = 1);
+cl_ulong get_device_info_global_mem_size(cl_device_id device,
+                                         unsigned int divisor = 1);
+cl_ulong get_device_info_max_constant_buffer_size(cl_device_id device,
+                                                  unsigned int divisor = 1);
+
 #endif // _deviceInfo_h

--- a/test_conformance/allocations/allocation_functions.cpp
+++ b/test_conformance/allocations/allocation_functions.cpp
@@ -188,26 +188,14 @@ int allocate_size(cl_context context, cl_command_queue *queue,
     // one we don't end up returning a garbage value
     *number_of_mems = 0;
 
-    error = clGetDeviceInfo(device_id, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
-                            sizeof(max_individual_allocation_size),
-                            &max_individual_allocation_size, NULL);
-    test_error_abort(error,
-                     "clGetDeviceInfo failed for CL_DEVICE_MAX_MEM_ALLOC_SIZE");
-    error = clGetDeviceInfo(device_id, CL_DEVICE_GLOBAL_MEM_SIZE,
-                            sizeof(global_mem_size), &global_mem_size, NULL);
-    test_error_abort(error,
-                     "clGetDeviceInfo failed for CL_DEVICE_GLOBAL_MEM_SIZE");
+    max_individual_allocation_size =
+        get_device_info_max_mem_alloc_size(device_id);
+    global_mem_size = get_device_info_global_mem_size(device_id);
 
     if (global_mem_size > (cl_ulong)SIZE_MAX)
     {
         global_mem_size = (cl_ulong)SIZE_MAX;
     }
-
-    //  log_info("Device reports CL_DEVICE_MAX_MEM_ALLOC_SIZE=%llu bytes (%gMB),
-    //  CL_DEVICE_GLOBAL_MEM_SIZE=%llu bytes (%gMB).\n",
-    //           max_individual_allocation_size,
-    //           toMB(max_individual_allocation_size), global_mem_size,
-    //           toMB(global_mem_size));
 
     if (size_to_allocate > global_mem_size)
     {

--- a/test_conformance/allocations/main.cpp
+++ b/test_conformance/allocations/main.cpp
@@ -24,8 +24,10 @@
 
 typedef long long unsigned llu;
 
+#define REDUCTION_PERCENTAGE_DEFAULT 50
+
 int g_repetition_count = 1;
-int g_reduction_percentage = 100;
+int g_reduction_percentage = REDUCTION_PERCENTAGE_DEFAULT;
 int g_write_allocations = 1;
 int g_multiple_allocations = 0;
 int g_execute_kernel = 1;
@@ -44,24 +46,9 @@ test_status init_cl(cl_device_id device)
 {
     int error;
 
-    error = clGetDeviceInfo(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
-                            sizeof(g_max_individual_allocation_size),
-                            &g_max_individual_allocation_size, NULL);
-    if (error)
-    {
-        print_error(error,
-                    "clGetDeviceInfo failed for CL_DEVICE_MAX_MEM_ALLOC_SIZE");
-        return TEST_FAIL;
-    }
-    error =
-        clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE,
-                        sizeof(g_global_mem_size), &g_global_mem_size, NULL);
-    if (error)
-    {
-        print_error(error,
-                    "clGetDeviceInfo failed for CL_DEVICE_GLOBAL_MEM_SIZE");
-        return TEST_FAIL;
-    }
+    g_max_individual_allocation_size =
+        get_device_info_max_mem_alloc_size(device);
+    g_global_mem_size = get_device_info_global_mem_size(device);
 
     log_info("Device reports CL_DEVICE_MAX_MEM_ALLOC_SIZE=%llu bytes (%gMB), "
              "CL_DEVICE_GLOBAL_MEM_SIZE=%llu bytes (%gMB).\n",

--- a/test_conformance/api/test_kernels.cpp
+++ b/test_conformance/api/test_kernels.cpp
@@ -389,8 +389,8 @@ int test_set_kernel_arg_constant(cl_device_id deviceID, cl_context context, cl_c
     std::vector<cl_int> randomTestDataB(num_elements);
 
     /* Verify our test buffer won't be bigger than allowed */
-    error = clGetDeviceInfo( deviceID, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, sizeof( maxSize ), &maxSize, 0 );
-    test_error( error, "Unable to get max constant buffer size" );
+    maxSize = get_device_info_max_constant_buffer_size(
+        deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if (maxSize < sizeof(cl_int) * num_elements)
     {
         log_error( "ERROR: Unable to test constant argument to kernel: max size of constant buffer is reported as %d!\n", (int)maxSize );

--- a/test_conformance/images/clGetInfo/test_1D.cpp
+++ b/test_conformance/images/clGetInfo/test_1D.cpp
@@ -39,15 +39,20 @@ int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_fo
     imageInfo.format = format;
     pixelSize = get_pixel_size( imageInfo.format );
 
-    int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof( memSize ), &memSize, NULL );
+    int error = clGetDeviceInfo(device, CL_DEVICE_IMAGE2D_MAX_WIDTH,
+                                sizeof(maxWidth), &maxWidth, NULL);
     test_error( error, "Unable to get max image 1D size from device" );
 
-  if (memSize > (cl_ulong)SIZE_MAX) {
-    memSize = (cl_ulong)SIZE_MAX;
-    maxAllocSize = (cl_ulong)SIZE_MAX;
-  }
+    /* Reduce the size used by the test by half */
+    maxAllocSize = get_device_info_max_mem_alloc_size(
+        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    memSize =
+        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+
+    if (memSize > (cl_ulong)SIZE_MAX)
+    {
+        memSize = (cl_ulong)SIZE_MAX;
+    }
 
     if( gTestSmallImages )
     {

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -37,15 +37,20 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
     imageInfo.type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, sizeof( maxArraySize ), &maxArraySize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof( memSize ), &memSize, NULL );
+    error |= clGetDeviceInfo(device, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE,
+                             sizeof(maxArraySize), &maxArraySize, NULL);
     test_error( error, "Unable to get max image 1D array size from device" );
 
-  if (memSize > (cl_ulong)SIZE_MAX) {
-    memSize = (cl_ulong)SIZE_MAX;
-    maxAllocSize = (cl_ulong)SIZE_MAX;
-  }
+    /* Reduce the size used by the test by half */
+    maxAllocSize = get_device_info_max_mem_alloc_size(
+        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    memSize =
+        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+
+    if (memSize > (cl_ulong)SIZE_MAX)
+    {
+        memSize = (cl_ulong)SIZE_MAX;
+    }
 
     if( gTestSmallImages )
     {
@@ -162,15 +167,20 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof( maxHeight ), &maxHeight, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, sizeof( maxArraySize ), &maxArraySize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof( memSize ), &memSize, NULL );
+    error |= clGetDeviceInfo(device, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE,
+                             sizeof(maxArraySize), &maxArraySize, NULL);
     test_error( error, "Unable to get max image 1D array size from device" );
 
-  if (memSize > (cl_ulong)SIZE_MAX) {
-    memSize = (cl_ulong)SIZE_MAX;
-    maxAllocSize = (cl_ulong)SIZE_MAX;
-  }
+    /* Reduce the size used by the test by half */
+    maxAllocSize = get_device_info_max_mem_alloc_size(
+        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    memSize =
+        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+
+    if (memSize > (cl_ulong)SIZE_MAX)
+    {
+        memSize = (cl_ulong)SIZE_MAX;
+    }
 
     if( gTestSmallImages )
     {

--- a/test_conformance/images/clGetInfo/test_2D.cpp
+++ b/test_conformance/images/clGetInfo/test_2D.cpp
@@ -301,15 +301,20 @@ int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_fo
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof( maxHeight ), &maxHeight, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof( memSize ), &memSize, NULL );
+    error |= clGetDeviceInfo(device, CL_DEVICE_IMAGE2D_MAX_HEIGHT,
+                             sizeof(maxHeight), &maxHeight, NULL);
     test_error( error, "Unable to get max image 2D width or max image 3D height or max memory allocation size or global memory size from device" );
 
-  if (memSize > (cl_ulong)SIZE_MAX) {
-    memSize = (cl_ulong)SIZE_MAX;
-    maxAllocSize = (cl_ulong)SIZE_MAX;
-  }
+    /* Reduce the size used by the test by half */
+    maxAllocSize = get_device_info_max_mem_alloc_size(
+        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    memSize =
+        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+
+    if (memSize > (cl_ulong)SIZE_MAX)
+    {
+        memSize = (cl_ulong)SIZE_MAX;
+    }
 
     if( gTestSmallImages )
     {

--- a/test_conformance/images/clGetInfo/test_3D.cpp
+++ b/test_conformance/images/clGetInfo/test_3D.cpp
@@ -40,15 +40,20 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE3D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE3D_MAX_HEIGHT, sizeof( maxHeight ), &maxHeight, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE3D_MAX_DEPTH, sizeof( maxDepth ), &maxDepth, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
-    error |= clGetDeviceInfo( device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof( memSize ), &memSize, NULL );
+    error |= clGetDeviceInfo(device, CL_DEVICE_IMAGE3D_MAX_DEPTH,
+                             sizeof(maxDepth), &maxDepth, NULL);
     test_error( error, "Unable to get max image 3D size from device" );
 
-  if (memSize > (cl_ulong)SIZE_MAX) {
-    memSize = (cl_ulong)SIZE_MAX;
-    maxAllocSize = (cl_ulong)SIZE_MAX;
-  }
+    /* Reduce the size used by the test by half */
+    maxAllocSize = get_device_info_max_mem_alloc_size(
+        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    memSize =
+        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+
+    if (memSize > (cl_ulong)SIZE_MAX)
+    {
+        memSize = (cl_ulong)SIZE_MAX;
+    }
 
     if( gTestSmallImages )
     {


### PR DESCRIPTION
Some conformance tests use directly the size returned by the runtime
for max memory size to allocate buffers.
This doesn't leave enough memory for the system to run the tests.