### PR TITLE
Remove unnecessary code from unary_u_*.cpp

### DIFF
--- a/test_conformance/math_brute_force/unary_u_double.cpp
+++ b/test_conformance/math_brute_force/unary_u_double.cpp
@@ -243,7 +243,6 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
                     float err = Bruteforce_Ulp_Error_Double(test, correct);
                     int fail = !(fabsf(err) <= f->double_ulps);
 
-                    // half_sin/cos/tan are only valid between +-2**16, Inf, NaN
                     if (fail)
                     {
                         if (ftz)

--- a/test_conformance/math_brute_force/unary_u_float.cpp
+++ b/test_conformance/math_brute_force/unary_u_float.cpp
@@ -126,8 +126,6 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
     float maxErrorVal = 0.0f;
     uint64_t step = getTestStep(sizeof(float), BUFFER_SIZE);
     int scale = (int)((1ULL << 32) / (16 * BUFFER_SIZE / sizeof(double)) + 1);
-    int isRangeLimited = 0;
-    float half_sin_cos_tan_limit = 0;
 
     logFunctionInfo(f->name, sizeof(cl_float), relaxedMode);
 
@@ -146,22 +144,6 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
                                    &build_info)))
             return error;
     }
-
-    if (0 == strcmp(f->name, "half_sin") || 0 == strcmp(f->name, "half_cos"))
-    {
-        isRangeLimited = 1;
-        half_sin_cos_tan_limit = 1.0f
-            + float_ulps
-                * (FLT_EPSILON / 2.0f); // out of range results from finite
-                                        // inputs must be in [-1,1]
-    }
-    else if (0 == strcmp(f->name, "half_tan"))
-    {
-        isRangeLimited = 1;
-        half_sin_cos_tan_limit =
-            INFINITY; // out of range resut from finite inputs must be numeric
-    }
-
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
@@ -249,7 +231,6 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
 
         if (gSkipCorrectnessTesting) break;
 
-
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;
         for (size_t j = 0; j < BUFFER_SIZE / sizeof(float); j++)
@@ -265,18 +246,6 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
                     double correct = f->func.f_u(s[j]);
                     float err = Ulp_Error(test, correct);
                     int fail = !(fabsf(err) <= float_ulps);
-
-                    // half_sin/cos/tan are only valid between +-2**16, Inf, NaN
-                    if (isRangeLimited
-                        && fabsf(s[j]) > MAKE_HEX_FLOAT(0x1.0p16f, 0x1L, 16)
-                        && fabsf(s[j]) < INFINITY)
-                    {
-                        if (fabsf(test) <= half_sin_cos_tan_limit)
-                        {
-                            err = 0;
-                            fail = 0;
-                        }
-                    }
 
                     if (fail)
                     {


### PR DESCRIPTION
Only nan() is tested by unary_u_float.cpp and unary_u_double.cpp. Testing of half_sin, half_tan and half_cos is done in unary_float.cpp and unary_double.cpp.

----

This was spotted because Clang complained `fabsf(s[j])` was a no-op (`-Wabsolute-value`).