### PR TITLE
add basic test for cl_khr_pci_bus_info

### DIFF
--- a/test_conformance/computeinfo/CMakeLists.txt
+++ b/test_conformance/computeinfo/CMakeLists.txt
@@ -5,6 +5,7 @@ set(${MODULE_NAME}_SOURCES
         device_uuid.cpp
         extended_versioning.cpp
         conforming_version.cpp
+        pci_bus_info.cpp
 )
 
 include(../CMakeCommon.txt)

--- a/test_conformance/computeinfo/device_uuid.cpp
+++ b/test_conformance/computeinfo/device_uuid.cpp
@@ -105,7 +105,7 @@ int test_device_uuid(cl_device_id deviceID, cl_context context,
     if (!is_extension_available(deviceID, "cl_khr_device_uuid"))
     {
         log_info("cl_khr_device_uuid not supported. Skipping test...\n");
-        return 0;
+        return TEST_SKIPPED_ITSELF;
     }
 
     int total_errors = 0;

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1421,15 +1421,16 @@ int test_computeinfo(cl_device_id deviceID, cl_context context,
 extern int test_extended_versioning(cl_device_id, cl_context, cl_command_queue,
                                     int);
 extern int test_device_uuid(cl_device_id, cl_context, cl_command_queue, int);
-
 extern int test_conformance_version(cl_device_id, cl_context, cl_command_queue,
                                     int);
+extern int test_pci_bus_info(cl_device_id, cl_context, cl_command_queue, int);
 
 test_definition test_list[] = {
     ADD_TEST(computeinfo),
     ADD_TEST(extended_versioning),
     ADD_TEST(device_uuid),
     ADD_TEST_VERSION(conformance_version, Version(3, 0)),
+    ADD_TEST(pci_bus_info),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/computeinfo/pci_bus_info.cpp
+++ b/test_conformance/computeinfo/pci_bus_info.cpp
@@ -27,7 +27,7 @@ int test_pci_bus_info(cl_device_id deviceID, cl_context context,
     if (!is_extension_available(deviceID, "cl_khr_pci_bus_info"))
     {
         log_info("cl_khr_pci_bus_info not supported. Skipping test...\n");
-        return 0;
+        return TEST_SKIPPED_ITSELF;
     }
 
     cl_int error;

--- a/test_conformance/computeinfo/pci_bus_info.cpp
+++ b/test_conformance/computeinfo/pci_bus_info.cpp
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2021 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "harness/compat.h"
+
+#include <array>
+#include <bitset>
+
+#include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+
+int test_pci_bus_info(cl_device_id deviceID, cl_context context,
+                      cl_command_queue ignoreQueue, int num_elements)
+{
+    if (!is_extension_available(deviceID, "cl_khr_pci_bus_info"))
+    {
+        log_info("cl_khr_pci_bus_info not supported. Skipping test...\n");
+        return 0;
+    }
+
+    cl_int error;
+
+    cl_device_pci_bus_info_khr info;
+
+    size_t size_ret;
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_PCI_BUS_INFO_KHR, 0, NULL,
+                            &size_ret);
+    test_error(error, "Unable to query CL_DEVICE_PCI_BUS_INFO_KHR size");
+    test_assert_error(
+        size_ret == sizeof(info),
+        "Query for CL_DEVICE_PCI_BUS_INFO_KHR returned an unexpected size");
+
+    error = clGetDeviceInfo(deviceID, CL_DEVICE_PCI_BUS_INFO_KHR, sizeof(info),
+                            &info, NULL);
+    test_error(error, "Unable to query CL_DEVICE_PCI_BUS_INFO_KHR");
+
+    log_info("\tPCI Bus Info: %04x:%02x:%02x.%x\n", info.pci_domain,
+             info.pci_bus, info.pci_device, info.pci_function);
+
+    return TEST_PASS;
+}


### PR DESCRIPTION
Adds a minimal test for `cl_khr_pci_bus_info`.  This test simply queries the PCI bus ID and prints it as part of the `computeinfo` test, similar to the test for `cl_khr_device_uuid`.

NOTE: This test requires up-to-date headers with support for the `cl_khr_pci_bus_info` structure and enum: https://github.com/KhronosGroup/OpenCL-Headers/pull/166