### PR TITLE
Command buffer event sync

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_NAME CL_KHR_COMMAND_BUFFER)
 set(${MODULE_NAME}_SOURCES
     main.cpp
     basic_command_buffer.cpp
+    command_buffer_event_sync.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -25,7 +25,7 @@
 BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
                                                cl_context context,
                                                cl_command_queue queue)
-    : CommandBufferTestBase(device), context(context), queue(queue),
+    : CommandBufferTestBase(device), context(context), queue(nullptr),
       num_elements(0), command_buffer(this), simultaneous_use_support(false),
       out_of_order_support(false),
       // try to use simultaneous path by default
@@ -33,7 +33,14 @@ BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
       // due to simultaneous cases extend buffer size
       buffer_size_multiplier(1)
 
-{}
+{
+    cl_int error = clRetainCommandQueue(queue);
+    if (error != CL_SUCCESS)
+    {
+        throw std::runtime_error("clRetainCommandQueue failed\n");
+    }
+    this->queue = queue;
+}
 
 //--------------------------------------------------------------------------
 bool BasicCommandBufferTest::Skip()

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -13,157 +13,163 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "command_buffer_test_base.h"
+#include "basic_command_buffer.h"
 #include "procs.h"
-#include "harness/typeWrappers.h"
 
 #include <algorithm>
 #include <cstring>
 #include <vector>
 
