### PR TITLE
test_compiler_defines_for_extensions: fix overflow

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -322,8 +322,15 @@ int test_compiler_defines_for_extensions(cl_device_id device, cl_context context
     }
 
     // Build the kernel
-    char *kernel_code = (char*)malloc(1025*256*(num_not_supported_extensions+num_of_supported_extensions));
-    memset(kernel_code, 0, 1025*256*(num_not_supported_extensions+num_of_supported_extensions));
+    char *kernel_code = (char *)malloc(
+        1
+        + 1025 * 256
+            * (num_not_supported_extensions + num_of_supported_extensions));
+    memset(
+        kernel_code, 0,
+        1
+            + 1025 * 256
+                * (num_not_supported_extensions + num_of_supported_extensions));
 
     int i, index = 0;
     strcat(kernel_code, kernel_strings[0]);


### PR DESCRIPTION
GCC 11.2.0 warns about a possible string overflow (when
num_not_supported_extensions+num_of_supported_extensions == 0)
since no space would be allocated for the terminating
null byte that string manipulation fns expect to find.

This unconditionally adds an extra byte to the allocation to silence
the warning and fix building with -Werror.