### PR TITLE
gl: Fix array size expression

### DIFF
--- a/test_conformance/gl/test_images_read_common.cpp
+++ b/test_conformance/gl/test_images_read_common.cpp
@@ -786,7 +786,7 @@ int test_images_read_common(cl_device_id device, cl_context context,
 
             // Note a successful format test, if we passed every size.
 
-            if (sidx == sizeof(sizes) / sizeof(sizes[0]))
+            if (sidx == nsizes)
             {
                 log_info("passed: Image read test for GL format  %s : %s : %s "
                          ": %s\n\n",


### PR DESCRIPTION
`sizes` is a pointer argument, so the expression does not compute the presumably intended number of elements in `sizes`.

Fixes a `-Wsizeof-pointer-div` warning.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>