### PR TITLE
Do not dereference null pointer for no matching tests

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -713,20 +713,20 @@ int parseAndCallCommandLineTests(int argc, const char *argv[],
             ret = saveResultsToJson(filename, argv[0], testList,
                                     selectedTestList, resultTestList, testNum);
         }
-    }
 
-    if (std::any_of(resultTestList, resultTestList + testNum,
-                    [](test_status result) {
-                        switch (result)
-                        {
-                            case TEST_PASS:
-                            case TEST_SKIP: return false;
-                            case TEST_FAIL:
-                            default: return true;
-                        };
-                    }))
-    {
-        ret = EXIT_FAILURE;
+        if (std::any_of(resultTestList, resultTestList + testNum,
+                        [](test_status result) {
+                            switch (result)
+                            {
+                                case TEST_PASS:
+                                case TEST_SKIP: return false;
+                                case TEST_FAIL:
+                                default: return true;
+                            };
+                        }))
+        {
+            ret = EXIT_FAILURE;
+        }
     }
 
     free(selectedTestList);


### PR DESCRIPTION
When invoking for example

    test_c11_atomics test-that-does-not-exist

`parseAndCallCommandLineTests()` would attempt to dereference `resultTestList` which is still a null pointer.