### PR TITLE
images: Stop checking gDeviceType != CL_DEVICE_TYPE_GPU

### DIFF
--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -557,7 +557,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                 // Apple requires its CPU implementation to do
                                 // correctly rounded address arithmetic in all
                                 // modes
-                                || gDeviceType != CL_DEVICE_TYPE_GPU
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                             )
                                 offset = 0.0f; // Loop only once
@@ -875,7 +875,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                 // Apple requires its CPU implementation to do
                                 // correctly rounded address arithmetic in all
                                 // modes
-                                || gDeviceType != CL_DEVICE_TYPE_GPU
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                             )
                                 offset = 0.0f; // Loop only once
@@ -1214,7 +1214,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                         // offsets (0.0, 0.0) E.g., test one
                                         // pixel.
                                         if (!imageSampler->normalized_coords
-                                            || gDeviceType != CL_DEVICE_TYPE_GPU
+                                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
                                             || NORM_OFFSET == 0)
                                         {
                                             norm_offset_x = 0.0f;
@@ -1396,7 +1396,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                         // offsets (0.0, 0.0) E.g., test one
                                         // pixel.
                                         if (!imageSampler->normalized_coords
-                                            || gDeviceType != CL_DEVICE_TYPE_GPU
+                                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
                                             || NORM_OFFSET == 0)
                                         {
                                             norm_offset_x = 0.0f;

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -1214,7 +1214,8 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                         // offsets (0.0, 0.0) E.g., test one
                                         // pixel.
                                         if (!imageSampler->normalized_coords
-                                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                            || !(gDeviceType
+                                                 & CL_DEVICE_TYPE_GPU)
                                             || NORM_OFFSET == 0)
                                         {
                                             norm_offset_x = 0.0f;
@@ -1396,7 +1397,8 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                         // offsets (0.0, 0.0) E.g., test one
                                         // pixel.
                                         if (!imageSampler->normalized_coords
-                                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                            || !(gDeviceType
+                                                 & CL_DEVICE_TYPE_GPU)
                                             || NORM_OFFSET == 0)
                                         {
                                             norm_offset_x = 0.0f;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -418,7 +418,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                 if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                     // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                    || gDeviceType != CL_DEVICE_TYPE_GPU
+                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
                     offset = 0.0f;          // Loop only once
@@ -474,7 +474,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -572,7 +572,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                 if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                     // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                    || gDeviceType != CL_DEVICE_TYPE_GPU
+                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
                     offset = 0.0f;          // Loop only once
@@ -658,7 +658,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -778,7 +778,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                         // E.g., test one pixel.
-                        if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                             norm_offset_x = 0.0f;
                             norm_offset_y = 0.0f;
                             checkOnlyOnePixel = 1;
@@ -813,7 +813,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -874,7 +874,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                         // E.g., test one pixel.
-                        if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                             norm_offset_x = 0.0f;
                             norm_offset_y = 0.0f;
                             checkOnlyOnePixel = 1;
@@ -909,7 +909,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -978,7 +978,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                 if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                     // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                    || gDeviceType != CL_DEVICE_TYPE_GPU
+                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
                     offset = 0.0f;          // Loop only once
@@ -1054,7 +1054,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -415,12 +415,15 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                 int checkOnlyOnePixel = 0;
                 int found_pixel = 0;
                 float offset = NORM_OFFSET;
-                if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                if (!imageSampler->normalized_coords
+                    || imageSampler->filter_mode != CL_FILTER_NEAREST
+                    || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                    // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                    // Apple requires its CPU implementation to do correctly
+                    // rounded address arithmetic in all modes
                     || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                    )
+                )
                     offset = 0.0f;          // Loop only once
 
                 for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel; norm_offset_x += NORM_OFFSET) {
@@ -474,7 +477,10 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -569,12 +575,15 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                 int checkOnlyOnePixel = 0;
                 int found_pixel = 0;
                 float offset = NORM_OFFSET;
-                if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                if (!imageSampler->normalized_coords
+                    || imageSampler->filter_mode != CL_FILTER_NEAREST
+                    || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                    // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                    // Apple requires its CPU implementation to do correctly
+                    // rounded address arithmetic in all modes
                     || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                    )
+                )
                     offset = 0.0f;          // Loop only once
 
                 for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel; norm_offset_x += NORM_OFFSET) {
@@ -658,7 +667,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -778,7 +790,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                         // E.g., test one pixel.
-                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                        if (!imageSampler->normalized_coords
+                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                            || NORM_OFFSET == 0)
+                        {
                             norm_offset_x = 0.0f;
                             norm_offset_y = 0.0f;
                             checkOnlyOnePixel = 1;
@@ -813,7 +828,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -874,7 +892,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                         // E.g., test one pixel.
-                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                        if (!imageSampler->normalized_coords
+                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                            || NORM_OFFSET == 0)
+                        {
                             norm_offset_x = 0.0f;
                             norm_offset_y = 0.0f;
                             checkOnlyOnePixel = 1;
@@ -909,7 +930,10 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -975,12 +999,15 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                 int checkOnlyOnePixel = 0;
                 int found_pixel = 0;
                 float offset = NORM_OFFSET;
-                if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                if (!imageSampler->normalized_coords
+                    || imageSampler->filter_mode != CL_FILTER_NEAREST
+                    || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                    // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                    // Apple requires its CPU implementation to do correctly
+                    // rounded address arithmetic in all modes
                     || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                    )
+                )
                     offset = 0.0f;          // Loop only once
 
                 for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel; norm_offset_x += NORM_OFFSET) {
@@ -1054,7 +1081,10 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -84,7 +84,7 @@ int test_read_image_type(cl_device_id device, cl_context context,
     // of operations for linear filtering on the GPU.  We do not test linear
     // filtering for the CL_RGB CL_UNORM_INT_101010 image format; however, we
     // test it internally for a set of other image formats.
-    if ((gDeviceType == CL_DEVICE_TYPE_GPU)
+    if ((gDeviceType & CL_DEVICE_TYPE_GPU)
         && (imageSampler->filter_mode == CL_FILTER_LINEAR)
         && (format->image_channel_order == CL_RGB)
         && (format->image_channel_data_type == CL_UNORM_INT_101010))

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -487,9 +487,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                     int checkOnlyOnePixel = 0;
                     int found_pixel = 0;
                     float offset = NORM_OFFSET;
-                    if (!imageSampler->normalized_coords || imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                    if (!imageSampler->normalized_coords
+                        || imageSampler->filter_mode != CL_FILTER_NEAREST
+                        || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                        // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                        // Apple requires its CPU implementation to do correctly
+                        // rounded address arithmetic in all modes
                         || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
@@ -553,7 +556,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -646,9 +652,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                     int checkOnlyOnePixel = 0;
                     int found_pixel = 0;
                     float offset = NORM_OFFSET;
-                    if (!imageSampler->normalized_coords || imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                    if (!imageSampler->normalized_coords
+                        || imageSampler->filter_mode != CL_FILTER_NEAREST
+                        || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                        // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                        // Apple requires its CPU implementation to do correctly
+                        // rounded address arithmetic in all modes
                         || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
@@ -720,7 +729,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -826,7 +838,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 checkOnlyOnePixel = 1;
                             }
@@ -857,7 +872,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -913,7 +931,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 checkOnlyOnePixel = 1;
                             }
@@ -944,7 +965,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -490,7 +490,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                     if (!imageSampler->normalized_coords || imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                         // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                        || gDeviceType != CL_DEVICE_TYPE_GPU
+                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
                         offset = 0.0f;          // Loop only once
@@ -553,7 +553,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -649,7 +649,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
                     if (!imageSampler->normalized_coords || imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                         // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                        || gDeviceType != CL_DEVICE_TYPE_GPU
+                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                     )
                         offset = 0.0f;          // Loop only once
@@ -720,7 +720,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -826,7 +826,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 checkOnlyOnePixel = 1;
                             }
@@ -857,7 +857,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }
@@ -913,7 +913,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 checkOnlyOnePixel = 1;
                             }
@@ -944,7 +944,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     checkOnlyOnePixel = 1;
                                 }

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -578,12 +578,15 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                     int checkOnlyOnePixel = 0;
                     int found_pixel = 0;
                     float offset = NORM_OFFSET;
-                    if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                    if (!imageSampler->normalized_coords
+                        || imageSampler->filter_mode != CL_FILTER_NEAREST
+                        || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                        // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                        // Apple requires its CPU implementation to do correctly
+                        // rounded address arithmetic in all modes
                         || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                        )
+                    )
                         offset = 0.0f;          // Loop only once
 
                     for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel; norm_offset_x += NORM_OFFSET) {
@@ -647,7 +650,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -746,12 +752,15 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                     int checkOnlyOnePixel = 0;
                     int found_pixel = 0;
                     float offset = NORM_OFFSET;
-                    if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                    if (!imageSampler->normalized_coords
+                        || imageSampler->filter_mode != CL_FILTER_NEAREST
+                        || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                        // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                        // Apple requires its CPU implementation to do correctly
+                        // rounded address arithmetic in all modes
                         || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                        )
+                    )
                         offset = 0.0f;          // Loop only once
 
                     for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel; norm_offset_x += NORM_OFFSET) {
@@ -824,7 +833,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -935,7 +947,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -965,7 +980,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -1021,7 +1039,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords
+                                || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                || NORM_OFFSET == 0)
+                            {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -1051,7 +1072,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords
+                                    || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                    || NORM_OFFSET == 0)
+                                {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -581,7 +581,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                     if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                         // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                        || gDeviceType != CL_DEVICE_TYPE_GPU
+                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                         )
                         offset = 0.0f;          // Loop only once
@@ -647,7 +647,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -749,7 +749,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
                     if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                         // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                        || gDeviceType != CL_DEVICE_TYPE_GPU
+                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                         )
                         offset = 0.0f;          // Loop only once
