### PR TITLE
Add missing newlines in log messages for image tests

### DIFF
--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
@@ -69,13 +69,13 @@ int image2d_from_buffer_positive(cl_device_id device, cl_context context,
 {
     if (!is_extension_available(device, "cl_khr_image2d_from_buffer"))
     {
-        printf("Extension cl_khr_image2d_from_buffer not available");
+        log_info("Extension cl_khr_image2d_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -99,7 +99,7 @@ int image2d_from_buffer_positive(cl_device_id device, cl_context context,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             cl_uint row_pitch_alignment_2d = 0;
@@ -143,12 +143,12 @@ int image2d_from_buffer_positive(cl_device_id device, cl_context context,
                 if (base_address_alignment
                     > base_address_alignment_2d * element_size)
                 {
-                    test_fail("Unexpected base_address_alignment");
+                    test_fail("Unexpected base_address_alignment\n");
                 }
 
                 if (row_pitch_alignment > row_pitch_alignment_2d * element_size)
                 {
-                    test_fail("Unexpected row_pitch_alignment");
+                    test_fail("Unexpected row_pitch_alignment\n");
                 }
             }
         }
@@ -167,13 +167,13 @@ int memInfo_image_from_buffer_positive(cl_device_id device, cl_context context,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -197,7 +197,7 @@ int memInfo_image_from_buffer_positive(cl_device_id device, cl_context context,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -249,7 +249,8 @@ int memInfo_image_from_buffer_positive(cl_device_id device, cl_context context,
 
                 if (returned_buffer != buffer)
                 {
-                    test_fail("Unexpected CL_MEM_ASSOCIATED_MEMOBJECT buffer");
+                    test_fail(
+                        "Unexpected CL_MEM_ASSOCIATED_MEMOBJECT buffer\n");
                 }
 
                 err = clReleaseMemObject(buffer);
@@ -275,13 +276,13 @@ int imageInfo_image_from_buffer_positive(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -305,7 +306,7 @@ int imageInfo_image_from_buffer_positive(cl_device_id device,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -376,7 +377,7 @@ int imageInfo_image_from_buffer_positive(cl_device_id device,
                     {
                         test_fail(
                             "Unexpected row pitch "
-                            "CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT");
+                            "CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT\n");
                     }
                 }
 
@@ -391,9 +392,9 @@ int imageInfo_image_from_buffer_positive(cl_device_id device,
 
                     if (returned_slice_pitch != slice_pitch)
                     {
-                        test_fail(
-                            "Unexpected row pitch "
-                            "CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT");
+                        test_fail("Unexpected row pitch "
+                                  "CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_"
+                                  "EXT\n");
                     }
                 }
 
@@ -425,13 +426,13 @@ int image_from_buffer_alignment_negative(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -455,7 +456,7 @@ int image_from_buffer_alignment_negative(cl_device_id device,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -575,13 +576,13 @@ int image_from_small_buffer_negative(cl_device_id device, cl_context context,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -605,7 +606,7 @@ int image_from_small_buffer_negative(cl_device_id device, cl_context context,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -665,7 +666,7 @@ static int image_from_buffer_fill_check(cl_command_queue queue, cl_mem image,
 
                     if (read_buffer[index] != pattern)
                     {
-                        test_fail("Image pattern check failed");
+                        test_fail("Image pattern check failed\n");
                     }
                 }
             }
@@ -683,13 +684,13 @@ int image_from_buffer_fill_positive(cl_device_id device, cl_context context,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -713,7 +714,7 @@ int image_from_buffer_fill_positive(cl_device_id device, cl_context context,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -877,7 +878,7 @@ static int image_from_buffer_read_check(cl_command_queue queue, cl_mem buffer,
             {
                 if (host_ptr[j] != pattern)
                 {
-                    test_fail("Image pattern check failed");
+                    test_fail("Image pattern check failed\n");
                 }
             }
             host_ptr = host_ptr + row_pitch;
@@ -897,13 +898,13 @@ int image_from_buffer_read_positive(cl_device_id device, cl_context context,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 

--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_requirements_info.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_requirements_info.cpp
@@ -31,7 +31,7 @@ int cl_image_requirements_size_ext_negative(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -80,13 +80,13 @@ int cl_image_requirements_size_ext_consistency(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
     if (!is_extension_available(device, "cl_ext_image_from_buffer"))
     {
-        printf("Extension cl_ext_image_from_buffer not available");
+        log_info("Extension cl_ext_image_from_buffer not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -116,7 +116,7 @@ int cl_image_requirements_size_ext_consistency(cl_device_id device,
                     != get_format_list(context, imageType, formatList, flag)
                 || formatList.size() == 0)
             {
-                test_fail("Failure to get supported formats list");
+                test_fail("Failure to get supported formats list\n");
             }
 
             for (auto format : formatList)
@@ -154,7 +154,7 @@ int cl_image_requirements_size_ext_consistency(cl_device_id device,
                 if (max_size != size)
                 {
                     test_fail("CL_IMAGE_REQUIREMENTS_SIZE_EXT different from "
-                              "CL_MEM_SIZE");
+                              "CL_MEM_SIZE\n");
                 }
 
                 err = clReleaseMemObject(image_buffer);
@@ -179,7 +179,7 @@ int clGetImageRequirementsInfoEXT_negative(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -292,7 +292,7 @@ int cl_image_requirements_max_val_ext_negative(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -387,7 +387,7 @@ int cl_image_requirements_max_val_ext_positive(cl_device_id device,
 {
     if (!is_extension_available(device, "cl_ext_image_requirements_info"))
     {
-        printf("Extension cl_ext_image_requirements_info not available");
+        log_info("Extension cl_ext_image_requirements_info not available\n");
         return TEST_SKIPPED_ITSELF;
     }
 
@@ -412,7 +412,7 @@ int cl_image_requirements_max_val_ext_positive(cl_device_id device,
 
     if (!(max_width <= width_1d && max_width > 0))
     {
-        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_WIDTH_EXT value");
+        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_WIDTH_EXT value\n");
     }
 
     /* CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT */
@@ -433,7 +433,7 @@ int cl_image_requirements_max_val_ext_positive(cl_device_id device,
 
     if (!(max_height <= height_2d && max_height > 0))
     {
-        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT value");
+        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT value\n");
     }
 
     /* CL_IMAGE_REQUIREMENTS_MAX_DEPTH_EXT */
@@ -454,7 +454,7 @@ int cl_image_requirements_max_val_ext_positive(cl_device_id device,
 
     if (!(max_depth <= depth_3d && max_depth > 0))
     {
-        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_DEPTH_EXT value");
+        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_DEPTH_EXT value\n");
     }
 
     /* CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT */
@@ -475,7 +475,8 @@ int cl_image_requirements_max_val_ext_positive(cl_device_id device,
 
     if (!(max_array_size <= array_size && max_array_size > 0))
     {
-        test_fail("Unexpected CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT value");
+        test_fail(
+            "Unexpected CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT value\n");
     }
 
     return TEST_PASS;


### PR DESCRIPTION
Also use log_info instead of printf for skipped tests, for consistency.

Signed-off-by: Stuart Brady <stuart.brady@arm.com>