### PR TITLE
Enable test_vulkan by default in presubmit

### DIFF
--- a/presubmit.sh
+++ b/presubmit.sh
@@ -13,6 +13,7 @@ TOOLCHAIN_PREFIX_aarch64=aarch64-linux-gnu
 TOOLCHAIN_FILE=${TOP}/toolchain.cmake
 touch ${TOOLCHAIN_FILE}
 BUILD_OPENGL_TEST="OFF"
+BUILD_VULKAN_TEST="ON"
 
 cmake --version
 echo
@@ -102,6 +103,7 @@ cmake .. -G Ninja \
       -DOPENCL_LIBRARIES="${CMAKE_OPENCL_LIBRARIES_OPTION}" \
       -DUSE_CL_EXPERIMENTAL=ON \
       -DGL_IS_SUPPORTED=${BUILD_OPENGL_TEST} \
+      -DVULKAN_IS_SUPPORTED=${BUILD_VULKAN_TEST} \
       -DVULKAN_INCLUDE_DIR=${TOP}/Vulkan-Headers/include/ \
       -DVULKAN_LIB_DIR=${TOP}/Vulkan-Loader/build/loader/
 cmake --build . -j3


### PR DESCRIPTION
test_vulkan is disabled by default as part of
PR #1530.
Given the ongoing development to test_vulkan,
it is important to have this enabled in CI builds
to avoid breaking test builds.
Enable the test build as part of presubmit script.