### PR TITLE
Fix semaphore tests

### DIFF
--- a/test_conformance/api/test_semaphores.cpp
+++ b/test_conformance/api/test_semaphores.cpp
@@ -986,6 +986,8 @@ int test_semaphores_import_export_fd(cl_device_id deviceID, cl_context context,
             CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR),
         static_cast<cl_semaphore_properties_khr>(
             CL_SEMAPHORE_HANDLE_SYNC_FD_KHR),
+        static_cast<cl_semaphore_properties_khr>(
+            CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR),
         0
     };
     cl_semaphore_khr sema_1 =
@@ -1012,7 +1014,8 @@ int test_semaphores_import_export_fd(cl_device_id deviceID, cl_context context,
     cl_semaphore_properties_khr sema_2_props[] = {
         static_cast<cl_semaphore_properties_khr>(CL_SEMAPHORE_TYPE_KHR),
         static_cast<cl_semaphore_properties_khr>(CL_SEMAPHORE_TYPE_BINARY_KHR),
-        CL_SEMAPHORE_HANDLE_SYNC_FD_KHR,
+        static_cast<cl_semaphore_properties_khr>(
+            CL_SEMAPHORE_HANDLE_SYNC_FD_KHR),
         static_cast<cl_semaphore_properties_khr>(handle), 0
     };
 


### PR DESCRIPTION
Semaphore properties are null-terminated
lists. `CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR` is a null-terminated property. Each should be separately null-terminated.

Signed-off-by: Ahmed Hesham <ahmed.hesham@arm.com>