### PR TITLE
Added missing tests for integer_dot_product_input_4x8bit and integer_dot_product_input_4x8bit_packed on feature_macro compiler test.

### DIFF
--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -579,22 +579,25 @@ int test_feature_macro_fp64(cl_device_id deviceID, cl_context context,
                                         compiler_status, supported);
 }
 
-int test_feature_macro_integer_dot_product_input_4x8bit_packed(cl_device_id deviceID, cl_context context,
-                             								   std::string test_macro_name, cl_bool& supported)
+int test_feature_macro_integer_dot_product_input_4x8bit_packed(
+    cl_device_id deviceID, cl_context context, std::string test_macro_name,
+    cl_bool& supported)
 {
     cl_int error = TEST_FAIL;
     cl_bool api_status;
     cl_bool compiler_status;
     log_info("\n%s ...\n", test_macro_name.c_str());
-    
-	if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
-	{
-		supported = false;
-		return TEST_PASS;
-	}
-	
-	error = check_api_feature_info_capabilities<cl_device_integer_dot_product_capabilities_khr>(
-        deviceID, context, api_status, CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
+
+    if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
+    {
+        supported = false;
+        return TEST_PASS;
+    }
+
+    error = check_api_feature_info_capabilities<
+        cl_device_integer_dot_product_capabilities_khr>(
+        deviceID, context, api_status,
+        CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
         CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR);
     if (error != CL_SUCCESS)
     {
@@ -612,22 +615,25 @@ int test_feature_macro_integer_dot_product_input_4x8bit_packed(cl_device_id devi
                                         compiler_status, supported);
 }
 
-int test_feature_macro_integer_dot_product_input_4x8bit(cl_device_id deviceID, cl_context context,
-                             							std::string test_macro_name, cl_bool& supported)
+int test_feature_macro_integer_dot_product_input_4x8bit(
+    cl_device_id deviceID, cl_context context, std::string test_macro_name,
+    cl_bool& supported)
 {
     cl_int error = TEST_FAIL;
     cl_bool api_status;
     cl_bool compiler_status;
     log_info("\n%s ...\n", test_macro_name.c_str());
 
-	if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
-	{
-		supported = false;
-		return TEST_PASS;
-	}
+    if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
+    {
+        supported = false;
+        return TEST_PASS;
+    }
 
-    error = check_api_feature_info_capabilities<cl_device_integer_dot_product_capabilities_khr>(
-        deviceID, context, api_status, CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
+    error = check_api_feature_info_capabilities<
+        cl_device_integer_dot_product_capabilities_khr>(
+        deviceID, context, api_status,
+        CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
         CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR);
     if (error != CL_SUCCESS)
     {
@@ -814,8 +820,8 @@ int test_features_macro(cl_device_id deviceID, cl_context context,
     NEW_FEATURE_MACRO_TEST(images);
     NEW_FEATURE_MACRO_TEST(fp64);
     NEW_FEATURE_MACRO_TEST(int64);
-	NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit);
-	NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit_packed);
+    NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit);
+    NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit_packed);
 
     error |= test_consistency_c_features_list(deviceID, supported_features_vec);
 

--- a/test_conformance/compiler/test_feature_macro.cpp
+++ b/test_conformance/compiler/test_feature_macro.cpp
@@ -579,6 +579,72 @@ int test_feature_macro_fp64(cl_device_id deviceID, cl_context context,
                                         compiler_status, supported);
 }
 
+int test_feature_macro_integer_dot_product_input_4x8bit_packed(cl_device_id deviceID, cl_context context,
+                             								   std::string test_macro_name, cl_bool& supported)
+{
+    cl_int error = TEST_FAIL;
+    cl_bool api_status;
+    cl_bool compiler_status;
+    log_info("\n%s ...\n", test_macro_name.c_str());
+    
+	if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
+	{
+		supported = false;
+		return TEST_PASS;
+	}
+	
+	error = check_api_feature_info_capabilities<cl_device_integer_dot_product_capabilities_khr>(
+        deviceID, context, api_status, CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
+        CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR);
+    if (error != CL_SUCCESS)
+    {
+        return error;
+    }
+
+    error = check_compiler_feature_info(deviceID, context, test_macro_name,
+                                        compiler_status);
+    if (error != CL_SUCCESS)
+    {
+        return error;
+    }
+
+    return feature_macro_verify_results(test_macro_name, api_status,
+                                        compiler_status, supported);
+}
+
+int test_feature_macro_integer_dot_product_input_4x8bit(cl_device_id deviceID, cl_context context,
+                             							std::string test_macro_name, cl_bool& supported)
+{
+    cl_int error = TEST_FAIL;
+    cl_bool api_status;
+    cl_bool compiler_status;
+    log_info("\n%s ...\n", test_macro_name.c_str());
+
+	if (!is_extension_available(deviceID, "cl_khr_integer_dot_product"))
+	{
+		supported = false;
+		return TEST_PASS;
+	}
+
+    error = check_api_feature_info_capabilities<cl_device_integer_dot_product_capabilities_khr>(
+        deviceID, context, api_status, CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR,
+        CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR);
+    if (error != CL_SUCCESS)
+    {
+        return error;
+    }
+
+    error = check_compiler_feature_info(deviceID, context, test_macro_name,
+                                        compiler_status);
+    if (error != CL_SUCCESS)
+    {
+        return error;
+    }
+
+    return feature_macro_verify_results(test_macro_name, api_status,
+                                        compiler_status, supported);
+}
+
 int test_feature_macro_int64(cl_device_id deviceID, cl_context context,
                              std::string test_macro_name, cl_bool& supported)
 {
@@ -748,6 +814,8 @@ int test_features_macro(cl_device_id deviceID, cl_context context,
     NEW_FEATURE_MACRO_TEST(images);
     NEW_FEATURE_MACRO_TEST(fp64);
     NEW_FEATURE_MACRO_TEST(int64);
+	NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit);
+	NEW_FEATURE_MACRO_TEST(integer_dot_product_input_4x8bit_packed);
 
     error |= test_consistency_c_features_list(deviceID, supported_features_vec);
 


### PR DESCRIPTION
Currently, the feature macro test queries the device for the CL_DEVICE_OPENCL_C_FEATURES which returns an array of the optional features supported by the it.

Then does a check one by one to see whether they are supported or not. If they are supported they are appended to an array that gets compared to the one returned by the CL_DEVICE_OPENCL_C_FEATURES query.

Now, devices supporting cl_khr_integer_dot_product will return __opencl_c_integer_dot_product_input_4x8bit and
__opencl_c_integer_dot_product_input_4x8bit_packed but since we never test for them they never get appended and so the comparison fails, and so does the test.

This PR adds the 2 missing tests.
