### PR TITLE
Math bruteforce test - enable erf/erfc functions

### DIFF
--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -218,13 +218,8 @@ const Func functionList[] = {
     ENTRY(cosh, 4.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY_EXT(cospi, 4.0f, 4.0f, 0.00048828125f, FTZ_OFF, unaryF,
               0.00048828125f), // relaxed ulp 2^-11
-    //                                  ENTRY( erfc,                  16.0f,
-    //                                  16.0f,         FTZ_OFF,     unaryF),
-    //                                  //disabled for 1.0 due to lack of
-    //                                  reference implementation ENTRY( erf,
-    //                                  16.0f,         16.0f,         FTZ_OFF,
-    //                                  unaryF), //disabled for 1.0 due to lack
-    //                                  of reference implementation
+    ENTRY( erfc, 16.0f, 16.0f, FTZ_OFF, unaryF),
+    ENTRY( erf, 16.0f, 16.0f, FTZ_OFF, unaryF),
     ENTRY_EXT(exp, 3.0f, 4.0f, 3.0f, FTZ_OFF, unaryF,
               4.0f), // relaxed error is actually overwritten in unary.c as it
                      // is 3+floor(fabs(2*x))

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -286,7 +286,7 @@ static test_definition test_list[] = {
     ADD_TEST(half_sin),      ADD_TEST(half_sqrt),  ADD_TEST(half_tan),
     ADD_TEST(add),           ADD_TEST(subtract),   ADD_TEST(divide),
     ADD_TEST(divide_cr),     ADD_TEST(multiply),   ADD_TEST(assignment),
-    ADD_TEST(not),
+    ADD_TEST(not ),          ADD_TEST(erf),        ADD_TEST(erfc),
 };
 
 #undef ADD_TEST

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -5720,3 +5720,9 @@ int reference_notl(long double x)
     int r = !x;
     return r;
 }
+
+long double reference_erfcl(long double x) { return erfc(x); }
+long double reference_erfl(long double x) { return erf(x); }
+
+double reference_erfc(double x) { return erfc(x); }
+double reference_erf(double x) { return erf(x); }

--- a/test_conformance/math_brute_force/reference_math.h
+++ b/test_conformance/math_brute_force/reference_math.h
@@ -233,4 +233,8 @@ long double reference_ldexpl(long double x, int n);
 long double reference_assignmentl(long double x);
 int reference_notl(long double x);
 
+long double reference_erfcl(long double x);
+long double reference_erfl(long double x);
+double reference_erfc(double x);
+double reference_erf(double x);
 #endif


### PR DESCRIPTION
It was disabled because lack of reference implementation. However the reference implementation exists. Then no reason to start testing these functions.