### PR TITLE
Fix memory oob problem in test half

### DIFF
--- a/test_conformance/half/main.cpp
+++ b/test_conformance/half/main.cpp
@@ -131,8 +131,7 @@ exit:
 static int ParseArgs( int argc, const char **argv )
 {
     int i;
-    argList = (const char **)calloc( argc - 1, sizeof( char*) );
-
+    argList = (const char **)calloc(argc, sizeof(char *));
     if( NULL == argList )
     {
         vlog_error( "Failed to allocate memory for argList.\n" );


### PR DESCRIPTION
Allocate memory for argc arguments
instead of argc - 1.