### PR TITLE
[NFC] Fix unused variable warning in Release builds

### DIFF
--- a/test_conformance/basic/test_progvar.cpp
+++ b/test_conformance/basic/test_progvar.cpp
@@ -1256,6 +1256,7 @@ static int l_capacity( cl_device_id device, cl_context context, cl_command_queue
     char prog_src[MAX_STR];
     int num_printed = snprintf(prog_src,sizeof(prog_src),prog_src_template,max_size, max_size);
     assert( num_printed < MAX_STR ); // or increase MAX_STR
+    (void)num_printed;
 
     StringTable ksrc;
     ksrc.add( prog_src );


### PR DESCRIPTION
The condition inside the assert is dropped in Release builds, so `num_printed` becomes unused.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>