### PR TITLE
[NFC] commonfns: Remove unused `values` arrays

### DIFF
--- a/test_conformance/commonfns/test_degrees.cpp
+++ b/test_conformance/commonfns/test_degrees.cpp
@@ -116,7 +116,6 @@ test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, in
     cl_float     *input_ptr[1], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[2];
     size_t threads[1];
     int          num_elements;
     int          err;
@@ -180,8 +179,6 @@ test_degrees(cl_device_id device, cl_context context, cl_command_queue queue, in
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );
@@ -346,7 +343,6 @@ test_degrees_double(cl_device_id device, cl_context context, cl_command_queue qu
     cl_double    *input_ptr[1], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[2];
     size_t threads[1];
     int          num_elements;
     int          err;
@@ -410,8 +406,6 @@ test_degrees_double(cl_device_id device, cl_context context, cl_command_queue qu
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_fmax.cpp
+++ b/test_conformance/commonfns/test_fmax.cpp
@@ -88,7 +88,6 @@ test_fmax(cl_device_id device, cl_context context, cl_command_queue queue, int n
     cl_float     *input_ptr[2], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[3];
     size_t  threads[1];
     int num_elements;
     int err;
@@ -170,10 +169,6 @@ test_fmax(cl_device_id device, cl_context context, cl_command_queue queue, int n
     if (err)
     return -1;
 
-
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_fmaxf.cpp
+++ b/test_conformance/commonfns/test_fmaxf.cpp
@@ -94,7 +94,6 @@ test_fmaxf(cl_device_id device, cl_context context, cl_command_queue queue, int 
     cl_float    *input_ptr[2], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[3];
     size_t  threads[1];
     int num_elements;
     int err;
@@ -180,9 +179,6 @@ test_fmaxf(cl_device_id device, cl_context context, cl_command_queue queue, int 
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
     for (i=0; i < kTotalVecCount; i++)
         {
             err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_fmin.cpp
+++ b/test_conformance/commonfns/test_fmin.cpp
@@ -93,7 +93,6 @@ test_fmin(cl_device_id device, cl_context context, cl_command_queue queue, int n
     cl_float    *input_ptr[2], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[3];
     size_t threads[1];
     int num_elements;
     int err;
@@ -178,9 +177,6 @@ test_fmin(cl_device_id device, cl_context context, cl_command_queue queue, int n
     if (err)
     return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
     for (i=0; i<kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_fminf.cpp
+++ b/test_conformance/commonfns/test_fminf.cpp
@@ -89,7 +89,6 @@ test_fminf(cl_device_id device, cl_context context, cl_command_queue queue, int 
     cl_float     *input_ptr[2], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void        *values[3];
     size_t  threads[1];
     int num_elements;
     int err;
@@ -173,9 +172,6 @@ test_fminf(cl_device_id device, cl_context context, cl_command_queue queue, int 
     if (err)
     return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_mix.cpp
+++ b/test_conformance/commonfns/test_mix.cpp
@@ -54,7 +54,6 @@ test_mix(cl_device_id device, cl_context context, cl_command_queue queue, int nu
     cl_float        *input_ptr[3], *output_ptr, *p;
     cl_program        program;
     cl_kernel        kernel;
-    void            *values[4];
     size_t            lengths[1];
     size_t    threads[1];
     float            max_err;
@@ -137,11 +136,6 @@ test_mix(cl_device_id device, cl_context context, cl_command_queue queue, int nu
     err = create_single_kernel_helper( context, &program, &kernel, 1, &mix_kernel_code, "test_mix" );
     test_error( err, "Unable to create test kernel" );
 
-
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
-    values[3] = streams[3];
   err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
   err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
   err |= clSetKernelArg(kernel, 2, sizeof streams[2], &streams[2] );

--- a/test_conformance/commonfns/test_radians.cpp
+++ b/test_conformance/commonfns/test_radians.cpp
@@ -117,7 +117,6 @@ test_radians(cl_device_id device, cl_context context, cl_command_queue queue, in
     cl_float     *input_ptr[1], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void         *values[2];
     size_t       threads[1];
     int          num_elements;
     int          err;
@@ -181,8 +180,6 @@ test_radians(cl_device_id device, cl_context context, cl_command_queue queue, in
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );
@@ -347,7 +344,6 @@ test_radians_double(cl_device_id device, cl_context context, cl_command_queue qu
     cl_double     *input_ptr[1], *output_ptr, *p;
     cl_program   *program;
     cl_kernel    *kernel;
-    void         *values[2];
     size_t       threads[1];
     int          num_elements;
     int          err;
@@ -412,8 +408,6 @@ test_radians_double(cl_device_id device, cl_context context, cl_command_queue qu
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_sign.cpp
+++ b/test_conformance/commonfns/test_sign.cpp
@@ -106,7 +106,6 @@ test_sign(cl_device_id device, cl_context context, cl_command_queue queue, int n
   cl_float    *input_ptr[1], *output_ptr, *p;
   cl_program  program[kTotalVecCount];
   cl_kernel   kernel[kTotalVecCount];
-  void        *values[2];
   size_t  threads[1];
   int num_elements;
   int err;
@@ -168,8 +167,6 @@ test_sign(cl_device_id device, cl_context context, cl_command_queue queue, int n
   if (err)
     return -1;
 
-  values[0] = streams[0];
-  values[1] = streams[1];
   for (i=0; i<kTotalVecCount; i++)
   {
       err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );
@@ -321,7 +318,6 @@ test_sign_double(cl_device_id device, cl_context context, cl_command_queue queue
   cl_double    *input_ptr[1], *output_ptr, *p;
   cl_program  program[kTotalVecCount];
   cl_kernel   kernel[kTotalVecCount];
-  void        *values[2];
   size_t  threads[1];
   int num_elements;
   int err;
@@ -382,8 +378,6 @@ test_sign_double(cl_device_id device, cl_context context, cl_command_queue queue
   if (err)
     return -1;
 
-  values[0] = streams[0];
-  values[1] = streams[1];
   for (i=0; i<kTotalVecCount; i++)
   {
       err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );

--- a/test_conformance/commonfns/test_step.cpp
+++ b/test_conformance/commonfns/test_step.cpp
@@ -98,7 +98,6 @@ test_step(cl_device_id device, cl_context context, cl_command_queue queue, int n
     cl_float    *input_ptr[2], *output_ptr, *p;
   cl_program  program[kTotalVecCount];
   cl_kernel   kernel[kTotalVecCount];
-    void        *values[3];
     size_t  threads[1];
     int num_elements;
     int err;
@@ -173,9 +172,6 @@ test_step(cl_device_id device, cl_context context, cl_command_queue queue, int n
                                       &step3_kernel_code, "test_step3");
     if (err) return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
   for (i=0; i <kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );
@@ -362,7 +358,6 @@ test_step_double(cl_device_id device, cl_context context, cl_command_queue queue
     cl_double    *input_ptr[2], *output_ptr, *p;
     cl_program  program[kTotalVecCount];
     cl_kernel   kernel[kTotalVecCount];
-    void        *values[3];
     size_t  threads[1];
     int num_elements;
     int err;
@@ -440,9 +435,6 @@ test_step_double(cl_device_id device, cl_context context, cl_command_queue queue
     if (err)
         return -1;
 
-    values[0] = streams[0];
-    values[1] = streams[1];
-    values[2] = streams[2];
     for (i=0; i < kTotalVecCount; i++)
     {
         err = clSetKernelArg(kernel[i], 0, sizeof streams[0], &streams[0] );


### PR DESCRIPTION
The arrays were assigned to, but the values were never used again.