### PR TITLE
Report inputs for worst errors

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_double.cpp
@@ -565,7 +565,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
         else
             vlog("passed");
 
-        vlog("\t{%8.2f, %lld} @ %a", maxError, maxError2, maxErrorVal);
+        vlog("\t{%8.2f, %lld} @ {%a, %a}", maxError, maxError2, maxErrorVal,
+             maxErrorVal2);
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/binary_two_results_i_float.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_float.cpp
@@ -550,7 +550,8 @@ int TestFunc_FloatI_Float_Float(const Func *f, MTdata d, bool relaxedMode)
         else
             vlog("passed");
 
-        vlog("\t{%8.2f, %lld} @ %a", maxError, maxError2, maxErrorVal);
+        vlog("\t{%8.2f, %lld} @ {%a, %a}", maxError, maxError2, maxErrorVal,
+             maxErrorVal2);
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/unary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_double.cpp
@@ -402,7 +402,8 @@ int TestFunc_DoubleI_Double(const Func *f, MTdata d, bool relaxedMode)
         else
             vlog("passed");
 
-        vlog("\t{%8.2f, %lld} @ %a", maxError, maxError2, maxErrorVal);
+        vlog("\t{%8.2f, %lld} @ {%a, %a}", maxError, maxError2, maxErrorVal,
+             maxErrorVal2);
     }
 
     vlog("\n");

--- a/test_conformance/math_brute_force/unary_two_results_i_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_float.cpp
@@ -400,7 +400,8 @@ int TestFunc_FloatI_Float(const Func *f, MTdata d, bool relaxedMode)
         else
             vlog("passed");
 
-        vlog("\t{%8.2f, %lld} @ %a", maxError, maxError2, maxErrorVal);
+        vlog("\t{%8.2f, %lld} @ {%a, %a}", maxError, maxError2, maxErrorVal,
+             maxErrorVal2);
     }
 
     vlog("\n");


### PR DESCRIPTION
Builtin functions producing two results can have their worst error, for each result, on different inputs. Report both inputs.

The format might be a bit awkward, but tries to stay minimal like the output formats in other tests. An alternative could be to remove these variables, but someone could find value in them I suppose.