### PR TITLE
relationals: Fix vector component accessor selection

### DIFF
--- a/test_conformance/relationals/test_shuffles.cpp
+++ b/test_conformance/relationals/test_shuffles.cpp
@@ -216,11 +216,8 @@ const char *get_order_string( ShuffleOrder &order, size_t vecSize, cl_uint lengt
     if (!byNumber) {
         byNumber = (useNumbersFlip++)%2;
     }
-    // Do not use xyzw for vectors whose length is not 2 or 4 per the spec.
-    if (vecSize != 2 || vecSize != 4 || vecSize != 3)
-        byNumber = 1;
 
-    if( byNumber || vecSize > 4 )
+    if (byNumber)
     {
         idx = 0;
         // Randomly chose upper and lower case S
@@ -251,7 +248,9 @@ char * get_order_name( ExplicitType vecType, size_t inVecSize, size_t outVecSize
     if( inVecSize == 1 )
         inOrderStr[ 0 ] = 0;
     else
-        sprintf( inOrderStr, "%d.%s", (int)inVecSize, get_order_string( inOrder, outVecSize, lengthToUse, inUseNumerics, d ) );
+        sprintf(inOrderStr, "%d.%s", (int)inVecSize,
+                get_order_string(inOrder, inVecSize, lengthToUse, inUseNumerics,
+                                 d));
     if( outVecSize == 1 )
         outOrderStr[ 0 ] = 0;
     else
@@ -398,7 +397,9 @@ static int create_shuffle_kernel( cl_context context, cl_program *outProgram, cl
     for( unsigned int i = 0; i < numOrders; i++ )
     {
         if( inOrders != NULL )
-            strcpy( inOrder, get_order_string( inOrders[ i ], outVecSize, lengthToUse[i], inUseNumerics, d ) );
+            strcpy(inOrder,
+                   get_order_string(inOrders[i], inVecSize, lengthToUse[i],
+                                    inUseNumerics, d));
         strcpy( shuffledOrder, get_order_string( outOrders[ i ], outVecSize, lengthToUse[i], outUseNumerics, d ) );
 
 


### PR DESCRIPTION
It seems the intent was to use `.xyzw` vector component accessors in
the kernel whenever `vecSize` is 2, 3, or 4.  The condition was wrong
(i.e., always true for any value of `vecSize`), causing it to always
create a kernel with numeric (`.s0123...`) vector component accessors.

The restriction on the use of `.xyzw` for 8 and 16-component vectors
has been lifted a while ago (see
https://github.com/KhronosGroup/OpenCL-Docs/issues/549) so we do not
need this check at all.

Also, fix the `vecSize` argument of two calls of `get_order_string`
when getting the order string for the "in" kernel argument.  Pass
`inVecSize` in these cases, not `outVecSize`.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>