### PR TITLE
suppress MSVC strdup warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ endif()
 if(MSVC)
     # Don't warn when using standard non-secure functions.
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    # Don't warn about using the portable "strdup" function.
+    add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
     # Fix std::min and std::max handling with windows.harness.
     add_compile_definitions(NOMINMAX)
 endif()

--- a/test_common/CMakeLists.txt
+++ b/test_common/CMakeLists.txt
@@ -21,8 +21,3 @@ set(HARNESS_SOURCES
 )
 
 add_library(harness STATIC ${HARNESS_SOURCES})
-
-if(MSVC)
-    # Don't warn about using the portable "strdup" function.
-    target_compile_definitions(harness PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
-endif()


### PR DESCRIPTION
This PR adds the `_CRT_NONSTDC_NO_DEPRECATE` define for all files when building with MSVC, not just for the harness.  This suppresses a warning related to `strdup` that was being generated for nearly all files, since `strdup` was called from the commonly included header `errorHelpers.h`.