### PR TITLE
Fix image test image2d_from_buffer_positive

### DIFF
--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
@@ -73,6 +73,12 @@ int image2d_from_buffer_positive(cl_device_id device, cl_context context,
         return TEST_SKIPPED_ITSELF;
     }
 
+    if (!is_extension_available(device, "cl_ext_image_requirements_info"))
+    {
+        printf("Extension cl_ext_image_requirements_info not available");
+        return TEST_SKIPPED_ITSELF;
+    }
+
     std::vector<cl_mem_object_type> imageTypes{
         CL_MEM_OBJECT_IMAGE1D,       CL_MEM_OBJECT_IMAGE2D,
         CL_MEM_OBJECT_IMAGE3D,       CL_MEM_OBJECT_IMAGE1D_BUFFER,


### PR DESCRIPTION
This test is failing in case when extensions `cl_ext_image_requirements_info` is not supported and `cl_khr_image2d_from_buffer` is supported. In function `get_image_requirement_alignment` there is macro run `GET_EXTENSION_FUNC` with function `clGetImageRequirementsInfoEXT`. Then test should check if extension `cl_ext_image_requirements_info` is supported