### PR TITLE
[NFC] Declare format tables as const

### DIFF
--- a/test_conformance/gl/common.h
+++ b/test_conformance/gl/common.h
@@ -32,12 +32,8 @@ struct format {
 };
 
 // These are the typically tested formats.
-// TODO: These variables should be made const; until then, suppress unused
-// variable warnings as not every translation unit including this header uses
-// all variables.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-static struct format common_formats[] = {
+// clang-format off
+static const format common_formats[] = {
 #ifdef __APPLE__
   { GL_RGBA8,        GL_BGRA,             GL_UNSIGNED_INT_8_8_8_8,         kUChar },
   { GL_RGBA8,        GL_BGRA,             GL_UNSIGNED_INT_8_8_8_8_REV,     kUChar },
@@ -57,26 +53,30 @@ static struct format common_formats[] = {
 };
 
 #ifdef GL_VERSION_3_2
-static struct format depth_formats[] = {
+static const format depth_formats[] = {
   { GL_DEPTH_COMPONENT16,  GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT,                 kUShort },
   { GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_FLOAT,                          kFloat },
   { GL_DEPTH24_STENCIL8,   GL_DEPTH_STENCIL,   GL_UNSIGNED_INT_24_8,              kUInt },
   { GL_DEPTH32F_STENCIL8,  GL_DEPTH_STENCIL,   GL_FLOAT_32_UNSIGNED_INT_24_8_REV, kFloat },
 };
 #endif
-#pragma GCC diagnostic pop
+// clang-format on
 
 int test_images_write_common(cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t* sizes, size_t nsizes );
+                             cl_command_queue queue, const format *formats,
+                             size_t nformats, GLenum *targets, size_t ntargets,
+                             sizevec_t *sizes, size_t nsizes);
 
-int test_images_read_common( cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t *sizes, size_t nsizes );
+int test_images_read_common(cl_device_id device, cl_context context,
+                            cl_command_queue queue, const format *formats,
+                            size_t nformats, GLenum *targets, size_t ntargets,
+                            sizevec_t *sizes, size_t nsizes);
 
-int test_images_get_info_common( cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t *sizes, size_t nsizes );
+int test_images_get_info_common(cl_device_id device, cl_context context,
+                                cl_command_queue queue, const format *formats,
+                                size_t nformats, GLenum *targets,
+                                size_t ntargets, sizevec_t *sizes,
+                                size_t nsizes);
 
 int is_rgb_101010_supported( cl_context context, GLenum gl_target );
 

--- a/test_conformance/gl/test_images_getinfo_common.cpp
+++ b/test_conformance/gl/test_images_getinfo_common.cpp
@@ -86,10 +86,11 @@ static int test_image_info( cl_context context, cl_command_queue queue,
   return CheckGLObjectInfo(streams[0], object_type, glTexture, glTarget, 0);
 }
 
-static int test_image_format_get_info(
-    cl_context context, cl_command_queue queue,
-    size_t width, size_t height, size_t depth,
-    GLenum target, struct format* fmt, MTdata data)
+static int test_image_format_get_info(cl_context context,
+                                      cl_command_queue queue, size_t width,
+                                      size_t height, size_t depth,
+                                      GLenum target, const format *fmt,
+                                      MTdata data)
 {
   int error = 0;
 
@@ -197,9 +198,11 @@ static int test_image_format_get_info(
     &actualType, (void **)&outBuffer );
 }
 
-int test_images_get_info_common( cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t *sizes, size_t nsizes )
+int test_images_get_info_common(cl_device_id device, cl_context context,
+                                cl_command_queue queue, const format *formats,
+                                size_t nformats, GLenum *targets,
+                                size_t ntargets, sizevec_t *sizes,
+                                size_t nsizes)
 {
   int error = 0;
   RandomSeed seed(gRandomSeed);

--- a/test_conformance/gl/test_images_read_common.cpp
+++ b/test_conformance/gl/test_images_read_common.cpp
@@ -386,10 +386,9 @@ static int test_image_read( cl_context context, cl_command_queue queue,
     width, height, depth, sampleNum, outFormat, outType, outResultBuffer );
 }
 
-static int test_image_format_read(
-    cl_context context, cl_command_queue queue,
-    size_t width, size_t height, size_t depth,
-    GLenum target, struct format* fmt, MTdata data)
+static int test_image_format_read(cl_context context, cl_command_queue queue,
+                                  size_t width, size_t height, size_t depth,
+                                  GLenum target, const format *fmt, MTdata data)
 {
   int error = 0;
 
@@ -645,9 +644,10 @@ static int test_image_format_read(
   }
 }
 
-int test_images_read_common( cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t *sizes, size_t nsizes )
+int test_images_read_common(cl_device_id device, cl_context context,
+                            cl_command_queue queue, const format *formats,
+                            size_t nformats, GLenum *targets, size_t ntargets,
+                            sizevec_t *sizes, size_t nsizes)
 {
   int error = 0;
   RandomSeed seed(gRandomSeed);

--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -660,8 +660,9 @@ static int test_image_format_write( cl_context context, cl_command_queue queue,
 // combination.
 
 int test_images_write_common(cl_device_id device, cl_context context,
-  cl_command_queue queue, struct format* formats, size_t nformats,
-  GLenum *targets, size_t ntargets, sizevec_t* sizes, size_t nsizes )
+                             cl_command_queue queue, const format *formats,
+                             size_t nformats, GLenum *targets, size_t ntargets,
+                             sizevec_t *sizes, size_t nsizes)
 {
   int err = 0;
   int error = 0;


### PR DESCRIPTION
Without `const`, these variables would be flagged up by `-Wunused-variable`.

Preserve constness across functions that use these variables.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>