### PR TITLE
remove implicit conversion to pointer to fix 32-bit compile

### DIFF
--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.hpp
@@ -37,7 +37,7 @@ public:
     virtual size_t size() const;
     virtual const VulkanWrapper &operator[](size_t idx) const;
     virtual VulkanWrapper &operator[](size_t idx);
-    virtual operator const VulkanNative *() const;
+    virtual const VulkanNative *operator ()() const;
 };
 
 template <class VulkanKey, class VulkanValue> class VulkanMap {
@@ -343,7 +343,7 @@ VulkanWrapper &VulkanList<VulkanWrapper, VulkanNative>::operator[](size_t idx)
 }
 
 template <class VulkanWrapper, class VulkanNative>
-VulkanList<VulkanWrapper, VulkanNative>::operator const VulkanNative *() const
+const VulkanNative *VulkanList<VulkanWrapper, VulkanNative>::operator ()() const
 {
     return m_nativeList.data();
 }

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_list_map.hpp
@@ -37,7 +37,7 @@ public:
     virtual size_t size() const;
     virtual const VulkanWrapper &operator[](size_t idx) const;
     virtual VulkanWrapper &operator[](size_t idx);
-    virtual const VulkanNative *operator ()() const;
+    virtual const VulkanNative *operator()() const;
 };
 
 template <class VulkanKey, class VulkanValue> class VulkanMap {
@@ -343,7 +343,7 @@ VulkanWrapper &VulkanList<VulkanWrapper, VulkanNative>::operator[](size_t idx)
 }
 
 template <class VulkanWrapper, class VulkanNative>
-const VulkanNative *VulkanList<VulkanWrapper, VulkanNative>::operator ()() const
+const VulkanNative *VulkanList<VulkanWrapper, VulkanNative>::operator()() const
 {
     return m_nativeList.data();
 }

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.cpp
@@ -182,7 +182,7 @@ bool checkVkSupport()
     const VulkanInstance &instance = getVulkanInstance();
     const VulkanPhysicalDeviceList &physicalDeviceList =
         instance.getPhysicalDeviceList();
-    if (physicalDeviceList == NULL)
+    if (physicalDeviceList() == NULL)
     {
         std::cout << "physicalDeviceList is null, No GPUs found with "
                      "Vulkan support !!!\n";

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
@@ -625,12 +625,12 @@ void VulkanQueue::submit(const VulkanSemaphoreList &waitSemaphoreList,
     vkSubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     vkSubmitInfo.pNext = NULL;
     vkSubmitInfo.waitSemaphoreCount = (uint32_t)waitSemaphoreList.size();
-    vkSubmitInfo.pWaitSemaphores = waitSemaphoreList;
+    vkSubmitInfo.pWaitSemaphores = waitSemaphoreList();
     vkSubmitInfo.pWaitDstStageMask = vkPipelineStageFlagsList.data();
     vkSubmitInfo.commandBufferCount = (uint32_t)commandBufferList.size();
-    vkSubmitInfo.pCommandBuffers = commandBufferList;
+    vkSubmitInfo.pCommandBuffers = commandBufferList();
     vkSubmitInfo.signalSemaphoreCount = (uint32_t)signalSemaphoreList.size();
-    vkSubmitInfo.pSignalSemaphores = signalSemaphoreList;
+    vkSubmitInfo.pSignalSemaphores = signalSemaphoreList();
 
     vkQueueSubmit(m_vkQueue, 1, &vkSubmitInfo, NULL);
 }
@@ -728,7 +728,7 @@ void VulkanDescriptorSetLayout::VulkanDescriptorSetLayoutCommon(
     vkDescriptorSetLayoutCreateInfo.flags = 0;
     vkDescriptorSetLayoutCreateInfo.bindingCount =
         (uint32_t)descriptorSetLayoutBindingList.size();
-    vkDescriptorSetLayoutCreateInfo.pBindings = descriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutCreateInfo.pBindings = descriptorSetLayoutBindingList();
 
     vkCreateDescriptorSetLayout(m_device, &vkDescriptorSetLayoutCreateInfo,
                                 NULL, &m_vkDescriptorSetLayout);
@@ -799,7 +799,7 @@ void VulkanPipelineLayout::VulkanPipelineLayoutCommon(
     vkPipelineLayoutCreateInfo.flags = 0;
     vkPipelineLayoutCreateInfo.setLayoutCount =
         (uint32_t)descriptorSetLayoutList.size();
-    vkPipelineLayoutCreateInfo.pSetLayouts = descriptorSetLayoutList;
+    vkPipelineLayoutCreateInfo.pSetLayouts = descriptorSetLayoutList();
     vkPipelineLayoutCreateInfo.pushConstantRangeCount = 0;
     vkPipelineLayoutCreateInfo.pPushConstantRanges = NULL;
 
@@ -1577,7 +1577,7 @@ VulkanImage::VulkanImage(
     vkImageCreateInfo.queueFamilyIndexCount =
         (uint32_t)m_device.getPhysicalDevice().getQueueFamilyList().size();
     vkImageCreateInfo.pQueueFamilyIndices =
-        m_device.getPhysicalDevice().getQueueFamilyList();
+        m_device.getPhysicalDevice().getQueueFamilyList()();
     vkImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkExternalMemoryImageCreateInfo vkExternalMemoryImageCreateInfo = {};

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
@@ -728,7 +728,8 @@ void VulkanDescriptorSetLayout::VulkanDescriptorSetLayoutCommon(
     vkDescriptorSetLayoutCreateInfo.flags = 0;
     vkDescriptorSetLayoutCreateInfo.bindingCount =
         (uint32_t)descriptorSetLayoutBindingList.size();
-    vkDescriptorSetLayoutCreateInfo.pBindings = descriptorSetLayoutBindingList();
+    vkDescriptorSetLayoutCreateInfo.pBindings =
+        descriptorSetLayoutBindingList();
 
     vkCreateDescriptorSetLayout(m_device, &vkDescriptorSetLayoutCreateInfo,
                                 NULL, &m_vkDescriptorSetLayout);


### PR DESCRIPTION
This is an alternative proposal to fix 32-bit compiles, see #1465.

This version removes the implicit conversion to a pointer and relies on an explicit conversion instead, by overloading `operator()`.  Note that this is a similar pattern used by the OpenCL C++ bindings:

https://github.com/KhronosGroup/OpenCL-CLHPP/blob/main/include/CL/opencl.hpp#L1913

By removing the implicit conversion there is only one overload for both 32-bit and 64-bit builds.