### PR TITLE
Fix build, glext should not be used with GLEW

### DIFF
--- a/test_common/gl/setup_win32.cpp
+++ b/test_common/gl/setup_win32.cpp
@@ -18,8 +18,6 @@
 #include "testBase.h"
 #include "harness/errorHelpers.h"
 
-#include <GL/gl.h>
-#include <GL/glut.h>
 #include <CL/cl_ext.h>
 
 typedef CL_API_ENTRY cl_int (CL_API_CALL *clGetGLContextInfoKHR_fn)(

--- a/test_common/gl/setup_win32.cpp
+++ b/test_common/gl/setup_win32.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#define GL_GLEXT_PROTOTYPES
 
 #include "setup.h"
 #include "testBase.h"

--- a/test_common/gl/setup_x11.cpp
+++ b/test_common/gl/setup_x11.cpp
@@ -18,9 +18,6 @@
 #include "testBase.h"
 #include "harness/errorHelpers.h"
 
-#include <GL/gl.h>
-#include <GL/glut.h>
-#include <GL/freeglut.h>
 #include <GL/glx.h>
 #include <CL/cl_ext.h>
 

--- a/test_common/gl/setup_x11.cpp
+++ b/test_common/gl/setup_x11.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#define GL_GLEXT_PROTOTYPES
 
 #include "setup.h"
 #include "testBase.h"
@@ -21,7 +20,6 @@
 
 #include <GL/gl.h>
 #include <GL/glut.h>
-#include <GL/glext.h>
 #include <GL/freeglut.h>
 #include <GL/glx.h>
 #include <CL/cl_ext.h>


### PR DESCRIPTION
This issue has been noticed by @pierremoreau some time ago
https://github.com/KhronosGroup/OpenCL-CTS/pull/3#issuecomment-486544336

This issue is described here as well: https://stackoverflow.com/questions/65009898/incompatible-function-prototypes-between-glew-h-and-glext-h

Because glew delivers more definitions than glext we should stay with glew.