### PR TITLE
c11 atomic fence: relaxed requirements for an auxiliary atomic_store

### DIFF
--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -2914,7 +2914,8 @@ public:
                 + "-1);\n"
                   "  if(hisAtomicValue != hisValue)\n"
                   "  { // fail\n"
-                  "    atomic_store(&destMemory[myId], myValue-1);\n";
+                  "    atomic_store_explicit(&destMemory[myId], myValue-1,"
+                  " memory_order_relaxed, memory_scope_work_group);\n";
             if (LocalMemory())
                 program += "    hisId = "
                            "(hisId+get_local_size(0)-1)%get_local_size(0);\n";


### PR DESCRIPTION
I had a case where the test kernel wasn't building because atomic_store requires support for __opencl_c_atomic_order_seq_cst and the device didn't have it.
I believe this store is only used to record some data in the failure case, so it being relaxed is probably fine since further reads of the data come after barriers, like around here: https://github.com/KhronosGroup/OpenCL-CTS/blob/59a1198e5f2f04540736ea0ae03c88069b2a3543/test_conformance/c11_atomics/common.h#L1014-L1019