### PR TITLE
Make building the Vulkan interop tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(D3D10_IS_SUPPORTED "Run DirectX 10 interop tests" OFF)
 option(D3D11_IS_SUPPORTED "Run DirectX 11 interop tests" OFF)
 option(GL_IS_SUPPORTED "Run OpenGL interop tests" OFF)
 option(GLES_IS_SUPPORTED "Run OpenGL ES interop tests" OFF)
+option(VULKAN_IS_SUPPORTED "Run Vulkan interop tests" OFF)
 
 
 #-----------------------------------------------------------

--- a/test_conformance/CMakeLists.txt
+++ b/test_conformance/CMakeLists.txt
@@ -52,7 +52,9 @@ add_subdirectory( pipes )
 add_subdirectory( device_timer )
 add_subdirectory( spirv_new )
 add_subdirectory( spir )
-add_subdirectory( vulkan )
+if(VULKAN_IS_SUPPORTED)
+    add_subdirectory( vulkan )
+endif()
 
 file(GLOB CSV_FILES "opencl_conformance_tests_*.csv")
 


### PR DESCRIPTION
Allow enabling/disabling building of the Vulkan interop tests via CMake option without modifying the CMake. This matches the optionality of the D3D10, D3D11, GL, and GLES interop tests.