### PR TITLE
do not directly use media sharing extension function names

### DIFF
--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/main.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/main.cpp
@@ -31,12 +31,12 @@ test_definition test_list[] = { ADD_TEST(context_create),
 
 const int test_num = ARRAY_SIZE(test_list);
 
-clGetDeviceIDsFromDX9MediaAdapterKHR_fn clGetDeviceIDsFromDX9MediaAdapterKHR =
+clGetDeviceIDsFromDX9MediaAdapterKHR_fn clGetDeviceIDsFromDX9MediaAdapterKHR_ =
     NULL;
-clCreateFromDX9MediaSurfaceKHR_fn clCreateFromDX9MediaSurfaceKHR = NULL;
-clEnqueueAcquireDX9MediaSurfacesKHR_fn clEnqueueAcquireDX9MediaSurfacesKHR =
+clCreateFromDX9MediaSurfaceKHR_fn clCreateFromDX9MediaSurfaceKHR_ = NULL;
+clEnqueueAcquireDX9MediaSurfacesKHR_fn clEnqueueAcquireDX9MediaSurfacesKHR_ =
     NULL;
-clEnqueueReleaseDX9MediaSurfacesKHR_fn clEnqueueReleaseDX9MediaSurfacesKHR =
+clEnqueueReleaseDX9MediaSurfacesKHR_fn clEnqueueReleaseDX9MediaSurfacesKHR_ =
     NULL;
 
 cl_platform_id gPlatformIDdetected;
@@ -45,43 +45,43 @@ cl_device_type gDeviceTypeSelected = CL_DEVICE_TYPE_DEFAULT;
 
 bool MediaSurfaceSharingExtensionInit()
 {
-    clGetDeviceIDsFromDX9MediaAdapterKHR =
+    clGetDeviceIDsFromDX9MediaAdapterKHR_ =
         (clGetDeviceIDsFromDX9MediaAdapterKHR_fn)
             clGetExtensionFunctionAddressForPlatform(
                 gPlatformIDdetected, "clGetDeviceIDsFromDX9MediaAdapterKHR");
-    if (clGetDeviceIDsFromDX9MediaAdapterKHR == NULL)
+    if (clGetDeviceIDsFromDX9MediaAdapterKHR_ == NULL)
     {
         log_error("clGetExtensionFunctionAddressForPlatform("
                   "clGetDeviceIDsFromDX9MediaAdapterKHR) returned NULL.\n");
         return false;
     }
 
-    clCreateFromDX9MediaSurfaceKHR = (clCreateFromDX9MediaSurfaceKHR_fn)
+    clCreateFromDX9MediaSurfaceKHR_ = (clCreateFromDX9MediaSurfaceKHR_fn)
         clGetExtensionFunctionAddressForPlatform(
             gPlatformIDdetected, "clCreateFromDX9MediaSurfaceKHR");
-    if (clCreateFromDX9MediaSurfaceKHR == NULL)
+    if (clCreateFromDX9MediaSurfaceKHR_ == NULL)
     {
         log_error("clGetExtensionFunctionAddressForPlatform("
                   "clCreateFromDX9MediaSurfaceKHR) returned NULL.\n");
         return false;
     }
 
-    clEnqueueAcquireDX9MediaSurfacesKHR =
+    clEnqueueAcquireDX9MediaSurfacesKHR_ =
         (clEnqueueAcquireDX9MediaSurfacesKHR_fn)
             clGetExtensionFunctionAddressForPlatform(
                 gPlatformIDdetected, "clEnqueueAcquireDX9MediaSurfacesKHR");
-    if (clEnqueueAcquireDX9MediaSurfacesKHR == NULL)
+    if (clEnqueueAcquireDX9MediaSurfacesKHR_ == NULL)
     {
         log_error("clGetExtensionFunctionAddressForPlatform("
                   "clEnqueueAcquireDX9MediaSurfacesKHR) returned NULL.\n");
         return false;
     }
 
-    clEnqueueReleaseDX9MediaSurfacesKHR =
+    clEnqueueReleaseDX9MediaSurfacesKHR_ =
         (clEnqueueReleaseDX9MediaSurfacesKHR_fn)
             clGetExtensionFunctionAddressForPlatform(
                 gPlatformIDdetected, "clEnqueueReleaseDX9MediaSurfacesKHR");
-    if (clEnqueueReleaseDX9MediaSurfacesKHR == NULL)
+    if (clEnqueueReleaseDX9MediaSurfacesKHR_ == NULL)
     {
         log_error("clGetExtensionFunctionAddressForPlatform("
                   "clEnqueueReleaseDX9MediaSurfacesKHR) returned NULL.\n");

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_create_context.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_create_context.cpp
@@ -138,7 +138,7 @@ int context_create(cl_device_id deviceID, cl_context context,
         std::vector<clMemWrapper> planesList(planesNum);
         for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
         {
-            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                 ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfo, planeIdx,
                 &error);
             if (error != CL_SUCCESS)
@@ -170,7 +170,7 @@ int context_create(cl_device_id deviceID, cl_context context,
         }
 
         cl_event event;
-        error = clEnqueueAcquireDX9MediaSurfacesKHR(
+        error = clEnqueueAcquireDX9MediaSurfacesKHR_(
             cmdQueue, static_cast<cl_uint>(memObjList.size()),
             &memObjList.at(0), 0, NULL, &event);
         if (error != CL_SUCCESS)
@@ -228,7 +228,7 @@ int context_create(cl_device_id deviceID, cl_context context,
             result.ResultSub(CResult::TEST_FAIL);
         }
 
-        error = clEnqueueReleaseDX9MediaSurfacesKHR(
+        error = clEnqueueReleaseDX9MediaSurfacesKHR_(
             cmdQueue, static_cast<cl_uint>(memObjList.size()),
             &memObjList.at(0), 0, NULL, &event);
         if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_functions_api.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_functions_api.cpp
@@ -133,7 +133,7 @@ int api_functions(cl_device_id deviceID, cl_context context,
         std::vector<clMemWrapper> planesList(planesNum);
         for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
         {
-            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                 ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfo, planeIdx,
                 &error);
             if (error != CL_SUCCESS)
@@ -173,7 +173,7 @@ int api_functions(cl_device_id deviceID, cl_context context,
                 return result.Result();
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -625,7 +625,7 @@ int api_functions(cl_device_id deviceID, cl_context context,
                 }
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_functions_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_functions_kernel.cpp
@@ -169,7 +169,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
         std::vector<clMemWrapper> planeDstList(planesNum);
         for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
         {
-            planeSrcList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+            planeSrcList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                 ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfoSrc, planeIdx,
                 &error);
             if (error != CL_SUCCESS)
@@ -182,7 +182,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
             }
             memObjSrcList.push_back(planeSrcList[planeIdx]);
 
-            planeDstList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+            planeDstList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                 ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfoDst, planeIdx,
                 &error);
             if (error != CL_SUCCESS)
@@ -222,7 +222,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
                 return result.Result();
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjSrcList.size()),
                 &memObjSrcList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -233,7 +233,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
                 return result.Result();
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjDstList.size()),
                 &memObjDstList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -375,7 +375,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
                 result.ResultSub(CResult::TEST_FAIL);
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjSrcList.size()),
                 &memObjSrcList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -385,7 +385,7 @@ int kernel_functions(cl_device_id deviceID, cl_context context,
                 result.ResultSub(CResult::TEST_FAIL);
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjDstList.size()),
                 &memObjDstList[0], 0, 0, 0);
             if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_get_device_ids.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_get_device_ids.cpp
@@ -65,7 +65,7 @@ int get_device_ids(cl_device_id deviceID, cl_context context,
         }
 
         cl_uint devicesAllNum = 0;
-        error = clGetDeviceIDsFromDX9MediaAdapterKHR(
+        error = clGetDeviceIDsFromDX9MediaAdapterKHR_(
             gPlatformIDdetected, 1, &mediaAdapterTypes[0], &mediaDevices[0],
             CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR, 0, 0, &devicesAllNum);
         if (error != CL_SUCCESS && error != CL_DEVICE_NOT_FOUND)
@@ -80,7 +80,7 @@ int get_device_ids(cl_device_id deviceID, cl_context context,
         if (devicesAllNum > 0)
         {
             devicesAll.resize(devicesAllNum);
-            error = clGetDeviceIDsFromDX9MediaAdapterKHR(
+            error = clGetDeviceIDsFromDX9MediaAdapterKHR_(
                 gPlatformIDdetected, 1, &mediaAdapterTypes[0], &mediaDevices[0],
                 CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR, devicesAllNum,
                 &devicesAll[0], 0);
@@ -94,7 +94,7 @@ int get_device_ids(cl_device_id deviceID, cl_context context,
         }
 
         cl_uint devicesPreferredNum = 0;
-        error = clGetDeviceIDsFromDX9MediaAdapterKHR(
+        error = clGetDeviceIDsFromDX9MediaAdapterKHR_(
             gPlatformIDdetected, 1, &mediaAdapterTypes[0], &mediaDevices[0],
             CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR, 0, 0,
             &devicesPreferredNum);
@@ -110,7 +110,7 @@ int get_device_ids(cl_device_id deviceID, cl_context context,
         if (devicesPreferredNum > 0)
         {
             devicesPreferred.resize(devicesPreferredNum);
-            error = clGetDeviceIDsFromDX9MediaAdapterKHR(
+            error = clGetDeviceIDsFromDX9MediaAdapterKHR_(
                 gPlatformIDdetected, 1, &mediaAdapterTypes[0], &mediaDevices[0],
                 CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR,
                 devicesPreferredNum, &devicesPreferred[0], 0);

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_interop_sync.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_interop_sync.cpp
@@ -145,7 +145,7 @@ int interop_user_sync(cl_device_id deviceID, cl_context context,
         std::vector<clMemWrapper> planesList(planesNum);
         for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
         {
-            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+            planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                 ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfo, planeIdx,
                 &error);
             if (error != CL_SUCCESS)
@@ -231,7 +231,7 @@ int interop_user_sync(cl_device_id deviceID, cl_context context,
 #endif
         }
 
-        error = clEnqueueAcquireDX9MediaSurfacesKHR(
+        error = clEnqueueAcquireDX9MediaSurfacesKHR_(
             cmdQueue, static_cast<cl_uint>(memObjList.size()),
             &memObjList.at(0), 0, 0, 0);
         if (error != CL_SUCCESS)
@@ -271,7 +271,7 @@ int interop_user_sync(cl_device_id deviceID, cl_context context,
             result.ResultSub(CResult::TEST_FAIL);
         }
 
-        error = clEnqueueReleaseDX9MediaSurfacesKHR(
+        error = clEnqueueReleaseDX9MediaSurfacesKHR_(
             cmdQueue, static_cast<cl_uint>(memObjList.size()),
             &memObjList.at(0), 0, 0, 0);
         if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_memory_access.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_memory_access.cpp
@@ -137,7 +137,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
             std::vector<clMemWrapper> planesList(planesNum);
             for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
             {
-                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                     ctx, CL_MEM_WRITE_ONLY, adapterType, &surfaceInfo, planeIdx,
                     &error);
                 if (error != CL_SUCCESS)
@@ -151,7 +151,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 memObjList.push_back(planesList[planeIdx]);
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -183,7 +183,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 offset += planeWidth * planeHeight;
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -223,7 +223,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
             std::vector<clMemWrapper> planesList(planesNum);
             for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
             {
-                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                     ctx, CL_MEM_READ_ONLY, adapterType, &surfaceInfo, planeIdx,
                     &error);
                 if (error != CL_SUCCESS)
@@ -237,7 +237,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 memObjList.push_back(planesList[planeIdx]);
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -277,7 +277,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 result.ResultSub(CResult::TEST_FAIL);
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -317,7 +317,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
             std::vector<clMemWrapper> planesList(planesNum);
             for (unsigned int planeIdx = 0; planeIdx < planesNum; ++planeIdx)
             {
-                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR(
+                planesList[planeIdx] = clCreateFromDX9MediaSurfaceKHR_(
                     ctx, CL_MEM_READ_WRITE, adapterType, &surfaceInfo, planeIdx,
                     &error);
                 if (error != CL_SUCCESS)
@@ -331,7 +331,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 memObjList.push_back(planesList[planeIdx]);
             }
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -397,7 +397,7 @@ int memory_access(cl_device_id deviceID, cl_context context,
                 }
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/test_other_data_types.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/test_other_data_types.cpp
@@ -204,7 +204,7 @@ int other_data_types(cl_device_id deviceID, cl_context context,
 #endif
 
         // create OCL shared object
-        clMemWrapper objectSrcShared = clCreateFromDX9MediaSurfaceKHR(
+        clMemWrapper objectSrcShared = clCreateFromDX9MediaSurfaceKHR_(
             ctx, CL_MEM_READ_WRITE, adapterType, &surfaceSrcInfo, 0, &error);
         if (error != CL_SUCCESS)
         {
@@ -214,7 +214,7 @@ int other_data_types(cl_device_id deviceID, cl_context context,
             return result.Result();
         }
 
-        clMemWrapper objectDstShared = clCreateFromDX9MediaSurfaceKHR(
+        clMemWrapper objectDstShared = clCreateFromDX9MediaSurfaceKHR_(
             ctx, CL_MEM_READ_WRITE, adapterType, &surfaceDstInfo, 0, &error);
         if (error != CL_SUCCESS)
         {
@@ -269,7 +269,7 @@ int other_data_types(cl_device_id deviceID, cl_context context,
             return TEST_NOT_IMPLEMENTED;
 #endif
 
-            error = clEnqueueAcquireDX9MediaSurfacesKHR(
+            error = clEnqueueAcquireDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)
@@ -464,7 +464,7 @@ int other_data_types(cl_device_id deviceID, cl_context context,
                 }
             }
 
-            error = clEnqueueReleaseDX9MediaSurfacesKHR(
+            error = clEnqueueReleaseDX9MediaSurfacesKHR_(
                 cmdQueue, static_cast<cl_uint>(memObjList.size()),
                 &memObjList[0], 0, 0, 0);
             if (error != CL_SUCCESS)

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/utils.cpp
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/utils.cpp
@@ -1639,7 +1639,7 @@ cl_int deviceExistForCLTest(
     std::string adapterStr;
     AdapterToString(media_adapters_type, adapterStr);
 
-    _error = clGetDeviceIDsFromDX9MediaAdapterKHR(
+    _error = clGetDeviceIDsFromDX9MediaAdapterKHR_(
         platform, 1, &media_adapters_type, &media_adapters,
         CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR, 0, 0, &devicesAllNum);
 

--- a/test_conformance/extensions/cl_khr_dx9_media_sharing/utils.h
+++ b/test_conformance/extensions/cl_khr_dx9_media_sharing/utils.h
@@ -27,12 +27,12 @@
 
 
 extern clGetDeviceIDsFromDX9MediaAdapterKHR_fn
-    clGetDeviceIDsFromDX9MediaAdapterKHR;
-extern clCreateFromDX9MediaSurfaceKHR_fn clCreateFromDX9MediaSurfaceKHR;
+    clGetDeviceIDsFromDX9MediaAdapterKHR_;
+extern clCreateFromDX9MediaSurfaceKHR_fn clCreateFromDX9MediaSurfaceKHR_;
 extern clEnqueueAcquireDX9MediaSurfacesKHR_fn
-    clEnqueueAcquireDX9MediaSurfacesKHR;
+    clEnqueueAcquireDX9MediaSurfacesKHR_;
 extern clEnqueueReleaseDX9MediaSurfacesKHR_fn
-    clEnqueueReleaseDX9MediaSurfacesKHR;
+    clEnqueueReleaseDX9MediaSurfacesKHR_;
 
 extern cl_platform_id gPlatformIDdetected;
 extern cl_device_id gDeviceIDdetected;


### PR DESCRIPTION
fixes #1254 

This is one possible way to fix #1254, which is caused by function pointers declared at file scope with the same name as the extension function API.  In this version I've appended an underscore to the extension function names.  I'm fine choosing a different convention instead, just let me know what to use, thanks!