### PR TITLE
Fix some Wunused-but-set warnings

### DIFF
--- a/test_conformance/SVM/test_shared_address_space_coarse_grain.cpp
+++ b/test_conformance/SVM/test_shared_address_space_coarse_grain.cpp
@@ -57,7 +57,6 @@ cl_int create_linked_lists_on_host(cl_command_queue cmdq, cl_mem nodes, Node *pN
 cl_int verify_linked_lists_on_host(int ci, cl_command_queue cmdq, cl_mem nodes, Node *pNodes2, cl_int ListLength, size_t numLists, cl_bool useNewAPI )
 {
   cl_int error = CL_SUCCESS;
-  cl_int correct_count;
 
   Node *pNodes;
   if (useNewAPI == CL_FALSE)
@@ -71,8 +70,6 @@ cl_int verify_linked_lists_on_host(int ci, cl_command_queue cmdq, cl_mem nodes, 
     error = clEnqueueSVMMap(cmdq, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, pNodes2, sizeof(Node)*ListLength * numLists, 0, NULL,NULL);
     test_error2(error, pNodes, "clEnqueueSVMMap failed");
   }
-
-  correct_count = 0;
 
   error = verify_linked_lists(pNodes, numLists, ListLength);
   if(error) return -1;

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -1185,7 +1185,7 @@ int test_min_max_image_buffer_size(cl_device_id deviceID, cl_context context,
 int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
                                 cl_command_queue queue, int num_elements)
 {
-    int error, retVal, i;
+    int error, i;
     size_t maxSize;
     char *programSrc;
     char *ptr;
@@ -1320,8 +1320,6 @@ int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
         }
 
         /* Try to set a large argument to the kernel */
-        retVal = 0;
-
         mem = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_long), NULL,
                              &error);
         test_error(error, "clCreateBuffer failed");

--- a/test_conformance/basic/test_float2int.cpp
+++ b/test_conformance/basic/test_float2int.cpp
@@ -61,7 +61,6 @@ test_float2int(cl_device_id device, cl_context context, cl_command_queue queue, 
     cl_int          *output_ptr;
     cl_program        program;
     cl_kernel        kernel;
-    void            *values[2];
     size_t    threads[1];
     int                err;
     int                i;
@@ -103,8 +102,6 @@ test_float2int(cl_device_id device, cl_context context, cl_command_queue queue, 
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
   err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0]);
   err = clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1]);
     if (err != CL_SUCCESS)

--- a/test_conformance/basic/test_int2float.cpp
+++ b/test_conformance/basic/test_int2float.cpp
@@ -60,7 +60,6 @@ test_int2float(cl_device_id device, cl_context context, cl_command_queue queue, 
     cl_float        *output_ptr;
     cl_program        program;
     cl_kernel        kernel;
-    void            *values[2];
     size_t    threads[1];
     int                err;
     int                i;
@@ -102,8 +101,6 @@ test_int2float(cl_device_id device, cl_context context, cl_command_queue queue, 
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0]);
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1]);
     if (err != CL_SUCCESS)

--- a/test_conformance/buffers/test_buffer_read.cpp
+++ b/test_conformance/buffers/test_buffer_read.cpp
@@ -768,7 +768,6 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
     size_t      global_work_size[3];
     cl_int      err;
     int         i;
-    size_t      lastIndex;
     size_t      ptrSizes[5];
     int         src_flag_id;
     int         total_errors = 0;
@@ -849,11 +848,11 @@ int test_buffer_read_async( cl_device_id deviceID, cl_context context, cl_comman
                 return -1;
             }
 
-            lastIndex = ( num_elements * ( 1 << i ) - 1 ) * ptrSizes[0];
             err = clEnqueueReadBuffer(queue, buffer, false, 0,
                                       ptrSizes[i] * num_elements, outptr[i], 0,
                                       NULL, &event);
 #ifdef CHECK_FOR_NON_WAIT