-#define CHECK_VERIFICATION_ERROR(reference, result, index)                     \
-    {                                                                          \
-        if (reference != result)                                               \
-        {                                                                      \
-            log_error("Expected %d was %d at index %u\n", reference, result,   \
-                      index);                                                  \
-            return TEST_FAIL;                                                  \
-        }                                                                      \
+
+//--------------------------------------------------------------------------
+BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
+                                               cl_context context,
+                                               cl_command_queue queue)
+    : CommandBufferTestBase(device), context(context), queue(queue),
+      num_elements(0), command_buffer(this), simultaneous_use_support(false),
+      out_of_order_support(false),
+      // try to use simultaneous path by default
+      simultaneous_use_requested(true),
+      // due to simultaneous cases extend buffer size
+      buffer_size_multiplier(1)
+
+{}
+
+//--------------------------------------------------------------------------
+bool BasicCommandBufferTest::Skip()
+{
+    cl_command_queue_properties required_properties;
+    cl_int error = clGetDeviceInfo(
+        device, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR,
+        sizeof(required_properties), &required_properties, NULL);
+    test_error(error,
+               "Unable to query "
+               "CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR");
+
+    cl_command_queue_properties queue_properties;
+
+    error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES,
+                                  sizeof(queue_properties), &queue_properties,
+                                  NULL);
+    test_error(error, "Unable to query CL_QUEUE_PROPERTIES");
+
+    // Skip if queue properties don't contain those required
+    return required_properties != (required_properties & queue_properties);
+}
+
+//--------------------------------------------------------------------------
+cl_int BasicCommandBufferTest::SetUpKernel()
+{
+    cl_int error = CL_SUCCESS;
+
+    // Kernel performs a parallel copy from an input buffer to output buffer
+    // is created.
+    const char *kernel_str =
+        R"(
+  __kernel void copy(__global int* in, __global int* out, __global int* offset) {
+      size_t id = get_global_id(0);
+      int ind = offset[0] + id;
+      out[ind] = in[ind];
+  })";
+
+    error = create_single_kernel_helper_create_program(context, &program, 1,
+                                                       &kernel_str);
+    test_error(error, "Failed to create program with source");
+
+    error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
+    test_error(error, "Failed to build program");
+
+    kernel = clCreateKernel(program, "copy", &error);
+    test_error(error, "Failed to create copy kernel");
+
+    return CL_SUCCESS;
+}
+
+//--------------------------------------------------------------------------
+cl_int BasicCommandBufferTest::SetUpKernelArgs()
+{
+    cl_int error = CL_SUCCESS;
+    in_mem =
+        clCreateBuffer(context, CL_MEM_READ_ONLY,
+                       sizeof(cl_int) * num_elements * buffer_size_multiplier,
+                       nullptr, &error);
+    test_error(error, "clCreateBuffer failed");
+
+    out_mem =
+        clCreateBuffer(context, CL_MEM_WRITE_ONLY,
+                       sizeof(cl_int) * num_elements * buffer_size_multiplier,
+                       nullptr, &error);
+    test_error(error, "clCreateBuffer failed");
+
+    cl_int offset = 0;
+    off_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                             sizeof(cl_int), &offset, &error);
+    test_error(error, "clCreateBuffer failed");
+
+    error = clSetKernelArg(kernel, 0, sizeof(in_mem), &in_mem);
+    test_error(error, "clSetKernelArg failed");
+
+    error = clSetKernelArg(kernel, 1, sizeof(out_mem), &out_mem);
+    test_error(error, "clSetKernelArg failed");
+
+    error = clSetKernelArg(kernel, 2, sizeof(off_mem), &off_mem);
+    test_error(error, "clSetKernelArg failed");
+
+    return CL_SUCCESS;
+}
+
+//--------------------------------------------------------------------------
+cl_int BasicCommandBufferTest::SetUp(int elements)
+{
+    cl_int error = init_extension_functions();
+    if (error != CL_SUCCESS)
+    {
+        return error;
     }
+
+    // Query if device supports simultaneous use
+    cl_device_command_buffer_capabilities_khr capabilities;
+    error = clGetDeviceInfo(device, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
+                            sizeof(capabilities), &capabilities, NULL);
+    test_error(error,
+               "Unable to query CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR");
+    simultaneous_use_support = simultaneous_use_requested
+        && (capabilities & CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR)
+            != 0;
+    out_of_order_support =
+        capabilities & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR;
+
+    if (elements <= 0)
+    {
+        return CL_INVALID_VALUE;
+    }
+    num_elements = static_cast<size_t>(elements);
+
+    error = SetUpKernel();
+    test_error(error, "SetUpKernel failed");
+
+    error = SetUpKernelArgs();
+    test_error(error, "SetUpKernelArgs failed");
+
+    if (simultaneous_use_support)
+    {
+        cl_command_buffer_properties_khr properties[3] = {
+            CL_COMMAND_BUFFER_FLAGS_KHR, CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR,
+            0
+        };
+        command_buffer =
+            clCreateCommandBufferKHR(1, &queue, properties, &error);
+    }
+    else
+    {
+        command_buffer = clCreateCommandBufferKHR(1, &queue, nullptr, &error);
+    }
+    test_error(error, "clCreateCommandBufferKHR failed");
+
+    return CL_SUCCESS;
+}
 
 namespace {
-
-// Helper test fixture for constructing OpenCL objects used in testing
-// a variety of simple command-buffer enqueue scenarios.
-struct BasicCommandBufferTest : CommandBufferTestBase
-{
-
-    BasicCommandBufferTest(cl_device_id device, cl_context context,
-                           cl_command_queue queue)
-        : CommandBufferTestBase(device), context(context), queue(queue),
-          command_buffer(this), num_elements(0), simultaneous_use(false),
-          out_of_order_support(false)
-    {}
-
-    virtual bool Skip()
-    {
-        cl_command_queue_properties required_properties;
-        cl_int error = clGetDeviceInfo(
-            device, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR,
-            sizeof(required_properties), &required_properties, NULL);
-        test_error(error,
-                   "Unable to query "
-                   "CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR");
-
-        cl_command_queue_properties queue_properties;
-
-        error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES,
-                                      sizeof(queue_properties),
-                                      &queue_properties, NULL);
-        test_error(error, "Unable to query CL_QUEUE_PROPERTIES");
-
-        // Skip if queue properties don't contain those required
-        return required_properties != (required_properties & queue_properties);
-    }
-
-    virtual cl_int SetUp(int elements)
-    {
-        cl_int error = init_extension_functions();
-        if (error != CL_SUCCESS)
-        {
-            return error;
-        }
-
-        // Query if device supports simultaneous use
-        cl_device_command_buffer_capabilities_khr capabilities;
-        error =
-            clGetDeviceInfo(device, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
-                            sizeof(capabilities), &capabilities, NULL);
-        test_error(error,
-                   "Unable to query CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR");
-        simultaneous_use =
-            capabilities & CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR;
-        out_of_order_support =
-            capabilities & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR;
-
-        if (elements <= 0)
-        {
-            return CL_INVALID_VALUE;
-        }
-        num_elements = static_cast<size_t>(elements);
-
-        // Kernel performs a parallel copy from an input buffer to output buffer
-        // is created.
-        const char *kernel_str =
-            R"(
-        __kernel void copy(__global int* in, __global int* out) {
-            size_t id = get_global_id(0);
-            out[id] = in[id];
-        })";
-
-        error = create_single_kernel_helper_create_program(context, &program, 1,
-                                                           &kernel_str);
-        test_error(error, "Failed to create program with source");
-
-        error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
-        test_error(error, "Failed to build program");
-
-        in_mem = clCreateBuffer(context, CL_MEM_READ_ONLY,
-                                sizeof(cl_int) * num_elements, nullptr, &error);
-        test_error(error, "clCreateBuffer failed");
-
-        out_mem =
-            clCreateBuffer(context, CL_MEM_WRITE_ONLY,
-                           sizeof(cl_int) * num_elements, nullptr, &error);
-        test_error(error, "clCreateBuffer failed");
-
-        kernel = clCreateKernel(program, "copy", &error);
-        test_error(error, "Failed to create copy kernel");
-
-        error = clSetKernelArg(kernel, 0, sizeof(in_mem), &in_mem);
-        test_error(error, "clSetKernelArg failed");
-
-        error = clSetKernelArg(kernel, 1, sizeof(out_mem), &out_mem);
-        test_error(error, "clSetKernelArg failed");
-
-        if (simultaneous_use)
-        {
-            cl_command_buffer_properties_khr properties[3] = {
-                CL_COMMAND_BUFFER_FLAGS_KHR,
-                CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR, 0
-            };
-            command_buffer =
-                clCreateCommandBufferKHR(1, &queue, properties, &error);
-        }
-        else
-        {
-            command_buffer =
-                clCreateCommandBufferKHR(1, &queue, nullptr, &error);
-        }
-        test_error(error, "clCreateCommandBufferKHR failed");
-
-        return CL_SUCCESS;
-    }
-
-    // Test body returning an OpenCL error code
-    virtual cl_int Run() = 0;
-
-
-protected:
-    size_t data_size() const { return num_elements * sizeof(cl_int); }
-
-    cl_context context;
-    cl_command_queue queue;
-    clCommandBufferWrapper command_buffer;
-    clProgramWrapper program;
-    clKernelWrapper kernel;
-    clMemWrapper in_mem, out_mem;
-    size_t num_elements;
-
-    // Device support query results
-    bool simultaneous_use;
-    bool out_of_order_support;
-};
 
 // Test enqueuing a command-buffer containing a single NDRange command once
 struct BasicEnqueueTest : public BasicCommandBufferTest
