### PR TITLE
Include headers from the specified directory on Apple

### DIFF
--- a/test_common/gl/setup.h
+++ b/test_common/gl/setup.h
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "gl_headers.h"
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/opencl.h>

--- a/test_common/harness/ThreadPool.h
+++ b/test_common/harness/ThreadPool.h
@@ -16,7 +16,7 @@
 #ifndef THREAD_POOL_H
 #define THREAD_POOL_H
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>

--- a/test_common/harness/clImageHelper.h
+++ b/test_common/harness/clImageHelper.h
@@ -16,7 +16,7 @@
 #ifndef test_conformance_clImageHelper_h
 #define test_conformance_clImageHelper_h
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>

--- a/test_common/harness/errorHelpers.h
+++ b/test_common/harness/errorHelpers.h
@@ -18,7 +18,7 @@
 
 #include <sstream>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/opencl.h>

--- a/test_common/harness/kernelHelpers.h
+++ b/test_common/harness/kernelHelpers.h
@@ -31,7 +31,7 @@
 
 #include <string.h>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/opencl.h>

--- a/test_common/harness/mt19937.h
+++ b/test_common/harness/mt19937.h
@@ -49,7 +49,7 @@
 #ifndef MT19937_H
 #define MT19937_H 1
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/cl_platform.h>
 #else
 #include <CL/cl_platform.h>

--- a/test_common/harness/threadTesting.h
+++ b/test_common/harness/threadTesting.h
@@ -16,7 +16,7 @@
 #ifndef _threadTesting_h
 #define _threadTesting_h
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/opencl.h>

--- a/test_conformance/api/test_null_buffer_arg.cpp
+++ b/test_conformance/api/test_null_buffer_arg.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 #include <stdio.h>
-#if defined(__APPLE__)
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #include <OpenCL/cl_platform.h>
 #else

--- a/test_conformance/math_brute_force/reference_math.h
+++ b/test_conformance/math_brute_force/reference_math.h
@@ -16,7 +16,7 @@
 #ifndef REFERENCE_MATH_H
 #define REFERENCE_MATH_H
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>

--- a/test_conformance/spir/kernelargs.h
+++ b/test_conformance/spir/kernelargs.h
@@ -17,7 +17,7 @@
 #define __KERNELARGS_H
 
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>

--- a/test_conformance/spir/run_build_test.cpp
+++ b/test_conformance/spir/run_build_test.cpp
@@ -15,7 +15,7 @@
 //
 #include "harness/compat.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>

--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -15,7 +15,7 @@
 //
 #include "harness/compat.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && CL_TARGET_OPENCL_VERSION <= 120
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>


### PR DESCRIPTION
Currently I'm building [CLMTL](https://github.com/daemyung/clmtl) which is OpenCL over Metal. I want to use OpenCL CTS to verify my implementation. But there is no way to include OpenGL headers because including path is embedded to Apple's OpenCL framework. This PR allows to include OpenCL headers.