### PR TITLE
Fix build issue of 32 bitness binaries in vulcan test when using Intel compiler.

### DIFF
--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -81,12 +81,13 @@ int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
     const VulkanMemoryTypeList& memoryTypeList =
         vkDummyBuffer.getMemoryTypeList();
 
-    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
-        vkDevice, bufferSize, memoryTypeList[0], vkExternalMemoryHandleType);
+    VulkanDeviceMemory* vkDeviceMem =
+        new VulkanDeviceMemory(vkDevice, bufferSize, memoryTypeList[(size_t)0],
+                               vkExternalMemoryHandleType);
     VulkanBufferList vkBufferList(1, vkDevice, bufferSize,
                                   vkExternalMemoryHandleType);
 
-    vkDeviceMem->bindBuffer(vkBufferList[0], 0);
+    vkDeviceMem->bindBuffer(vkBufferList[(size_t)0], 0);
 
     void* handle = NULL;
     int fd;
@@ -238,14 +239,14 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
     const VulkanMemoryTypeList& memoryTypeList = vkImage2D->getMemoryTypeList();
     uint64_t totalImageMemSize = vkImage2D->getSize();
 
-    log_info("Memory type index: %d\n", (uint32_t)memoryTypeList[0]);
+    log_info("Memory type index: %d\n", (uint32_t)memoryTypeList[(size_t)0]);
     log_info("Memory type property: %d\n",
-             memoryTypeList[0].getMemoryTypeProperty());
+             memoryTypeList[(size_t)0].getMemoryTypeProperty());
     log_info("Image size : %d\n", totalImageMemSize);
 
-    VulkanDeviceMemory* vkDeviceMem =
-        new VulkanDeviceMemory(vkDevice, totalImageMemSize, memoryTypeList[0],
-                               vkExternalMemoryHandleType);
+    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
+        vkDevice, totalImageMemSize, memoryTypeList[(size_t)0],
+        vkExternalMemoryHandleType);
     vkDeviceMem->bindImage(*vkImage2D, 0);
 
     void* handle = NULL;

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -784,7 +784,7 @@ int run_test_with_multi_import_same_ctx(
                 VulkanBufferList vkBufferList(numBuffers, vkDevice, pBufferSize,
                                               vkExternalMemoryHandleType);
                 uint32_t interBufferOffset =
-                    (uint32_t)(vkBufferList[0].getSize());
+                    (uint32_t)(vkBufferList[(size_t)0].getSize());
 
                 for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
                 {
@@ -1126,7 +1126,7 @@ int run_test_with_multi_import_diff_ctx(
                 VulkanBufferList vkBufferList(numBuffers, vkDevice, pBufferSize,
                                               vkExternalMemoryHandleType);
                 uint32_t interBufferOffset =
-                    (uint32_t)(vkBufferList[0].getSize());
+                    (uint32_t)(vkBufferList[(size_t)0].getSize());
 
                 for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
                 {


### PR DESCRIPTION
This fix solves error messages:

>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(787,44): : error : use of overloaded operator '[]' is ambiguous (with operand types 'VulkanBufferList' and 'int')
2>                    (uint32_t)(vkBufferList[0].getSize());
2>                               ~~~~~~~~~~~~^~
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\.\vulkan_interop_common/vulkan_list_map.hpp(39,28): note: candidate function
2>    virtual VulkanWrapper &operator[](size_t idx);
2>                           ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\.\vulkan_interop_common/vulkan_list_map.hpp(38,34): note: candidate function
2>    virtual const VulkanWrapper &operator[](size_t idx) const;
C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(787,44): note: built-in candidate operator[](const unsigned long long *, int)
2>                    (uint32_t)(vkBufferList[0].getSize());
2>                                           ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(787,44): note: built-in candidate operator[](const volatile unsigned long long *, int)
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(828,28): : warning : unused variable 'buffer_size' [-Wunused-variable]
2>                    size_t buffer_size = vkBufferList[bIdx].getSize();
2>                           ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(1129,44): : error : use of overloaded operator '[]' is ambiguous (with operand types 'VulkanBufferList' and 'int')
2>                    (uint32_t)(vkBufferList[0].getSize());
2>                               ~~~~~~~~~~~~^~
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\.\vulkan_interop_common/vulkan_list_map.hpp(39,28): note: candidate function
2>    virtual VulkanWrapper &operator[](size_t idx);
2>                           ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\.\vulkan_interop_common/vulkan_list_map.hpp(38,34): note: candidate function
2>    virtual const VulkanWrapper &operator[](size_t idx) const;
2>                                 ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(1129,44): note: built-in candidate operator[](const unsigned long long *, int)
2>                    (uint32_t)(vkBufferList[0].getSize());
2>                                           ^
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(1129,44): note: built-in candidate operator[](const volatile unsigned long long *, int)
2>C:\Repos\_CTS_KHR\OpenCL-CTS\test_conformance\vulkan\test_vulkan_interop_buffer.cpp(1177,28): : warning : unused variable 'buffer_size' [-Wunused-variable]
2>                    size_t buffer_size = vkBufferList[bIdx].getSize();
2>                           ^