### PR TITLE
Monkey-patch around a crash when SG size > 128 WIs

### DIFF
--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -31,7 +31,7 @@
 #define NR_OF_ACTIVE_WORK_ITEMS 4
 
 extern MTdata gMTdata;
-typedef std::bitset<128> bs128;
+typedef std::bitset<1280> bs128;
 extern cl_half_rounding_mode g_rounding_mode;
 
 bs128 cl_uint4_to_bs128(cl_uint4 v);


### PR DESCRIPTION
This PR is more of a discussion opener:

cl_khr_sub_group_ballot seems to implicitly assume max 128 sized SGs due to the return value type uint4. However, the max SG size is not stated anywhere in the specs and thus should not affect the other sub group functionality to my understanding.

The 128 assumption is used for WI masking for the basic subgroup test, causing a crash when exceeding it.

This just ups the limit to 1280 to push the limit up to work around the issue. A proper fix would be to use dynamic bit vector size here or define a max SG size in the specs (which doesn't make sense).