### PR TITLE
Fix conversion data loss in test api min max constant buffer size

### DIFF
--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -1735,11 +1735,12 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         test_error(error, "clEnqueueReadBuffer failed");
 
         for (i = 0; i < numberOfInts; i++)
-            if (constantData[i] != resultData[i]) {
+            if (constantData[i] != resultData[i])
+            {
                 log_error("Data failed to verify: constantData[%zu]=%d != "
                           "resultData[%zu]=%d\n",
-                          "resultData[%d]=%d\n",
-                          i, constantData[i], i, resultData[i]);
+                          "resultData[%d]=%d\n", i, constantData[i], i,
+                          resultData[i]);
                 free(constantData);
                 free(resultData);
                 free_mtdata(d);

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -1582,7 +1582,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
     size_t threads[1], localThreads[1];
     cl_int *constantData, *resultData;
     cl_ulong maxSize, stepSize, currentSize, maxGlobalSize, maxAllocSize;
-    cl_ulong i;
+    size_t i;
     cl_event event;
     cl_int event_status;
     MTdata d;
@@ -1736,8 +1736,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
 
         for (i = 0; i < numberOfInts; i++)
             if (constantData[i] != resultData[i]) {
-                log_error("Data failed to verify: constantData[%lld]=%d != "
-                          "resultData[%lld]=%d\n",
+                log_error("Data failed to verify: constantData[%zu]=%d != "
+                          "resultData[%zu]=%d\n",
                           "resultData[%d]=%d\n",
                           i, constantData[i], i, resultData[i]);
                 free(constantData);

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -90,7 +90,7 @@ const char *sample_sampler_kernel_pattern[] = {
 const char *sample_const_arg_kernel[] = {
     "__kernel void sample_test(__constant int *src1, __global int *dst)\n"
     "{\n"
-    "    int  tid = get_global_id(0);\n"
+    "    size_t  tid = get_global_id(0);\n"
     "\n"
     "    dst[tid] = src1[tid];\n"
     "\n"
@@ -1582,7 +1582,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
     size_t threads[1], localThreads[1];
     cl_int *constantData, *resultData;
     cl_ulong maxSize, stepSize, currentSize, maxGlobalSize, maxAllocSize;
-    int i;
+    cl_ulong i;
     cl_event event;
     cl_int event_status;
     MTdata d;
@@ -1612,6 +1612,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
     error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
                             sizeof(maxAllocSize), &maxAllocSize, 0);
     test_error(error, "Unable to get CL_DEVICE_MAX_MEM_ALLOC_SIZE ");
+    log_info("Reported max alloc size of %lld bytes.\n", maxAllocSize);
 
     if (maxSize > maxAllocSize) maxSize = maxAllocSize;
 
@@ -1645,7 +1646,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
             return EXIT_FAILURE;
         }
 
-        for (i = 0; i < (int)(numberOfInts); i++)
+        for (i = 0; i < numberOfInts; i++)
             constantData[i] = (int)genrand_int32(d);
 
         clMemWrapper streams[3];
@@ -1667,8 +1668,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         /* Test running the kernel and verifying it */
         threads[0] = numberOfInts;
         localThreads[0] = 1;
-        log_info("Filling constant buffer with %d cl_ints (%d bytes).\n",
-                 (int)threads[0], (int)(threads[0] * sizeof(cl_int)));
+        log_info("Filling constant buffer with %lld cl_ints (%lld bytes).\n",
+                 threads[0], threads[0] * sizeof(cl_int));
 
         error = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, threads,
                                        localThreads, 0, NULL, &event);
@@ -1733,10 +1734,10 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
                                     sizeToAllocate, resultData, 0, NULL, NULL);
         test_error(error, "clEnqueueReadBuffer failed");
 
-        for (i = 0; i < (int)(numberOfInts); i++)
-            if (constantData[i] != resultData[i])
-            {
-                log_error("Data failed to verify: constantData[%d]=%d != "
+        for (i = 0; i < numberOfInts; i++)
+            if (constantData[i] != resultData[i]) {
+                log_error("Data failed to verify: constantData[%lld]=%d != "
+                          "resultData[%lld]=%d\n",
                           "resultData[%d]=%d\n",
                           i, constantData[i], i, resultData[i]);
                 free(constantData);


### PR DESCRIPTION
It fix issue when bigger sizes above UINT_MAX are reported. Then test works and display results incorrectly.