### PR TITLE
basic: Return error on unhandled image format

### DIFF
--- a/test_conformance/basic/test_image_param.cpp
+++ b/test_conformance/basic/test_image_param.cpp
@@ -117,7 +117,8 @@ int validate_results( size_t width, size_t height, cl_image_format &format, char
             }
             default:
                 // Should never get here
-                break;
+                log_error("Unhandled channel data type\n");
+                return -1;
         }
 
         if( format.image_channel_order == CL_BGRA )


### PR DESCRIPTION
Fail when an unhandled image format is encountered instead of continuing validation with uninitialized variables.

Fixes a `-Wsometimes-uninitialized` warning for e.g. the `tolerance` variable.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>