### PR TITLE
testHarness: Print error string when clFinish fails

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -861,7 +861,7 @@ test_status callSingleTestFunction(test_definition test,
         int error = clFinish(queue);
         if (error)
         {
-            log_error("clFinish failed: %d", error);
+            log_error("clFinish failed: %s\n", IGetErrorString(error));
             status = TEST_FAIL;
         }
         clReleaseCommandQueue(queue);


### PR DESCRIPTION
Most other tests seem to print an error string rather than an error code.