### PR TITLE
cmake: Add set_gnulike_module_compile_flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,17 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D__SSE__")
 endif()
 
+# Set a module's COMPILE_FLAGS if using gcc or clang.
+macro(set_gnulike_module_compile_flags flags)
+    if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+        SET_SOURCE_FILES_PROPERTIES(
+            ${${MODULE_NAME}_SOURCES}
+            PROPERTIES
+            COMPILE_FLAGS ${flags}
+        )
+    endif()
+endmacro(set_gnulike_module_compile_flags)
+
 if(MSVC)
     # Don't warn when using standard non-secure functions.
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -21,13 +21,7 @@ set(${MODULE_NAME}_SOURCES
 
 # Make unused variables not fatal in this module; see
 # https://github.com/KhronosGroup/OpenCL-CTS/issues/1484
-if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-  SET_SOURCE_FILES_PROPERTIES(
-    ${${MODULE_NAME}_SOURCES}
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-error=unused-variable"
-  )
-endif()
+set_gnulike_module_compile_flags("-Wno-error=unused-variable")
 
 include(../../CMakeCommon.txt)
 

--- a/test_conformance/math_brute_force/CMakeLists.txt
+++ b/test_conformance/math_brute_force/CMakeLists.txt
@@ -40,14 +40,8 @@ set(${MODULE_NAME}_SOURCES
     utility.h
 )
 
-# math_brute_force compiles cleanly with -Wall but other tests not (yet), so
-# enable -Wall locally.
-if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-    SET_SOURCE_FILES_PROPERTIES(
-        ${${MODULE_NAME}_SOURCES}
-        PROPERTIES
-        COMPILE_FLAGS "-Wall -Wno-format -Wno-strict-aliasing -Wno-unknown-pragmas"
-    )
-endif()
+# math_brute_force compiles cleanly with -Wall (except for a few remaining
+# warnings), but other tests not (yet); so enable -Wall locally.
+set_gnulike_module_compile_flags("-Wall -Wno-format -Wno-strict-aliasing -Wno-unknown-pragmas")
 
 include(../CMakeCommon.txt)


### PR DESCRIPTION
Factor out a macro to set module-specific compilation flags for GNU-like compilers.  This simplifies setting compilation flags per test.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>