### PR TITLE
subgroups: Fix setting cl_halfs and progress check.

### DIFF
--- a/test_conformance/subgroups/main.cpp
+++ b/test_conformance/subgroups/main.cpp
@@ -19,8 +19,10 @@
 #include <string.h>
 #include "procs.h"
 #include "harness/testHarness.h"
+#include "CL/cl_half.h"
 
 MTdata gMTdata;
+cl_half_rounding_mode g_rounding_mode;
 
 test_definition test_list[] = {
     ADD_TEST_VERSION(sub_group_info_ext, Version(2, 0)),
@@ -65,6 +67,22 @@ static test_status InitCL(cl_device_id device)
         {
             ret = TEST_SKIP;
         }
+    }
+    // Determine the rounding mode to be used in float to half conversions in
+    // init and reference code
+    const cl_device_fp_config fpConfig = get_default_rounding_mode(device);
+
+    if (fpConfig == CL_FP_ROUND_TO_NEAREST)
+    {
+        g_rounding_mode = CL_HALF_RTE;
+    }
+    else if (fpConfig == CL_FP_ROUND_TO_ZERO && gIsEmbedded)
+    {
+        g_rounding_mode = CL_HALF_RTZ;
+    }
+    else
+    {
+        assert(false && "Unreachable");
     }
     return ret;
 }

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -301,7 +301,7 @@ static float to_float(subgroups::cl_half x) { return cl_half_to_float(x.data); }
 static subgroups::cl_half to_half(float x)
 {
     subgroups::cl_half value;
-    value.data = cl_half_from_float(x, CL_HALF_RTE);
+    value.data = convert_float_to_half(x);
     return value;
 }
 

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -301,7 +301,7 @@ static float to_float(subgroups::cl_half x) { return cl_half_to_float(x.data); }
 static subgroups::cl_half to_half(float x)
 {
     subgroups::cl_half value;
-    value.data = convert_float_to_half(x);
+    value.data = cl_half_from_float(x, g_rounding_mode);
     return value;
 }
 

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -1080,7 +1080,7 @@ template <typename Ty>
 typename std::enable_if<TypeManager<Ty>::is_sb_scalar_type::value>::type
 set_value(Ty &lhs, const cl_ulong &rhs)
 {
-    lhs.data = rhs;
+    lhs.data = cl_half_from_float(static_cast<cl_float>(rhs), CL_HALF_RTE);
 }
 
 // compare for common vectors

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -1080,7 +1080,7 @@ template <typename Ty>
 typename std::enable_if<TypeManager<Ty>::is_sb_scalar_type::value>::type
 set_value(Ty &lhs, const cl_ulong &rhs)
 {
-    lhs.data = cl_half_from_float(static_cast<cl_float>(rhs), CL_HALF_RTE);
+    lhs.data = convert_float_to_half(static_cast<cl_float>(rhs));
 }
 
 // compare for common vectors
@@ -1292,6 +1292,11 @@ template <typename Ty, typename Fns, size_t TSIZE = 0> struct test
             }
             else if (strstr(TypeManager<Ty>::name(), "half"))
             {
+                if( DetectFloatToHalfRoundingMode(queue) )
+                {
+                    log_error("Unable to detect rounding mode\n");
+                    return TEST_FAIL;
+                }
                 kernel_sstr << "#pragma OPENCL EXTENSION cl_khr_fp16: enable\n";
             }
         }

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -1292,7 +1292,7 @@ template <typename Ty, typename Fns, size_t TSIZE = 0> struct test
             }
             else if (strstr(TypeManager<Ty>::name(), "half"))
             {
-                if( DetectFloatToHalfRoundingMode(queue) )
+                if (DetectFloatToHalfRoundingMode(queue))
                 {
                     log_error("Unable to detect rounding mode\n");
                     return TEST_FAIL;

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -28,6 +28,7 @@
 #define NR_OF_ACTIVE_WORK_ITEMS 4
 
 extern MTdata gMTdata;
+extern cl_half_rounding_mode g_rounding_mode;
 
 struct WorkGroupParams
 {
@@ -1080,7 +1081,7 @@ template <typename Ty>
 typename std::enable_if<TypeManager<Ty>::is_sb_scalar_type::value>::type
 set_value(Ty &lhs, const cl_ulong &rhs)
 {
-    lhs.data = convert_float_to_half(static_cast<cl_float>(rhs));
+    lhs.data = cl_half_from_float(static_cast<cl_float>(rhs), g_rounding_mode);
 }
 
 // compare for common vectors
@@ -1292,11 +1293,6 @@ template <typename Ty, typename Fns, size_t TSIZE = 0> struct test
             }
             else if (strstr(TypeManager<Ty>::name(), "half"))
             {
-                if (DetectFloatToHalfRoundingMode(queue))
-                {
-                    log_error("Unable to detect rounding mode\n");
-                    return TEST_FAIL;
-                }
                 kernel_sstr << "#pragma OPENCL EXTENSION cl_khr_fp16: enable\n";
             }
         }


### PR DESCRIPTION
cl_float testing uses set_value such that a generated cl_ulong of 1 is
stored as 1.0F in a logical sense. However, cl_half values aren't
intrinsic to C++ and generated cl_ulongs less than 1024 in particular
are interpreted bitwise as subnormals. The test fails on compute devices
lacking subnormal support. Perform the logical conversion to cl_half.

Fix independent forward progress check.