### PR TITLE
define NOMINMAX in the CMakefile to fix std::min and std::max on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ endif()
 if(MSVC)
     # Don't warn when using standard non-secure functions.
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    # Fix std::min and std::max handling with windows.harness.
+    add_compile_definitions(NOMINMAX)
 endif()
 
 if( WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" )

--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -1707,7 +1707,7 @@ Version get_max_OpenCL_C_for_context(cl_context context)
                       else
                       {
                           current_version =
-                              (std::min)(device_version, current_version);
+                              std::min(device_version, current_version);
                       }
                   });
     return current_version;

--- a/test_common/harness/os_helpers.cpp
+++ b/test_common/harness/os_helpers.cpp
@@ -333,9 +333,6 @@ std::string exe_dir()
 
 
 #include <windows.h>
-#if defined(max)
-#undef max
-#endif
 
 #include <cctype>
 #include <algorithm>

--- a/test_conformance/basic/test_async_copy2D.cpp
+++ b/test_conformance/basic/test_async_copy2D.cpp
@@ -203,13 +203,13 @@ int test_copy2D(cl_device_id deviceID, cl_context context,
         / (numElementsPerLine + srcStride);
     size_t maxTotalLinesOut = (max_alloc_size / elementSize + dstStride)
         / (numElementsPerLine + dstStride);
-    size_t maxTotalLines = (std::min)(maxTotalLinesIn, maxTotalLinesOut);
+    size_t maxTotalLines = std::min(maxTotalLinesIn, maxTotalLinesOut);
     size_t maxLocalWorkgroups =
         maxTotalLines / (localWorkgroupSize * lineCopiesPerWorkItem);
 
     size_t localBufferSize = localWorkgroupSize * localStorageSpacePerWorkitem
         - (localIsDst ? dstStride : srcStride);
-    size_t numberOfLocalWorkgroups = (std::min)(1111, (int)maxLocalWorkgroups);
+    size_t numberOfLocalWorkgroups = std::min(1111, (int)maxLocalWorkgroups);
     size_t totalLines =
         numberOfLocalWorkgroups * localWorkgroupSize * lineCopiesPerWorkItem;
     size_t inBufferSize = elementSize

--- a/test_conformance/basic/test_async_copy3D.cpp
+++ b/test_conformance/basic/test_async_copy3D.cpp
@@ -230,13 +230,13 @@ int test_copy3D(cl_device_id deviceID, cl_context context,
     size_t maxTotalPlanesOut = ((max_alloc_size / elementSize) + dstPlaneStride)
         / ((numLines * numElementsPerLine + numLines * dstLineStride)
            + dstPlaneStride);
-    size_t maxTotalPlanes = (std::min)(maxTotalPlanesIn, maxTotalPlanesOut);
+    size_t maxTotalPlanes = std::min(maxTotalPlanesIn, maxTotalPlanesOut);
     size_t maxLocalWorkgroups =
         maxTotalPlanes / (localWorkgroupSize * planesCopiesPerWorkItem);
 
     size_t localBufferSize = localWorkgroupSize * localStorageSpacePerWorkitem
         - (localIsDst ? dstPlaneStride : srcPlaneStride);
-    size_t numberOfLocalWorkgroups = (std::min)(1111, (int)maxLocalWorkgroups);
+    size_t numberOfLocalWorkgroups = std::min(1111, (int)maxLocalWorkgroups);
     size_t totalPlanes =
         numberOfLocalWorkgroups * localWorkgroupSize * planesCopiesPerWorkItem;
     size_t inBufferSize = elementSize

--- a/test_conformance/integer_ops/test_integer_dot_product.cpp
+++ b/test_conformance/integer_ops/test_integer_dot_product.cpp
@@ -14,11 +14,6 @@
 // limitations under the License.
 //
 
-// This is needed for std::numeric_limits<>::min() and max() to work on Windows.
-#if defined(_WIN32)
-#define NOMINMAX
-#endif
-
 #include <algorithm>
 #include <limits>
 #include <numeric>


### PR DESCRIPTION
I think this is a reasonable fix for #1306.

* Defines NOMINMAX as part of the CMake file for Windows (MSVC) only.
* Removes all (I think!) of the workarounds in the other test files.