### PR TITLE
Remove trivially dead code

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -521,7 +521,6 @@ int TestFunc_Double_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/binary_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_i_double.cpp
@@ -523,7 +523,6 @@ int TestFunc_Double_Double_Int(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/binary_operator_double.cpp
+++ b/test_conformance/math_brute_force/binary_operator_double.cpp
@@ -523,7 +523,6 @@ int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata d,
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/binary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_double.cpp
@@ -651,7 +651,6 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/i_unary_double.cpp
+++ b/test_conformance/math_brute_force/i_unary_double.cpp
@@ -354,7 +354,6 @@ int TestFunc_Int_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/macro_binary_double.cpp
+++ b/test_conformance/math_brute_force/macro_binary_double.cpp
@@ -491,7 +491,6 @@ int TestMacro_Int_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/macro_unary_double.cpp
+++ b/test_conformance/math_brute_force/macro_unary_double.cpp
@@ -338,7 +338,6 @@ int TestMacro_Int_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/mad_double.cpp
+++ b/test_conformance/math_brute_force/mad_double.cpp
@@ -385,7 +385,6 @@ int TestFunc_mad_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/ternary_double.cpp
+++ b/test_conformance/math_brute_force/ternary_double.cpp
@@ -821,7 +821,6 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/unary_double.cpp
+++ b/test_conformance/math_brute_force/unary_double.cpp
@@ -382,7 +382,6 @@ int TestFunc_Double_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting) vlog("\t%8.2f @ %a", maxError, maxErrorVal);

--- a/test_conformance/math_brute_force/unary_two_results_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_double.cpp
@@ -502,7 +502,6 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/unary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_double.cpp
@@ -475,7 +475,6 @@ int TestFunc_DoubleI_Double(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting)

--- a/test_conformance/math_brute_force/unary_u_double.cpp
+++ b/test_conformance/math_brute_force/unary_u_double.cpp
@@ -366,7 +366,6 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
             vlog_perf(clocksPerOp, LOWER_IS_BETTER, "clocks / element", "%sD%s",
                       f->name, sizeNames[j]);
         }
-        for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
     }
 
     if (!gSkipCorrectnessTesting) vlog("\t%8.2f @ %a", maxError, maxErrorVal);


### PR DESCRIPTION
This patch removes the following dead loop:
```c++
for (; j < gMaxVectorSizeIndex; j++) vlog("\t     -- ");
```

which is right after this loop:
```c++
for (j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++) {
  // ... no breaks ...
}
```
in other tests.