### PR TITLE
Fix -Wreorder warnings

### DIFF
--- a/test_conformance/basic/test_progvar.cpp
+++ b/test_conformance/basic/test_progvar.cpp
@@ -81,20 +81,20 @@ class TypeInfo {
 
 public:
     TypeInfo()
-        : name(""), m_buf_elem_type(""), m_is_vecbase(false),
+        : name(""), m_elem_type(0), m_num_elem(0), m_is_vecbase(false),
           m_is_atomic(false), m_is_like_size_t(false), m_is_bool(false),
-          m_elem_type(0), m_num_elem(0), m_size(0), m_value_size(0)
+          m_size(0), m_value_size(0), m_buf_elem_type("")
     {}
     TypeInfo(const char* name_arg)
-        : name(name_arg), m_buf_elem_type(name_arg), m_is_vecbase(false),
+        : name(name_arg), m_elem_type(0), m_num_elem(0), m_is_vecbase(false),
           m_is_atomic(false), m_is_like_size_t(false), m_is_bool(false),
-          m_elem_type(0), m_num_elem(0), m_size(0), m_value_size(0)
+          m_size(0), m_value_size(0), m_buf_elem_type(name_arg)
     {}
 
     // Vectors
     TypeInfo(TypeInfo* elem_type, int num_elem)
-        : m_is_vecbase(false), m_is_atomic(false), m_is_like_size_t(false),
-          m_is_bool(false), m_elem_type(elem_type), m_num_elem(num_elem)
+        : m_elem_type(elem_type), m_num_elem(num_elem), m_is_vecbase(false),
+          m_is_atomic(false), m_is_like_size_t(false), m_is_bool(false)
     {
         char
             the_name[10]; // long enough for longest vector type name "double16"
@@ -325,7 +325,7 @@ static int num_type_info = 0; // Number of valid entries in type_info[]
 // A helper class to form kernel source arguments for clCreateProgramWithSource.
 class StringTable {
 public:
-    StringTable(): m_c_strs(NULL), m_lengths(NULL), m_frozen(false), m_strings()
+    StringTable(): m_strings(), m_c_strs(NULL), m_lengths(NULL), m_frozen(false)
     {}
     ~StringTable() { release_frozen(); }
 

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -41,8 +41,8 @@ struct BasicCommandBufferTest : CommandBufferTestBase
     BasicCommandBufferTest(cl_device_id device, cl_context context,
                            cl_command_queue queue)
         : CommandBufferTestBase(device), context(context), queue(queue),
-          command_buffer(this), simultaneous_use(false),
-          out_of_order_support(false), num_elements(0)
+          command_buffer(this), num_elements(0), simultaneous_use(false),
+          out_of_order_support(false)
     {}
 
     virtual bool Skip()
@@ -442,7 +442,7 @@ struct OutOfOrderTest : public BasicCommandBufferTest
     OutOfOrderTest(cl_device_id device, cl_context context,
                    cl_command_queue queue)
         : BasicCommandBufferTest(device, context, queue),
-          out_of_order_command_buffer(this), out_of_order_queue(nullptr),
+          out_of_order_queue(nullptr), out_of_order_command_buffer(this),
           event(nullptr)
     {}
 

--- a/test_conformance/spir/run_build_test.cpp
+++ b/test_conformance/spir/run_build_test.cpp
@@ -80,8 +80,9 @@ void Task::setErrorLog(cl_program prog) {
 //
 // BuildTask
 //
-BuildTask::BuildTask(cl_program prog, cl_device_id dev, const char* options) :
-    m_program(prog), Task(dev, options) {}
+BuildTask::BuildTask(cl_program prog, cl_device_id dev, const char* options)
+    : Task(dev, options), m_program(prog)
+{}
 
 bool BuildTask::execute() {
     cl_int err_code = clBuildProgram(m_program, 0, NULL, m_options.c_str(), NULL, NULL);
@@ -102,8 +103,9 @@ SpirBuildTask::SpirBuildTask(cl_program prog, cl_device_id dev, const char* opti
 // CompileTask
 //
 
-CompileTask::CompileTask(cl_program prog, cl_device_id dev, const char* options) :
-    m_program(prog), Task(dev, options) {}
+CompileTask::CompileTask(cl_program prog, cl_device_id dev, const char* options)
+    : Task(dev, options), m_program(prog)
+{}
 
 void CompileTask::addHeader(const char* hname, cl_program hprog) {
     m_headers.push_back(std::make_pair(hname, hprog));
@@ -162,9 +164,10 @@ SpirCompileTask::SpirCompileTask(cl_program prog, cl_device_id dev, const char* 
 // LinkTask
 //
 LinkTask::LinkTask(cl_program* programs, int num_programs, cl_context ctxt,
-                   cl_device_id dev, const char* options) :
-    m_programs(programs), m_numPrograms(num_programs), m_context(ctxt), m_executable(NULL),
-    Task(dev, options) {}
+                   cl_device_id dev, const char* options)
+    : Task(dev, options), m_executable(NULL), m_programs(programs),
+      m_numPrograms(num_programs), m_context(ctxt)
+{}
 
 bool LinkTask::execute() {
     cl_int err_code;


### PR DESCRIPTION
Initialize class members in the order in which they are declared in the class.