### PR TITLE
Vulkan: Use linear tiling

### DIFF
--- a/test_conformance/vulkan/main.cpp
+++ b/test_conformance/vulkan/main.cpp
@@ -143,6 +143,7 @@ bool useDeviceLocal = false;
 bool disableNTHandleType = false;
 bool enableOffset = false;
 bool non_dedicated = false;
+bool useOptimalTiling = false;
 
 static void printUsage(const char *execName)
 {
@@ -192,6 +193,10 @@ size_t parseParams(int argc, const char *argv[], const char **argList)
             if (!strcmp(argv[i], "--non_dedicated"))
             {
                 non_dedicated = true;
+            }
+            if (!strcmp(argv[i], "--useOptimalTiling"))
+            {
+                useOptimalTiling = true;
             }
             if (strcmp(argv[i], "-h") == 0)
             {

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.hpp
@@ -33,7 +33,8 @@
 const VulkanInstance& getVulkanInstance();
 const VulkanPhysicalDevice& getVulkanPhysicalDevice();
 const VulkanQueueFamily&
-getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_MASK_ALL);
+getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_COMPUTE
+                         | VULKAN_QUEUE_FLAG_GRAPHICS);
 const VulkanMemoryType&
 getVulkanMemoryType(const VulkanDevice& device,
                     VulkanMemoryTypeProperty memoryTypeProperty);

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
@@ -1652,7 +1652,7 @@ VulkanImage2D::VulkanImage2D(
     : VulkanImage(device, VULKAN_IMAGE_TYPE_2D, format,
                   VulkanExtent3D(width, height, 1), numMipLevels, 1,
                   externalMemoryHandleType, imageCreateFlag,
-                  VULKAN_IMAGE_TILING_OPTIMAL, imageUsage, sharingMode)
+                  VULKAN_IMAGE_TILING_LINEAR, imageUsage, sharingMode)
 {}
 
 VulkanImage2D::~VulkanImage2D() {}

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+extern bool useOptimalTiling;
+
 #ifdef _WIN32
 #include <Windows.h>
 #include <dxgi1_2.h>
@@ -1558,6 +1560,11 @@ VulkanImage::VulkanImage(
       m_format(format), m_numMipLevels(numMipLevels), m_numLayers(arrayLayers),
       m_vkImage(VK_NULL_HANDLE)
 {
+    if (useOptimalTiling)
+    {
+        imageTiling = VULKAN_IMAGE_TILING_OPTIMAL;
+    }
+
     VkImageCreateInfo vkImageCreateInfo = {};
     vkImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     vkImageCreateInfo.pNext = NULL;

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_wrapper.hpp
@@ -450,7 +450,7 @@ public:
         VulkanExternalMemoryHandleType externalMemoryHandleType =
             VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
         VulkanImageCreateFlag imageCreateFlags = VULKAN_IMAGE_CREATE_FLAG_NONE,
-        VulkanImageTiling imageTiling = VULKAN_IMAGE_TILING_OPTIMAL,
+        VulkanImageTiling imageTiling = VULKAN_IMAGE_TILING_LINEAR,
         VulkanImageUsage imageUsage =
             VULKAN_IMAGE_USAGE_SAMPLED_STORAGE_TRANSFER_SRC_DST,
         VulkanSharingMode sharingMode = VULKAN_SHARING_MODE_EXCLUSIVE);


### PR DESCRIPTION
The external memory sharing spec does not require
OpenCL to deduce if a Vulkan image is tiled or linear. Use tiled images.

Additionally, when selecting a queue family, the Vulkan implementation is not required to report the transfer bit for compute or graphics queues, it is implied.