### PR TITLE
Thread dimensions optimization

### DIFF
--- a/test_conformance/thread_dimensions/test_thread_dimensions.cpp
+++ b/test_conformance/thread_dimensions/test_thread_dimensions.cpp
@@ -30,6 +30,22 @@
 #define MAX_TOTAL_GLOBAL_THREADS_FOR_TEST (1<<24)
 int limit_size = 0;
 
+// Finds a local work size equal to or smaller than the passed-in local work
+// size that evenly divides the passed-in global work size.
+static cl_uint find_local_size(cl_uint local_size, cl_uint global_size)
+{
+    cl_uint ret;
+    if (local_size >= global_size) {
+        ret = global_size;
+    } else {
+        ret = local_size;
+        while (global_size % ret != 0) {
+            ret--;
+        }
+    }
+    return ret;
+}
+
 static int
 get_maximums(cl_kernel kernel, cl_context context,
              size_t *max_workgroup_size_result,
@@ -658,33 +674,28 @@ test_thread_dimensions(cl_device_id device, cl_context context, cl_command_queue
                             }
                         } else {
                             local_x_size = (int)get_random_float(1, (int)max_workgroup_size, d);
-                            while ((local_x_size > 1) && (final_x_size%local_x_size != 0))
-                                local_x_size--;
+                            local_x_size = find_local_size(local_x_size, final_x_size);
                             int remainder = (int)floor((double)max_workgroup_size/local_x_size);
                             // Evenly prefer dimensions 2 and 1 first
                             if (local_test % 2) {
                                 if (dimensions > 1) {
                                     local_y_size = (int)get_random_float(1, (int)remainder, d);
-                                    while ((local_y_size > 1) && (final_y_size%local_y_size != 0))
-                                        local_y_size--;
+                                    local_y_size = find_local_size(local_y_size, final_y_size);
                                     remainder = (int)floor((double)remainder/local_y_size);
                                 }
                                 if (dimensions > 2) {
                                     local_z_size = (int)get_random_float(1, (int)remainder, d);
-                                    while ((local_z_size > 1) && (final_z_size%local_z_size != 0))
-                                        local_z_size--;
+                                    local_z_size = find_local_size(local_z_size, final_z_size);
                                 }
                             } else {
                                 if (dimensions > 2) {
                                     local_z_size = (int)get_random_float(1, (int)remainder, d);
-                                    while ((local_z_size > 1) && (final_z_size%local_z_size != 0))
-                                        local_z_size--;
+                                    local_z_size = find_local_size(local_z_size, final_z_size);
                                     remainder = (int)floor((double)remainder/local_z_size);
                                 }
                                 if (dimensions > 1) {
                                     local_y_size = (int)get_random_float(1, (int)remainder, d);
-                                    while ((local_y_size > 1) && (final_y_size%local_y_size != 0))
-                                        local_y_size--;
+                                    local_y_size = find_local_size(local_y_size, final_y_size);
                                 }
                             }
                         }
