### PR TITLE
Remove NULL Platform Check for Negative clGetPlatformInfo (#1222)

### DIFF
--- a/test_conformance/api/negative_platform.cpp
+++ b/test_conformance/api/negative_platform.cpp
@@ -42,15 +42,7 @@ int test_negative_get_platform_info(cl_device_id deviceID, cl_context context,
 {
     cl_platform_id platform = getPlatformFromDevice(deviceID);
 
-    cl_int err = clGetPlatformInfo(nullptr, CL_PLATFORM_VERSION, sizeof(char*),
-                                   nullptr, nullptr);
-    test_failure_error_ret(
-        err, CL_INVALID_PLATFORM,
-        "clGetPlatformInfo should return CL_INVALID_PLATFORM  when: \"platform "
-        "is not a valid platform\" using a nullptr",
-        TEST_FAIL);
-
-    err =
+    cl_int err =
         clGetPlatformInfo(reinterpret_cast<cl_platform_id>(deviceID),
                           CL_PLATFORM_VERSION, sizeof(char*), nullptr, nullptr);
     test_failure_error_ret(


### PR DESCRIPTION
Part of the negative CTS test for clGetPlatformInfo
incorrectly tested with a NULL platform. As this is a
special case it meant that the test was not correct.
This change removes the incorrect part of the test so that
it conforms with the OpenCL specification.

Signed-off-by: Chetankumar Mistry <chetan.mistry@arm.com>