### PR TITLE
test_harness: Update test status upon api failure

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -819,6 +819,8 @@ test_status callSingleTestFunction(test_definition test,
         if (!context)
         {
             print_error(error, "Unable to create testing context");
+            gFailCount++;
+            gTestsFailed++;
             return TEST_FAIL;
         }
 
@@ -841,6 +843,8 @@ test_status callSingleTestFunction(test_definition test,
         {
             print_error(error, "Unable to create testing command queue");
             clReleaseContext(context);
+            gFailCount++;
+            gTestsFailed++;
             return TEST_FAIL;
         }
     }
@@ -888,6 +892,8 @@ test_status callSingleTestFunction(test_definition test,
         if (error)
         {
             log_error("clFinish failed: %s\n", IGetErrorString(error));
+            gFailCount++;
+            gTestsFailed++;
             status = TEST_FAIL;
         }
         clReleaseCommandQueue(queue);


### PR DESCRIPTION
In tests that use the harness, such as SVM svm_atomic_fetch_add, a failure in the clCreateContext call does not result in an overall fail status because of the way error codes are returned in the harness. This patch fixes it so that the conformance test correctly identifies and reports specific subtests that failed. 