### PR TITLE
api: Update semaphores to check for pending signal

### DIFF
--- a/test_conformance/api/main.cpp
+++ b/test_conformance/api/main.cpp
@@ -161,7 +161,6 @@ test_definition test_list[] = {
     ADD_TEST_VERSION(semaphores_order_2, Version(1, 2)),
     ADD_TEST_VERSION(semaphores_order_3, Version(1, 2)),
     ADD_TEST_VERSION(semaphores_import_export_fd, Version(1, 2)),
-    ADD_TEST_VERSION(semaphores_invalid_command, Version(1, 2)),
 };
 
 const int test_num = ARRAY_SIZE(test_list);

--- a/test_conformance/api/procs.h
+++ b/test_conformance/api/procs.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -237,7 +237,3 @@ extern int test_semaphores_import_export_fd(cl_device_id deviceID,
                                             cl_context context,
                                             cl_command_queue queue,
                                             int num_elements);
-extern int test_semaphores_invalid_command(cl_device_id deviceID,
-                                           cl_context context,
-                                           cl_command_queue queue,
-                                           int num_elements);


### PR DESCRIPTION
A semaphore must have a pending signal or be signaled before waiting on it.  Add a check for signal. Additionally, remove check for invalid semaphore usage, which is implementation defined behavior, and un-testable.