### PR TITLE
Add cl_khr_command_buffer to list of extensions

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -78,6 +78,7 @@ const char *known_extensions[] = {
     "cl_khr_semaphore",
     "cl_khr_external_semaphore",
     "cl_khr_external_semaphore_sync_fd",
+    "cl_khr_command_buffer",
 };
 
 size_t num_known_extensions = sizeof(known_extensions) / sizeof(char *);


### PR DESCRIPTION
cl_khr_command_buffer is now public as a provisional khr extension, which implementations may report. This extension name needs to be added to the hardcoded list of extensions in the compiler tests