### PR TITLE
Command buffer queue substitution

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_NAME CL_KHR_COMMAND_BUFFER)
 set(${MODULE_NAME}_SOURCES
     main.cpp
     basic_command_buffer.cpp
+    command_buffer_queue_substitution.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -24,7 +24,7 @@
 BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
                                                cl_context context,
                                                cl_command_queue queue)
-    : CommandBufferTestBase(device), context(context), queue(queue),
+    : CommandBufferTestBase(device), context(context), queue(nullptr),
       num_elements(0), command_buffer(this), simultaneous_use_support(false),
       out_of_order_support(false),
       // try to use simultaneous path by default
@@ -32,7 +32,14 @@ BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
       // due to simultaneous cases extend buffer size
       buffer_size_multiplier(1)
 
-{}
+{
+    cl_int error = clRetainCommandQueue(queue);
+    if (error != CL_SUCCESS)
+    {
+        throw std::runtime_error("clRetainCommandQueue failed\n");
+    }
+    this->queue = queue;
+}
 
 bool BasicCommandBufferTest::Skip()
 {

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -83,12 +83,21 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
     // Kernel performs a parallel copy from an input buffer to output buffer
     // is created.
     const char *kernel_str =
+#if USE_COMMAND_BUF_KENEL_ARG
         R"(
     __kernel void copy(__global int* in, __global int* out, int offset) {
         size_t id = get_global_id(0);
         int ind = offset + id;
         out[ind] = in[ind];
     })";
+#else
+        R"(
+    __kernel void copy(__global int* in, __global int* out, __global int* offset) {
+        size_t id = get_global_id(0);
+        int ind = offset[0] + id;
+        out[ind] = in[ind];
+    })";
+#endif
 
     error = create_single_kernel_helper_create_program(context, &program, 1,
                                                        &kernel_str);
@@ -105,6 +114,13 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
         sizeof(cl_int) * num_elements * (double_buffers_size?2:1), nullptr, &error);
     test_error(error, "clCreateBuffer failed");
 
+    cl_int offset=0;
+#if !USE_COMMAND_BUF_KENEL_ARG
+    off_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(cl_int), &offset, &error);
+    test_error(error, "clCreateBuffer failed");
+#endif
+
     kernel = clCreateKernel(program, "copy", &error);
     test_error(error, "Failed to create copy kernel");
 
@@ -114,9 +130,13 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
     error = clSetKernelArg(kernel, 1, sizeof(out_mem), &out_mem);
     test_error(error, "clSetKernelArg failed");
 
-    const cl_int offset=0;
+#if USE_COMMAND_BUF_KENEL_ARG
     error = clSetKernelArg(kernel, 2, sizeof(cl_int), &offset);
     test_error(error, "clSetKernelArg failed");
+#else
+    error = clSetKernelArg(kernel, 2, sizeof(off_mem), &off_mem);
+    test_error(error, "clSetKernelArg failed");
+#endif
 
     if (simultaneous_use)
     {

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -21,14 +21,14 @@
 #include <vector>
 
 
-BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device, cl_context context,
-                       cl_command_queue queue)
+BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
+                                               cl_context context,
+                                               cl_command_queue queue)
     : CommandBufferTestBase(device), context(context), queue(queue),
-      num_elements(0),
-      command_buffer(this),
-      simultaneous_use(false),
+      num_elements(0), command_buffer(this), simultaneous_use(false),
       out_of_order_support(false),
-      simultaneous_use_requested(true), // try to use simultaneous path by default
+      simultaneous_use_requested(
+          true), // try to use simultaneous path by default
       double_buffers_size(false) // due to simultaneous case extend buffer size
 
 {}
@@ -46,8 +46,8 @@ bool BasicCommandBufferTest::Skip()
     cl_command_queue_properties queue_properties;
 
     error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES,
-                                  sizeof(queue_properties),
-                                  &queue_properties, NULL);
+                                  sizeof(queue_properties), &queue_properties,
+                                  NULL);
     test_error(error, "Unable to query CL_QUEUE_PROPERTIES");
 
     // Skip if queue properties don't contain those required
@@ -64,13 +64,13 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
 
     // Query if device supports simultaneous use
     cl_device_command_buffer_capabilities_khr capabilities;
-    error =
-        clGetDeviceInfo(device, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
-                        sizeof(capabilities), &capabilities, NULL);
+    error = clGetDeviceInfo(device, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
+                            sizeof(capabilities), &capabilities, NULL);
     test_error(error,
                "Unable to query CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR");
-    simultaneous_use = simultaneous_use_requested &&
-        (capabilities & CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR) != 0;
+    simultaneous_use = simultaneous_use_requested
+        && (capabilities & CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR)
+            != 0;
     out_of_order_support =
         capabilities & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR;
 
@@ -107,17 +107,21 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
     test_error(error, "Failed to build program");
 
     in_mem = clCreateBuffer(context, CL_MEM_READ_ONLY,
-        sizeof(cl_int) * num_elements * (double_buffers_size?2:1), nullptr, &error);
+                            sizeof(cl_int) * num_elements
+                                * (double_buffers_size ? 2 : 1),
+                            nullptr, &error);
     test_error(error, "clCreateBuffer failed");
 
     out_mem = clCreateBuffer(context, CL_MEM_WRITE_ONLY,
-        sizeof(cl_int) * num_elements * (double_buffers_size?2:1), nullptr, &error);
+                             sizeof(cl_int) * num_elements
+                                 * (double_buffers_size ? 2 : 1),
+                             nullptr, &error);
     test_error(error, "clCreateBuffer failed");
 
-    cl_int offset=0;
+    cl_int offset = 0;
 #if !USE_COMMAND_BUF_KENEL_ARG
     off_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-        sizeof(cl_int), &offset, &error);
