### PR TITLE
test_subgroups - Set safe input values for half type and mul, add operations

### DIFF
--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -418,8 +418,6 @@ void fill_and_shuffle_safe_values(std::vector<cl_ulong> &safe_values,
         set_one = 1;
     }
 
-    std::random_device random_device;
-    std::mt19937 mersenne_twister_engine(random_device());
     int offset_size = sb_size - safe_values.size();
     if (offset_size > 0)
     {
@@ -430,6 +428,7 @@ void fill_and_shuffle_safe_values(std::vector<cl_ulong> &safe_values,
         safe_values.resize(sb_size);
     }
 
+    std::mt19937 mersenne_twister_engine(10000);
     std::shuffle(safe_values.begin(), safe_values.end(),
                  mersenne_twister_engine);
 };
@@ -439,19 +438,18 @@ void genrand(Ty *x, Ty *t, cl_int *m, int ns, int nw, int ng)
 {
     int nj = (nw + ns - 1) / ns;
 
+    std::vector<cl_ulong> safe_values;
+    if (operation == ArithmeticOp::mul_ || operation == ArithmeticOp::add_)
+    {
+        fill_and_shuffle_safe_values<Ty>(safe_values, ns);
+    }
+
     for (int k = 0; k < ng; ++k)
     {
         for (int j = 0; j < nj; ++j)
         {
             int ii = j * ns;
             int n = ii + ns > nw ? nw - ii : ns;
-
-            std::vector<cl_ulong> safe_values;
-            if (operation == ArithmeticOp::mul_
-                || operation == ArithmeticOp::add_)
-            {
-                fill_and_shuffle_safe_values<Ty>(safe_values, ns);
-            }
 
             for (int i = 0; i < n; ++i)
             {

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -434,7 +434,7 @@ void fill_and_shuffle_safe_values(std::vector<cl_ulong> &safe_values,
 };
 
 template <typename Ty, ArithmeticOp operation>
-void genrand(Ty *x, Ty *t, cl_int *m, int ns, int nw, int ng)
+void generate_inputs(Ty *x, Ty *t, cl_int *m, int ns, int nw, int ng)
 {
     int nj = (nw + ns - 1) / ns;
 
@@ -636,7 +636,7 @@ template <typename Ty, ArithmeticOp operation> struct SCEX_NU
         int ns = test_params.subgroup_size;
         int ng = test_params.global_workgroup_size;
         ng = ng / nw;
-        genrand<Ty, operation>(x, t, m, ns, nw, ng);
+        generate_inputs<Ty, operation>(x, t, m, ns, nw, ng);
     }
 
     static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,
@@ -734,7 +734,7 @@ template <typename Ty, ArithmeticOp operation> struct SCIN_NU
         int ns = test_params.subgroup_size;
         int ng = test_params.global_workgroup_size;
         ng = ng / nw;
-        genrand<Ty, operation>(x, t, m, ns, nw, ng);
+        generate_inputs<Ty, operation>(x, t, m, ns, nw, ng);
     }
 
     static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,
@@ -850,7 +850,7 @@ template <typename Ty, ArithmeticOp operation> struct RED_NU
         int ns = test_params.subgroup_size;
         int ng = test_params.global_workgroup_size;
         ng = ng / nw;
-        genrand<Ty, operation>(x, t, m, ns, nw, ng);
+        generate_inputs<Ty, operation>(x, t, m, ns, nw, ng);
     }
 
     static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -393,7 +393,7 @@ template <typename Ty> bool is_floating_point()
         || std::is_same<Ty, subgroups::cl_half>::value;
 }
 
-// limit possible input values to avoid arithmetic rouding/overflow issues.
+// limit possible input values to avoid arithmetic rounding/overflow issues.
 // for each subgroup values defined different values
 // for rest of workitems set 1
 // shuffle values

--- a/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
+++ b/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
@@ -52,7 +52,7 @@ template <typename Ty, ArithmeticOp operation> struct RED_CLU
         int ns = test_params.subgroup_size;
         int ng = test_params.global_workgroup_size;
         ng = ng / nw;
-        genrand<Ty, operation>(x, t, m, ns, nw, ng);
+        generate_inputs<Ty, operation>(x, t, m, ns, nw, ng);
     }
 
     static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,


### PR DESCRIPTION
While arithmetic operations for half type (especially mul operation) we notice overflow appear in results. In this proposal I set 4 values different than 1 and for all other workitems 1. I think this will be safe no matter how big is subgroup. 