### PR TITLE
Limit workgroup size for atomics tests

### DIFF
--- a/test_conformance/atomics/test_atomics.cpp
+++ b/test_conformance/atomics/test_atomics.cpp
@@ -202,7 +202,7 @@ int test_atomic_function(cl_device_id deviceID, cl_context context, cl_command_q
 
         // Limit workSize to avoid extremely large local buffer size and slow
         // run.
-        if (testFns.NumResultsFn && workSize > 65536) workSize = 65536;
+        if (workSize > 65536) workSize = 65536;
 
         // "workSize" is limited to that of the first dimension as only a 1DRange is executed.
         if( maxSizes[0] < workSize )

--- a/test_conformance/atomics/test_atomics.cpp
+++ b/test_conformance/atomics/test_atomics.cpp
@@ -200,6 +200,10 @@ int test_atomic_function(cl_device_id deviceID, cl_context context, cl_command_q
         error = clGetKernelWorkGroupInfo( kernel, deviceID, CL_KERNEL_WORK_GROUP_SIZE, sizeof( workSize ), &workSize, NULL );
         test_error( error, "Unable to obtain max work group size for device and kernel combo" );
 
+        // Limit workSize to avoid extremely large local buffer size and slow
+        // run.
+        if (testFns.NumResultsFn && workSize > 65536) workSize = 65536;
+
         // "workSize" is limited to that of the first dimension as only a 1DRange is executed.
         if( maxSizes[0] < workSize )
         {


### PR DESCRIPTION
This avoids extremely large local buffer size and slow run.