### PR TITLE
test_bufferreadwriterect - Limit memory allocation on host side

### DIFF
--- a/test_common/CMakeLists.txt
+++ b/test_common/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HARNESS_SOURCES
     harness/imageHelpers.cpp
     harness/kernelHelpers.cpp
     harness/deviceInfo.cpp
+    harness/hostInfo.cpp
     harness/os_helpers.cpp
     harness/parseParameters.cpp
     harness/propertyHelpers.cpp

--- a/test_common/harness/hostInfo.cpp
+++ b/test_common/harness/hostInfo.cpp
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "hostInfo.h"
+
+/* Read phisicall host memory */
+#if defined(unix) || defined(__unix__) || defined(__unix)
+
+#include <sys/sysinfo.h>
+
+cl_ulong get_host_physicall_memory()
+{
+    cl_ulong physical_memory = 0;
+    static struct sysinfo s_info;
+    sysinfo(&s_info);
+    physical_memory = s_info.totalram;
+    return physical_memory;
+}
+
+#endif
+
+#if defined(_WIN64) || defined(_WIN64) || defined(_WIN32)
+
+#include <windows.h>
+
+cl_ulong get_host_physicall_memory()
+{
+    cl_ulong physical_memory = 0;
+    GetPhysicallyInstalledSystemMemory(&physical_memory);
+    physical_memory *= 1024;
+    return physical_memory;
+}
+
+#endif

--- a/test_common/harness/hostInfo.h
+++ b/test_common/harness/hostInfo.h
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _hostInfo_h
+#define _hostInfo_h
+
+#include <CL/opencl.h>
+
+/* Read phisicall host memory */
+cl_ulong get_host_physicall_memory();
+
+#endif // _hostInfo_h

--- a/test_conformance/basic/test_bufferreadwriterect.cpp
+++ b/test_conformance/basic/test_bufferreadwriterect.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "hostInfo.h"
 
 #include "procs.h"
 
@@ -363,6 +364,16 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
         return -1;
     }
 
+    // check max host memory. limit max host memory 50%. The test
+    size_t host_max_memory = get_host_physicall_memory();
+    log_info("Physicall host memory = %llu bytes.\n", host_max_memory);
+    if (max_mem_alloc_size > host_max_memory / 2)
+    {
+        log_info("Need to limit CL_DEVICE_MAX_MEM_ALLOC_SIZE from %llu to %llu "
+                 "bytes.\n",
+                 max_mem_alloc_size, host_max_memory / 2);
+        max_mem_alloc_size = host_max_memory / 2;
+    }
     // Guess at a reasonable maximum dimension.
     size_t max_mem_alloc_dim = (size_t)cbrt((double)(max_mem_alloc_size/sizeof(BufferType)))/alloc_scale;
     if (max_mem_alloc_dim == 0) {


### PR DESCRIPTION
Usually device memory is almost the same or smaller than host memory. Looks like this test was written as it always true. However in condition when device memory is much bigger than host memory buffers allocation on host side (for verification) cause out of memory on the system. This code prevents this situation.
We can discuss how much `max_mem_alloc_size` should be limited. In my proposal is set to `host_max_memory / 2`