+                             sizeof(cl_int), &offset, &error);
     test_error(error, "clCreateBuffer failed");
 #endif
 
@@ -141,16 +145,15 @@ cl_int BasicCommandBufferTest::SetUp(int elements)
     if (simultaneous_use)
     {
         cl_command_buffer_properties_khr properties[3] = {
-            CL_COMMAND_BUFFER_FLAGS_KHR,
-            CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR, 0
+            CL_COMMAND_BUFFER_FLAGS_KHR, CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR,
+            0
         };
         command_buffer =
             clCreateCommandBufferKHR(1, &queue, properties, &error);
     }
     else
     {
-        command_buffer =
-            clCreateCommandBufferKHR(1, &queue, nullptr, &error);
+        command_buffer = clCreateCommandBufferKHR(1, &queue, nullptr, &error);
     }
     test_error(error, "clCreateCommandBufferKHR failed");
 
@@ -560,4 +563,3 @@ int test_out_of_order(cl_device_id device, cl_context context,
 {
     return MakeAndRunTest<OutOfOrderTest>(device, context, queue, num_elements);
 }
-

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -52,7 +52,7 @@ protected:
     size_t data_size() const { return num_elements * sizeof(cl_int); }
 
     cl_context context;
-    cl_command_queue queue;
+    clCommandQueueWrapper queue;
     clCommandBufferWrapper command_buffer;
     clProgramWrapper program;
     clKernelWrapper kernel;
@@ -74,17 +74,25 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
 {
     CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
 
-    auto test_fixture = T(device, context, queue);
-    cl_int error = test_fixture.SetUp(num_elements);
-    test_error_ret(error, "Error in test initialization", TEST_FAIL);
-
-    if (test_fixture.Skip())
+    try
     {
-        return TEST_SKIPPED_ITSELF;
-    }
+        auto test_fixture = T(device, context, queue);
 
-    error = test_fixture.Run();
-    test_error_ret(error, "Test Failed", TEST_FAIL);
+        cl_int error = test_fixture.SetUp(num_elements);
+        test_error_ret(error, "Error in test initialization", TEST_FAIL);
+
+        if (test_fixture.Skip())
+        {
+            return TEST_SKIPPED_ITSELF;
+        }
+
+        error = test_fixture.Run();
+        test_error_ret(error, "Test Failed", TEST_FAIL);
+    } catch (const std::runtime_error &e)
+    {
+        log_error("%s", e.what());
+        return TEST_FAIL;
+    }
 
     return TEST_PASS;
 }

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _CL_KHR_BASIC_COMMAND_BUFFER_H
+#define _CL_KHR_BASIC_COMMAND_BUFFER_H
+
+#include "command_buffer_test_base.h"
+#include "harness/typeWrappers.h"
+
+#define ADD_PROP(prop)                                                         \
+    {                                                                          \
+        prop, #prop                                                            \
+    }
+
+#define CHECK_VERIFICATION_ERROR(reference, result, index)                     \
+    {                                                                          \
+        if (reference != result)                                               \
+        {                                                                      \
+            log_error("Expected %d was %d at index %u\n", reference, result,   \
+                      index);                                                  \
+            return TEST_FAIL;                                                  \
+        }                                                                      \
+    }
+
+// Helper test fixture for constructing OpenCL objects used in testing
+// a variety of simple command-buffer enqueue scenarios.
+struct BasicCommandBufferTest : CommandBufferTestBase
+{
+
+    BasicCommandBufferTest(cl_device_id device, cl_context context,
+                           cl_command_queue queue);
+
+    virtual bool Skip();
+    virtual cl_int SetUp(int elements);
+
+    // Test body returning an OpenCL error code
+    virtual cl_int Run() = 0;
+
+protected:
+    size_t data_size() const { return num_elements * sizeof(cl_int); }
+
+    cl_context context;
+    cl_command_queue queue;
+    clCommandBufferWrapper command_buffer;
+    clProgramWrapper program;
+    clKernelWrapper kernel;
+    clMemWrapper in_mem, out_mem;
+    size_t num_elements;
+
+    // Device support query results
+    bool simultaneous_use;
+    bool out_of_order_support;
+
+    // user request for simultaneous use
+    bool simultaneous_use_requested;
+    bool double_buffers_size;
+};
+
+template <class T>
+int MakeAndRunTest(cl_device_id device, cl_context context,
+                   cl_command_queue queue, int num_elements)
+{
+    CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
+
+    auto test_fixture = T(device, context, queue);
+    cl_int error = test_fixture.SetUp(num_elements);
+    test_error_ret(error, "Error in test initialization", TEST_FAIL);
+
+    if (test_fixture.Skip())
+    {
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    error = test_fixture.Run();
+    test_error_ret(error, "Test Failed", TEST_FAIL);
+
+    return TEST_PASS;
+}
+
+#endif // _CL_KHR_BASIC_COMMAND_BUFFER_H

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -19,9 +19,6 @@
 #include "command_buffer_test_base.h"
 #include "harness/typeWrappers.h"
 
-// temporary flag to be removed once simultaneous test will be sorted out
-#define USE_COMMAND_BUF_KENEL_ARG 0
-
 #define ADD_PROP(prop)                                                         \
     {                                                                          \
         prop, #prop                                                            \

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -19,6 +19,9 @@
 #include "command_buffer_test_base.h"
 #include "harness/typeWrappers.h"
 
+// temporary flag to be removed once simultaneous test will be sorted out
+#define USE_COMMAND_BUF_KENEL_ARG 0
+
 #define ADD_PROP(prop)                                                         \
     {                                                                          \
         prop, #prop                                                            \
@@ -56,7 +59,7 @@ protected:
     clCommandBufferWrapper command_buffer;
     clProgramWrapper program;
     clKernelWrapper kernel;
-    clMemWrapper in_mem, out_mem;
+    clMemWrapper in_mem, out_mem, off_mem;
     size_t num_elements;
 
     // Device support query results

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -78,13 +78,13 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
     {
         auto test_fixture = T(device, context, queue);
 
-        cl_int error = test_fixture.SetUp(num_elements);
-        test_error_ret(error, "Error in test initialization", TEST_FAIL);
-
         if (test_fixture.Skip())
         {
             return TEST_SKIPPED_ITSELF;
         }
+
+        cl_int error = test_fixture.SetUp(num_elements);
+        test_error_ret(error, "Error in test initialization", TEST_FAIL);
 
         error = test_fixture.Run();
         test_error_ret(error, "Test Failed", TEST_FAIL);

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -63,12 +63,12 @@ protected:
     size_t num_elements;
 
     // Device support query results
-    bool simultaneous_use;
+    bool simultaneous_use_support;
     bool out_of_order_support;
 
     // user request for simultaneous use
     bool simultaneous_use_requested;
-    bool double_buffers_size;
+    unsigned buffer_size_multiplier;
 };
 
 template <class T>

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -226,15 +226,10 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
             pd.offset * sizeof(cl_int), data_size(), 0, nullptr, nullptr);
         test_error(error, "clEnqueueFillBuffer failed");
 
-#if USE_COMMAND_BUF_KENEL_ARG
-        error = clSetKernelArg(kernel, 2, sizeof(cl_int), &pd.offset);
-        test_error(error, "clSetKernelArg failed");
-#else
         error =
             clEnqueueFillBuffer(pd.queue, off_mem, &pd.offset, sizeof(cl_int),
                                 0, sizeof(cl_int), 0, nullptr, nullptr);
         test_error(error, "clEnqueueFillBuffer failed");
-#endif
 
         if (!user_event)
         {
@@ -263,7 +258,7 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
         cl_int offset = static_cast<cl_int>(num_elements);
 
         std::vector<SimulPassData> simul_passes = {
-            { pattern_pri, 0, queue, std::vector<cl_int>(num_elements) },
+            { pattern_pri, 0, q, std::vector<cl_int>(num_elements) },
             { pattern_sec, offset, q, std::vector<cl_int>(num_elements) }
         };
 

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -32,8 +32,7 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     SubstituteQueueTest(cl_device_id device, cl_context context,
                         cl_command_queue queue)
         : BasicCommandBufferTest(device, context, queue),
-          properties_use_requested(prop_use),
-          out_of_order_queue(false),
+          properties_use_requested(prop_use), out_of_order_queue(false),
           user_event(nullptr)
     {
         double_buffers_size = simultaneous_use_requested = simul_use;
@@ -42,15 +41,14 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     //--------------------------------------------------------------------------
     bool Skip() override
     {
-      if (properties_use_requested && queue == nullptr)
-        return true;
+        if (properties_use_requested && queue == nullptr) return true;
 
-      return (simultaneous_use_requested && !simultaneous_use)
-          || BasicCommandBufferTest::Skip();
+        return (simultaneous_use_requested && !simultaneous_use)
+            || BasicCommandBufferTest::Skip();
     }
 
     //--------------------------------------------------------------------------
-    cl_int CreateCommandQueueWithProperties(cl_command_queue &queue_with_prop)
+    cl_int CreateCommandQueueWithProperties(cl_command_queue& queue_with_prop)
     {
         cl_int error = 0;
         cl_queue_properties_khr device_props = 0;
@@ -62,31 +60,30 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
 
         using PropPair = std::pair<cl_queue_properties_khr, std::string>;
 
-        auto check_property = [&](const PropPair & prop)
-        {
-          if (device_props & prop.first)
-          {
-            log_info("Queue property %s supported. Testing ... \n",
-                     prop.second.c_str());
-            queue_with_prop = clCreateCommandQueue
-                (context, device, prop.first, &error);
-          }
-          else
-              log_info("Queue property %s not supported \n", prop.second.c_str());
+        auto check_property = [&](const PropPair& prop) {
+            if (device_props & prop.first)
+            {
+                log_info("Queue property %s supported. Testing ... \n",
+                         prop.second.c_str());
+                queue_with_prop =
+                    clCreateCommandQueue(context, device, prop.first, &error);
+            }
+            else
+                log_info("Queue property %s not supported \n",
+                         prop.second.c_str());
         };
 
         // in case of extending property list in future
-        std::vector< PropPair > props = {
-          ADD_PROP(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE),
-          ADD_PROP(CL_QUEUE_PROFILING_ENABLE)
+        std::vector<PropPair> props = {
+            ADD_PROP(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE),
+            ADD_PROP(CL_QUEUE_PROFILING_ENABLE)
         };
 
-        for ( auto && prop : props )
+        for (auto&& prop : props)
         {
-          check_property(prop);
-          test_error(error, "clCreateCommandQueue failed");
-          if (queue_with_prop!=nullptr)
-              return CL_SUCCESS;
+            check_property(prop);
+            test_error(error, "clCreateCommandQueue failed");
+            if (queue_with_prop != nullptr) return CL_SUCCESS;
         }
 
         return CL_INVALID_QUEUE_PROPERTIES;
@@ -96,13 +93,14 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     cl_int SetUp(int elements) override
     {
         // By default command queue is created without properties,
-        // if test requires queue with properties default queue must be replaced.
+        // if test requires queue with properties default queue must be
+        // replaced.
         if (properties_use_requested)
         {
             // due to the skip condition
             queue = nullptr;
-            if ( CreateCommandQueueWithProperties(queue) != CL_SUCCESS )
-              return CL_SUCCESS;
+            if (CreateCommandQueueWithProperties(queue) != CL_SUCCESS)
+                return CL_SUCCESS;
         }
 
         return BasicCommandBufferTest::SetUp(elements);
@@ -113,12 +111,14 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     {
         cl_int error = CL_SUCCESS;
         cl_command_queue_properties cqp;
-        error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES, sizeof(cqp), &cqp, NULL);
+        error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES, sizeof(cqp),
+                                      &cqp, NULL);
         test_error(error, "clGetCommandQueueInfo failed");
 
-        if(properties_use_requested && (cqp & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE))
+        if (properties_use_requested
+            && (cqp & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE))
         {
-          out_of_order_queue = true;
+            out_of_order_queue = true;
         }
 
         // record command buffer with primary queue
@@ -135,22 +135,22 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
         else
         {
             const cl_command_queue_properties queue_properties = 0;
-            new_queue = clCreateCommandQueue
-                (context, device, queue_properties, &error);
+            new_queue =
+                clCreateCommandQueue(context, device, queue_properties, &error);
             test_error(error, "clCreateCommandQueue failed");
         }
 
         if (simultaneous_use)
         {
-          // enque simultaneous command-buffers with substitute queue
-          error = RunSimultaneous(new_queue);
-          test_error(error, "RunSimultaneous failed");
+            // enque simultaneous command-buffers with substitute queue
+            error = RunSimultaneous(new_queue);
+            test_error(error, "RunSimultaneous failed");
         }
         else
         {
-          // enque single command-buffer with substitute queue
-          error = RunSingle(new_queue);
-          test_error(error, "RunSingle failed");
+            // enque single command-buffer with substitute queue
+            error = RunSingle(new_queue);
+            test_error(error, "RunSingle failed");
         }
 
         clReleaseCommandQueue(new_queue);
@@ -164,118 +164,118 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     //--------------------------------------------------------------------------
     cl_int RecordCommandBuffer()
     {
-      cl_int error = CL_SUCCESS;
+        cl_int error = CL_SUCCESS;
 
-      if(out_of_order_queue)
-      {
-        if (simultaneous_use)
+        if (out_of_order_queue)
         {
-          log_info("Queue property CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE "
-                   "not supported with simultaneous use\n");
-          return CL_INVALID_QUEUE_PROPERTIES;
+            if (simultaneous_use)
+            {
+                log_info(
+                    "Queue property CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE "
+                    "not supported with simultaneous use\n");
+                return CL_INVALID_QUEUE_PROPERTIES;
+            }
+
+            cl_sync_point_khr sync_point;
+            error = clCommandFillBufferKHR(
+                command_buffer, nullptr, in_mem, &pattern_pri, sizeof(cl_int),
+                0, data_size(), 0, nullptr, &sync_point, nullptr);
+            test_error(error, "clCommandFillBufferKHR failed");
+
+            error = clCommandNDRangeKernelKHR(
+                command_buffer, nullptr, nullptr, kernel, 1, nullptr,
+                &num_elements, nullptr, 1, &sync_point, nullptr, nullptr);
+            test_error(error, "clCommandNDRangeKernelKHR failed");
+        }
+        else
+        {
+            error = clCommandNDRangeKernelKHR(
+                command_buffer, nullptr, nullptr, kernel, 1, nullptr,
+                &num_elements, nullptr, 0, nullptr, nullptr, nullptr);
+            test_error(error, "clCommandNDRangeKernelKHR failed");
         }
 
-        cl_sync_point_khr sync_point;
-        error = clCommandFillBufferKHR
-            (command_buffer, nullptr, in_mem, &pattern_pri, sizeof(cl_int), 0,
-             data_size(), 0, nullptr, &sync_point, nullptr);
-        test_error(error, "clCommandFillBufferKHR failed");
-
-        error = clCommandNDRangeKernelKHR(
-            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
-            nullptr, 1, &sync_point, nullptr, nullptr);
-        test_error(error, "clCommandNDRangeKernelKHR failed");
-      }
-      else
-      {
-        error = clCommandNDRangeKernelKHR(
-            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
-            nullptr, 0, nullptr, nullptr, nullptr);
-        test_error(error, "clCommandNDRangeKernelKHR failed");
-      }
-
-      error = clFinalizeCommandBufferKHR(command_buffer);
-      test_error(error, "clFinalizeCommandBufferKHR failed");
-      return CL_SUCCESS;
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+        return CL_SUCCESS;
     }
 
     //--------------------------------------------------------------------------
     cl_int RunSingle(const cl_command_queue& q)
     {
-      cl_int error = CL_SUCCESS;
-      std::vector<cl_int> output_data(num_elements);
+        cl_int error = CL_SUCCESS;
+        std::vector<cl_int> output_data(num_elements);
 
-      if (!out_of_order_queue)
-      {
-        error = clEnqueueFillBuffer(q, in_mem, &pattern_pri, sizeof(cl_int),
-                                    0, data_size(), 0, nullptr, nullptr);
-        test_error(error, "clEnqueueFillBuffer failed");
-      }
+        if (!out_of_order_queue)
+        {
+            error = clEnqueueFillBuffer(q, in_mem, &pattern_pri, sizeof(cl_int),
+                                        0, data_size(), 0, nullptr, nullptr);
+            test_error(error, "clEnqueueFillBuffer failed");
+        }
 
-      cl_command_queue queues[] = { q };
-      error = clEnqueueCommandBufferKHR(1, queues, command_buffer, 0,
-                                        nullptr, nullptr);
-      test_error(error, "clEnqueueCommandBufferKHR failed");
+        cl_command_queue queues[] = { q };
+        error = clEnqueueCommandBufferKHR(1, queues, command_buffer, 0, nullptr,
+                                          nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
 
-      error = clEnqueueReadBuffer(q, out_mem, CL_TRUE, 0, data_size(),
-                                  output_data.data(), 0, nullptr, nullptr);
-      test_error(error, "clEnqueueReadBuffer failed");
+        error = clEnqueueReadBuffer(q, out_mem, CL_TRUE, 0, data_size(),
+                                    output_data.data(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueReadBuffer failed");
 
-      error = clFinish(q);
-      test_error(error, "clFinish failed");
+        error = clFinish(q);
+        test_error(error, "clFinish failed");
 
-      for (size_t i = 0; i < num_elements; i++)
-      {
-          CHECK_VERIFICATION_ERROR(pattern_pri, output_data[i], i);
-      }
+        for (size_t i = 0; i < num_elements; i++)
+        {
+            CHECK_VERIFICATION_ERROR(pattern_pri, output_data[i], i);
+        }
 
-      return CL_SUCCESS;
+        return CL_SUCCESS;
     }
 
     //--------------------------------------------------------------------------
     // tuple order: pattern, offset, queue, output-buffer
     using SimulPassData =
-      std::tuple<cl_int, cl_int, cl_command_queue, std::vector<cl_int>>;
+        std::tuple<cl_int, cl_int, cl_command_queue, std::vector<cl_int>>;
 
     //--------------------------------------------------------------------------
-    cl_int EnqueueSimultaneousPass (SimulPassData & pd)
+    cl_int EnqueueSimultaneousPass(SimulPassData& pd)
     {
-      const cl_int offset = std::get<1>(pd);
-      auto & q = std::get<2>(pd);
-      cl_int error = clEnqueueFillBuffer
-          (q, in_mem, &std::get<0>(pd), sizeof(cl_int),
-           offset * sizeof(cl_int), data_size(), 0, nullptr, nullptr);
-      test_error(error, "clEnqueueFillBuffer failed");
+        const cl_int offset = std::get<1>(pd);
+        auto& q = std::get<2>(pd);
+        cl_int error = clEnqueueFillBuffer(
+            q, in_mem, &std::get<0>(pd), sizeof(cl_int),
+            offset * sizeof(cl_int), data_size(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueFillBuffer failed");
 
 #if USE_COMMAND_BUF_KENEL_ARG
-      error = clSetKernelArg(kernel, 2, sizeof(cl_int), &offset);
-      test_error(error, "clSetKernelArg failed");
+        error = clSetKernelArg(kernel, 2, sizeof(cl_int), &offset);
+        test_error(error, "clSetKernelArg failed");
 #else
-         error = clEnqueueFillBuffer
-             (q, off_mem, &offset, sizeof(cl_int), 0, sizeof(cl_int),
-              0, nullptr, nullptr);
-         test_error(error, "clEnqueueFillBuffer failed");
+        error = clEnqueueFillBuffer(q, off_mem, &offset, sizeof(cl_int), 0,
+                                    sizeof(cl_int), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueFillBuffer failed");
 
 #endif
 
-      if (!user_event)
-      {
-        user_event = clCreateUserEvent(context, &error);
-        test_error(error, "clCreateUserEvent failed");
-      }
+        if (!user_event)
+        {
+            user_event = clCreateUserEvent(context, &error);
+            test_error(error, "clCreateUserEvent failed");
+        }
 
-      cl_command_queue queues[] = { q };
-      error = clEnqueueCommandBufferKHR
-          (1, queues, command_buffer, 1, &user_event, nullptr);
-      test_error(error, "clEnqueueCommandBufferKHR failed");
+        cl_command_queue queues[] = { q };
+        error = clEnqueueCommandBufferKHR(1, queues, command_buffer, 1,
+                                          &user_event, nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
 
-      error = clEnqueueReadBuffer
-          (q, out_mem, CL_FALSE, offset * sizeof(cl_int),
-           data_size(), std::get<3>(pd).data(), 0, nullptr, nullptr);
+        error = clEnqueueReadBuffer(
+            q, out_mem, CL_FALSE, offset * sizeof(cl_int), data_size(),
+            std::get<3>(pd).data(), 0, nullptr, nullptr);
 
-      test_error(error, "clEnqueueReadBuffer failed");
+        test_error(error, "clEnqueueReadBuffer failed");
 
-      return CL_SUCCESS;
+        return CL_SUCCESS;
     }
 
     //--------------------------------------------------------------------------
@@ -285,31 +285,31 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
 
         // tuple order: pattern, offset, queue, output-buffer
         std::vector<SimulPassData> simul_passes = {
-          { pattern_pri, 0, queue, std::vector<cl_int>(num_elements) },
-          { pattern_sec, num_elements, q, std::vector<cl_int>(num_elements) }
+            { pattern_pri, 0, queue, std::vector<cl_int>(num_elements) },
+            { pattern_sec, num_elements, q, std::vector<cl_int>(num_elements) }
         };
 
-        for ( auto && pass : simul_passes )
+        for (auto&& pass : simul_passes)
         {
-          error = EnqueueSimultaneousPass(pass);
-          test_error(error, "EnqueuePass failed");
+            error = EnqueueSimultaneousPass(pass);
+            test_error(error, "EnqueuePass failed");
         }
 
         error = clSetUserEventStatus(user_event, CL_COMPLETE);
         test_error(error, "clSetUserEventStatus failed");
 
-        for ( auto && pass : simul_passes )
+        for (auto&& pass : simul_passes)
         {
-          error = clFinish(std::get<2>(pass));
-          test_error(error, "clFinish failed");
+            error = clFinish(std::get<2>(pass));
+            test_error(error, "clFinish failed");
 
-          auto & pattern = std::get<0>(pass);
-          auto & res_data = std::get<3>(pass);
+            auto& pattern = std::get<0>(pass);
+            auto& res_data = std::get<3>(pass);
 
-          for (size_t i = 0; i < num_elements; i++)
-          {
-              CHECK_VERIFICATION_ERROR(pattern, res_data[i], i);
-          }
+            for (size_t i = 0; i < num_elements; i++)
+            {
+                CHECK_VERIFICATION_ERROR(pattern, res_data[i], i);
+            }
         }
 
         return CL_SUCCESS;
@@ -329,21 +329,24 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
 } // anonymous namespace
 
 int test_queue_substitution(cl_device_id device, cl_context context,
-                      cl_command_queue queue, int num_elements)
+                            cl_command_queue queue, int num_elements)
 {
-    return MakeAndRunTest<SubstituteQueueTest<false, false> >(device, context, queue, num_elements);
+    return MakeAndRunTest<SubstituteQueueTest<false, false>>(
+        device, context, queue, num_elements);
 }
 
 int test_properties_queue_substitution(cl_device_id device, cl_context context,
-                      cl_command_queue queue, int num_elements)
+                                       cl_command_queue queue, int num_elements)
 {
-    return MakeAndRunTest<SubstituteQueueTest<true, false> >(device, context, queue, num_elements);
+    return MakeAndRunTest<SubstituteQueueTest<true, false>>(
+        device, context, queue, num_elements);
 }
 
-int test_simultaneous_queue_substitution(cl_device_id device, cl_context context,
-                      cl_command_queue queue, int num_elements)
+int test_simultaneous_queue_substitution(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements)
 {
-    return MakeAndRunTest<SubstituteQueueTest<false, true> >(device, context, queue, num_elements);
+    return MakeAndRunTest<SubstituteQueueTest<false, true>>(
+        device, context, queue, num_elements);
 }
-
-

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -1,0 +1,287 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "basic_command_buffer.h"
+#include "procs.h"
+
+#include <vector>
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Command-queue substitution tests which handles below cases:
+// -substitution on queue without properties
+// -substitution on queue with properties
+// -simultaneous use queue substitution
+
+template <bool prop_use, bool simul_use>
+struct SubstituteQueueTest : public BasicCommandBufferTest
+{
+    SubstituteQueueTest(cl_device_id device, cl_context context,
+                        cl_command_queue queue)
+        : BasicCommandBufferTest(device, context, queue),
+          properties_use_requested(prop_use),
+          user_event(nullptr)
+    {
+        double_buffers_size = simultaneous_use_requested = simul_use;
+    }
+
+    //--------------------------------------------------------------------------
+    bool Skip() override
+    {
+      if (properties_use_requested && queue == nullptr)
+        return true;
+
+      return (simultaneous_use_requested && !simultaneous_use)
+          || BasicCommandBufferTest::Skip();
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int CreateCommandQueueWithProperties(cl_command_queue &queue_with_prop)
+    {
+        cl_int error = 0;
+        cl_queue_properties_khr device_props = 0;
+
+        error = clGetDeviceInfo(device, CL_DEVICE_QUEUE_PROPERTIES,
+                                sizeof(device_props), &device_props, nullptr);
+        test_error(error,
+                   "clGetDeviceInfo for CL_DEVICE_QUEUE_PROPERTIES failed");
+
+        using PropPair = std::pair<cl_queue_properties_khr, std::string>;
+
+        auto check_property = [&](const PropPair & prop)
+        {
+          if (device_props & prop.first)
+          {
+            log_info("Queue property %s supported. Testing ... \n",
+                     prop.second.c_str());
+            queue_with_prop = clCreateCommandQueue
+                (context, device, prop.first, &error);
+          }
+          else
+              log_info("Queue property %s not supported \n", prop.second.c_str());
+        };
+
+        // in case of extending property list in future
+        std::vector< PropPair > props = {
+          ADD_PROP(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE),
+          ADD_PROP(CL_QUEUE_PROFILING_ENABLE)
+        };
+
+        for ( auto && prop : props )
+        {
+          check_property(prop);
+          test_error(error, "clCreateCommandQueue failed");
+          if (queue_with_prop!=nullptr)
+              return CL_SUCCESS;
+        }
+
+        return CL_INVALID_QUEUE_PROPERTIES;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int SetUp(int elements) override
+    {
+        // By default command queue is created without properties,
+        // if test requires queue with properties default queue must be replaced.
+        if (properties_use_requested)
+        {
+            // due to the skip condition
+            queue = nullptr;
+            if ( CreateCommandQueueWithProperties(queue) != CL_SUCCESS )
+              return CL_SUCCESS;
+        }
+
+        return BasicCommandBufferTest::SetUp(elements);
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int Run() override
+    {
+        cl_int error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        // create substitute queue
+        cl_command_queue new_queue = nullptr;
+        if (properties_use_requested)
+        {
+            error = CreateCommandQueueWithProperties(new_queue);
+            test_error(error, "CreateCommandQueueWithProperties failed");
+        }
+        else
+        {
+            const cl_command_queue_properties queue_properties = 0;
+            new_queue = clCreateCommandQueue
+                (context, device, queue_properties, &error);
+            test_error(error, "clCreateCommandQueue failed");
+        }
+
+        if (simultaneous_use)
+        {
+          error = RunSimultaneous(new_queue);
+          test_error(error, "RunSimultaneous failed");
+        }
+        else
+        {
+          error = RunSingle(new_queue);
+          test_error(error, "RunSingle failed");
+        }
+
+        clReleaseCommandQueue(new_queue);
+        if (properties_use_requested)
+        {
+            clReleaseCommandQueue(queue);
+        }
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int RunSingle(const cl_command_queue& q)
+    {
+      cl_int error = CL_SUCCESS;
+      std::vector<cl_int> output_data(num_elements);
+      const cl_int pattern = 42;
+      error = clEnqueueFillBuffer(q, in_mem, &pattern, sizeof(cl_int),
+                                  0, data_size(), 0, nullptr, nullptr);
+      test_error(error, "clEnqueueFillBuffer failed");
+
+      cl_command_queue queues[] = { q };
+      error = clEnqueueCommandBufferKHR(1, queues, command_buffer, 0,
+                                        nullptr, nullptr);
+      test_error(error, "clEnqueueCommandBufferKHR failed");
+
+      error = clEnqueueReadBuffer(q, out_mem, CL_TRUE, 0, data_size(),
+                                  output_data.data(), 0, nullptr, nullptr);
+      test_error(error, "clEnqueueReadBuffer failed");
+
+      error = clFinish(q);
+      test_error(error, "clFinish failed");
+
+      for (size_t i = 0; i < num_elements; i++)
+      {
+          CHECK_VERIFICATION_ERROR(pattern, output_data[i], i);
+      }
+
+      return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    // tuple order: pattern, offset, queue, output-buffer
+    using SimulPassData =
+      std::tuple<cl_int, cl_int, cl_command_queue, std::vector<cl_int>>;
+
+    //--------------------------------------------------------------------------
+    cl_int EnqueueSimultaneousPass (SimulPassData & pd)
+    {
+      const cl_int offset = std::get<1>(pd);
+      auto & q = std::get<2>(pd);
+      cl_int error = clEnqueueFillBuffer
+          (q, in_mem, &std::get<0>(pd), sizeof(cl_int),
+           offset * sizeof(cl_int), data_size(), 0, nullptr, nullptr);
+      test_error(error, "clEnqueueFillBuffer failed");
+
+      error = clSetKernelArg(kernel, 2, sizeof(cl_int), &offset);
+      test_error(error, "clSetKernelArg failed");
+
+      if (!user_event)
+      {
+        user_event = clCreateUserEvent(context, &error);
+        test_error(error, "clCreateUserEvent failed");
+      }
+
+      cl_command_queue queues[] = { q };
+      error = clEnqueueCommandBufferKHR
+          (1, queues, command_buffer, 1, &user_event, nullptr);
+      test_error(error, "clEnqueueCommandBufferKHR failed");
+
+      error = clEnqueueReadBuffer
+          (q, out_mem, CL_FALSE, offset * sizeof(cl_int),
+           data_size(), std::get<3>(pd).data(), 0, nullptr, nullptr);
+
+      test_error(error, "clEnqueueReadBuffer failed");
+
+      return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int RunSimultaneous(const cl_command_queue& q)
+    {
+        cl_int error = CL_SUCCESS;
+
+        // tuple order: pattern, offset, queue, output-buffer
+        std::vector<SimulPassData> simul_passes = {
+          { 0xA, 0, queue, std::vector<cl_int>(num_elements) },
+          { 0xB, num_elements, q, std::vector<cl_int>(num_elements) }
+        };
+
+        for ( auto && pass : simul_passes )
+        {
+          error = EnqueueSimultaneousPass(pass);
+          test_error(error, "EnqueuePass failed");
+        }
+
+        error = clSetUserEventStatus(user_event, CL_COMPLETE);
+        test_error(error, "clSetUserEventStatus failed");
+
+        for ( auto && pass : simul_passes )
+        {
+          error = clFinish(std::get<2>(pass));
+          test_error(error, "clFinish failed");
+
+          auto & pattern = std::get<0>(pass);
+          auto & res_data = std::get<3>(pass);
+
+          for (size_t i = 0; i < num_elements; i++)
+          {
+              CHECK_VERIFICATION_ERROR(pattern, res_data[i], i);
+          }
+        }
+
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    bool properties_use_requested = false;
+    clEventWrapper user_event = nullptr;
+};
+
+//#undef CHECK_VERIFICATION_ERROR
+
+} // anonymous namespace
+
+int test_queue_substitution(cl_device_id device, cl_context context,
+                      cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<SubstituteQueueTest<false, false> >(device, context, queue, num_elements);
+}
+
+int test_properties_queue_substitution(cl_device_id device, cl_context context,
+                      cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<SubstituteQueueTest<true, false> >(device, context, queue, num_elements);
+}
+
+int test_simultaneous_queue_substitution(cl_device_id device, cl_context context,
+                      cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<SubstituteQueueTest<false, true> >(device, context, queue, num_elements);
+}
+
+

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -41,21 +41,21 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     //--------------------------------------------------------------------------
     bool Skip() override
     {
-        if (properties_use_requested )
+        if (properties_use_requested)
         {
-          Version version = get_device_cl_version(device);
-          const cl_device_info host_queue_query = version >= Version(2, 0)
-              ? CL_DEVICE_QUEUE_ON_HOST_PROPERTIES
-              : CL_DEVICE_QUEUE_PROPERTIES;
+            Version version = get_device_cl_version(device);
+            const cl_device_info host_queue_query = version >= Version(2, 0)
+                ? CL_DEVICE_QUEUE_ON_HOST_PROPERTIES
+                : CL_DEVICE_QUEUE_PROPERTIES;
 
-          cl_queue_properties host_queue_props = 0;
-          int error = clGetDeviceInfo(device, host_queue_query,
-                                      sizeof(host_queue_props),
-                                      &host_queue_props, NULL);
-          test_error(error, "clGetDeviceInfo failed");
+            cl_queue_properties host_queue_props = 0;
+            int error = clGetDeviceInfo(device, host_queue_query,
+                                        sizeof(host_queue_props),
+                                        &host_queue_props, NULL);
+            test_error(error, "clGetDeviceInfo failed");
 
-          if ((host_queue_props&CL_QUEUE_PROFILING_ENABLE)==0)
-            return true;
+            if ((host_queue_props & CL_QUEUE_PROFILING_ENABLE) == 0)
+                return true;
         }
 
         return BasicCommandBufferTest::Skip()

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -247,8 +247,16 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
            offset * sizeof(cl_int), data_size(), 0, nullptr, nullptr);
       test_error(error, "clEnqueueFillBuffer failed");
 
+#if USE_COMMAND_BUF_KENEL_ARG
       error = clSetKernelArg(kernel, 2, sizeof(cl_int), &offset);
       test_error(error, "clSetKernelArg failed");
+#else
+         error = clEnqueueFillBuffer
+             (q, off_mem, &offset, sizeof(cl_int), 0, sizeof(cl_int),
+              0, nullptr, nullptr);
+         test_error(error, "clEnqueueFillBuffer failed");
+
+#endif
 
       if (!user_event)
       {

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -49,17 +49,17 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
               : CL_DEVICE_QUEUE_PROPERTIES;
 
           cl_queue_properties host_queue_props = 0;
-          int error =
-              clGetDeviceInfo(device, host_queue_query, sizeof(host_queue_props),
-                              &host_queue_props, NULL);
+          int error = clGetDeviceInfo(device, host_queue_query,
+                                      sizeof(host_queue_props),
+                                      &host_queue_props, NULL);
           test_error(error, "clGetDeviceInfo failed");
 
           if ((host_queue_props&CL_QUEUE_PROFILING_ENABLE)==0)
             return true;
         }
 
-        return BasicCommandBufferTest::Skip() ||
-            (simultaneous_use_requested && !simultaneous_use_support);
+        return BasicCommandBufferTest::Skip()
+            || (simultaneous_use_requested && !simultaneous_use_support);
     }
 
     //--------------------------------------------------------------------------

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -260,10 +260,11 @@ struct SubstituteQueueTest : public BasicCommandBufferTest
     cl_int RunSimultaneous(const cl_command_queue& q)
     {
         cl_int error = CL_SUCCESS;
+        cl_int offset = static_cast<cl_int>(num_elements);
 
         std::vector<SimulPassData> simul_passes = {
             { pattern_pri, 0, queue, std::vector<cl_int>(num_elements) },
-            { pattern_sec, num_elements, q, std::vector<cl_int>(num_elements) }
+            { pattern_sec, offset, q, std::vector<cl_int>(num_elements) }
         };
 
         for (auto&& pass : simul_passes)

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -16,9 +16,15 @@
 #include "harness/testHarness.h"
 
 test_definition test_list[] = {
-    ADD_TEST(single_ndrange), ADD_TEST(interleaved_enqueue),
-    ADD_TEST(mixed_commands), ADD_TEST(explicit_flush),
-    ADD_TEST(user_events),    ADD_TEST(out_of_order)
+    ADD_TEST(single_ndrange),
+    ADD_TEST(interleaved_enqueue),
+    ADD_TEST(mixed_commands),
+    ADD_TEST(explicit_flush),
+    ADD_TEST(user_events),
+    ADD_TEST(out_of_order),
+    ADD_TEST(queue_substitution),
+    ADD_TEST(properties_queue_substitution),
+    ADD_TEST(simultaneous_queue_substitution)
 };
 
 

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -15,17 +15,15 @@
 #include "procs.h"
 #include "harness/testHarness.h"
 
-test_definition test_list[] = {
-    ADD_TEST(single_ndrange),
-    ADD_TEST(interleaved_enqueue),
-    ADD_TEST(mixed_commands),
-    ADD_TEST(explicit_flush),
-    ADD_TEST(user_events),
-    ADD_TEST(out_of_order),
-    ADD_TEST(queue_substitution),
-    ADD_TEST(properties_queue_substitution),
-    ADD_TEST(simultaneous_queue_substitution)
-};
+test_definition test_list[] = { ADD_TEST(single_ndrange),
+                                ADD_TEST(interleaved_enqueue),
+                                ADD_TEST(mixed_commands),
+                                ADD_TEST(explicit_flush),
+                                ADD_TEST(user_events),
+                                ADD_TEST(out_of_order),
+                                ADD_TEST(queue_substitution),
+                                ADD_TEST(properties_queue_substitution),
+                                ADD_TEST(simultaneous_queue_substitution) };
 
 
 int main(int argc, const char *argv[])

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -33,10 +33,14 @@ extern int test_out_of_order(cl_device_id device, cl_context context,
                              cl_command_queue queue, int num_elements);
 extern int test_queue_substitution(cl_device_id device, cl_context context,
                                    cl_command_queue queue, int num_elements);
-extern int test_properties_queue_substitution(cl_device_id device, cl_context context,
-                                              cl_command_queue queue, int num_elements);
-extern int test_simultaneous_queue_substitution(cl_device_id device, cl_context context,
-                                                cl_command_queue queue, int num_elements);
+extern int test_properties_queue_substitution(cl_device_id device,
+                                              cl_context context,
+                                              cl_command_queue queue,
+                                              int num_elements);
+extern int test_simultaneous_queue_substitution(cl_device_id device,
+                                                cl_context context,
+                                                cl_command_queue queue,
+                                                int num_elements);
 
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -31,5 +31,12 @@ extern int test_user_events(cl_device_id device, cl_context context,
                             cl_command_queue queue, int num_elements);
 extern int test_out_of_order(cl_device_id device, cl_context context,
                              cl_command_queue queue, int num_elements);
+extern int test_queue_substitution(cl_device_id device, cl_context context,
+                                   cl_command_queue queue, int num_elements);
+extern int test_properties_queue_substitution(cl_device_id device, cl_context context,
+                                              cl_command_queue queue, int num_elements);
+extern int test_simultaneous_queue_substitution(cl_device_id device, cl_context context,
+                                                cl_command_queue queue, int num_elements);
+
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/


### PR DESCRIPTION
Introduce series of queue substitution tests for [cl_khr_command_buffer](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_command_buffer) extension according to point 1.3 of [issue](https://github.com/KhronosGroup/OpenCL-CTS/issues/1369) description.