### PR TITLE
[NFC] Fix some sign-compare warnings

### DIFF
--- a/test_common/harness/os_helpers.cpp
+++ b/test_common/harness/os_helpers.cpp
@@ -283,7 +283,7 @@ std::string exe_path()
             exit(2);
         }; // if
 
-        if (len < path.size())
+        if (static_cast<size_t>(len) < path.size())
         {
             // We got the path.
             path.resize(len);

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1362,8 +1362,7 @@ int test_computeinfo(cl_device_id deviceID, cl_context context,
     else
     {
         // print device info
-        int onInfo;
-        for (onInfo = 0;
+        for (size_t onInfo = 0;
              onInfo < sizeof(device_infos) / sizeof(device_infos[0]); onInfo++)
         {
             log_info("Getting device IDs for %s devices\n",
@@ -1390,9 +1389,8 @@ int test_computeinfo(cl_device_id deviceID, cl_context context,
                 test_error(err, "clGetDeviceIDs failed");
             }
 
-            int onDevice;
-            for (onDevice = 0; onDevice < device_infos[onInfo].num_devices;
-                 onDevice++)
+            for (size_t onDevice = 0;
+                 onDevice < device_infos[onInfo].num_devices; onDevice++)
             {
                 log_info("%s Device %d of %d Info:\n",
                          device_infos[onInfo].device_type_name, onDevice + 1,

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -390,7 +390,7 @@ int test_device_partition_type_support(cl_device_id parentDevice, const cl_devic
     } else {
         test_error_ret( err, "Unable to get device partition properties (1)", -1 );
     };
-    for ( int i = 0; i < supportedProps.size(); i++)
+    for (size_t i = 0; i < supportedProps.size(); i++)
     {
         if (supportedProps[i] == partitionType)
         {

--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -6890,7 +6890,7 @@ int main (int argc, const char* argv[])
     cl_uint size_t_width = 0;                            // device address bits (32 or 64).
     cl_int err;
     int failed = 0;
-    int ntests = 0;
+    size_t ntests = 0;
     custom_cout atf_info;
     custom_cerr atf_error;
     override_buff atf_cout(std::cout, atf_info);

--- a/test_conformance/spirv_new/test_get_program_il.cpp
+++ b/test_conformance/spirv_new/test_get_program_il.cpp
@@ -41,7 +41,7 @@ TEST_SPIRV_FUNC(get_program_il)
 
         std::vector<unsigned char> spirv_binary = readSPIRV(spvName);
 
-        int file_bytes = spirv_binary.size();
+        size_t file_bytes = spirv_binary.size();
         if (file_bytes == 0)
         {
             test_fail("ERROR: SPIRV file %s not found!\n", spvName);


### PR DESCRIPTION
Fix some sign-compare warnings.

In `os_helpers.cpp`, the preceding `if` already handles negative values, so cast to unsigned.