### PR TITLE
Fold functions for nextafter

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -329,7 +329,9 @@ static int TestFunc_Double_Double_Double_common(const Func *f, MTdata d,
 
     test_info.isFDim = 0 == strcmp("fdim", f->nameInCode);
     test_info.skipNanInf = 0;
-    test_info.isNextafter = isNextafter;
+    test_info.isNextafter = 0 == strcmp("nextafter", f->nameInCode);
+    assert(isNextafter == test_info.isNextafter && "Unexpected parameter");
+
     // cl_kernels aren't thread safe, so we make one for each vector size for
     // every thread
     for (i = gMinVectorSizeIndex; i < gMaxVectorSizeIndex; i++)

--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -285,9 +285,7 @@ static size_t specialValuesDoubleCount =
 
 static cl_int TestDouble(cl_uint job_id, cl_uint thread_id, void *p);
 
-static int TestFunc_Double_Double_Double_common(const Func *f, MTdata d,
-                                                int isNextafter,
-                                                bool relaxedMode)
+int TestFunc_Double_Double_Double(const Func *f, MTdata d, bool relaxedMode)
 {
     TestInfo test_info;
     cl_int error;
@@ -330,7 +328,6 @@ static int TestFunc_Double_Double_Double_common(const Func *f, MTdata d,
     test_info.isFDim = 0 == strcmp("fdim", f->nameInCode);
     test_info.skipNanInf = 0;
     test_info.isNextafter = 0 == strcmp("nextafter", f->nameInCode);
-    assert(isNextafter == test_info.isNextafter && "Unexpected parameter");
 
     // cl_kernels aren't thread safe, so we make one for each vector size for
     // every thread
@@ -935,15 +932,4 @@ static cl_int TestDouble(cl_uint job_id, cl_uint thread_id, void *data)
 
 exit:
     return error;
-}
-
-int TestFunc_Double_Double_Double(const Func *f, MTdata d, bool relaxedMode)
-{
-    return TestFunc_Double_Double_Double_common(f, d, 0, relaxedMode);
-}
-
-int TestFunc_Double_Double_Double_nextafter(const Func *f, MTdata d,
-                                            bool relaxedMode)
-{
-    return TestFunc_Double_Double_Double_common(f, d, 1, relaxedMode);
 }

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -318,7 +318,8 @@ static int TestFunc_Float_Float_Float_common(const Func *f, MTdata d,
     test_info.relaxedMode = relaxedMode;
     test_info.isFDim = 0 == strcmp("fdim", f->nameInCode);
     test_info.skipNanInf = test_info.isFDim && !gInfNanSupport;
-    test_info.isNextafter = isNextafter;
+    test_info.isNextafter = 0 == strcmp("nextafter", f->nameInCode);
+    assert(isNextafter == test_info.isNextafter && "Unexpected parameter");
 
     // cl_kernels aren't thread safe, so we make one for each vector size for
     // every thread

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -273,8 +273,7 @@ typedef struct TestInfo
 
 static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *p);
 
-static int TestFunc_Float_Float_Float_common(const Func *f, MTdata d,
-                                             int isNextafter, bool relaxedMode)
+int TestFunc_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
 {
     TestInfo test_info;
     cl_int error;
@@ -319,7 +318,6 @@ static int TestFunc_Float_Float_Float_common(const Func *f, MTdata d,
     test_info.isFDim = 0 == strcmp("fdim", f->nameInCode);
     test_info.skipNanInf = test_info.isFDim && !gInfNanSupport;
     test_info.isNextafter = 0 == strcmp("nextafter", f->nameInCode);
-    assert(isNextafter == test_info.isNextafter && "Unexpected parameter");
 
     // cl_kernels aren't thread safe, so we make one for each vector size for
     // every thread
@@ -1094,15 +1092,4 @@ static cl_int TestFloat(cl_uint job_id, cl_uint thread_id, void *data)
 exit:
     if (overflow) free(overflow);
     return error;
-}
-
-int TestFunc_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
-{
-    return TestFunc_Float_Float_Float_common(f, d, 0, relaxedMode);
-}
-
-int TestFunc_Float_Float_Float_nextafter(const Func *f, MTdata d,
-                                         bool relaxedMode)
-{
-    return TestFunc_Float_Float_Float_common(f, d, 1, relaxedMode);
 }

--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -58,7 +58,6 @@
 #define unaryF_u NULL
 #define macro_unaryF NULL
 #define binaryF NULL
-#define binaryF_nextafter NULL
 #define binaryOperatorF NULL
 #define binaryF_i NULL
 #define macro_binaryF NULL
@@ -134,12 +133,6 @@ static constexpr vtbl _binary = {
     TestFunc_Double_Double_Double,
 };
 
-static constexpr vtbl _binary_nextafter = {
-    "binary_nextafter",
-    TestFunc_Float_Float_Float_nextafter,
-    TestFunc_Double_Double_Double_nextafter,
-};
-
 static constexpr vtbl _binary_operator = {
     "binaryOperator",
     TestFunc_Float_Float_Float_Operator,
@@ -193,7 +186,6 @@ static constexpr vtbl _mad_tbl = {
 #define unaryF_u &_unary_u
 #define macro_unaryF &_macro_unary
 #define binaryF &_binary
-#define binaryF_nextafter &_binary_nextafter
 #define binaryOperatorF &_binary_operator
 #define binaryF_i &_binary_i
 #define macro_binaryF &_macro_binary
@@ -285,7 +277,7 @@ const Func functionList[] = {
     ENTRY(minmag, 0.0f, 0.0f, FTZ_OFF, binaryF),
     ENTRY(modf, 0.0f, 0.0f, FTZ_OFF, unaryF_two_results),
     ENTRY(nan, 0.0f, 0.0f, FTZ_OFF, unaryF_u),
-    ENTRY(nextafter, 0.0f, 0.0f, FTZ_OFF, binaryF_nextafter),
+    ENTRY(nextafter, 0.0f, 0.0f, FTZ_OFF, binaryF),
     ENTRY_EXT(pow, 16.0f, 16.0f, 8192.0f, FTZ_OFF, binaryF,
               8192.0f), // in derived mode the ulp error is calculated as
                         // exp2(y*log2(x)) and in non-derived it is the same as


### PR DESCRIPTION
Remove unnecessary functions. The first commit adds some asserts to prove that the assumptions used by the second commit are correct.