### PR TITLE
[NFCI] Remove unused variables and enable -Wunused-variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ endmacro(add_cxx_flag_if_supported)
 
 if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
     add_cxx_flag_if_supported(-Wmisleading-indentation)
+    add_cxx_flag_if_supported(-Wunused-variable)
     add_cxx_flag_if_supported(-Wno-narrowing)
     add_cxx_flag_if_supported(-Wno-format)
     add_cxx_flag_if_supported(-Werror)

--- a/test_common/gl/helpers.cpp
+++ b/test_common/gl/helpers.cpp
@@ -1381,7 +1381,6 @@ void * CreateGLTexture2DArrayMultisample(size_t width, size_t height,
 
   //calculating colors
   double color_delta = 1.0 / (total_layers * samples);
-  double color = color_delta;
 
   if (attachment != GL_DEPTH_ATTACHMENT && attachment != GL_DEPTH_STENCIL_ATTACHMENT) {
     glDisable(GL_DEPTH_TEST);

--- a/test_conformance/SVM/test_byte_granularity.cpp
+++ b/test_conformance/SVM/test_byte_granularity.cpp
@@ -58,7 +58,6 @@ int test_svm_byte_granularity(cl_device_id deviceID, cl_context c, cl_command_qu
 
   cl_uint     num_devices = 0;
   cl_int      err = CL_SUCCESS;
-  cl_int        rval = CL_SUCCESS;
 
   err = create_cl_objects(deviceID, &byte_manipulation_kernels[0], &context, &program, &queues[0], &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER);
   if(err == 1) return 0; // no devices capable of requested SVM level, so don't execute but count test as passing.

--- a/test_conformance/SVM/test_migrate.cpp
+++ b/test_conformance/SVM/test_migrate.cpp
@@ -78,9 +78,6 @@ int test_svm_migrate(cl_device_id deviceID, cl_context c, cl_command_queue queue
     cl_uint amem[GLOBAL_SIZE];
     cl_uint bmem[GLOBAL_SIZE];
     cl_uint cmem[GLOBAL_SIZE];
-    cl_uint ramem[GLOBAL_SIZE];
-    cl_uint rbmem[GLOBAL_SIZE];
-    cl_uint rcmem[GLOBAL_SIZE];
     cl_event evs[20];
 
     const size_t global_size = GLOBAL_SIZE;

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -665,8 +665,6 @@ int test_min_max_image_2d_width(cl_device_id deviceID, cl_context context,
     cl_image_format image_format_desc;
     cl_ulong maxAllocSize;
     cl_uint minRequiredDimension;
-    size_t length;
-
 
     PASSIVE_REQUIRE_IMAGE_SUPPORT(deviceID)
 
@@ -746,7 +744,6 @@ int test_min_max_image_2d_height(cl_device_id deviceID, cl_context context,
     cl_image_format image_format_desc;
     cl_ulong maxAllocSize;
     cl_uint minRequiredDimension;
-    size_t length;
 
     PASSIVE_REQUIRE_IMAGE_SUPPORT(deviceID)
 

--- a/test_conformance/api/test_kernel_arg_info.cpp
+++ b/test_conformance/api/test_kernel_arg_info.cpp
@@ -22,11 +22,8 @@
 
 #define MINIMUM_OPENCL_PIPE_VERSION Version(2, 0)
 
-static constexpr size_t CL_VERSION_LENGTH = 128;
 static constexpr size_t KERNEL_ARGUMENT_LENGTH = 128;
 static constexpr char KERNEL_ARGUMENT_NAME[] = "argument";
-static constexpr size_t KERNEL_ARGUMENT_NAME_LENGTH =
-    sizeof(KERNEL_ARGUMENT_NAME) + 1;
 static constexpr int SINGLE_KERNEL_ARG_NUMBER = 0;
 static constexpr int MAX_NUMBER_OF_KERNEL_ARGS = 128;
 
@@ -183,7 +180,6 @@ static std::string generate_kernel(const std::vector<KernelArgInfo>& all_args,
     ret += "kernel void get_kernel_arg_info(\n";
     for (int i = 0; i < all_args.size(); ++i)
     {
-        const KernelArgInfo& arg = all_args[i];
         ret += generate_argument(all_args[i]);
         if (i == all_args.size() - 1)
         {
@@ -542,6 +538,7 @@ size_t get_param_size(const std::string& arg_type, cl_device_id deviceID,
         cl_int err = clGetDeviceInfo(deviceID, CL_DEVICE_ADDRESS_BITS,
                                      sizeof(device_address_bits),
                                      &device_address_bits, NULL);
+        test_error_ret(err, "clGetDeviceInfo", 0);
         return (device_address_bits / 8);
     }
 

--- a/test_conformance/api/test_mem_object_info.cpp
+++ b/test_conformance/api/test_mem_object_info.cpp
@@ -363,8 +363,6 @@ int test_get_imageObject_info( cl_mem * image, cl_mem_flags objectFlags, cl_imag
     cl_mem_flags flags;
     cl_uint mapCount;
     cl_uint refCount;
-    size_t rowPitchMultiplier;
-    size_t slicePitchMultiplier;
     cl_context otherCtx;
     size_t offset;
     size_t sz;

--- a/test_conformance/api/test_null_buffer_arg.cpp
+++ b/test_conformance/api/test_null_buffer_arg.cpp
@@ -149,7 +149,6 @@ int test_null_buffer_arg(cl_device_id device, cl_context context,
     cl_command_queue queue, int num_elements)
 {
     unsigned int test_success = 0;
-    unsigned int i;
     unsigned int buffer_size;
     cl_int status;
     cl_program program;

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -526,26 +526,6 @@ void CL_CALLBACK mem_obj_destructor_callback( cl_mem, void *data )
     free( data );
 }
 
-// All possible combinations of valid cl_mem_flags.
-static cl_mem_flags all_flags[16] = {
-  0,
-  CL_MEM_READ_WRITE,
-  CL_MEM_READ_ONLY,
-  CL_MEM_WRITE_ONLY,
-  CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_WRITE_ONLY | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
-  CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR,
-  CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
-  CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
-  CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
-  CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-  CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
-};
-
 #define TEST_DEVICE_PARAM( device, paramName, val, name, type, cast )    \
 error = clGetDeviceInfo( device, paramName, sizeof( val ), &val, &size );        \
 test_error( error, "Unable to get device " name );                            \

--- a/test_conformance/api/test_sub_group_dispatch.cpp
+++ b/test_conformance/api/test_sub_group_dispatch.cpp
@@ -56,11 +56,9 @@ cl_int get_sub_group_num(cl_command_queue queue, cl_kernel kernel, clMemWrapper&
 
 int test_sub_group_dispatch(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-    static const size_t gsize0 = 80;
-    int i, error;
+    int error;
     size_t realSize;
     size_t kernel_max_subgroup_size, kernel_subgroup_count;
-    size_t global[] = {1,1,1};
     size_t max_local;
 
     cl_platform_id platform;

--- a/test_conformance/basic/test_fpmath_float.cpp
+++ b/test_conformance/basic/test_fpmath_float.cpp
@@ -49,8 +49,6 @@ static const char *fpmul_kernel_code =
 "}\n";
 
 
-static const float    MAX_ERR = 1e-5f;
-
 static int
 verify_fpadd(float *inptrA, float *inptrB, float *outptr, int n)
 {

--- a/test_conformance/basic/test_hiloeo.cpp
+++ b/test_conformance/basic/test_hiloeo.cpp
@@ -43,8 +43,6 @@ static const unsigned int out_vector_idx[] =   { 0, 0, 1, 1, 3, 4};
 // input type name is strcat(gentype, vector_size_names[i]);
 // and output type name is
 // strcat(gentype, vector_size_names[out_vector_idx[i]]);
-static const int size_to_idx[] = {-1,0,1,2,3,-1,-1,-1,4,
-    -1,-1,-1,-1,-1,-1,-1,5};
 static const char *vector_size_names[] = { "", "2", "3", "4", "8", "16"};
 
 static const size_t  kSizes[] = { 1, 1, 2, 2, 4, 4, 8, 8, 4, 8 };

--- a/test_conformance/basic/test_hostptr.cpp
+++ b/test_conformance/basic/test_hostptr.cpp
@@ -32,8 +32,6 @@ const char *hostptr_kernel_code =
 "    dst[tid] = srcA[tid] + srcB[tid];\n"
 "}\n";
 
-static const float    MAX_ERR = 1e-5f;
-
 static int verify_hostptr(cl_float *inptrA, cl_float *inptrB, cl_float *outptr, int n)
 {
     cl_float       r;

--- a/test_conformance/basic/test_preprocessors.cpp
+++ b/test_conformance/basic/test_preprocessors.cpp
@@ -97,10 +97,10 @@ int test_kernel_preprocessor_macros(cl_device_id deviceID, cl_context context, c
     char programSource[4096];
     char curFileName[512];
     char *programPtr = programSource;
-    int i = 0;
     snprintf(curFileName, 512, "%s", __FILE__);
 #ifdef _WIN32
     // Replace "\" with "\\"
+    int i = 0;
     while(curFileName[i] != '\0') {
         if (curFileName[i] == '\\') {
             int j = i + 1;

--- a/test_conformance/basic/test_progvar.cpp
+++ b/test_conformance/basic/test_progvar.cpp
@@ -1642,8 +1642,6 @@ int test_progvar_func_scope(cl_device_id device, cl_context context, cl_command_
                  "supported on this device\n");
         return TEST_SKIPPED_ITSELF;
     }
-    size_t max_size = 0;
-    size_t pref_size = 0;
 
     cl_int err = CL_SUCCESS;
 

--- a/test_conformance/basic/test_queue_priority.cpp
+++ b/test_conformance/basic/test_queue_priority.cpp
@@ -48,13 +48,9 @@ static const char *fpmul_kernel_code =
 "    dst[tid] = srcA[tid] * srcB[tid];\n"
 "}\n";
 
-
-static const float    MAX_ERR = 1e-5f;
-
 static int
 verify_fpadd(float *inptrA, float *inptrB, float *outptr, int n, int fileNum)
 {
-    float       r;
     int         i;
 
     float * reference_ptr = (float *)malloc(n * sizeof(float));
@@ -82,7 +78,6 @@ verify_fpadd(float *inptrA, float *inptrB, float *outptr, int n, int fileNum)
 static int
 verify_fpsub(float *inptrA, float *inptrB, float *outptr, int n, int fileNum)
 {
-    float       r;
     int         i;
 
     float * reference_ptr = (float *)malloc(n * sizeof(float));
@@ -110,7 +105,6 @@ verify_fpsub(float *inptrA, float *inptrB, float *outptr, int n, int fileNum)
 static int
 verify_fpmul(float *inptrA, float *inptrB, float *outptr, int n, int fileNum)
 {
-    float       r;
     int         i;
 
     float * reference_ptr = (float *)malloc(n * sizeof(float));

--- a/test_conformance/basic/test_readimage3d.cpp
+++ b/test_conformance/basic/test_readimage3d.cpp
@@ -142,7 +142,7 @@ int test_readimage3d(cl_device_id device, cl_context context, cl_command_queue q
 	int img_width = 64;
 	int img_height = 64;
 	int img_depth = 64;
-	int i, err;
+	int err;
 	size_t origin[3] = {0, 0, 0};
 	size_t region[3] = {img_width, img_height, img_depth};
 	size_t length = img_width * img_height * img_depth * 4 * sizeof(float);

--- a/test_conformance/buffers/test_buffer_migrate.cpp
+++ b/test_conformance/buffers/test_buffer_migrate.cpp
@@ -80,7 +80,7 @@ static cl_int migrateMemObject(enum migrations migrate, cl_command_queue *queues
 
 static cl_int restoreBuffer(cl_command_queue *queues, cl_mem *buffers, cl_uint num_devices, cl_mem_migration_flags *flags, cl_uint *buffer)
 {
-  cl_uint i, j;
+  cl_uint i;
   cl_int  err;
 
   // If the buffer was previously migrated with undefined content, reload the content.

--- a/test_conformance/buffers/test_image_migrate.cpp
+++ b/test_conformance/buffers/test_image_migrate.cpp
@@ -128,7 +128,6 @@ int test_image_migrate(cl_device_id deviceID, cl_context context, cl_command_que
   cl_mem_migration_flags *flagsA, *flagsB, *flagsC;
   cl_device_partition_property property[] = {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, 0, 0};
   cl_mem *imageA, *imageB, *imageC;
-  cl_mem_flags flags;
   cl_image_format format;
   cl_sampler sampler = NULL;
   cl_program program = NULL;

--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -361,8 +361,6 @@ int test_compiler_defines_for_extensions(cl_device_id device, cl_context context
     clProgramWrapper program;
     clKernelWrapper kernel;
 
-    Version version = get_device_cl_version(device);
-
     error = create_single_kernel_helper(context, &program, &kernel, 1,
                                         (const char **)&kernel_code, "test");
     test_error(error, "create_single_kernel_helper failed");

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -908,12 +908,6 @@ void dumpConfigInfo(config_info* info)
                 {
                     cl_name_version new_version_item =
                         info->config.cl_name_version_array[f];
-                    cl_version new_version_major =
-                        CL_VERSION_MAJOR_KHR(new_version_item.version);
-                    cl_version new_version_minor =
-                        CL_VERSION_MINOR_KHR(new_version_item.version);
-                    cl_version new_version_patch =
-                        CL_VERSION_PATCH_KHR(new_version_item.version);
                     log_info("\t\t\"%s\" %d.%d.%d\n", new_version_item.name,
                              CL_VERSION_MAJOR_KHR(new_version_item.version),
                              CL_VERSION_MINOR_KHR(new_version_item.version),

--- a/test_conformance/conversions/fplib.cpp
+++ b/test_conformance/conversions/fplib.cpp
@@ -79,7 +79,6 @@ float qcom_s64_2_f32(int64_t data, bool sat, roundingMode rnd)
             uint32_t mantissa;
             if (mantShift >= 0){
                 uint64_t temp = (uint64_t)data >> mantShift;
-                uint64_t mask = (1 << mantShift) - 1;
                 if ((temp << mantShift) != data)
                     inExact = 1;
                 mantissa = (uint32_t)temp;
@@ -124,7 +123,6 @@ float qcom_s64_2_f32(int64_t data, bool sat, roundingMode rnd)
             uint32_t    mantissa;
             if (mantShift >= 0){
                 uint64_t temp = (uint64_t)data >> mantShift;
-                uint64_t mask = (1 << mantShift) - 1;
                 if (temp << mantShift != data)
                     inExact = 1;
                 mantissa = (uint32_t)temp;
@@ -183,7 +181,6 @@ float qcom_u64_2_f32(uint64_t data, bool sat, roundingMode rnd)
             uint32_t    mantissa;
             if (mantShift >= 0){
                 uint64_t temp = data >> mantShift;
-                uint64_t mask = (1 << mantShift) - 1;
                 if (temp << mantShift != data)
                     inExact = 1;
                 mantissa = (uint32_t)temp;
@@ -209,7 +206,6 @@ float qcom_u64_2_f32(uint64_t data, bool sat, roundingMode rnd)
             uint32_t  mantissa;
             if (mantShift >= 0){
                 uint64_t temp = (uint64_t)data >> mantShift;
-                uint64_t mask = (1 << mantShift) - 1;
                 if (temp << mantShift != data)
                     inExact = 1;
                 mantissa = (uint32_t)temp;

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -1666,8 +1666,6 @@ static cl_program   MakeProgram( Type outType, Type inType, SaturationMode sat, 
                                         &programSource, testName, flags);
     if (error)
     {
-        char    buffer[2048] = "";
-
         vlog_error("Failed to build kernel/program.\n", error);
         clReleaseProgram(program);
         return NULL;

--- a/test_conformance/events/test_callbacks.cpp
+++ b/test_conformance/events/test_callbacks.cpp
@@ -79,7 +79,6 @@ int test_callback_event_single( cl_device_id device, cl_context context, cl_comm
 
   /*  use struct as call back para */
   CALL_BACK_USER_DATA user_data[EVENT_CALLBACK_TYPE_TOTAL];
-  int index [EVENT_CALLBACK_TYPE_TOTAL]={ 0,1,2};
   for( int i=0;i< EVENT_CALLBACK_TYPE_TOTAL; i++)
   {
        user_data[i].enevt_type=event_callback_types[i];

--- a/test_conformance/events/test_events.cpp
+++ b/test_conformance/events/test_events.cpp
@@ -604,8 +604,6 @@ int test_event_enqueue_marker( cl_device_id deviceID, cl_context context, cl_com
 #ifdef CL_VERSION_1_2
 int test_event_enqueue_marker_with_event_list( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-
-    cl_int status;
     SETUP_EVENT( context, queue );
     cl_event event_list[3]={ NULL, NULL, NULL};
 
@@ -649,8 +647,6 @@ int test_event_enqueue_marker_with_event_list( cl_device_id deviceID, cl_context
 
 int test_event_enqueue_barrier_with_event_list( cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
 {
-
-    cl_int status;
     SETUP_EVENT( context, queue );
     cl_event event_list[3]={ NULL, NULL, NULL};
 

--- a/test_conformance/gl/common.h
+++ b/test_conformance/gl/common.h
@@ -32,7 +32,11 @@ struct format {
 };
 
 // These are the typically tested formats.
-
+// TODO: These variables should be made const; until then, suppress unused
+// variable warnings as not every translation unit including this header uses
+// all variables.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 static struct format common_formats[] = {
 #ifdef __APPLE__
   { GL_RGBA8,        GL_BGRA,             GL_UNSIGNED_INT_8_8_8_8,         kUChar },
@@ -60,6 +64,7 @@ static struct format depth_formats[] = {
   { GL_DEPTH32F_STENCIL8,  GL_DEPTH_STENCIL,   GL_FLOAT_32_UNSIGNED_INT_24_8_REV, kFloat },
 };
 #endif
+#pragma GCC diagnostic pop
 
 int test_images_write_common(cl_device_id device, cl_context context,
   cl_command_queue queue, struct format* formats, size_t nformats,

--- a/test_conformance/gl/test_image_methods.cpp
+++ b/test_conformance/gl/test_image_methods.cpp
@@ -337,7 +337,6 @@ int test_image_methods_depth( cl_device_id device, cl_context context, cl_comman
     return 0;
   }
 
-    size_t pixelSize;
     int result = 0;
   GLenum depth_targets[] = {GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY};
   size_t ntargets = sizeof(depth_targets) / sizeof(depth_targets[0]);
@@ -378,7 +377,6 @@ int test_image_methods_multisample( cl_device_id device, cl_context context, cl_
     return 0;
   }
 
-    size_t pixelSize;
   int result = 0;
   GLenum targets[] = {GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_2D_MULTISAMPLE_ARRAY};
   size_t ntargets = sizeof(targets) / sizeof(targets[0]);

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -427,7 +427,6 @@ static int test_image_write( cl_context context, cl_command_queue queue,
 int supportsHalf(cl_context context, bool* supports_half)
 {
   int error;
-  size_t  size;
   cl_uint numDev;
 
   error = clGetContextInfo(context, CL_CONTEXT_NUM_DEVICES, sizeof(cl_uint), &numDev, NULL);
@@ -446,7 +445,6 @@ int supportsHalf(cl_context context, bool* supports_half)
 int supportsMsaa(cl_context context, bool* supports_msaa)
 {
   int error;
-  size_t  size;
   cl_uint numDev;
 
   error = clGetContextInfo(context, CL_CONTEXT_NUM_DEVICES, sizeof(cl_uint), &numDev, NULL);
@@ -465,7 +463,6 @@ int supportsMsaa(cl_context context, bool* supports_msaa)
 int supportsDepth(cl_context context, bool* supports_depth)
 {
   int error;
-  size_t  size;
   cl_uint numDev;
 
   error = clGetContextInfo(context, CL_CONTEXT_NUM_DEVICES, sizeof(cl_uint), &numDev, NULL);
@@ -486,7 +483,6 @@ static int test_image_format_write( cl_context context, cl_command_queue queue,
   GLenum internalFormat,  GLenum glType, ExplicitType type, MTdata d )
 {
   int error;
-  int samples = 8;
   // If we're testing a half float format, then we need to determine the
   // rounding mode of this machine.  Punt if we fail to do so.
 

--- a/test_conformance/half/Test_vStoreHalf.cpp
+++ b/test_conformance/half/Test_vStoreHalf.cpp
@@ -81,7 +81,7 @@ ReferenceF(cl_uint jid, cl_uint tid, void *userInfo)
     cl_ushort *r = cri->r + off;
     f2h f = cri->f;
     cl_ulong i = cri->i + off;
-    cl_uint j, rr;
+    cl_uint j;
 
     if (off + count > lim)
         count = lim - off;

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -81,7 +81,6 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
 
   for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
   {
-    float lod_float = (float) lod;
     origin[1] = lod;
     size_t width_lod, row_pitch_lod;
 

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -82,7 +82,6 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
 
     for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
     {
-        float lod_float = (float) lod;
         size_t width_lod, row_pitch_lod, slice_pitch_lod;
         if( gTestMipmaps )
             origin[2] = lod;

--- a/test_conformance/images/clReadWriteImage/test_read_2D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D.cpp
@@ -81,7 +81,6 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
 
     for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
     {
-        float lod_float = (float) lod;
         origin[2] = lod;
         size_t width_lod, height_lod, row_pitch_lod;
 

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -83,9 +83,8 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
 
     for(size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
     {
-        float lod_float = (float) lod;
         origin[3] = lod;
-        size_t width_lod, height_lod, depth_lod, row_pitch_lod, slice_pitch_lod;
+        size_t width_lod, height_lod, row_pitch_lod, slice_pitch_lod;
 
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
         height_lod = (imageInfo->height >> lod) ? (imageInfo->height >> lod) : 1;

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -83,7 +83,6 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
 
     for(size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
     {
-        float lod_float = (float) lod;
         origin[3] = lod;
         size_t width_lod, height_lod, depth_lod, row_pitch_lod, slice_pitch_lod;
 

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -17,5 +17,15 @@ set(${MODULE_NAME}_SOURCES
     ../common.cpp
 )
 
+# Make unused variables not fatal in this module; see
+# https://github.com/KhronosGroup/OpenCL-CTS/issues/1484
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+  SET_SOURCE_FILES_PROPERTIES(
+    ${${MODULE_NAME}_SOURCES}
+    PROPERTIES
+    COMPILE_FLAGS "-Wno-error=unused-variable"
+  )
+endif()
+
 include(../../CMakeCommon.txt)
 

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -5357,10 +5357,10 @@ long double reference_acosl(long double x)
         0x3243F6A8885A308DULL, 0x313198A2E0370734ULL
     }; // first 126 bits of pi
        // http://www.super-computing.org/pi-hexa_current.html
-    long double head, tail, temp;
+    long double head, tail;
 #if __LDBL_MANT_DIG__ >= 64
     // long double has 64-bits of precision or greater
-    temp = (long double)pi_bits[0] * 0x1.0p64L;
+    long double temp = (long double)pi_bits[0] * 0x1.0p64L;
     head = temp + (long double)pi_bits[1];
     temp -= head; // rounding err rounding pi_bits[1] into head
     tail = (long double)pi_bits[1] + temp;

--- a/test_conformance/pipes/test_pipe_limits.cpp
+++ b/test_conformance/pipes/test_pipe_limits.cpp
@@ -163,7 +163,7 @@ int test_pipe_max_args(cl_device_id deviceID, cl_context context, cl_command_que
     cl_int err;
     cl_int size;
     int num_pipe_elements = 1024;
-    int i, j;
+    int i;
     int max_pipe_args;
     std::stringstream source;
     clEventWrapper producer_sync_event = NULL;

--- a/test_conformance/pipes/test_pipe_read_write.cpp
+++ b/test_conformance/pipes/test_pipe_read_write.cpp
@@ -626,7 +626,6 @@ int test_pipe_readwrite_struct_generic( cl_device_id deviceID, cl_context contex
     size_t size = sizeof(TestStruct);
     size_t global_work_size[3];
     cl_int err;
-    int total_errors = 0;
     int i;
     MTdataHolder d(gRandomSeed);
     clEventWrapper producer_sync_event = NULL;

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -232,10 +232,8 @@ int waitForEvent(cl_event* event)
 //-----------------------------------------
 static cl_program makePrintfProgram(cl_kernel *kernel_ptr, const cl_context context,const unsigned int testId,const unsigned int testNum,bool isLongSupport,bool is64bAddrSpace)
 {
-    int err,i;
+    int err;
     cl_program program;
-    cl_device_id devID;
-    char buildLog[ 1024 * 128 ];
     char testname[256] = {0};
     char addrSpaceArgument[256] = {0};
     char addrSpacePAddArgument[256] = {0};

--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -842,8 +842,6 @@ static void hexRefBuilder(printDataGenParameters& params, char* refResult, const
 */
 void generateRef(const cl_device_id device)
 {
-    int fd = -1;
-    char _refBuffer[ANALYSIS_BUFFER_SIZE];
     const cl_device_fp_config fpConfig = get_default_rounding_mode(device);
     const RoundingMode hostRound = get_round();
     RoundingMode deviceRound;

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -173,8 +173,6 @@ static cl_program makeSelectProgram(cl_kernel *kernel_ptr, const cl_context cont
     char extension[128] = "";
     int  err = 0;
 
-    int i; // generic, re-usable loop variable
-
     const char *source[] = {
         extension,
         "__kernel void ", testname,

--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -213,7 +213,6 @@ cl_kernel create_kernel_helper( cl_program program, const std::string& kernel_na
 {
     int error = CL_SUCCESS;
     cl_kernel kernel = NULL;
-    cl_device_id device = get_program_device(program);
     /* And create a kernel from it */
     kernel = clCreateKernel( program, kernel_name.c_str(), &error );
     if( kernel == NULL || error != CL_SUCCESS)

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -203,7 +203,6 @@ int get_program_with_il(clProgramWrapper &prog, const cl_device_id deviceID,
 test_status InitCL(cl_device_id id)
 {
     test_status spirv_status;
-    bool force = true;
     spirv_status = check_spirv_compilation_readiness(id);
     if (spirv_status != TEST_PASS)
     {

--- a/test_conformance/spirv_new/test_cl_khr_spirv_no_integer_wrap_decoration.cpp
+++ b/test_conformance/spirv_new/test_cl_khr_spirv_no_integer_wrap_decoration.cpp
@@ -109,7 +109,6 @@ int test_ext_cl_khr_spirv_no_integer_wrap_decoration(cl_device_id deviceID,
         kernelStr = kernelStream.str();
     }
 
-    size_t kernelLen = kernelStr.size();
     const char *kernelBuf = kernelStr.c_str();
 
     for (int i = 0; i < num; i++) {

--- a/test_conformance/spirv_new/test_op_fmath.cpp
+++ b/test_conformance/spirv_new/test_op_fmath.cpp
@@ -79,10 +79,7 @@ int test_fmath(cl_device_id deviceID,
         kernelStr = kernelStream.str();
     }
 
-    size_t kernelLen = kernelStr.size();
     const char *kernelBuf = kernelStr.c_str();
-
-    const char *options = fast_math ? "-cl-fast-relaxed-math" : NULL;
 
     std::vector<T> h_ref(num);
 

--- a/test_conformance/spirv_new/test_op_function.cpp
+++ b/test_conformance/spirv_new/test_op_function.cpp
@@ -33,7 +33,6 @@ int test_function(cl_device_id deviceID,
     err = clEnqueueWriteBuffer(queue, in, CL_TRUE, 0, bytes, &h_in[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy to in buffer");
 
-    cl_uint bits = sizeof(void *) * 8;
     std::string spvStr = std::string("op_function") + "_" + std::string(funcType);
     const char *spvName = spvStr.c_str();
 

--- a/test_conformance/spirv_new/test_op_negate.cpp
+++ b/test_conformance/spirv_new/test_op_negate.cpp
@@ -43,7 +43,6 @@ int test_negation(cl_device_id deviceID,
     err = clEnqueueWriteBuffer(queue, in, CL_TRUE, 0, bytes, &h_in[0], 0, NULL, NULL);
     SPIRV_CHECK_ERROR(err, "Failed to copy to in buffer");
 
-    cl_uint bits = sizeof(void *) * 8;
     std::string spvStr = std::string(funcName) + "_" + std::string(Tname);
     const char *spvName = spvStr.c_str();
 

--- a/test_conformance/spirv_new/test_op_opaque.cpp
+++ b/test_conformance/spirv_new/test_op_opaque.cpp
@@ -17,7 +17,6 @@ or Khronos Conformance Test Source License Agreement as executed between Khronos
 TEST_SPIRV_FUNC(op_type_opaque_simple)
 {
     const char *name = "opaque";
-    int num = (int)(1 << 10);
     cl_int err = CL_SUCCESS;
     std::vector<unsigned char> buffer_vec = readSPIRV(name);
 

--- a/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
+++ b/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
@@ -75,7 +75,6 @@ int test_vector_times_scalar(cl_device_id deviceID,
         kernelStr = kernelStream.str();
     }
 
-    size_t kernelLen = kernelStr.size();
     const char *kernelBuf = kernelStr.c_str();
 
     std::vector<Tv> h_ref(num);
@@ -107,7 +106,6 @@ int test_vector_times_scalar(cl_device_id deviceID,
         SPIRV_CHECK_ERROR(err, "Failed to read from ref");
     }
 
-    cl_uint bits = sizeof(void *) * 8;
     std::string ref = "vector_times_scalar_";
     ref += Tname;
     const char *spvName = ref.c_str();


### PR DESCRIPTION
Remove unused variables throughout the code base and enable the
`-Wunused-variable` warning flag globally to prevent new unused
variable issues being introduced in the future.

This is mostly a non-functional change, with one exception:

 - In `test_conformance/api/test_kernel_arg_info.cpp`, an error check
   of the clGetDeviceInfo return value was added.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>