### PR TITLE
Use clCommandQueueWrapper in math_brute_force

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -133,7 +133,9 @@ struct ThreadInfo
     double maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -795,7 +797,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -131,7 +131,9 @@ struct ThreadInfo
     double maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -952,7 +954,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/binary_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_i_double.cpp
@@ -132,7 +132,9 @@ struct ThreadInfo
     cl_int maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -717,7 +719,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/binary_i_float.cpp
+++ b/test_conformance/math_brute_force/binary_i_float.cpp
@@ -130,7 +130,9 @@ struct ThreadInfo
     cl_int maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -710,7 +712,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/binary_operator_double.cpp
+++ b/test_conformance/math_brute_force/binary_operator_double.cpp
@@ -132,7 +132,9 @@ struct ThreadInfo
     double maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -762,7 +764,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/binary_operator_float.cpp
+++ b/test_conformance/math_brute_force/binary_operator_float.cpp
@@ -130,7 +130,9 @@ struct ThreadInfo
     double maxErrorValue2; // position of the max error value (param 2).  Init
                            // to 0.
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -889,7 +891,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/macro_binary_double.cpp
+++ b/test_conformance/math_brute_force/macro_binary_double.cpp
@@ -126,7 +126,9 @@ struct ThreadInfo
     cl_mem inBuf2; // input buffer for the thread
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -707,7 +709,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/macro_binary_float.cpp
+++ b/test_conformance/math_brute_force/macro_binary_float.cpp
@@ -124,7 +124,9 @@ struct ThreadInfo
     cl_mem inBuf2; // input buffer for the thread
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
     MTdata d;
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -696,7 +698,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf2);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/macro_unary_double.cpp
+++ b/test_conformance/math_brute_force/macro_unary_double.cpp
@@ -118,7 +118,9 @@ struct ThreadInfo
 {
     cl_mem inBuf; // input buffer for the thread
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -478,7 +480,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/macro_unary_float.cpp
+++ b/test_conformance/math_brute_force/macro_unary_float.cpp
@@ -117,7 +117,9 @@ struct ThreadInfo
 {
     cl_mem inBuf; // input buffer for the thread
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -492,7 +494,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/unary_double.cpp
+++ b/test_conformance/math_brute_force/unary_double.cpp
@@ -120,7 +120,9 @@ struct ThreadInfo
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
     float maxError; // max error value. Init to 0.
     double maxErrorValue; // position of the max error value.  Init to 0.
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -516,7 +518,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;

--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -118,7 +118,9 @@ struct ThreadInfo
     cl_mem outBuf[VECTOR_SIZE_COUNT]; // output buffers for the thread
     float maxError; // max error value. Init to 0.
     double maxErrorValue; // position of the max error value.  Init to 0.
-    cl_command_queue tQueue; // per thread command queue to improve performance
+
+    // Per thread command queue to improve performance
+    clCommandQueueWrapper tQueue;
 };
 
 struct TestInfo
@@ -693,7 +695,6 @@ exit:
         clReleaseMemObject(threadInfo.inBuf);
         for (auto j = gMinVectorSizeIndex; j < gMaxVectorSizeIndex; j++)
             clReleaseMemObject(threadInfo.outBuf[j]);
-        clReleaseCommandQueue(threadInfo.tQueue);
     }
 
     return error;


### PR DESCRIPTION
Simplify code by avoiding manual resource management.

This commit only modifies tests that use one queue per thread.  The
other unmodified tests are single-threaded and use the global
`gQueue`.

Original patch by Marco Antognini.

Signed-off-by: Marco Antognini <marco.antognini@arm.com>
Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>