@@ -710,12 +721,9 @@ test_thread_dimensions(cl_device_id device, cl_context context, cl_command_queue
                             local_z_size = (int)max_local_workgroup_size[2];
 
                         // Cleanup the local dimensions
-                        while ((local_x_size > 1) && (final_x_size%local_x_size != 0))
-                            local_x_size--;
-                        while ((local_y_size > 1) && (final_y_size%local_y_size != 0))
-                            local_y_size--;
-                        while ((local_z_size > 1) && (final_z_size%local_z_size != 0))
-                            local_z_size--;
+                        local_x_size = find_local_size(local_x_size, final_x_size);
+                        local_y_size = find_local_size(local_y_size, final_y_size);
+                        local_z_size = find_local_size(local_z_size, final_z_size);
                         if ((previous_local_x_size == local_x_size) && (previous_local_y_size == local_y_size) && (previous_local_z_size == local_z_size))
                             continue;
 

--- a/test_conformance/thread_dimensions/test_thread_dimensions.cpp
+++ b/test_conformance/thread_dimensions/test_thread_dimensions.cpp
@@ -35,11 +35,15 @@ int limit_size = 0;
 static cl_uint find_local_size(cl_uint local_size, cl_uint global_size)
 {
     cl_uint ret;
-    if (local_size >= global_size) {
+    if (local_size >= global_size)
+    {
         ret = global_size;
-    } else {
+    }
+    else
+    {
         ret = local_size;
-        while (global_size % ret != 0) {
+        while (global_size % ret != 0)
+        {
             ret--;
         }
     }
@@ -674,28 +678,36 @@ test_thread_dimensions(cl_device_id device, cl_context context, cl_command_queue
                             }
                         } else {
                             local_x_size = (int)get_random_float(1, (int)max_workgroup_size, d);
-                            local_x_size = find_local_size(local_x_size, final_x_size);
-                            int remainder = (int)floor((double)max_workgroup_size/local_x_size);
+                            local_x_size =
+                                find_local_size(local_x_size, final_x_size);
+                            int remainder = (int)floor(
+                                (double)max_workgroup_size / local_x_size);
                             // Evenly prefer dimensions 2 and 1 first
                             if (local_test % 2) {
                                 if (dimensions > 1) {
                                     local_y_size = (int)get_random_float(1, (int)remainder, d);
-                                    local_y_size = find_local_size(local_y_size, final_y_size);
-                                    remainder = (int)floor((double)remainder/local_y_size);
+                                    local_y_size = find_local_size(
+                                        local_y_size, final_y_size);
+                                    remainder = (int)floor((double)remainder
+                                                           / local_y_size);
                                 }
                                 if (dimensions > 2) {
                                     local_z_size = (int)get_random_float(1, (int)remainder, d);
-                                    local_z_size = find_local_size(local_z_size, final_z_size);
+                                    local_z_size = find_local_size(
+                                        local_z_size, final_z_size);
                                 }
                             } else {
                                 if (dimensions > 2) {
                                     local_z_size = (int)get_random_float(1, (int)remainder, d);
-                                    local_z_size = find_local_size(local_z_size, final_z_size);
-                                    remainder = (int)floor((double)remainder/local_z_size);
+                                    local_z_size = find_local_size(
+                                        local_z_size, final_z_size);
+                                    remainder = (int)floor((double)remainder
+                                                           / local_z_size);
                                 }
                                 if (dimensions > 1) {
                                     local_y_size = (int)get_random_float(1, (int)remainder, d);
-                                    local_y_size = find_local_size(local_y_size, final_y_size);
+                                    local_y_size = find_local_size(
+                                        local_y_size, final_y_size);
                                 }
                             }
                         }
@@ -721,10 +733,15 @@ test_thread_dimensions(cl_device_id device, cl_context context, cl_command_queue
                             local_z_size = (int)max_local_workgroup_size[2];
 
                         // Cleanup the local dimensions
-                        local_x_size = find_local_size(local_x_size, final_x_size);
-                        local_y_size = find_local_size(local_y_size, final_y_size);
-                        local_z_size = find_local_size(local_z_size, final_z_size);
-                        if ((previous_local_x_size == local_x_size) && (previous_local_y_size == local_y_size) && (previous_local_z_size == local_z_size))
+                        local_x_size =
+                            find_local_size(local_x_size, final_x_size);
+                        local_y_size =
+                            find_local_size(local_y_size, final_y_size);
+                        local_z_size =
+                            find_local_size(local_z_size, final_z_size);
+                        if ((previous_local_x_size == local_x_size)
+                            && (previous_local_y_size == local_y_size)
+                            && (previous_local_z_size == local_z_size))
                             continue;
 
                         if (explicit_local == 0) {


### PR DESCRIPTION
Implements the optimization described by #1397.

This doesn't affect most of our devices with typical maximum work-group sizes, but for our FPGA emulation device with a very large maximum work-group size (Max work item sizes 67108864x67108864x67108864) it improves the execution time of this test by more than 10 seconds.