### PR TITLE
[NFC] Fix -Wmissing-braces warnings

### DIFF
--- a/test_conformance/spirv_new/test_op_composite_construct.cpp
+++ b/test_conformance/spirv_new/test_op_composite_construct.cpp
@@ -55,7 +55,7 @@ int test_composite_construct(cl_device_id deviceID, cl_context context,
 
 TEST_SPIRV_FUNC(op_composite_construct_int4)
 {
-    cl_int4 value = {123, 122, 121, 119};
+    cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
     return test_composite_construct(deviceID, context, queue, "composite_construct_int4", results);
 }
@@ -66,7 +66,7 @@ TEST_SPIRV_FUNC(op_composite_construct_struct)
     typedef AbstractStruct2<cl_int2, CustomType1> CustomType2;
 
     CustomType1 value1 = {2100483600, 128};
-    cl_int2 intvals = {2100480000, 2100480000};
+    cl_int2 intvals = { { 2100480000, 2100480000 } };
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);

--- a/test_conformance/spirv_new/test_op_constant.cpp
+++ b/test_conformance/spirv_new/test_op_constant.cpp
@@ -97,14 +97,14 @@ TEST_CONSTANT(double  , cl_double , 3.141592653589793)
 
 TEST_SPIRV_FUNC(op_constant_int4_simple)
 {
-    cl_int4 value = {123, 122, 121, 119};
+    cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
     return test_constant(deviceID, context, queue, "constant_int4_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_constant_int3_simple)
 {
-    cl_int3 value = {123, 122, 121, 0};
+    cl_int3 value = { { 123, 122, 121, 0 } };
     std::vector<cl_int3> results(256, value);
     return test_constant(deviceID, context, queue, "constant_int3_simple",
                          results, isVectorNotEqual<cl_int3, 3>);
@@ -130,7 +130,7 @@ TEST_SPIRV_FUNC(op_constant_struct_struct_simple)
     typedef AbstractStruct2<cl_int2, CustomType1> CustomType2;
 
     CustomType1 value1 = {2100483600, 128};
-    cl_int2 intvals = {2100480000, 2100480000};
+    cl_int2 intvals = { { 2100480000, 2100480000 } };
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);

--- a/test_conformance/spirv_new/test_op_copy_object.cpp
+++ b/test_conformance/spirv_new/test_op_copy_object.cpp
@@ -93,14 +93,14 @@ TEST_COPY(double  , cl_double , 3.141592653589793)
 
 TEST_SPIRV_FUNC(op_copy_int4_simple)
 {
-    cl_int4 value = {123, 122, 121, 119};
+    cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
     return test_copy(deviceID, context, queue, "copy_int4_simple", results);
 }
 
 TEST_SPIRV_FUNC(op_copy_int3_simple)
 {
-    cl_int3 value = {123, 122, 121, 0};
+    cl_int3 value = { { 123, 122, 121, 0 } };
     std::vector<cl_int3> results(256, value);
     return test_copy(deviceID, context, queue, "copy_int3_simple",
                      results, isVectorNotEqual<cl_int3, 3>);
@@ -126,7 +126,7 @@ TEST_SPIRV_FUNC(op_copy_struct_struct_simple)
     typedef AbstractStruct2<cl_int2, CustomType1> CustomType2;
 
     CustomType1 value1 = {2100483600, 128};
-    cl_int2 intvals = {2100480000, 2100480000};
+    cl_int2 intvals = { { 2100480000, 2100480000 } };
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -75,7 +75,7 @@ template <typename Ty> struct BALLOT
                     {
                         v = genrand_int32(gMTdata);
                     }
-                    cl_uint4 v4 = { v, 0, 0, 0 };
+                    cl_uint4 v4 = { { v, 0, 0, 0 } };
                     t[wi_id + wg_offset] = v4;
                 }
             }
@@ -307,13 +307,13 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_EXTRACT
 
                     if (wi_id & 1)
                     {
-                        bit_value ? expected_result = { 1, 0, 0, 1 }
-                                  : expected_result = { 0, 0, 0, 1 };
+                        bit_value ? expected_result = { { 1, 0, 0, 1 } }
+                                  : expected_result = { { 0, 0, 0, 1 } };
                     }
                     else
                     {
-                        bit_value ? expected_result = { 1, 0, 0, 2 }
-                                  : expected_result = { 0, 0, 0, 2 };
+                        bit_value ? expected_result = { { 1, 0, 0, 2 } }
+                                  : expected_result = { { 0, 0, 0, 2 } };
                     }
 
                     device_result = my[wg_offset + wi_id];
@@ -398,8 +398,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_INVERSE
                 for (wi_id = 0; wi_id < current_sbs; ++wi_id)
                 { // for each subgroup work item
 
-                    wi_id & 1 ? expected_result = { 1, 0, 0, 1 }
-                              : expected_result = { 1, 0, 0, 2 };
+                    wi_id & 1 ? expected_result = { { 1, 0, 0, 1 } }
+                              : expected_result = { { 1, 0, 0, 2 } };
 
                     device_result = my[wg_offset + wi_id];
                     if (!compare(device_result, expected_result))
@@ -691,7 +691,7 @@ template <typename Ty, BallotOp operation> struct SMASK
                 {
                     int midx = 4 * wg_offset + 4 * wi_id;
                     cl_uint max_sub_group_size = m[midx + 2];
-                    cl_uint4 expected_mask = { 0 };
+                    cl_uint4 expected_mask = { { 0 } };
                     expected_mask = generate_bit_mask(
                         wi_id, operation_names(operation), max_sub_group_size);
                     set_value(t[wg_offset + wi_id], expected_mask);


### PR DESCRIPTION
The `cl_*` types need two levels of braces for initialization: the outer braces for the union and the inner braces for the array.