### PR TITLE
Remove undesired conversions from size_t to int

### DIFF
--- a/test_conformance/math_brute_force/i_unary_float.cpp
+++ b/test_conformance/math_brute_force/i_unary_float.cpp
@@ -31,7 +31,7 @@ static int BuildKernel(const char *name, int vectorSize, cl_kernel *k,
                         sizeNames[vectorSize],
                         "* in)\n"
                         "{\n"
-                        "   int i = get_global_id(0);\n"
+                        "   size_t i = get_global_id(0);\n"
                         "   out[i] = ",
                         name,
                         "( in[i] );\n"


### PR DESCRIPTION
Improve math_brute_force kernels by consistently using size_t to store the result of get_global_id().

This change was missed in 5d7be40e (Remove undesired conversions from size_t to int (#1153), 2021-02-11).