### PR TITLE
basic/async: Check for extension only once per test

### DIFF
--- a/test_conformance/basic/test_async_copy2D.cpp
+++ b/test_conformance/basic/test_async_copy2D.cpp
@@ -117,13 +117,6 @@ int test_copy2D(cl_device_id deviceID, cl_context context,
     log_info("Testing %s with srcStride = %d, dstStride = %d\n", vecNameString,
              srcStride, dstStride);
 
-    if (!is_extension_available(deviceID, "cl_khr_extended_async_copies"))
-    {
-        log_info(
-            "Device does not support extended async copies. Skipping test.\n");
-        return 0;
-    }
-
     cl_long max_local_mem_size;
     error =
         clGetDeviceInfo(deviceID, CL_DEVICE_LOCAL_MEM_SIZE,
@@ -385,6 +378,13 @@ int test_copy2D_all_types(cl_device_id deviceID, cl_context context,
     unsigned int size, typeIndex, srcStride, dstStride;
 
     int errors = 0;
+
+    if (!is_extension_available(deviceID, "cl_khr_extended_async_copies"))
+    {
+        log_info(
+            "Device does not support extended async copies. Skipping test.\n");
+        return 0;
+    }
 
     for (typeIndex = 0; vecType[typeIndex] != kNumExplicitTypes; typeIndex++)
     {

--- a/test_conformance/basic/test_async_copy3D.cpp
+++ b/test_conformance/basic/test_async_copy3D.cpp
@@ -138,13 +138,6 @@ int test_copy3D(cl_device_id deviceID, cl_context context,
              vecNameString, srcLineStride, dstLineStride, srcPlaneStride,
              dstPlaneStride);
 
-    if (!is_extension_available(deviceID, "cl_khr_extended_async_copies"))
-    {
-        log_info(
-            "Device does not support extended async copies. Skipping test.\n");
-        return 0;
-    }
-
     cl_long max_local_mem_size;
     error =
         clGetDeviceInfo(deviceID, CL_DEVICE_LOCAL_MEM_SIZE,
@@ -466,6 +459,13 @@ int test_copy3D_all_types(cl_device_id deviceID, cl_context context,
         dstPlaneStride;
 
     int errors = 0;
+
+    if (!is_extension_available(deviceID, "cl_khr_extended_async_copies"))
+    {
+        log_info(
+            "Device does not support extended async copies. Skipping test.\n");
+        return 0;
+    }
 
     for (typeIndex = 0; vecType[typeIndex] != kNumExplicitTypes; typeIndex++)
     {

--- a/test_conformance/basic/test_async_copy_fence.cpp
+++ b/test_conformance/basic/test_async_copy_fence.cpp
@@ -360,14 +360,6 @@ int test_copy_fence(cl_device_id deviceID, cl_context context,
     size_t elementSize = get_explicit_type_size(vecType) * vecSize;
     log_info("Testing %s\n", vecNameString);
 
-    if (!is_extension_available(deviceID, "cl_khr_async_work_group_copy_fence"))
-    {
-        log_info(
-            "Device does not support extended async copies fence. Skipping "
-            "test.\n");
-        return 0;
-    }
-
     cl_long max_local_mem_size;
     error =
         clGetDeviceInfo(deviceID, CL_DEVICE_LOCAL_MEM_SIZE,
@@ -731,6 +723,14 @@ int test_copy_fence_all_types(cl_device_id deviceID, cl_context context,
     unsigned int size, typeIndex;
 
     int errors = 0;
+
+    if (!is_extension_available(deviceID, "cl_khr_async_work_group_copy_fence"))
+    {
+        log_info(
+            "Device does not support extended async copies fence. Skipping "
+            "test.\n");
+        return 0;
+    }
 
     for (typeIndex = 0; vecType[typeIndex] != kNumExplicitTypes; typeIndex++)
     {


### PR DESCRIPTION
As the extension is vector size and type independent, we only need to check for the extension once per test and not for every possible combination of inputs, thereby drastically reducing the log output of the test when the extension is not supported.