### PR TITLE
spir: Fix -Wcatch-value warnings

### DIFF
--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -6253,7 +6253,7 @@ static bool test_image_enumeration(cl_context context, cl_command_queue queue,
                 (FailE)(it.toString(), kernelName);
                 std::cout << "enum_" << it.toString() << " FAILED" << std::endl;
             }
-        } catch(std::exception e)
+        } catch (const std::exception &e)
         {
             (FailE)(it.toString(), kernelName);
             print_error(1, e.what());
@@ -6356,7 +6356,7 @@ static bool test_image_enumeration_3d(cl_context context, cl_command_queue queue
                 (FailE)(it.toString(), kernelName);
                 std::cout << "enum_" << it.toString() << " FAILED" << std::endl;
             }
-        } catch(std::exception e)
+        } catch (const std::exception &e)
         {
             (FailE)(it.toString(), kernelName);
             print_error(1, e.what());
@@ -6521,7 +6521,7 @@ test_kernel_attributes(cl_device_id device, cl_uint width, const char *folder)
         }
         (SuccE)(test_name, "");
         log_info("kernel_attributes passed.\n");
-    } catch(std::exception e)
+    } catch (const std::exception &e)
     {
         (FailE)(test_name, "");
         log_info("kernel_attributes FAILED\n");
@@ -6587,7 +6587,7 @@ static bool test_binary_type(cl_device_id device, cl_uint width, const char *fol
         }
         (SuccE)(test_name, "");
         log_info("binary_type passed.\n");
-    } catch(std::exception e)
+    } catch (const std::exception &e)
     {
         (FailE)(test_name, "");
         log_info("binary_type FAILED\n");

--- a/test_conformance/spir/run_build_test.cpp
+++ b/test_conformance/spir/run_build_test.cpp
@@ -462,8 +462,7 @@ bool TestRunner::runBuildTest(cl_device_id device, const char *folder,
                 log_info("kernel '%s' failed.\n", kernel_name.c_str());
                 (*m_failureHandler)(test_name, kernel_name);
             }
-        }
-        catch (std::runtime_error err)
+        } catch (const std::runtime_error& err)
         {
             ++failures;
             log_info("kernel '%s' failed: %s\n", kernel_name.c_str(), err.what());


### PR DESCRIPTION
`std::exception` and `std::runtime_error` are polymorphic types and as such they shouldn't be passed by value.