### PR TITLE
Change memory order and scope for atomics that gate final results being stored.

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -1111,7 +1111,7 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(
     if (!LocalMemory() && DeclaredInProgram())
     {
         if (((gAtomicMemCap & CL_DEVICE_ATOMIC_SCOPE_DEVICE) == 0)
-            || ((gAtomicMemCap & CL_DEVICE_ATOMIC_ORDER_ACQ_REL == 0)))
+            || ((gAtomicMemCap & CL_DEVICE_ATOMIC_ORDER_ACQ_REL) == 0))
         {
             log_info("\t\tTest disabled\n");
             return 0;

--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -1108,6 +1108,15 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(
         log_info("\t\tTest disabled\n");
         return 0;
     }
+    if (!LocalMemory() && DeclaredInProgram())
+    {
+        if (((gAtomicMemCap & CL_DEVICE_ATOMIC_SCOPE_DEVICE) == 0)
+            || ((gAtomicMemCap & CL_DEVICE_ATOMIC_ORDER_ACQ_REL == 0)))
+        {
+            log_info("\t\tTest disabled\n");
+            return 0;
+        }
+    }
 
     // set up work sizes based on device capabilities and test configuration
     error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_WORK_GROUP_SIZE,

--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -1041,8 +1041,8 @@ CBasicTest<HostAtomicType, HostDataType>::KernelCode(cl_uint maxNumDestItems)
             // global atomics declared in program scope
             code += R"(
                 if(atomic_fetch_add_explicit(&finishedThreads, 1u,
-                                           memory_order_relaxed,
-                                           memory_scope_work_group)
+                                           memory_order_acq_rel,
+                                           memory_scope_device)
                    == get_global_size(0)-1) // last finished thread
                    )";
         code += "    for(uint dstItemIdx = 0; dstItemIdx < numDestItems; "


### PR DESCRIPTION
memory_order_acq_rel with memory_scope_device is now used to guarantee that the correct memory consistency is observed before final results are stored.

Previously it was possible for kernels to be generated that all used relaxed memory ordering, which could lead to false-positive failures.

Fixes #1370