### PR TITLE
Add test for clGetEventInfo info queries.

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${MODULE_NAME}_SOURCES
     command_buffer_test_fill.cpp
     command_buffer_test_copy.cpp
     command_buffer_test_barrier.cpp
+    command_buffer_test_event_info.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_event_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_event_info.cpp
@@ -1,0 +1,254 @@
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "basic_command_buffer.h"
+#include "procs.h"
+#include <vector>
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// get event info tests which handles below cases:
+//
+// -command type
+// -command queue
+// -context
+// -execution status
+// -reference count
+
+struct CommandType : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        clEventWrapper event;
+        cl_int status;
+
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clWaitForEvents(1, &event);
+        test_error(error, "Unable to wait for event");
+
+        error = clGetEventInfo(event, CL_EVENT_COMMAND_TYPE, sizeof(status),
+                               &status, NULL);
+        test_error(error, "clGetEventInfo failed");
+
+        if (status != CL_COMMAND_COMMAND_BUFFER_KHR)
+        {
+            log_error(
+                "ERROR: Incorrect status returned from clGetEventInfo (%d)\n",
+                status);
+
+            return TEST_FAIL;
+        }
+
+        return CL_SUCCESS;
+    }
+};
+
+struct CommandQueue : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        clEventWrapper event;
+        size_t size;
+
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        cl_command_queue otherQueue;
+        error = clGetEventInfo(event, CL_EVENT_COMMAND_QUEUE,
+                               sizeof(otherQueue), &otherQueue, &size);
+        test_error(error, "Unable to get event info!");
+
+        // We can not check if this is the right queue because this is an opaque
+        // object.
+        if (size != sizeof(queue) || otherQueue == NULL)
+        {
+            log_error("ERROR: Returned command queue size does not validate "
+                      "(expected %zu, got %zu)\n",
+                      sizeof(queue), size);
+            return TEST_FAIL;
+        }
+
+        return CL_SUCCESS;
+    }
+};
+
+struct Context : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        clEventWrapper event;
+        size_t size;
+
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        cl_context testCtx;
+        error = clGetEventInfo(event, CL_EVENT_CONTEXT, sizeof(testCtx),
+                               &testCtx, &size);
+        test_error(error, "Unable to get event context info!");
+        if (size != sizeof(context))
+        {
+            log_error(
+                "ERROR: Returned context size does not validate (expected "
+                "%zu, got %zu)\n",
+                sizeof(context), size);
+            return -1;
+        }
+        if (testCtx != context)
+        {
+            log_error("ERROR: Returned context does not match (expected %p, "
+                      "got %p)\n",
+                      (void *)context, (void *)testCtx);
+            return -1;
+        }
+
+        return CL_SUCCESS;
+    }
+};
+
+struct ExecutionStatus : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        clEventWrapper event;
+        cl_int status;
+
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clGetEventInfo(event, CL_EVENT_COMMAND_EXECUTION_STATUS,
+                               sizeof(status), &status, NULL);
+        test_error(error, "clGetEventInfo failed");
+
+        if (!(status == CL_QUEUED || status == CL_SUBMITTED
+              || status == CL_RUNNING || status == CL_COMPLETE))
+        {
+            log_error(
+                "ERROR: Incorrect status returned from clGetEventInfo (%d)\n",
+                status);
+            return TEST_FAIL;
+        }
+
+        error = clWaitForEvents(1, &event);
+        test_error(error, "clWaitForEvents failed");
+
+        error = clGetEventInfo(event, CL_EVENT_COMMAND_EXECUTION_STATUS,
+                               sizeof(status), &status, NULL);
+        test_error(error, "clGetEventInfo failed");
+
+        if (status != CL_COMPLETE)
+        {
+            log_error(
+                "ERROR: Incorrect status returned from clGetEventInfo (%d)\n",
+                status);
+            return TEST_FAIL;
+        }
+
+        return CL_SUCCESS;
+    }
+};
+
+struct ReferenceCount : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        clEventWrapper event;
+        size_t size;
+        cl_uint count;
+
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clGetEventInfo(event, CL_EVENT_REFERENCE_COUNT, sizeof(count),
+                               &count, &size);
+        test_error(error, "clGetEventInfo failed");
+
+        if (size != sizeof(count) || count == 0)
+        {
+            log_error(
+                "ERROR: Wrong command reference count (expected return value 1 "
+                "of size %zu, returned size %zu, returned value %u)\n",
+                sizeof(count), size, count);
+            return TEST_FAIL;
+        }
+
+        return CL_SUCCESS;
+    }
+};
+};
+
+int test_event_info_command_type(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<CommandType>(device, context, queue, num_elements);
+}
+
+int test_event_info_command_queue(cl_device_id device, cl_context context,
+                                  cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<CommandQueue>(device, context, queue, num_elements);
+}
+
+int test_event_info_context(cl_device_id device, cl_context context,
+                            cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<Context>(device, context, queue, num_elements);
+}
+
+int test_event_info_execution_status(cl_device_id device, cl_context context,
+                                     cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<ExecutionStatus>(device, context, queue,
+                                           num_elements);
+}
+
+int test_event_info_reference_count(cl_device_id device, cl_context context,
+                                    cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<ReferenceCount>(device, context, queue, num_elements);
+}

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_event_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_event_info.cpp
@@ -125,14 +125,14 @@ struct Context : public BasicCommandBufferTest
                 "ERROR: Returned context size does not validate (expected "
                 "%zu, got %zu)\n",
                 sizeof(context), size);
