### PR TITLE
Remove unnecessary APPLE specific code

### DIFF
--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -62,11 +62,7 @@ static int32_t gEndTestNumber = -1;
 int gSkipCorrectnessTesting = 0;
 int gStopOnError = 0;
 static bool gSkipRestOfTests;
-#if defined(__APPLE__)
-int gMeasureTimes = 1;
-#else
 int gMeasureTimes = 0;
-#endif
 int gReportAverageTimes = 0;
 int gForceFTZ = 0;
 int gWimpyMode = 0;
@@ -805,11 +801,6 @@ int main(int argc, const char *argv[])
         return -1;
     }
 
-#if defined(__APPLE__)
-    struct timeval startTime;
-    gettimeofday(&startTime, NULL);
-#endif
-
     error = ParseArgs(argc, argv);
     if (error) return error;
 
@@ -865,14 +856,6 @@ int main(int argc, const char *argv[])
     }
 
     ReleaseCL();
-
-#if defined(__APPLE__)
-    struct timeval endTime;
-    gettimeofday(&endTime, NULL);
-    double time = (double)endTime.tv_sec - (double)startTime.tv_sec;
-    time += 1e-6 * ((double)endTime.tv_usec - (double)startTime.tv_usec);
-    vlog("time: %f s\n", time);
-#endif
 
     return ret;
 }
@@ -1211,9 +1194,6 @@ test_status InitCL(cl_device_id device)
         return TEST_FAIL;
     }
 
-#if defined(__APPLE__)
-    // FIXME: use clProtectedArray
-#endif
     // Allocate buffers
     cl_uint min_alignment = 0;
     error = clGetDeviceInfo(gDevice, CL_DEVICE_MEM_BASE_ADDR_ALIGN,

--- a/test_conformance/math_brute_force/unary_double.cpp
+++ b/test_conformance/math_brute_force/unary_double.cpp
@@ -20,10 +20,6 @@
 
 #include <cstring>
 
-#if defined(__APPLE__)
-#include <sys/time.h>
-#endif
-
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
 {
@@ -166,12 +162,6 @@ int TestFunc_Double_Double(const Func *f, MTdata d, bool relaxedMode)
     size_t i, j;
     float maxError = 0.0f;
     double maxErrorVal = 0.0;
-#if defined(__APPLE__)
-    struct timeval time_val;
-    gettimeofday(&time_val, NULL);
-    double start_time = time_val.tv_sec + 1e-6 * time_val.tv_usec;
-    double end_time;
-#endif
 
     logFunctionInfo(f->name, sizeof(cl_double), relaxedMode);
     // Init test_info
@@ -302,12 +292,6 @@ int TestFunc_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog("passed");
     }
 
-
-#if defined(__APPLE__)
-    gettimeofday(&time_val, NULL);
-    end_time = time_val.tv_sec + 1e-6 * time_val.tv_usec;
-#endif
-
     if (gMeasureTimes)
     {
         // Init input array
@@ -386,10 +370,6 @@ int TestFunc_Double_Double(const Func *f, MTdata d, bool relaxedMode)
     }
 
     if (!gSkipCorrectnessTesting) vlog("\t%8.2f @ %a", maxError, maxErrorVal);
-
-#if defined(__APPLE__)
-    vlog("\t(%2.2f seconds)", end_time - start_time);
-#endif
     vlog("\n");
 
 exit:

--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -20,10 +20,6 @@
 
 #include <cstring>
 
-#if defined(__APPLE__)
-#include <sys/time.h>
-#endif
-
 static int BuildKernel(const char *name, int vectorSize, cl_uint kernel_count,
                        cl_kernel *k, cl_program *p, bool relaxedMode)
 {


### PR DESCRIPTION
To reduce differences between tests, remove APPLE specific code from unary tests as no other test have similar logic.

Ensure gMeasureTimes is consistently initialised regardless of operating systems to ensure a consistent command line interface.

The remaining APPLE specific pieces of code relate either to include paths, or to the implementation of PreventSleep(), ResumeSleep() and GetTime(). Those are not removed in this commit.
