### PR TITLE
Update format script and drop Travis badge for branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# OpenCL-CTS [![Build Status](https://api.travis-ci.org/KhronosGroup/OpenCL-CTS.svg?branch=master)](https://travis-ci.org/KhronosGroup/OpenCL-CTS/branches)
+# OpenCL-CTS
 The OpenCL Conformance Tests

--- a/check-format.sh
+++ b/check-format.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Arg used to specify non-'origin/master' comparison branch
-ORIGIN_BRANCH=${1:-"origin/master"}
+# Arg used to specify non-'origin/main' comparison branch
+ORIGIN_BRANCH=${1:-"origin/main"}
 CLANG_BINARY=${2:-"`which clang-format-9`"}
 
 # Run git-clang-format to check for violations


### PR DESCRIPTION
`master` is now `main`, so update `check-format.sh` accordingly.

Also completely drop the Travis badge as we now use GitHub actions.  There is
no replacement badge as the current action is pre-submission, not
post-submission.