@@ -262,53 +268,6 @@ struct MixedCommandsTest : public BasicCommandBufferTest
     }
 };
 
-// Test enqueueing a command-buffer blocked on a user-event
-struct UserEventTest : public BasicCommandBufferTest
-{
-    using BasicCommandBufferTest::BasicCommandBufferTest;
-
-    cl_int Run() override
-    {
-        cl_int error = clCommandNDRangeKernelKHR(
-            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
-            nullptr, 0, nullptr, nullptr, nullptr);
-        test_error(error, "clCommandNDRangeKernelKHR failed");
-
-        error = clFinalizeCommandBufferKHR(command_buffer);
-        test_error(error, "clFinalizeCommandBufferKHR failed");
-
-        clEventWrapper user_event = clCreateUserEvent(context, &error);
-        test_error(error, "clCreateUserEvent failed");
-
-        const cl_int pattern = 42;
-        error = clEnqueueFillBuffer(queue, in_mem, &pattern, sizeof(cl_int), 0,
-                                    data_size(), 0, nullptr, nullptr);
-        test_error(error, "clEnqueueFillBuffer failed");
-
-        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 1,
-                                          &user_event, nullptr);
-        test_error(error, "clEnqueueCommandBufferKHR failed");
-
-        std::vector<cl_int> output_data(num_elements);
-        error = clEnqueueReadBuffer(queue, out_mem, CL_FALSE, 0, data_size(),
-                                    output_data.data(), 0, nullptr, nullptr);
-        test_error(error, "clEnqueueReadBuffer failed");
-
-        error = clSetUserEventStatus(user_event, CL_COMPLETE);
-        test_error(error, "clSetUserEventStatus failed");
-
-        error = clFinish(queue);
-        test_error(error, "clFinish failed");
-
-        for (size_t i = 0; i < num_elements; i++)
-        {
-            CHECK_VERIFICATION_ERROR(pattern, output_data[i], i);
-        }
-
-        return CL_SUCCESS;
-    }
-};
-
 // Test flushing the command-queue between command-buffer enqueues
 struct ExplicitFlushTest : public BasicCommandBufferTest
 {
@@ -375,7 +334,7 @@ struct ExplicitFlushTest : public BasicCommandBufferTest
 
     bool Skip() override
     {
-        return !simultaneous_use || BasicCommandBufferTest::Skip();
+        return !simultaneous_use_support || BasicCommandBufferTest::Skip();
     }
 };
 