-            return -1;
+            return TEST_FAIL;
         }
         if (testCtx != context)
         {
             log_error("ERROR: Returned context does not match (expected %p, "
                       "got %p)\n",
                       (void *)context, (void *)testCtx);
-            return -1;
+            return TEST_FAIL;
         }
 
         return CL_SUCCESS;

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -15,25 +15,28 @@
 #include "procs.h"
 #include "harness/testHarness.h"
 
-test_definition test_list[] = {
-    ADD_TEST(single_ndrange),
-    ADD_TEST(interleaved_enqueue),
-    ADD_TEST(mixed_commands),
-    ADD_TEST(explicit_flush),
-    ADD_TEST(user_events),
-    ADD_TEST(out_of_order),
-    ADD_TEST(queue_substitution),
-    ADD_TEST(properties_queue_substitution),
-    ADD_TEST(simultaneous_queue_substitution),
-    ADD_TEST(fill_image),
-    ADD_TEST(fill_buffer),
-    ADD_TEST(copy_image),
-    ADD_TEST(copy_buffer),
-    ADD_TEST(copy_buffer_to_image),
-    ADD_TEST(copy_image_to_buffer),
-    ADD_TEST(copy_buffer_rect),
-    ADD_TEST(barrier_wait_list),
-};
+test_definition test_list[] = { ADD_TEST(single_ndrange),
+                                ADD_TEST(interleaved_enqueue),
+                                ADD_TEST(mixed_commands),
+                                ADD_TEST(explicit_flush),
+                                ADD_TEST(user_events),
+                                ADD_TEST(out_of_order),
+                                ADD_TEST(queue_substitution),
+                                ADD_TEST(properties_queue_substitution),
+                                ADD_TEST(simultaneous_queue_substitution),
+                                ADD_TEST(fill_image),
+                                ADD_TEST(fill_buffer),
+                                ADD_TEST(copy_image),
+                                ADD_TEST(copy_buffer),
+                                ADD_TEST(copy_buffer_to_image),
+                                ADD_TEST(copy_image_to_buffer),
+                                ADD_TEST(copy_buffer_rect),
+                                ADD_TEST(barrier_wait_list),
+                                ADD_TEST(event_info_command_type),
+                                ADD_TEST(event_info_command_queue),
+                                ADD_TEST(event_info_execution_status),
+                                ADD_TEST(event_info_context),
+                                ADD_TEST(event_info_reference_count) };
 
 
 int main(int argc, const char *argv[])

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -57,6 +57,22 @@ extern int test_copy_buffer_rect(cl_device_id device, cl_context context,
                                  cl_command_queue queue, int num_elements);
 extern int test_barrier_wait_list(cl_device_id device, cl_context context,
                                   cl_command_queue queue, int num_elements);
-
+extern int test_event_info_command_type(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        int num_elements);
+extern int test_event_info_command_queue(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         int num_elements);
+extern int test_event_info_context(cl_device_id device, cl_context context,
+                                   cl_command_queue queue, int num_elements);
+extern int test_event_info_execution_status(cl_device_id device,
+                                            cl_context context,
+                                            cl_command_queue queue,
+                                            int num_elements);
+extern int test_event_info_reference_count(cl_device_id device,
+                                           cl_context context,
+                                           cl_command_queue queue,
+                                           int num_elements);
 
 #endif /*_CL_KHR_COMMAND_BUFFER_PROCS_H*/


### PR DESCRIPTION
Test clGetEventInfo() info queries from event returned by command-buffer enqueue for the single command-queue to command-buffer case:
* CL_EVENT_COMMAND_TYPE is CL_COMMAND_COMMAND_BUFFER_KHR
* CL_EVENT_COMMAND_QUEUE
* CL_EVENT_CONTEXT
* CL_EVENT_COMMAND_EXECUTION_STATUS
* CL_EVENT_REFERENCE_COUNT