### PR TITLE
Fix local memory out of bounds issue in `atomic_fence`

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -1149,8 +1149,14 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(cl_device_id dev
     }
     if(LocalRefValues())
     {
-      error = clSetKernelArg(kernel, argInd++, LocalRefValues() ? typeSize*((CurrentGroupSize()*NumNonAtomicVariablesPerThread()) + 4) : 1, NULL);
-      test_error(error, "Unable to set indexed kernel argument");
+        error = clSetKernelArg(
+            kernel, argInd++,
+            LocalRefValues() ? typeSize
+                    * ((CurrentGroupSize() * NumNonAtomicVariablesPerThread())
+                       + 4)
+                             : 1,
+            NULL);
+        test_error(error, "Unable to set indexed kernel argument");
     }
   }
   /* Configure host threads */

--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -1149,7 +1149,7 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(cl_device_id dev
     }
     if(LocalRefValues())
     {
-      error = clSetKernelArg(kernel, argInd++, LocalRefValues() ? typeSize*CurrentGroupSize()*NumNonAtomicVariablesPerThread() : 1, NULL);
+      error = clSetKernelArg(kernel, argInd++, LocalRefValues() ? typeSize*((CurrentGroupSize()*NumNonAtomicVariablesPerThread()) + 4) : 1, NULL);
       test_error(error, "Unable to set indexed kernel argument");
     }
   }


### PR DESCRIPTION
In the error condition, the atomic_fence kernel can illegally access local memory addresses.

In this snippet, `localValues` is in the local address space and provided as a kernel argument. Its size is effectively `get_local_size(0) * sizeof(int)`. The stores to `localValues` lead to OoB accesses.

```C
  size_t myId = get_local_id(0);

  ...

  if(hisAtomicValue != hisValue)
  { // fail
    atomic_store(&destMemory[myId], myValue-1);
    hisId = (hisId+get_local_size(0)-1)%get_local_size(0);
    if(myValue+1 < 1)
      localValues[myId*1+myValue+1] = hisId;
    if(myValue+2 < 1)
      localValues[myId*1+myValue+2] = hisAtomicValue;
    if(myValue+3 < 1)
      localValues[myId*1+myValue+3] = hisValue;
  }
```