### PR TITLE
subgroups: Fix Wformat warnings

### DIFF
--- a/test_conformance/subgroups/CMakeLists.txt
+++ b/test_conformance/subgroups/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_NAME SUBGROUPS)
 
 set(${MODULE_NAME}_SOURCES
     main.cpp
+    subhelpers.cpp
     test_barrier.cpp
     test_queries.cpp
     test_workitem.cpp

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -280,10 +280,10 @@ template <typename Ty, SubgroupsBroadcastOp operation> struct BC
                         {
                             log_error("ERROR: sub_group_%s(%s) "
                                       "mismatch for local id %d in sub "
-                                      "group %d in group %d - got %lu "
-                                      "expected %lu\n",
+                                      "group %d in group %d - %s\n",
                                       operation_names(operation),
-                                      TypeManager<Ty>::name(), i, j, k, rr, tr);
+                                      TypeManager<Ty>::name(), i, j, k,
+                                      print_expected_obtained(tr, rr).c_str());
                             return TEST_FAIL;
                         }
                     }
@@ -703,9 +703,10 @@ template <typename Ty, ArithmeticOp operation> struct SCEX_NU
                             log_error(
                                 "ERROR: %s_%s(%s) "
                                 "mismatch for local id %d in sub group %d in "
-                                "group %d Expected: %d Obtained: %d\n",
+                                "group %d %s\n",
                                 func_name.c_str(), operation_names(operation),
-                                TypeManager<Ty>::name(), i, j, k, tr, rr);
+                                TypeManager<Ty>::name(), i, j, k,
+                                print_expected_obtained(tr, rr).c_str());
                             return TEST_FAIL;
                         }
                         tr = calculate<Ty>(tr, mx[ii + active_work_item],
@@ -820,10 +821,10 @@ template <typename Ty, ArithmeticOp operation> struct SCIN_NU
                                 "ERROR: %s_%s(%s) "
                                 "mismatch for local id %d in sub group %d "
                                 "in "
-                                "group %d Expected: %d Obtained: %d\n",
+                                "group %d %s\n",
                                 func_name.c_str(), operation_names(operation),
                                 TypeManager<Ty>::name(), active_work_item, j, k,
-                                tr, rr);
+                                print_expected_obtained(tr, rr).c_str());
                             return TEST_FAIL;
                         }
                     }
@@ -926,10 +927,10 @@ template <typename Ty, ArithmeticOp operation> struct RED_NU
                     {
                         log_error("ERROR: %s_%s(%s) "
                                   "mismatch for local id %d in sub group %d in "
-                                  "group %d Expected: %d Obtained: %d\n",
+                                  "group %d %s\n",
                                   func_name.c_str(), operation_names(operation),
                                   TypeManager<Ty>::name(), active_work_item, j,
-                                  k, tr, rr);
+                                  k, print_expected_obtained(tr, rr).c_str());
                         return TEST_FAIL;
                     }
                 }

--- a/test_conformance/subgroups/subhelpers.cpp
+++ b/test_conformance/subgroups/subhelpers.cpp
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "subhelpers.h"
+
+// Define operator<< for cl_ types, accessing the .s member.
+#define OP_OSTREAM(Ty, VecSize)                                                \
+    std::ostream& operator<<(std::ostream& os, const Ty##VecSize& val)         \
+    {                                                                          \
+        os << +val.s[0]; /* unary plus forces char to be printed as number */  \
+        for (unsigned i = 1; i < VecSize; i++)                                 \
+        {                                                                      \
+            os << ", " << +val.s[i];                                           \
+        }                                                                      \
+        return os;                                                             \
+    }
+
+// Define operator<< for subgroups::cl_ types, accessing the .data member and
+// forwarding to operator<< for the cl_ types.
+#define OP_OSTREAM_SUBGROUP(Ty, VecSize)                                       \
+    std::ostream& operator<<(std::ostream& os, const Ty##VecSize& val)         \
+    {                                                                          \
+        return os << val.data;                                                 \
+    }
+
+// Define operator<< for all vector sizes.
+#define OP_OSTREAM_ALL_VEC(Ty)                                                 \
+    OP_OSTREAM(Ty, 2)                                                          \
+    OP_OSTREAM(Ty, 4)                                                          \
+    OP_OSTREAM(Ty, 8)                                                          \
+    OP_OSTREAM(Ty, 16)                                                         \
+    OP_OSTREAM_SUBGROUP(subgroups::Ty, 3)
+
+OP_OSTREAM_ALL_VEC(cl_char)
+OP_OSTREAM_ALL_VEC(cl_uchar)
+OP_OSTREAM_ALL_VEC(cl_short)
+OP_OSTREAM_ALL_VEC(cl_ushort)
+OP_OSTREAM_ALL_VEC(cl_int)
+OP_OSTREAM_ALL_VEC(cl_uint)
+OP_OSTREAM_ALL_VEC(cl_long)
+OP_OSTREAM_ALL_VEC(cl_ulong)
+OP_OSTREAM_ALL_VEC(cl_float)
+OP_OSTREAM_ALL_VEC(cl_double)
+OP_OSTREAM_ALL_VEC(cl_half)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, )
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 2)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 4)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 8)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 16)

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -456,6 +456,52 @@ struct cl_half16
 };
 }
 
