### PR TITLE
Update known extensions in compiler define test

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #endif
 
-
+// List should follow order in the extension spec
 const char *known_extensions[] = {
     "cl_khr_byte_addressable_store",
     "cl_khr_3d_image_writes",
@@ -42,6 +42,7 @@ const char *known_extensions[] = {
     "cl_khr_mipmap_image_writes",
     "cl_khr_srgb_image_writes",
     "cl_khr_subgroup_named_barrier",
+    "cl_khr_extended_async_copies",
     "cl_khr_subgroup_extended_types",
     "cl_khr_subgroup_non_uniform_vote",
     "cl_khr_subgroup_ballot",
@@ -51,6 +52,7 @@ const char *known_extensions[] = {
     "cl_khr_subgroup_clustered_reduce",
     "cl_khr_extended_bit_ops",
     "cl_khr_integer_dot_product",
+    "cl_khr_subgroup_rotate",
     // API-only extensions after this point.  If you add above here, modify
     // first_API_extension below.
     "cl_khr_icd",
@@ -82,10 +84,11 @@ const char *known_extensions[] = {
     "cl_khr_command_buffer",
     "cl_khr_external_memory",
     "cl_khr_external_memory_opaque_fd",
+    "cl_khr_command_buffer_mutable_dispatch",
 };
 
 size_t num_known_extensions = ARRAY_SIZE(known_extensions);
-size_t first_API_extension = 29;
+size_t first_API_extension = 31;
 
 const char *known_embedded_extensions[] = {
     "cles_khr_int64",


### PR DESCRIPTION
Add [cl_khr_command_buffer_mutable_dispatch](https://github.com/KhronosGroup/OpenCL-Docs/pull/819) and [cl_khr_extended_async_copies](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies) to the list of known extensions used in `test_compiler_defines_for_extensions`