@@ -431,7 +390,7 @@ struct InterleavedEnqueueTest : public BasicCommandBufferTest
 
     bool Skip() override
     {
-        return !simultaneous_use || BasicCommandBufferTest::Skip();
+        return !simultaneous_use_support || BasicCommandBufferTest::Skip();
     }
 };
 
@@ -442,7 +401,7 @@ struct OutOfOrderTest : public BasicCommandBufferTest
     OutOfOrderTest(cl_device_id device, cl_context context,
                    cl_command_queue queue)
         : BasicCommandBufferTest(device, context, queue),
-          out_of_order_queue(nullptr), out_of_order_command_buffer(this),
+          out_of_order_command_buffer(this), out_of_order_queue(nullptr),
           event(nullptr)
     {}
 
@@ -523,28 +482,6 @@ struct OutOfOrderTest : public BasicCommandBufferTest
     clEventWrapper event;
 };
 
-#undef CHECK_VERIFICATION_ERROR
-
-template <class T>
-int MakeAndRunTest(cl_device_id device, cl_context context,
-                   cl_command_queue queue, int num_elements)
-{
-    CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
-
-    auto test_fixture = T(device, context, queue);
-    cl_int error = test_fixture.SetUp(num_elements);
-    test_error_ret(error, "Error in test initialization", TEST_FAIL);
-
-    if (test_fixture.Skip())
-    {
-        return TEST_SKIPPED_ITSELF;
-    }
-
-    error = test_fixture.Run();
-    test_error_ret(error, "Test Failed", TEST_FAIL);
-
-    return TEST_PASS;
-}
 } // anonymous namespace
 
 int test_single_ndrange(cl_device_id device, cl_context context,
@@ -573,12 +510,6 @@ int test_explicit_flush(cl_device_id device, cl_context context,
 {
     return MakeAndRunTest<ExplicitFlushTest>(device, context, queue,
                                              num_elements);
-}
-
-int test_user_events(cl_device_id device, cl_context context,
-                     cl_command_queue queue, int num_elements)
-{
-    return MakeAndRunTest<UserEventTest>(device, context, queue, num_elements);
 }
 
 int test_out_of_order(cl_device_id device, cl_context context,

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _CL_KHR_BASIC_COMMAND_BUFFER_H
+#define _CL_KHR_BASIC_COMMAND_BUFFER_H
+
+#include "command_buffer_test_base.h"
+#include "harness/typeWrappers.h"
+
+#define ADD_PROP(prop)                                                         \
+    {                                                                          \
+        prop, #prop                                                            \
+    }
+
+#define CHECK_VERIFICATION_ERROR(reference, result, index)                     \
+    {                                                                          \
+        if (reference != result)                                               \
+        {                                                                      \
+            log_error("Expected %d was %d at index %u\n", reference, result,   \
+                      index);                                                  \
+            return TEST_FAIL;                                                  \
+        }                                                                      \
+    }
+
+// Helper test fixture for constructing OpenCL objects used in testing
+// a variety of simple command-buffer enqueue scenarios.
+struct BasicCommandBufferTest : CommandBufferTestBase
+{
+
+    BasicCommandBufferTest(cl_device_id device, cl_context context,
+                           cl_command_queue queue);
+
+    virtual bool Skip();
+
+    virtual cl_int SetUpKernel(void);
+    virtual cl_int SetUpKernelArgs(void);
+    virtual cl_int SetUp(int elements);
+
+    // Test body returning an OpenCL error code
+    virtual cl_int Run() = 0;
+
+protected:
+    virtual size_t data_size() const { return num_elements * sizeof(cl_int); }
+
+    cl_context context;
+    cl_command_queue queue;
+    clCommandBufferWrapper command_buffer;
+    clProgramWrapper program;
+    clKernelWrapper kernel;
+    clMemWrapper in_mem, out_mem, off_mem;
+    size_t num_elements;
+
+    // Device support query results
+    bool simultaneous_use_support;
+    bool out_of_order_support;
+
+    // user request for simultaneous use
+    bool simultaneous_use_requested;
+    unsigned buffer_size_multiplier;
+};
+
+template <class T>
+int MakeAndRunTest(cl_device_id device, cl_context context,
+                   cl_command_queue queue, int num_elements)
+{
+    CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
+
+    auto test_fixture = T(device, context, queue);
+    cl_int error = test_fixture.SetUp(num_elements);
+    test_error_ret(error, "Error in test initialization", TEST_FAIL);
+
+    if (test_fixture.Skip())
+    {
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    error = test_fixture.Run();
+    test_error_ret(error, "Test Failed", TEST_FAIL);
+
+    return TEST_PASS;
+}
+
+#endif // _CL_KHR_BASIC_COMMAND_BUFFER_H

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -55,7 +55,7 @@ protected:
     virtual size_t data_size() const { return num_elements * sizeof(cl_int); }
 
     cl_context context;
-    cl_command_queue queue;
+    clCommandQueueWrapper queue;
     clCommandBufferWrapper command_buffer;
     clProgramWrapper program;
     clKernelWrapper kernel;
@@ -77,17 +77,25 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
 {
     CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
 
-    auto test_fixture = T(device, context, queue);
-    cl_int error = test_fixture.SetUp(num_elements);
-    test_error_ret(error, "Error in test initialization", TEST_FAIL);
-
-    if (test_fixture.Skip())
+    try
     {
-        return TEST_SKIPPED_ITSELF;
-    }
+        auto test_fixture = T(device, context, queue);
 
-    error = test_fixture.Run();
-    test_error_ret(error, "Test Failed", TEST_FAIL);
+        cl_int error = test_fixture.SetUp(num_elements);
+        test_error_ret(error, "Error in test initialization", TEST_FAIL);
+
+        if (test_fixture.Skip())
+        {
+            return TEST_SKIPPED_ITSELF;
+        }
+
+        error = test_fixture.Run();
+        test_error_ret(error, "Test Failed", TEST_FAIL);
+    } catch (const std::runtime_error &e)
+    {
+        log_error("%s", e.what());
+        return TEST_FAIL;
+    }
 
     return TEST_PASS;
 }

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
@@ -1,0 +1,300 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "basic_command_buffer.h"
+#include "procs.h"
+
+#include <vector>
+#include <fstream>
+#include <stdio.h>
+
+enum class ReturnEventMode
+{
+    REM_REGULAR_WAIT_FOR_COMBUF = 0,
+    REM_COMBUF_WAIT_FOR_COMBUF,
+    REM_COMBUF_WAIT_FOR_OTHER_COMBUF,
+    REM_EVENT_CALLBACK,
+    REM_CLWAITFOREVENTS_WAIT_FOR_EVENT,
+    REM_CLWAITFOREVENTS_WAIT_FOR_EVENTS
+};
+
+enum class UserEventMode
+{
+    UEM_USER_EVENT_WAIT = 0,
+    UEM_USER_EVENTS_WAIT,
+    UEM_COMBUF_WAIT_FOR_RETULAR,
+    UEM_WAIT_FOR_OTHER_QUEUE_EVENT
+};
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <ReturnEventMode return_event_mode>
+struct CommandBufferReturnEvent : public BasicCommandBufferTest
+{
+    CommandBufferReturnEvent(cl_device_id device, cl_context context,
+                             cl_command_queue queue)
+        : BasicCommandBufferTest(device, context, queue), return_event(nullptr)
+    {
+        simultaneous_use_requested = false;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int Run() override
+    {
+        cl_int error = CL_SUCCESS;
+        switch (return_event_mode)
+        {
+            case ReturnEventMode::REM_REGULAR_WAIT_FOR_COMBUF:
+                error = RunRegularWaitForCombuf();
+                test_error(error, "RunSingle failed");
+                break;
+            case ReturnEventMode::REM_COMBUF_WAIT_FOR_COMBUF: break;
+            case ReturnEventMode::REM_COMBUF_WAIT_FOR_OTHER_COMBUF: break;
+            case ReturnEventMode::REM_EVENT_CALLBACK: break;
+            case ReturnEventMode::REM_CLWAITFOREVENTS_WAIT_FOR_EVENT: break;
+            case ReturnEventMode::REM_CLWAITFOREVENTS_WAIT_FOR_EVENTS: break;
+        }
+
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int RecordCommandBuffer()
+    {
+        cl_int error = CL_SUCCESS;
+
+        error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int RunRegularWaitForCombuf()
+    {
+        cl_int error = CL_SUCCESS;
+        std::vector<cl_int> output_data(num_elements);
+
+        // record command buffer
+        error = RecordCommandBuffer();
+        test_error(error, "RecordCommandBuffer failed");
+
+        const cl_int pattern = 0xA;
+        error = clEnqueueFillBuffer(queue, out_mem, &pattern, sizeof(cl_int), 0,
+                                    data_size(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueFillBuffer failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clEnqueueReadBuffer(queue, out_mem, CL_TRUE, 0, data_size(),
+                                    output_data.data(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueReadBuffer failed");
+
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
+
+        // verify the result - result buffer must contain initial pattern
+        for (size_t i = 0; i < num_elements; i++)
+        {
+            CHECK_VERIFICATION_ERROR(pattern, output_data[i], i);
+        }
+
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    clEventWrapper return_event;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Test enqueueing a command-buffer blocked on a user-event
+template <UserEventMode user_event_mode>
+struct CommandBufferUserEvent : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    CommandBufferUserEvent(cl_device_id device, cl_context context,
+                           cl_command_queue queue)
+        : BasicCommandBufferTest(device, context, queue), user_event(nullptr)
+    {
+        simultaneous_use_requested = false;
+    }
+
+
+    //--------------------------------------------------------------------------
+    cl_int Run() override
+    {
+        cl_int error = CL_SUCCESS;
+        switch (user_event_mode)
+        {
+            case UserEventMode::UEM_USER_EVENT_WAIT:
+                error = RunUserEventWait();
+                test_error(error, "RunSingle failed");
+                break;
+            case UserEventMode::UEM_USER_EVENTS_WAIT: break;
+            case UserEventMode::UEM_COMBUF_WAIT_FOR_RETULAR: break;
+            case UserEventMode::UEM_WAIT_FOR_OTHER_QUEUE_EVENT: break;
+        }
+
+        return CL_SUCCESS;
+    }
+
+    //--------------------------------------------------------------------------
+    cl_int RunUserEventWait()
+    {
+        cl_int error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        clEventWrapper user_event = clCreateUserEvent(context, &error);
+        test_error(error, "clCreateUserEvent failed");
+
+        const cl_int pattern = 42;
+        error = clEnqueueFillBuffer(queue, in_mem, &pattern, sizeof(cl_int), 0,
+                                    data_size(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueFillBuffer failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 1,
+                                          &user_event, nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        std::vector<cl_int> output_data(num_elements);
+        error = clEnqueueReadBuffer(queue, out_mem, CL_FALSE, 0, data_size(),
+                                    output_data.data(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueReadBuffer failed");
+
+        error = clSetUserEventStatus(user_event, CL_COMPLETE);
+        test_error(error, "clSetUserEventStatus failed");
+
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
+
+        for (size_t i = 0; i < num_elements; i++)
+        {
+            CHECK_VERIFICATION_ERROR(pattern, output_data[i], i);
+        }
+
+        return CL_SUCCESS;
+    }
+
+    clEventWrapper user_event;
+};
+
+} // anonymous namespace
+
+int test_regular_wait_for_command_buffer(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferReturnEvent<ReturnEventMode::REM_REGULAR_WAIT_FOR_COMBUF>>(
+        device, context, queue, num_elements);
+}
+
+int test_command_buffer_wait_for_command_buffer(cl_device_id device,
+                                                cl_context context,
+                                                cl_command_queue queue,
+                                                int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferReturnEvent<ReturnEventMode::REM_COMBUF_WAIT_FOR_COMBUF>>(
+        device, context, queue, num_elements);
+}
+
+int test_command_buffer_wait_for_other_command_buffer(cl_device_id device,
+                                                      cl_context context,
+                                                      cl_command_queue queue,
+                                                      int num_elements)
+{
+    return MakeAndRunTest<CommandBufferReturnEvent<
+        ReturnEventMode::REM_COMBUF_WAIT_FOR_OTHER_COMBUF>>(
+        device, context, queue, num_elements);
+}
+
+int test_event_callback(cl_device_id device, cl_context context,
+                        cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferReturnEvent<ReturnEventMode::REM_EVENT_CALLBACK>>(
+        device, context, queue, num_elements);
+}
+
+int test_clwaitforevents_wait_for_event(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements)
+{
+    return MakeAndRunTest<CommandBufferReturnEvent<
+        ReturnEventMode::REM_CLWAITFOREVENTS_WAIT_FOR_EVENT>>(
+        device, context, queue, num_elements);
+}
+
+int test_clwaitforevents_wait_for_events(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements)
+{
+    return MakeAndRunTest<CommandBufferReturnEvent<
+        ReturnEventMode::REM_CLWAITFOREVENTS_WAIT_FOR_EVENTS>>(
+        device, context, queue, num_elements);
+}
+
+int test_user_event_wait(cl_device_id device, cl_context context,
+                         cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferUserEvent<UserEventMode::UEM_USER_EVENT_WAIT>>(
+        device, context, queue, num_elements);
+}
+
+int test_user_events_wait(cl_device_id device, cl_context context,
+                          cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferUserEvent<UserEventMode::UEM_USER_EVENTS_WAIT>>(
+        device, context, queue, num_elements);
+}
+
+int test_command_buffer_wait_for_regular(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferUserEvent<UserEventMode::UEM_COMBUF_WAIT_FOR_RETULAR>>(
+        device, context, queue, num_elements);
+}
+
+int test_wait_for_other_queue_event(cl_device_id device, cl_context context,
+                                    cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferUserEvent<UserEventMode::UEM_WAIT_FOR_OTHER_QUEUE_EVENT>>(
+        device, context, queue, num_elements);
+}

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -23,14 +23,14 @@ test_definition test_list[] = {
     ADD_TEST(out_of_order),
     ADD_TEST(regular_wait_for_command_buffer),
     ADD_TEST(command_buffer_wait_for_command_buffer),
-    ADD_TEST(command_buffer_wait_for_other_command_buffer),
+    ADD_TEST(command_buffer_wait_for_sec_command_buffer),
     ADD_TEST(event_callback),
-    ADD_TEST(clwaitforevents_wait_for_event),
-    ADD_TEST(clwaitforevents_wait_for_events),
+    ADD_TEST(clwaitforevents_single),
+    ADD_TEST(clwaitforevents),
     ADD_TEST(user_event_wait),
     ADD_TEST(user_events_wait),
     ADD_TEST(command_buffer_wait_for_regular),
-    ADD_TEST(wait_for_other_queue_event)
+    ADD_TEST(wait_for_sec_queue_event)
 };
 
 

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -16,9 +16,21 @@
 #include "harness/testHarness.h"
 
 test_definition test_list[] = {
-    ADD_TEST(single_ndrange), ADD_TEST(interleaved_enqueue),
-    ADD_TEST(mixed_commands), ADD_TEST(explicit_flush),
-    ADD_TEST(user_events),    ADD_TEST(out_of_order)
+    ADD_TEST(single_ndrange),
+    ADD_TEST(interleaved_enqueue),
+    ADD_TEST(mixed_commands),
+    ADD_TEST(explicit_flush),
+    ADD_TEST(out_of_order),
+    ADD_TEST(regular_wait_for_command_buffer),
+    ADD_TEST(command_buffer_wait_for_command_buffer),
+    ADD_TEST(command_buffer_wait_for_other_command_buffer),
+    ADD_TEST(event_callback),
+    ADD_TEST(clwaitforevents_wait_for_event),
+    ADD_TEST(clwaitforevents_wait_for_events),
+    ADD_TEST(user_event_wait),
+    ADD_TEST(user_events_wait),
+    ADD_TEST(command_buffer_wait_for_regular),
+    ADD_TEST(wait_for_other_queue_event)
 };
 
 

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -24,13 +24,14 @@ test_definition test_list[] = {
     ADD_TEST(regular_wait_for_command_buffer),
     ADD_TEST(command_buffer_wait_for_command_buffer),
     ADD_TEST(command_buffer_wait_for_sec_command_buffer),
-    ADD_TEST(event_callback),
+    ADD_TEST(return_event_callback),
     ADD_TEST(clwaitforevents_single),
     ADD_TEST(clwaitforevents),
+    ADD_TEST(command_buffer_wait_for_regular),
+    ADD_TEST(wait_for_sec_queue_event),
     ADD_TEST(user_event_wait),
     ADD_TEST(user_events_wait),
-    ADD_TEST(command_buffer_wait_for_regular),
-    ADD_TEST(wait_for_sec_queue_event)
+    ADD_TEST(user_event_callback)
 };
 
 

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -27,9 +27,40 @@ extern int test_mixed_commands(cl_device_id device, cl_context context,
                                cl_command_queue queue, int num_elements);
 extern int test_explicit_flush(cl_device_id device, cl_context context,
                                cl_command_queue queue, int num_elements);
-extern int test_user_events(cl_device_id device, cl_context context,
-                            cl_command_queue queue, int num_elements);
 extern int test_out_of_order(cl_device_id device, cl_context context,
                              cl_command_queue queue, int num_elements);
+extern int test_regular_wait_for_command_buffer(cl_device_id device,
+                                                cl_context context,
+                                                cl_command_queue queue,
+                                                int num_elements);
+extern int test_command_buffer_wait_for_command_buffer(cl_device_id device,
+                                                       cl_context context,
+                                                       cl_command_queue queue,
+                                                       int num_elements);
+extern int test_command_buffer_wait_for_other_command_buffer(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    int num_elements);
+extern int test_event_callback(cl_device_id device, cl_context context,
+                               cl_command_queue queue, int num_elements);
+extern int test_clwaitforevents_wait_for_event(cl_device_id device,
+                                               cl_context context,
+                                               cl_command_queue queue,
+                                               int num_elements);
+extern int test_clwaitforevents_wait_for_events(cl_device_id device,
+                                                cl_context context,
+                                                cl_command_queue queue,
+                                                int num_elements);
+extern int test_user_event_wait(cl_device_id device, cl_context context,
+                                cl_command_queue queue, int num_elements);
+extern int test_user_events_wait(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_command_buffer_wait_for_regular(cl_device_id device,
+                                                cl_context context,
+                                                cl_command_queue queue,
+                                                int num_elements);
+extern int test_wait_for_other_queue_event(cl_device_id device,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -37,19 +37,16 @@ extern int test_command_buffer_wait_for_command_buffer(cl_device_id device,
                                                        cl_context context,
                                                        cl_command_queue queue,
                                                        int num_elements);
-extern int test_command_buffer_wait_for_other_command_buffer(
+extern int test_command_buffer_wait_for_sec_command_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     int num_elements);
 extern int test_event_callback(cl_device_id device, cl_context context,
                                cl_command_queue queue, int num_elements);
-extern int test_clwaitforevents_wait_for_event(cl_device_id device,
-                                               cl_context context,
-                                               cl_command_queue queue,
-                                               int num_elements);
-extern int test_clwaitforevents_wait_for_events(cl_device_id device,
-                                                cl_context context,
-                                                cl_command_queue queue,
-                                                int num_elements);
+extern int test_clwaitforevents_single(cl_device_id device, cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+extern int test_clwaitforevents(cl_device_id device, cl_context context,
+                                cl_command_queue queue, int num_elements);
 extern int test_user_event_wait(cl_device_id device, cl_context context,
                                 cl_command_queue queue, int num_elements);
 extern int test_user_events_wait(cl_device_id device, cl_context context,
@@ -58,9 +55,9 @@ extern int test_command_buffer_wait_for_regular(cl_device_id device,
                                                 cl_context context,
                                                 cl_command_queue queue,
                                                 int num_elements);
-extern int test_wait_for_other_queue_event(cl_device_id device,
-                                           cl_context context,
-                                           cl_command_queue queue,
-                                           int num_elements);
+extern int test_wait_for_sec_queue_event(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -40,17 +40,13 @@ extern int test_command_buffer_wait_for_command_buffer(cl_device_id device,
 extern int test_command_buffer_wait_for_sec_command_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     int num_elements);
-extern int test_event_callback(cl_device_id device, cl_context context,
-                               cl_command_queue queue, int num_elements);
+extern int test_return_event_callback(cl_device_id device, cl_context context,
+                                      cl_command_queue queue, int num_elements);
 extern int test_clwaitforevents_single(cl_device_id device, cl_context context,
                                        cl_command_queue queue,
                                        int num_elements);
 extern int test_clwaitforevents(cl_device_id device, cl_context context,
                                 cl_command_queue queue, int num_elements);
-extern int test_user_event_wait(cl_device_id device, cl_context context,
-                                cl_command_queue queue, int num_elements);
-extern int test_user_events_wait(cl_device_id device, cl_context context,
-                                 cl_command_queue queue, int num_elements);
 extern int test_command_buffer_wait_for_regular(cl_device_id device,
                                                 cl_context context,
                                                 cl_command_queue queue,
@@ -59,5 +55,11 @@ extern int test_wait_for_sec_queue_event(cl_device_id device,
                                          cl_context context,
                                          cl_command_queue queue,
                                          int num_elements);
+extern int test_user_event_wait(cl_device_id device, cl_context context,
+                                cl_command_queue queue, int num_elements);
+extern int test_user_events_wait(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_user_event_callback(cl_device_id device, cl_context context,
+                                    cl_command_queue queue, int num_elements);
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/


### PR DESCRIPTION
Added 11 test cases for both in-order and out-of-order command queues according to point 3.3 of issue specification:

https://github.com/KhronosGroup/OpenCL-CTS/issues/1369