### PR TITLE
Some fixes for detecting optional features in CL 3.0

### DIFF
--- a/test_conformance/half/Test_roundTrip.cpp
+++ b/test_conformance/half/Test_roundTrip.cpp
@@ -19,10 +19,13 @@
 
 #include "cl_utils.h"
 #include "tests.h"
+#include "harness/deviceInfo.h"
 #include "harness/testHarness.h"
 
 int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue queue, int num_elements )
 {
+    if (!is_extension_available(device, "cl_khr_fp16")) return 0;
+
     int vectorSize, error;
     uint64_t i, j;
     cl_program  programs[kVectorSizeCount+kStrangeVectorSizeCount] = {0};

--- a/test_conformance/half/Test_vLoadHalf.cpp
+++ b/test_conformance/half/Test_vLoadHalf.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "harness/compat.h"
+#include "harness/deviceInfo.h"
 #include "harness/testHarness.h"
 
 #include <string.h>
@@ -34,6 +35,8 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
     uint64_t time[kVectorSizeCount+kStrangeVectorSizeCount] = {0};
     uint64_t min_time[kVectorSizeCount+kStrangeVectorSizeCount] = {0};
     size_t q;
+
+    if (!is_extension_available(device, "cl_khr_fp16")) return 0;
 
     memset( min_time, -1, sizeof( min_time ) );
 

--- a/test_conformance/half/Test_vStoreHalf.cpp
+++ b/test_conformance/half/Test_vStoreHalf.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "harness/compat.h"
+#include "harness/deviceInfo.h"
 #include "harness/kernelHelpers.h"
 #include "harness/testHarness.h"
 
@@ -323,6 +324,8 @@ int test_vstorea_half_rtn( cl_device_id deviceID, cl_context context, cl_command
 
 int Test_vStoreHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
 {
+    if (!is_extension_available(device, "cl_khr_fp16")) return 0;
+
     int vectorSize, error;
     cl_program  programs[kVectorSizeCount+kStrangeVectorSizeCount][3];
     cl_kernel   kernels[kVectorSizeCount+kStrangeVectorSizeCount][3];
@@ -973,6 +976,8 @@ exit:
 
 int Test_vStoreaHalf_private( cl_device_id device, f2h referenceFunc, d2h doubleReferenceFunc, const char *roundName )
 {
+    if (!is_extension_available(device, "cl_khr_fp16")) return 0;
+
     int vectorSize, error;
     cl_program  programs[kVectorSizeCount+kStrangeVectorSizeCount][3];
     cl_kernel   kernels[kVectorSizeCount+kStrangeVectorSizeCount][3];


### PR DESCRIPTION
Those are needed if your implementation doesn't support `cl_khr_fp16` or `read_write` images