### PR TITLE
Test compiler - extend list of known extensions

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -49,7 +49,7 @@ const char *known_extensions[] = {
     "cl_khr_subgroup_shuffle",
     "cl_khr_subgroup_shuffle_relative",
     "cl_khr_subgroup_clustered_reduce",
-
+    "cl_khr_extended_bit_ops",
     // API-only extensions after this point.  If you add above here, modify
     // first_API_extension below.
     "cl_khr_icd",
@@ -71,10 +71,13 @@ const char *known_extensions[] = {
     "cl_khr_spirv_no_integer_wrap_decoration",
     "cl_khr_extended_versioning",
     "cl_khr_device_uuid",
+    "cl_khr_pci_bus_info",
+    "cl_khr_suggested_local_work_size",
+    "cl_khr_spirv_linkonce_odr",
 };
 
-size_t num_known_extensions = sizeof(known_extensions)/sizeof(char*);
-size_t first_API_extension = 27;
+size_t num_known_extensions = sizeof(known_extensions) / sizeof(char *);
+size_t first_API_extension = 28;
 
 const char *known_embedded_extensions[] = {
     "cles_khr_int64",


### PR DESCRIPTION
Recently added new extension should be defined in the test_compiler test: 
`cl_khr_pci_bus_info`
`cl_khr_extended_bit_ops`
`cl_khr_spirv_linkonce_odr`
`cl_khr_suggested_local_work_size`

Only `cl_khr_extended_bit_ops` adds new functions to OpenCL C language.

