### PR TITLE
Experiment with macos CI build

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         mainmatrix: [true]
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-10.15]
         include:
           - os: ubuntu-20.04
             mainmatrix: true


### PR DESCRIPTION
GitHub CI is in the process of migrating macos-latest to be v11 (rather than
v10.15).  Given our macos CI builds seem to not be reporting completion, but
nothing in the logs indicate why, experiment with an explicit version.

https://github.com/actions/virtual-environments/issues/4060