### PR TITLE
Fix image pixel reference calculation for CL_{INTENSITY,LUMINANCE} formats

### DIFF
--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -489,12 +489,14 @@ void read_image_pixel(void *imageData, image_descriptor *imageInfo, int x,
     }
     else if (format->image_channel_order == CL_INTENSITY)
     {
+        outData[0] = tempData[0];
         outData[1] = tempData[0];
         outData[2] = tempData[0];
         outData[3] = tempData[0];
     }
     else if (format->image_channel_order == CL_LUMINANCE)
     {
+        outData[0] = tempData[0];
         outData[1] = tempData[0];
         outData[2] = tempData[0];
     }


### PR DESCRIPTION
As per 6.15.15.7, the first three components have to be set to the luminance value and all components to the intensity value.

Signed-off-by: Kévin Petit <kpet@free.fr>