### PR TITLE
Remove dead CMake code

### DIFF
--- a/test_conformance/math_brute_force/CMakeLists.txt
+++ b/test_conformance/math_brute_force/CMakeLists.txt
@@ -34,15 +34,4 @@ set(${MODULE_NAME}_SOURCES
     utility.cpp
 )
 
-if (NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
-set_source_files_properties(
-${MODULE_NAME}_SOURCES
-    COMPILE_FLAGS -march=i686)
-endif (NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
-
-if(CMAKE_COMPILER_IS_GNUCC)
-set_source_files_properties(
-        COMPILE_FLAGS -O0)
-endif(CMAKE_COMPILER_IS_GNUCC)
-
 include(../CMakeCommon.txt)


### PR DESCRIPTION
Remove CMake statements that have no effect in math_brute_force.

`set_source_files_properties` without a list of files has no effect.

When `MODULE_NAME` is `FOO`, `set_source_files_properties(${MODULE_NAME}_SOURCES ...)` sets the properties of "FOO_SOURCES", not of the files listed in the variable named `FOO_SOURCES`.