### PR TITLE
Include release builds in GitHub Actions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,11 +3,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build ${{ matrix.os }} ${{ matrix.arch }}
+    name: Build ${{ matrix.os }} ${{ matrix.arch }}${{ matrix.extra }}
     runs-on: ${{ matrix.os }}
     env:
       JOB_ARCHITECTURE: ${{ matrix.arch }}
       JOB_ENABLE_GL: ${{ matrix.gl }}
+      JOB_ENABLE_DEBUG: ${{ matrix.debug }}
     strategy:
       fail-fast: false
       matrix:
@@ -17,12 +18,15 @@ jobs:
           - os: ubuntu-20.04
             mainmatrix: true
             gl: 1
+            extra: " gl"
           - os: ubuntu-20.04
             mainmatrix: false
             arch: arm
           - os: ubuntu-20.04
             mainmatrix: false
             arch: aarch64
+            debug: 1
+            extra: " debug"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ninja


### PR DESCRIPTION
The "Ninja" CMake generator does not support multiple configurations, i.e. it does not support use of the '--config' option when running 'cmake --build'.  As such, the default configuration (i.e. Debug) was getting used for all builds.
    
Use the CMAKE_BUILD_TYPE variable instead, so that we do release builds, but change one build (ubuntu-20.04 aarch64) to use Debug as its build type, to keep some build coverage for asserts, etc.
    
For Vulkan-Loader and OpenCL-ICD-Loader, we do release builds unconditionally, as we assume there is no need in the CI workflow to actually run the binaries that are built, and therefore no need for any additional debug info.

Signed-off-by: Stuart Brady <stuart.brady@arm.com>