### PR TITLE
define CL_NO_EXTENSION_PROTOTYPES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_definitions(-DCL_USE_DEPRECATED_OPENCL_2_0_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_2_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_1_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_0_APIS=1)
+add_definitions(-DCL_NO_PROTOTYPES)
 
 option(USE_CL_EXPERIMENTAL "Use Experimental definitions" OFF)
 if(USE_CL_EXPERIMENTAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions(-DCL_USE_DEPRECATED_OPENCL_2_0_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_2_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_1_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_0_APIS=1)
-add_definitions(-DCL_NO_PROTOTYPES)
+add_definitions(-DCL_NO_EXTENSION_PROTOTYPES)
 
 option(USE_CL_EXPERIMENTAL "Use Experimental definitions" OFF)
 if(USE_CL_EXPERIMENTAL)


### PR DESCRIPTION
This is an alternative to PR #1313.  I think this is a much more straightforward fix, so unless there is some other reason to want extension function prototypes in the near future I think we should go with this solution instead.

Fixes #1254.

In the latest version of the generated headers the `CL_NO_PROTOTYPES` define will suppress declaration of extension functions, so we can continue to declare function pointers with the same name.