+            size_t lastIndex = (num_elements * (1 << i) - 1) * ptrSizes[0];
             if ( ((uchar *)outptr[i])[lastIndex] ){
                 log_error( "    clEnqueueReadBuffer() possibly returned only after inappropriately waiting for execution to be finished\n" );
                 log_error( "    Function was run asynchornously, but last value in array was set in code line following clEnqueueReadBuffer()\n" );
@@ -904,7 +903,6 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
     size_t      global_work_size[3];
     cl_int      err;
     int         i;
-    size_t      lastIndex;
     size_t      ptrSizes[5];
     int         src_flag_id;
     int         total_errors = 0;
@@ -984,11 +982,11 @@ int test_buffer_read_array_barrier( cl_device_id deviceID, cl_context context, c
                 return -1;
             }
 
-            lastIndex = ( num_elements * ( 1 << i ) - 1 ) * ptrSizes[0];
             err = clEnqueueReadBuffer(queue, buffer, false, 0,
                                       ptrSizes[i] * num_elements,
                                       (void *)(outptr[i]), 0, NULL, &event);
 #ifdef CHECK_FOR_NON_WAIT
+            size_t lastIndex = (num_elements * (1 << i) - 1) * ptrSizes[0];
             if ( ((uchar *)outptr[i])[lastIndex] ){
                 log_error( "    clEnqueueReadBuffer() possibly returned only after inappropriately waiting for execution to be finished\n" );
                 log_error( "    Function was run asynchornously, but last value in array was set in code line following clEnqueueReadBuffer()\n" );

--- a/test_conformance/commonfns/test_mix.cpp
+++ b/test_conformance/commonfns/test_mix.cpp
@@ -54,7 +54,6 @@ test_mix(cl_device_id device, cl_context context, cl_command_queue queue, int nu
     cl_float        *input_ptr[3], *output_ptr, *p;
     cl_program        program;
     cl_kernel        kernel;
-    size_t            lengths[1];
     size_t    threads[1];
     float            max_err;
     int                err;
@@ -132,7 +131,6 @@ test_mix(cl_device_id device, cl_context context, cl_command_queue queue, int nu
         return -1;
     }
 
-    lengths[0] = strlen(mix_kernel_code);
     err = create_single_kernel_helper( context, &program, &kernel, 1, &mix_kernel_code, "test_mix" );
     test_error( err, "Unable to create test kernel" );
 

--- a/test_conformance/events/test_events.cpp
+++ b/test_conformance/events/test_events.cpp
@@ -422,7 +422,6 @@ int test_event_wait_for_array(cl_device_id deviceID, cl_context context,
 int test_event_flush(cl_device_id deviceID, cl_context context,
                      cl_command_queue queue, int num_elements)
 {
-    int loopCount = 0;
     cl_int status;
     SETUP_EVENT(context, queue);
 
@@ -445,7 +444,6 @@ int test_event_flush(cl_device_id deviceID, cl_context context,
 #else // _WIN32
         Sleep(1000);
 #endif
-        ++loopCount;
     }
 
     /*

--- a/test_conformance/mem_host_flags/checker_mem_host_write_only.hpp
+++ b/test_conformance/mem_host_flags/checker_mem_host_write_only.hpp
@@ -279,9 +279,6 @@ cl_int cBuffer_check_mem_host_write_only<T>::verify_RW_Buffer_rect()
 template <class T>
 cl_int cBuffer_check_mem_host_write_only<T>::update_host_mem_2()
 {
-    size_t global_work_size[3] = { 0, 1, 1 };
-    global_work_size[0] = this->get_block_size_bytes();
-
     cl_event event, event_2;
     cl_int err = clEnqueueCopyBuffer(
         this->m_queue, this->m_buffer, this->m_buffer2, 0, 0,

--- a/test_conformance/relationals/test_shuffles.cpp
+++ b/test_conformance/relationals/test_shuffles.cpp
@@ -337,7 +337,6 @@ static int create_shuffle_kernel( cl_context context, cl_program *outProgram, cl
                                  MTdata d, ShuffleMode shuffleMode = kNormalMode )
 {
     char inOrder[18], shuffledOrder[18];
-    size_t typeSize;
     char kernelSource[MAX_PROGRAM_SIZE], progLine[ 10240 ];
     char *programPtr;
     char inSizeName[4], outSizeName[4], outRealSizeName[4], inSizeArgName[4];
@@ -353,9 +352,6 @@ static int create_shuffle_kernel( cl_context context, cl_program *outProgram, cl
         inSizeArgName[ 0 ] = 0;
     else
         strcpy( inSizeArgName, inSizeName );
-
-
-    typeSize = get_explicit_type_size( vecType );
 
     *outRealVecSize = outVecSize;
 

--- a/test_conformance/workgroups/test_wg_all.cpp
+++ b/test_conformance/workgroups/test_wg_all.cpp
@@ -71,7 +71,6 @@ test_work_group_all(cl_device_id device, cl_context context, cl_command_queue qu
     cl_int       *output_ptr;
     cl_program   program;
     cl_kernel    kernel;
-    void         *values[2];
     size_t       threads[1];
     size_t       wg_size[1];
     size_t       num_elements;
@@ -124,8 +123,6 @@ test_work_group_all(cl_device_id device, cl_context context, cl_command_queue qu
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
     if (err != CL_SUCCESS)

--- a/test_conformance/workgroups/test_wg_any.cpp
+++ b/test_conformance/workgroups/test_wg_any.cpp
@@ -71,7 +71,6 @@ test_work_group_any(cl_device_id device, cl_context context, cl_command_queue qu
     cl_int       *output_ptr;
     cl_program   program;
     cl_kernel    kernel;
-    void         *values[2];
     size_t       threads[1];
     size_t       wg_size[1];
     size_t       num_elements;
@@ -124,8 +123,6 @@ test_work_group_any(cl_device_id device, cl_context context, cl_command_queue qu
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
     if (err != CL_SUCCESS)

--- a/test_conformance/workgroups/test_wg_broadcast.cpp
+++ b/test_conformance/workgroups/test_wg_broadcast.cpp
@@ -168,7 +168,6 @@ test_work_group_broadcast_1D(cl_device_id device, cl_context context, cl_command
     cl_float     *output_ptr;
     cl_program   program;
     cl_kernel    kernel;
-    void         *values[2];
     size_t       globalsize[1];
     size_t       wg_size[1];
     size_t       num_elements;
@@ -221,8 +220,6 @@ test_work_group_broadcast_1D(cl_device_id device, cl_context context, cl_command
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
     if (err != CL_SUCCESS)
@@ -275,7 +272,6 @@ test_work_group_broadcast_2D(cl_device_id device, cl_context context, cl_command
     cl_float     *output_ptr;
     cl_program   program;
     cl_kernel    kernel;
-    void         *values[2];
     size_t       globalsize[2];
     size_t       localsize[2];
     size_t       wg_size[1];
@@ -350,8 +346,6 @@ test_work_group_broadcast_2D(cl_device_id device, cl_context context, cl_command
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
     if (err != CL_SUCCESS)
@@ -402,7 +396,6 @@ test_work_group_broadcast_3D(cl_device_id device, cl_context context, cl_command
     cl_float     *output_ptr;
     cl_program   program;
     cl_kernel    kernel;
-    void         *values[2];
     size_t       globalsize[3];
     size_t       localsize[3];
     size_t       wg_size[1];
@@ -478,8 +471,6 @@ test_work_group_broadcast_3D(cl_device_id device, cl_context context, cl_command
         return -1;
     }
 
-    values[0] = streams[0];
-    values[1] = streams[1];
     err = clSetKernelArg(kernel, 0, sizeof streams[0], &streams[0] );
     err |= clSetKernelArg(kernel, 1, sizeof streams[1], &streams[1] );
     if (err != CL_SUCCESS)


### PR DESCRIPTION
To the best of my understanding, these occurrences of the `-Wunused-but-set` warnings do not reveal any underlying issues, so we can safely remove these variables.  There are more occurrences of this warning in other places (not touched by this commit) that require further analysis.