### PR TITLE
Remove dead variables and functions

### DIFF
--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -279,7 +279,6 @@ int TestFunc_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
     float maxError = 0.0f;
     double maxErrorVal = 0.0;
     double maxErrorVal2 = 0.0;
-    int skipTestingRelaxed = 0;
 
     logFunctionInfo(f->name, sizeof(cl_float), relaxedMode);
 

--- a/test_conformance/math_brute_force/binary_operator_double.cpp
+++ b/test_conformance/math_brute_force/binary_operator_double.cpp
@@ -469,7 +469,6 @@ static cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     float ulps = job->ulps;
     dptr func = job->f->dfunc;
     int ftz = job->ftz;
-    bool relaxedMode = job->relaxedMode;
     MTdata d = tinfo->d;
     cl_int error;
     const char *name = job->f->name;

--- a/test_conformance/math_brute_force/unary_two_results_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_float.cpp
@@ -124,9 +124,7 @@ static cl_int BuildKernelFn(cl_uint job_id, cl_uint thread_id UNUSED, void *p)
 
 int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
 {
-    uint32_t l;
     int error;
-    char const *testing_mode;
     cl_program programs[VECTOR_SIZE_COUNT];
     cl_kernel kernels[VECTOR_SIZE_COUNT];
     float maxError0 = 0.0f;


### PR DESCRIPTION
These were identified using Clang's -Wunused warning flag.

@EwanC: those are the remaining dead variables spotted while working on #1228.