### PR TITLE
Fix Intel compiler compilation issues on windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,10 @@ if(MSVC)
 endif()
 
 if( WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qlong-double -Qpc80 /DWIN32 /D_WINDOWS /W3 /GR /EHsc -nologo -Od -D_CRT_NONSTDC_NO_WARNINGS -EHsc -Wall -Qdiag-disable:68,111,177,186,161,869,1028,2259,2553,181,239,265,1188 -fp:strict -fp:source")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qlong-double -Qpc80 /DWIN32 /D_WINDOWS /W3 /GR /EHsc -nologo -Od -D_CRT_NONSTDC_NO_WARNINGS -EHsc -Wall -Qdiag-disable:68,111,177,186,161,869,1028,2259,2553,181,239,265,1188 -fp:strict -fp:source")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -QxCORE-AVX2 -Qlong-double -Qpc80 /DWIN32 /D_WINDOWS /W3 /GR /EHsc -nologo -Od -D_CRT_NONSTDC_NO_WARNINGS -EHsc -Wall -Qdiag-disable:68,111,177,186,161,869,1028,2259,2553,181,239,265,1188 -fp:strict -fp:source")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -QxCORE-AVX2 -Qlong-double -Qpc80 /DWIN32 /D_WINDOWS /W3 /GR /EHsc -nologo -Od -D_CRT_NONSTDC_NO_WARNINGS -EHsc -Wall -Qdiag-disable:68,111,177,186,161,869,1028,2259,2553,181,239,265,1188 -fp:strict -fp:source")
+    set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} libm.lib")
+    set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} libm.lib")
 endif()
 
 list(APPEND CLConform_LIBRARIES ${OPENCL_LIBRARIES})

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -29,7 +29,12 @@
 #include <cmath>
 #endif
 #ifdef __SSE2__
+#if defined(__INTEL_COMPILER)
+#include <intrin.h>
+#else
 #include <x86intrin.h>
+#endif
+
 #if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12)                \
     || (defined(__clang__) && !defined(__apple_build_version__)                \
         && __clang_major__ < 8)
@@ -2234,7 +2239,7 @@ static __m128 read_image_pixel_float(void *imageData,
                                          _mm_set_epi32(1, dPtr[2], 0, 0));
 #endif
                     break;
-                case 4: pixel = _mm_loadu_si128((__m128i_u *)ptr); break;
+                case 4: pixel = _mm_loadu_si128((__m128i *)ptr); break;
             }
             if (channelCount != 1) tempData = _mm_cvtepi32_ps(pixel);
             break;
@@ -2270,7 +2275,7 @@ static __m128 read_image_pixel_float(void *imageData,
                                          _mm_set_epi32(1, dPtr[2], 0, 0));
 #endif
                     break;
-                case 4: pixel = _mm_loadu_si128((__m128i_u *)ptr); break;
+                case 4: pixel = _mm_loadu_si128((__m128i *)ptr); break;
             }
             if (channelCount != 1)
             {


### PR DESCRIPTION
Changes from PR #1616 caused compilation errors on Windows and Intel Compiler. This changes fix compilation issues.
- extend compiler flags to -QxCORE-AVX2
- looks like Intel Compiler should use intrin.h
- this type __m128i_u is unknown 