### PR TITLE
Fix slice pitch for 1D array images on image_from_buffer_read_positive kernel_read_write images subtest.

### DIFF
--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
@@ -940,8 +940,11 @@ int image_from_buffer_read_positive(cl_device_id device, cl_context context,
 
         const size_t row_pitch =
             aligned_size(TEST_IMAGE_SIZE * element_size, row_pitch_alignment);
-        const size_t slice_pitch =
-            aligned_size(row_pitch * TEST_IMAGE_SIZE, slice_pitch_alignment);
+        const size_t slice_pitch = aligned_size(
+            row_pitch
+                * (imageType == CL_MEM_OBJECT_IMAGE1D_ARRAY ? 1
+                                                            : TEST_IMAGE_SIZE),
+            slice_pitch_alignment);
 
         const size_t buffer_size = slice_pitch * TEST_IMAGE_SIZE;
 


### PR DESCRIPTION
The slice pitch for 1D array image corresponds to a 1D array slice, but the test was computing it as 2D resulting in an incorrect slice pitch after aligning to the slice pitch alignment.