### PR TITLE
[NFC] Fix BasicCommandBufferTest initialization order

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -25,12 +25,12 @@ BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
                                                cl_context context,
                                                cl_command_queue queue)
     : CommandBufferTestBase(device), context(context), queue(nullptr),
-      num_elements(0), command_buffer(this), simultaneous_use_support(false),
+      num_elements(0), simultaneous_use_support(false),
       out_of_order_support(false),
       // try to use simultaneous path by default
       simultaneous_use_requested(true),
       // due to simultaneous cases extend buffer size
-      buffer_size_multiplier(1)
+      buffer_size_multiplier(1), command_buffer(this)
 
 {
     cl_int error = clRetainCommandQueue(queue);

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -53,7 +53,6 @@ protected:
 
     cl_context context;
     clCommandQueueWrapper queue;
-    clCommandBufferWrapper command_buffer;
     clProgramWrapper program;
     clKernelWrapper kernel;
     clMemWrapper in_mem, out_mem, off_mem;
@@ -66,6 +65,7 @@ protected:
     // user request for simultaneous use
     bool simultaneous_use_requested;
     unsigned buffer_size_multiplier;
+    clCommandBufferWrapper command_buffer;
 };
 
 template <class T>


### PR DESCRIPTION
The `command_buffer` member is initialized with `this`, and should thus be initialized after all other members have been initialized, to avoid any potential uninitialized data accesses by `command_buffer`'s constructor.  This is currently not a problem, but would become a problem when `command_buffer`'s constructor accesses the object through its parameter.

Fixes a `-Wreorder` warning.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>