### PR TITLE
Fix vulkan test build issue on Intel compiler

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -14,10 +14,10 @@
 // limitations under the License.
 //
 
-#define NOMINMAX
 #include <vulkan_interop_common.hpp>
 #include <string>
 #include "harness/errorHelpers.h"
+#include <algorithm>
 
 #define MAX_2D_IMAGES 5
 #define MAX_2D_IMAGE_WIDTH 1024

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.cpp
@@ -14,9 +14,8 @@
 // limitations under the License.
 //
 
-#ifdef _WIN32
-#define NOMINMAX
-#endif
+
+#include <algorithm>
 #include "vulkan_list_map.hpp"
 #include "vulkan_utility.hpp"
 #include "vulkan_wrapper.hpp"

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
@@ -15,10 +15,10 @@
 //
 
 #ifdef _WIN32
-#define NOMINMAX
 #include <Windows.h>
 #include <dxgi1_2.h>
 #include <aclapi.h>
+#include <algorithm>
 #endif
 #include <vulkan/vulkan.h>
 #include "vulkan_wrapper.hpp"


### PR DESCRIPTION
Thich change allow build tests on Windows and Intel compiler:

error : namespace "std" has no member "max" 