### PR TITLE
Sync submission_details with conformance doc v26

### DIFF
--- a/test_conformance/submission_details_template.txt
+++ b/test_conformance/submission_details_template.txt
@@ -81,6 +81,12 @@ Platform Version:
 # 
 Tests version:
 
+# Commit SHAs (7-digit) of any cherry-picked patches subsequent to tagged
+# version. Any patches included must apply without conflicts to the tagged
+# version in the order listed.
+#
+Patches:
+
 # Implementations that support cl_khr_icd are required to use a loader to run
 # the tests and document the loader that was used.
 #


### PR DESCRIPTION
Add "Patches" field and description to match wording introduced in the conformance document:

> A conformance submission is valid only if it is made from a tagged version of the conformance test suite, where the tagged commit date is within 6 months of the submission date. If any patches to the tagged version are necessary to fix test bugs, they must be cherry-picked from subsequent main branch commits and applied without merge conflicts. Any required patches must be documented in the submission as a list of commit SHAs.

