### PR TITLE
[NFC] Fix multi-line comment warnings

### DIFF
--- a/test_conformance/spirv_new/test_op_fmath.cpp
+++ b/test_conformance/spirv_new/test_op_fmath.cpp
@@ -178,9 +178,10 @@ int test_fmath(cl_device_id deviceID,
     TEST_FMATH_FUNC(TYPE, fsub, MODE)                                          \
     TEST_FMATH_FUNC(TYPE, fmul, MODE)                                          \
     TEST_FMATH_FUNC(TYPE, fdiv, MODE)                                          \
-// disable those tests until we figure out what the precision requierements are
-//    TEST_FMATH_FUNC(TYPE, frem, MODE)           \
-//    TEST_FMATH_FUNC(TYPE, fmod, MODE)           \
+    // disable those tests until we figure out what the precision requirements
+    // are
+    //    TEST_FMATH_FUNC(TYPE, frem, MODE)
+    //    TEST_FMATH_FUNC(TYPE, fmod, MODE)
 
 #define TEST_FMATH_TYPE(TYPE)                   \
     TEST_FMATH_MODE(TYPE, regular)              \


### PR DESCRIPTION
Disabling of frem and fmod by b81b49e1 ("spirv: disable frem and fmod tests for now (#1614)", 2023-02-07) introduced some new warnings about multi-line `//` comments due to the trailing backslashes.  Fix these.

Also fix a typo.

cc: @karolherbst 