### PR TITLE
spirv: disable testing for OpFMod / OpFRem

### DIFF
--- a/test_conformance/spirv_new/test_op_fmath.cpp
+++ b/test_conformance/spirv_new/test_op_fmath.cpp
@@ -173,13 +173,14 @@ int test_fmath(cl_device_id deviceID,
                           lhs, rhs);                \
     }
 
-#define TEST_FMATH_MODE(TYPE, MODE)             \
-    TEST_FMATH_FUNC(TYPE, fadd, MODE)           \
-    TEST_FMATH_FUNC(TYPE, fsub, MODE)           \
-    TEST_FMATH_FUNC(TYPE, fmul, MODE)           \
-    TEST_FMATH_FUNC(TYPE, fdiv, MODE)           \
-    TEST_FMATH_FUNC(TYPE, frem, MODE)           \
-    TEST_FMATH_FUNC(TYPE, fmod, MODE)           \
+#define TEST_FMATH_MODE(TYPE, MODE)                                            \
+    TEST_FMATH_FUNC(TYPE, fadd, MODE)                                          \
+    TEST_FMATH_FUNC(TYPE, fsub, MODE)                                          \
+    TEST_FMATH_FUNC(TYPE, fmul, MODE)                                          \
+    TEST_FMATH_FUNC(TYPE, fdiv, MODE)                                          \
+// disable those tests until we figure out what the precision requierements are
+//    TEST_FMATH_FUNC(TYPE, frem, MODE)           \
+//    TEST_FMATH_FUNC(TYPE, fmod, MODE)           \
 
 #define TEST_FMATH_TYPE(TYPE)                   \
     TEST_FMATH_MODE(TYPE, regular)              \


### PR DESCRIPTION
The OpenCL SPIR-V Environment Specification does not require the SPIR-V opcodes `OpFMod` and `OpFRem` to match any OpenCL C semantics, so implementations implementing those two instructions according to Vulkan and/or OpenGL semantics will fail those tests without actually violating any OpenCL specification.

Instead `OpExtInst fmod` should be checked against OpenCL C `fmod` as this is actually specified to match in precision by the SPIR-V Environment Specification and this is what the SPIRV-LLVM-Translator ends up using for fmod anyway.

This also allows implementations to relax their implementations of `OpFMod` and `OpFRem` to trade performance for precision, but also to allow for more consistent results between OpenCL and Vulkan using those SPIR-V instructions.

Closes #1548

Signed-off-by: Karol Herbst <kherbst@redhat.com>