### PR TITLE
Add clSetCommandQueueProperty test

### DIFF
--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -146,6 +146,8 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(consistency_3d_image_writes, Version(3, 0)),
 
     ADD_TEST(min_image_formats),
+    ADD_TEST(set_command_queue_property),
+
     ADD_TEST(negative_get_platform_info),
     ADD_TEST(negative_get_platform_ids),
 

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -58,6 +58,11 @@ extern int        test_set_kernel_arg_constant(cl_device_id deviceID, cl_context
 extern int        test_set_kernel_arg_struct_array(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_kernel_global_constant(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 
+extern int test_set_command_queue_property(cl_device_id deviceID,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
+
 extern int        test_min_max_thread_dimensions(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_min_max_work_items_sizes(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int        test_min_max_work_group_size(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);


### PR DESCRIPTION
Add test to check that clSetCommandQueueProperty
successfully changes command queue properties.

Fixes #904

Signed-off-by: Ellen Norris-Thompson <ellen.norris-thompson@arm.com>