### PR TITLE
Remove __DATE__ and __TIME__ usage.

### DIFF
--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -434,7 +434,6 @@ static int ParseArgs( int argc, const char **argv )
             gArgCount++;
         }
     }
-    vlog( "\n\nTest binary built %s %s\n", __DATE__, __TIME__ );
 
     PrintArch();
 

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -483,8 +483,6 @@ static int ParseArgs( int argc, const char **argv )
     }
 
     vlog( "\n" );
-
-    vlog( "Test binary built %s %s\n", __DATE__, __TIME__ );
 
     PrintArch();
 

--- a/test_conformance/half/main.cpp
+++ b/test_conformance/half/main.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -222,7 +222,6 @@ static int ParseArgs( int argc, const char **argv )
       gWimpyMode = 1;
     }
 
-    vlog( "Test binary built %s %s\n", __DATE__, __TIME__ );
     PrintArch();
     if( gWimpyMode )
     {
@@ -248,4 +247,3 @@ static void PrintUsage( void )
         vlog("\t\t%s\n", test_list[i].name );
     }
 }
-

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -504,8 +504,6 @@ static int ParseArgs(int argc, const char **argv)
         gWimpyMode = 1;
     }
 
-    vlog("\nTest binary built %s %s\n", __DATE__, __TIME__);
-
     PrintArch();
 
     if (gWimpyMode)

--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1029,8 +1029,6 @@ test_status InitCL( cl_device_id device )
                               version.to_string().c_str());
         return TEST_SKIP;
     }
-
-    log_info( "Test binary built %s %s\n", __DATE__, __TIME__ );
 
     gFd = acquireOutputStream(&err);
     if (err != 0)

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -639,7 +639,6 @@ int main(int argc, const char* argv[])
         s_wimpy_mode = true;
     }
 
-    log_info( "Test binary built %s %s\n", __DATE__, __TIME__ );
     if (s_wimpy_mode) {
         log_info("\n");
         log_info("*** WARNING: Testing in Wimpy mode!                     ***\n");
@@ -668,4 +667,3 @@ static void printUsage( void )
         log_info( "\t%s\n", test_list[i].name );
     }
 }
-


### PR DESCRIPTION
These macros make the build non-deterministic.