### PR TITLE
Subgroups tests - sub_group_non_uniform_scan_exclusive function fixes

### DIFF
--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -637,12 +637,9 @@ template <typename Ty, ArithmeticOp operation> struct SCEX_NU
                 else
                 {
                     tr = TypeManager<Ty>::identify_limits(operation);
-                    int idx = 0;
                     for (const int &active_work_item : active_work_items)
                     {
                         rr = my[ii + active_work_item];
-                        if (idx == 0) continue;
-
                         if (!compare_ordered(rr, tr))
                         {
                             log_error(
@@ -655,7 +652,6 @@ template <typename Ty, ArithmeticOp operation> struct SCEX_NU
                         }
                         tr = calculate<Ty>(tr, mx[ii + active_work_item],
                                            operation);
-                        idx++;
                     }
                 }
             }

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -630,10 +630,6 @@ template <typename Ty, ArithmeticOp operation> struct SCEX_NU
                 {
                     continue;
                 }
-                else if (active_work_items.size() == 1)
-                {
-                    continue;
-                }
                 else
                 {
                     tr = TypeManager<Ty>::identify_limits(operation);


### PR DESCRIPTION
Reading once again [documentation ](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#_arithmetic_operations) I've noticed that test cases for `sub_group_non_uniform_scan_exclusive_ ` have defect. These changes cover part of definition described as:
`If there is no active work item in the subgroup with a subgroup local ID less than this work item’s subgroup local ID then an identity value I is returned. ... `