@@ -824,7 +824,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -935,7 +935,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -965,7 +965,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;
@@ -1021,7 +1021,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                             // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                             // E.g., test one pixel.
-                            if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                            if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                 norm_offset_x = 0.0f;
                                 norm_offset_y = 0.0f;
                                 checkOnlyOnePixel = 1;
@@ -1051,7 +1051,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                 // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                 // E.g., test one pixel.
-                                if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                     norm_offset_x = 0.0f;
                                     norm_offset_y = 0.0f;
                                     checkOnlyOnePixel = 1;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -600,7 +600,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                             // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                            || gDeviceType != CL_DEVICE_TYPE_GPU
+                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                             )
                             offset = 0.0f;          // Loop only once
@@ -741,7 +741,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                             // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                            || gDeviceType != CL_DEVICE_TYPE_GPU
+                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                             )
                             offset = 0.0f;          // Loop only once
@@ -918,7 +918,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
 #if defined( __APPLE__ )
                             // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
-                            || gDeviceType != CL_DEVICE_TYPE_GPU
+                            || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
                             )
                             offset = 0.0f;          // Loop only once
@@ -1108,7 +1108,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                     // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                     // E.g., test one pixel.
-                                    if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                    if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                         norm_offset_x = 0.0f;
                                         norm_offset_y = 0.0f;
                                         norm_offset_z = 0.0f;
