### PR TITLE
Fix double-release of memory objects

### DIFF
--- a/test_conformance/api/test_mem_object_info.cpp
+++ b/test_conformance/api/test_mem_object_info.cpp
@@ -348,14 +348,7 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
             TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_ASSOCIATED_MEMOBJECT, origObj, (cl_mem)bufferObject, "associated mem object", "%p", void * )
 
             TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_OFFSET, offset, (size_t)( addressAlign ), "offset", "%ld", size_t )
-
-            clReleaseMemObject( subBufferObject );
-            subBufferObject = NULL;
-
         }
-
-        clReleaseMemObject( bufferObject );
-        bufferObject = NULL;
     }
 
     return CL_SUCCESS;

--- a/test_conformance/api/test_mem_objects.cpp
+++ b/test_conformance/api/test_mem_objects.cpp
@@ -48,12 +48,7 @@ int test_mem_object_destructor_callback_single(clMemWrapper &memObject)
     test_error(error, "Unable to set destructor callback");
 
     // Now release the buffer, which SHOULD call the callbacks
-    error = clReleaseMemObject(memObject);
-    test_error(error, "Unable to release test buffer");
-
-    // Note: since we manually released the mem wrapper, we need to set it to
-    // NULL to prevent a double-release
-    memObject = NULL;
+    memObject.reset();
 
     // At this point, all three callbacks should have already been called
     int numErrors = 0;


### PR DESCRIPTION
A recent update to the object wrapper classes (#1268) changed the
behavior of assigning to a wrapper, whereby the wrapped object is now
released upon assignment. A couple of tests were manually calling
`clReleaseMemObject` and then assigning `nullptr` to the wrapper,
resulting in the wrapper calling `clReleaseMemObject` on an object that
had already been destroyed.