### PR TITLE
Fix sub_group_ballot_find_msb/lsb tests

### DIFF
--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -609,6 +609,12 @@ template <typename Ty, BallotOp operation> struct BALLOT_COUNT_SCAN_FIND
                     }
                     else if (operation == BallotOp::ballot_find_lsb)
                     {
+                        if (bs.none())
+                        {
+                            // Return value is undefined when no bits are set,
+                            // so skip validation:
+                            continue;
+                        }
                         for (int id = 0; id < sbs; ++id)
                         {
                             if (bs.test(id))
@@ -630,6 +636,12 @@ template <typename Ty, BallotOp operation> struct BALLOT_COUNT_SCAN_FIND
                     }
                     else if (operation == BallotOp::ballot_find_msb)
                     {
+                        if (bs.none())
+                        {
+                            // Return value is undefined when no bits are set,
+                            // so skip validation:
+                            continue;
+                        }
                         for (int id = sbs - 1; id >= 0; --id)
                         {
                             if (bs.test(id))


### PR DESCRIPTION
As per the OpenCL Extension Specification § 38.6 Ballots:

   If no bits representing predicate values from all work items in
   the subgroup are set in the bitfield value then the return value
   is undefined.

The case with no bits set is still worth testing, as it does not result
in undefined behavior, but only an undefined return value.

Signed-off-by: Stuart Brady <stuart.brady@arm.com>