### PR TITLE
Fix -Woverloaded-virtual warnings

### DIFF
--- a/test_conformance/mem_host_flags/checker_image_mem_host_write_only.hpp
+++ b/test_conformance/mem_host_flags/checker_image_mem_host_write_only.hpp
@@ -38,7 +38,7 @@ public:
     cl_int Setup_Test_Environment();
     cl_int update_host_mem_2();
 
-    cl_int verify_data();
+    cl_int verify_data(T *pdtaIn);
 };
 
 template <class T>
@@ -108,12 +108,13 @@ cl_int cImage_check_mem_host_write_only<T>::update_host_mem_2()
     return err;
 }
 
-template <class T> cl_int cImage_check_mem_host_write_only<T>::verify_data()
+template <class T>
+cl_int cImage_check_mem_host_write_only<T>::verify_data(T *pdtaIn)
 {
     cl_int err = CL_SUCCESS;
-    if (!this->host_m_1.Equal_rect_from_orig(
-            this->host_m_2, this->buffer_origin, this->region,
-            this->host_row_pitch, this->host_slice_pitch))
+    if (!this->host_m_1.Equal_rect_from_orig(pdtaIn, this->buffer_origin,
+                                             this->region, this->host_row_pitch,
+                                             this->host_slice_pitch))
     {
         log_error("Image and host data difference found\n");
         return FAILURE;
@@ -178,9 +179,10 @@ template <class T> cl_int cImage_check_mem_host_write_only<T>::verify_RW_Image()
 
     update_host_mem_2(); // Read buffer contents into mem_2
 
-    err =
-        this->verify_data(); // Compare the contents of mem_2 and mem_1,
-                             // mem_1 is same as mem_0 in setup test environment
+    err = this->verify_data(
+        this->host_m_2
+            .pData); // Compare the contents of mem_2 and mem_1,
+                     // mem_1 is same as mem_0 in setup test environment
     test_error(err, "verify_data error");
 
     v = 0;

--- a/test_conformance/spir/kernelargs.h
+++ b/test_conformance/spir/kernelargs.h
@@ -232,7 +232,7 @@ public:
         return &m_samplerObj;
     }
 
-    bool compare( const KernelArg& rhs ) const
+    bool compare(const KernelArg& rhs, float) const
     {
         if (const KernelArgSampler *Rhs = dynamic_cast<const KernelArgSampler*>(&rhs))
         {


### PR DESCRIPTION
Align `verify_data` with `checker_image_mem_host_read_only.hpp`, that is, take an explicit pointer to compare against.

Add a missing (but unused) `float` parameter to `KernelArgSampler::compare`.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>