+// Declare operator<< for cl_ types, accessing the .s member.
+#define OP_OSTREAM(Ty, VecSize)                                                \
+    std::ostream &operator<<(std::ostream &os, const Ty##VecSize &val);
+
+// Declare operator<< for subgroups::cl_ types, accessing the .data member and
+// forwarding to operator<< for the cl_ types.
+#define OP_OSTREAM_SUBGROUP(Ty, VecSize)                                       \
+    std::ostream &operator<<(std::ostream &os, const Ty##VecSize &val);
+
+// Declare operator<< for all vector sizes.
+#define OP_OSTREAM_ALL_VEC(Ty)                                                 \
+    OP_OSTREAM(Ty, 2)                                                          \
+    OP_OSTREAM(Ty, 4)                                                          \
+    OP_OSTREAM(Ty, 8)                                                          \
+    OP_OSTREAM(Ty, 16)                                                         \
+    OP_OSTREAM_SUBGROUP(subgroups::Ty, 3)
+
+OP_OSTREAM_ALL_VEC(cl_char)
+OP_OSTREAM_ALL_VEC(cl_uchar)
+OP_OSTREAM_ALL_VEC(cl_short)
+OP_OSTREAM_ALL_VEC(cl_ushort)
+OP_OSTREAM_ALL_VEC(cl_int)
+OP_OSTREAM_ALL_VEC(cl_uint)
+OP_OSTREAM_ALL_VEC(cl_long)
+OP_OSTREAM_ALL_VEC(cl_ulong)
+OP_OSTREAM_ALL_VEC(cl_float)
+OP_OSTREAM_ALL_VEC(cl_double)
+OP_OSTREAM_ALL_VEC(cl_half)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, )
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 2)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 4)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 8)
+OP_OSTREAM_SUBGROUP(subgroups::cl_half, 16)
+
+#undef OP_OSTREAM
+#undef OP_OSTREAM_SUBGROUP
+#undef OP_OSTREAM_ALL_VEC
+
+template <typename Ty>
+std::string print_expected_obtained(const Ty &expected, const Ty &obtained)
+{
+    std::ostringstream oss;
+    oss << "Expected: " << expected << " Obtained: " << obtained;
+    return oss.str();
+}
+
 static bool int64_ok(cl_device_id device)
 {
     char profile[128];

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -744,9 +744,12 @@ template <typename Ty, BallotOp operation> struct SMASK
                     {
                         log_error("ERROR:  get_sub_group_%s_mask... mismatch "
                                   "for local id %d in sub group %d in group "
-                                  "%d, obtained %d, expected %d\n",
+                                  "%d, %s\n",
                                   operation_names(operation), wi_id, sb_id,
-                                  wg_id, device_result, expected_result);
+                                  wg_id,
+                                  print_expected_obtained(expected_result,
+                                                          device_result)
+                                      .c_str());
                         return TEST_FAIL;
                     }
                 }

--- a/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
+++ b/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
@@ -51,7 +51,7 @@ template <typename Ty, ArithmeticOp operation> struct RED_CLU
     static void log_test(const WorkGroupParams &test_params,
                          const char *extra_text)
     {
-        log_info("  sub_group_clustered_reduce_%s(%s, %d bytes) ...%s\n",
+        log_info("  sub_group_clustered_reduce_%s(%s, %zu bytes) ...%s\n",
                  operation_names(operation), TypeManager<Ty>::name(),
                  sizeof(Ty), extra_text);
     }
@@ -90,7 +90,7 @@ template <typename Ty, ArithmeticOp operation> struct RED_CLU
                 if (dts != sizeof(Ty))
                 {
                     log_error("ERROR: sub_group_clustered_reduce_%s(%s) "
-                              "wrong data type size detected, expected: %d, "
+                              "wrong data type size detected, expected: %zu, "
                               "used by device %d, in group %d\n",
                               operation_names(operation),
                               TypeManager<Ty>::name(), sizeof(Ty), dts, k);


### PR DESCRIPTION
The main source of warnings was the use of `%d` for printing a templated type `T`, where `T` could be any cl_ scalar or vector type.

Introduce `print_expected_obtained`.  It takes const references to handle alignment of the cl_ types.

Define `operator<<` for all types used by the subgroup tests.  Ideally those would be template functions enabled by TypeManager data, but that requires some more work on the TypeManager (which we'd ideally do after more warnings have been enabled).  So for now, define the `operator<<` instances using preprocessor defines.

Also fix a few instances where the wrong format specifier was used for `size_t` types.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>