@@ -1147,7 +1147,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                         // E.g., test one pixel.
-                                        if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                             norm_offset_x = 0.0f;
                                             norm_offset_y = 0.0f;
                                             norm_offset_z = 0.0f;
@@ -1216,7 +1216,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                     // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                     // E.g., test one pixel.
-                                    if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0) {
+                                    if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
                                         norm_offset_x = 0.0f;
                                         norm_offset_y = 0.0f;
                                         norm_offset_z = 0.0f;
@@ -1255,7 +1255,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                         // E.g., test one pixel.
-                                        if (!imageSampler->normalized_coords || gDeviceType != CL_DEVICE_TYPE_GPU || NORM_OFFSET == 0 || NORM_OFFSET == 0 || NORM_OFFSET == 0) {
+                                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0 || NORM_OFFSET == 0 || NORM_OFFSET == 0) {
                                             norm_offset_x = 0.0f;
                                             norm_offset_y = 0.0f;
                                             norm_offset_z = 0.0f;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -1277,8 +1277,6 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                                         if (!imageSampler->normalized_coords
                                             || !(gDeviceType
                                                  & CL_DEVICE_TYPE_GPU)
-                                            || NORM_OFFSET == 0
-                                            || NORM_OFFSET == 0
                                             || NORM_OFFSET == 0)
                                         {
                                             norm_offset_x = 0.0f;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -597,12 +597,15 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         int checkOnlyOnePixel = 0;
                         int found_pixel = 0;
                         float offset = NORM_OFFSET;
-                        if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                        if (!imageSampler->normalized_coords
+                            || imageSampler->filter_mode != CL_FILTER_NEAREST
+                            || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                            // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                            // Apple requires its CPU implementation to do
+                            // correctly rounded address arithmetic in all modes
                             || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                            )
+                        )
                             offset = 0.0f;          // Loop only once
 
                         for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel ; norm_offset_x += NORM_OFFSET) {
@@ -738,12 +741,15 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         int checkOnlyOnePixel = 0;
                         int found_pixel = 0;
                         float offset = NORM_OFFSET;
-                        if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                        if (!imageSampler->normalized_coords
+                            || imageSampler->filter_mode != CL_FILTER_NEAREST
+                            || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                            // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                            // Apple requires its CPU implementation to do
+                            // correctly rounded address arithmetic in all modes
                             || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                            )
+                        )
                             offset = 0.0f;          // Loop only once
 
                         for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel ; norm_offset_x += NORM_OFFSET) {
@@ -915,12 +921,15 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
                         int checkOnlyOnePixel = 0;
                         int found_pixel = 0;
                         float offset = NORM_OFFSET;
-                        if (!imageSampler->normalized_coords ||  imageSampler->filter_mode != CL_FILTER_NEAREST || NORM_OFFSET == 0
+                        if (!imageSampler->normalized_coords
+                            || imageSampler->filter_mode != CL_FILTER_NEAREST
+                            || NORM_OFFSET == 0
 #if defined( __APPLE__ )
-                            // Apple requires its CPU implementation to do correctly rounded address arithmetic in all modes
+                            // Apple requires its CPU implementation to do
+                            // correctly rounded address arithmetic in all modes
                             || !(gDeviceType & CL_DEVICE_TYPE_GPU)
 #endif
-                            )
+                        )
                             offset = 0.0f;          // Loop only once
 
                         for (float norm_offset_x = -offset; norm_offset_x <= offset && !found_pixel ; norm_offset_x += NORM_OFFSET) {
@@ -1108,7 +1117,10 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                     // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                     // E.g., test one pixel.
-                                    if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                    if (!imageSampler->normalized_coords
+                                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                        || NORM_OFFSET == 0)
+                                    {
                                         norm_offset_x = 0.0f;
                                         norm_offset_y = 0.0f;
                                         norm_offset_z = 0.0f;
@@ -1147,7 +1159,11 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                         // E.g., test one pixel.
-                                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                        if (!imageSampler->normalized_coords
+                                            || !(gDeviceType
+                                                 & CL_DEVICE_TYPE_GPU)
+                                            || NORM_OFFSET == 0)
+                                        {
                                             norm_offset_x = 0.0f;
                                             norm_offset_y = 0.0f;
                                             norm_offset_z = 0.0f;
@@ -1216,7 +1232,10 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                     // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                     // E.g., test one pixel.
-                                    if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0) {
+                                    if (!imageSampler->normalized_coords
+                                        || !(gDeviceType & CL_DEVICE_TYPE_GPU)
+                                        || NORM_OFFSET == 0)
+                                    {
                                         norm_offset_x = 0.0f;
                                         norm_offset_y = 0.0f;
                                         norm_offset_z = 0.0f;
@@ -1255,7 +1274,13 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
                                         // If we are not on a GPU, or we are not normalized, then only test with offsets (0.0, 0.0)
                                         // E.g., test one pixel.
-                                        if (!imageSampler->normalized_coords || !(gDeviceType & CL_DEVICE_TYPE_GPU) || NORM_OFFSET == 0 || NORM_OFFSET == 0 || NORM_OFFSET == 0) {
+                                        if (!imageSampler->normalized_coords
+                                            || !(gDeviceType
+                                                 & CL_DEVICE_TYPE_GPU)
+                                            || NORM_OFFSET == 0
+                                            || NORM_OFFSET == 0
+                                            || NORM_OFFSET == 0)
+                                        {
                                             norm_offset_x = 0.0f;
                                             norm_offset_y = 0.0f;
                                             norm_offset_z = 0.0f;


### PR DESCRIPTION
If the device type also advertises CL_DEVICE_TYPE_DEFAULT (which should
be valid), this causes it to be considered a CPU device and the tests
enforce different precision and rounding expectations.