### PR TITLE
External memory updates

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -887,3 +887,67 @@ cl_semaphore_khr &clExternalSemaphore::getCLSemaphore()
 {
     return m_externalSemaphore;
 }
+
+cl_external_memory_handle_type_khr vkToOpenCLExternalMemoryHandleType(
+    VulkanExternalMemoryHandleType vkExternalMemoryHandleType)
+{
+    switch (vkExternalMemoryHandleType)
+    {
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
+            return CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR;
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT:
+            return CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR;
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT:
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT_KMT:
+            return CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR;
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE: return 0;
+    }
+    return 0;
+}
+
+VulkanImageTiling vkClExternalMemoryHandleTilingAssumption(
+    cl_device_id deviceId,
+    VulkanExternalMemoryHandleType vkExternalMemoryHandleType, int *error_ret)
+{
+    size_t size = 0;
+    VulkanImageTiling mode = VULKAN_IMAGE_TILING_OPTIMAL;
+
+    assert(error_ret
+           != nullptr); // errcode_ret is not optional, it must be checked
+
+    *error_ret = clGetDeviceInfo(
+        deviceId,
+        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR, 0,
+        nullptr, &size);
+    if (*error_ret != CL_SUCCESS)
+    {
+        return mode;
+    }
+
+    if (size == 0)
+    {
+        return mode;
+    }
+
+    std::vector<cl_external_memory_handle_type_khr> assume_linear_types(
+        size / sizeof(cl_external_memory_handle_type_khr));
+
+    *error_ret = clGetDeviceInfo(
+        deviceId,
+        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR, size,
+        assume_linear_types.data(), nullptr);
+    if (*error_ret != CL_SUCCESS)
+    {
+        return mode;
+    }
+
+    if (std::find(
+            assume_linear_types.begin(), assume_linear_types.end(),
+            vkToOpenCLExternalMemoryHandleType(vkExternalMemoryHandleType))
+        != assume_linear_types.end())
+    {
+        mode = VULKAN_IMAGE_TILING_LINEAR;
+    }
+
+    return mode;
+}

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -19,7 +19,7 @@
 #include "harness/errorHelpers.h"
 #include "harness/deviceInfo.h"
 #include <assert.h>
-#include <iostream>
+#include <algorithm>
 #include <stdexcept>
 
 #define ASSERT(x) assert((x))
@@ -917,8 +917,8 @@ VulkanImageTiling vkClExternalMemoryHandleTilingAssumption(
 
     *error_ret = clGetDeviceInfo(
         deviceId,
-        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR, 0,
-        nullptr, &size);
+        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR,
+        0, nullptr, &size);
     if (*error_ret != CL_SUCCESS)
     {
         return mode;
@@ -934,8 +934,8 @@ VulkanImageTiling vkClExternalMemoryHandleTilingAssumption(
 
     *error_ret = clGetDeviceInfo(
         deviceId,
-        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR, size,
-        assume_linear_types.data(), nullptr);
+        CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR,
+        size, assume_linear_types.data(), nullptr);
     if (*error_ret != CL_SUCCESS)
     {
         return mode;

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -129,4 +129,8 @@ public:
 
 extern void init_cl_vk_ext(cl_platform_id);
 
+VulkanImageTiling vkClExternalMemoryHandleTilingAssumption(
+    cl_device_id deviceId,
+    VulkanExternalMemoryHandleType vkExternalMemoryHandleType, int *error_ret);
+
 #endif // _opencl_vulkan_wrapper_hpp_

--- a/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
@@ -75,7 +75,7 @@
     VK_FUNC_DECL(vkDestroyImageView)                                           \
     VK_FUNC_DECL(vkCreateImage)                                                \
     VK_FUNC_DECL(vkGetImageMemoryRequirements)                                 \
-    VK_FUNC_DECL(vkGetImageMemoryRequirements2KHR)                             \
+    VK_FUNC_DECL(vkGetImageMemoryRequirements2)                                \
     VK_FUNC_DECL(vkDestroyImage)                                               \
     VK_FUNC_DECL(vkDestroyBuffer)                                              \
     VK_FUNC_DECL(vkDestroyPipeline)                                            \
@@ -88,9 +88,9 @@
     VK_FUNC_DECL(vkDestroyDescriptorSetLayout)                                 \
     VK_FUNC_DECL(vkGetPhysicalDeviceQueueFamilyProperties)                     \
     VK_FUNC_DECL(vkGetPhysicalDeviceFeatures)                                  \
-    VK_FUNC_DECL(vkGetPhysicalDeviceProperties2KHR)                            \
+    VK_FUNC_DECL(vkGetPhysicalDeviceProperties2)                               \
     VK_FUNC_DECL(vkGetBufferMemoryRequirements)                                \
-    VK_FUNC_DECL(vkGetBufferMemoryRequirements2KHR)                            \
+    VK_FUNC_DECL(vkGetBufferMemoryRequirements2)                               \
     VK_FUNC_DECL(vkGetMemoryFdKHR)                                             \
     VK_FUNC_DECL(vkGetSemaphoreFdKHR)                                          \
     VK_FUNC_DECL(vkEnumeratePhysicalDeviceGroups)                              \
@@ -162,7 +162,7 @@
 #define vkDestroyImageView _vkDestroyImageView
 #define vkCreateImage _vkCreateImage
 #define vkGetImageMemoryRequirements _vkGetImageMemoryRequirements
-#define vkGetImageMemoryRequirements2KHR _vkGetImageMemoryRequirements2KHR
+#define vkGetImageMemoryRequirements2 _vkGetImageMemoryRequirements2
 #define vkDestroyImage _vkDestroyImage
 #define vkDestroyBuffer _vkDestroyBuffer
 #define vkDestroyPipeline _vkDestroyPipeline
@@ -176,9 +176,9 @@
 #define vkGetPhysicalDeviceQueueFamilyProperties                               \
     _vkGetPhysicalDeviceQueueFamilyProperties
 #define vkGetPhysicalDeviceFeatures _vkGetPhysicalDeviceFeatures
-#define vkGetPhysicalDeviceProperties2KHR _vkGetPhysicalDeviceProperties2KHR
+#define vkGetPhysicalDeviceProperties2 _vkGetPhysicalDeviceProperties2
 #define vkGetBufferMemoryRequirements _vkGetBufferMemoryRequirements
-#define vkGetBufferMemoryRequirements2KHR _vkGetBufferMemoryRequirements2KHR
+#define vkGetBufferMemoryRequirements2 _vkGetBufferMemoryRequirements2
 #define vkGetMemoryFdKHR _vkGetMemoryFdKHR
 #define vkGetSemaphoreFdKHR _vkGetSemaphoreFdKHR
 #define vkEnumeratePhysicalDeviceGroups _vkEnumeratePhysicalDeviceGroups

--- a/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
@@ -75,6 +75,7 @@
     VK_FUNC_DECL(vkDestroyImageView)                                           \
     VK_FUNC_DECL(vkCreateImage)                                                \
     VK_FUNC_DECL(vkGetImageMemoryRequirements)                                 \
+    VK_FUNC_DECL(vkGetImageMemoryRequirements2KHR)                                \
     VK_FUNC_DECL(vkDestroyImage)                                               \
     VK_FUNC_DECL(vkDestroyBuffer)                                              \
     VK_FUNC_DECL(vkDestroyPipeline)                                            \
@@ -89,6 +90,7 @@
     VK_FUNC_DECL(vkGetPhysicalDeviceFeatures)                                  \
     VK_FUNC_DECL(vkGetPhysicalDeviceProperties2KHR)                            \
     VK_FUNC_DECL(vkGetBufferMemoryRequirements)                                \
+    VK_FUNC_DECL(vkGetBufferMemoryRequirements2KHR)                            \
     VK_FUNC_DECL(vkGetMemoryFdKHR)                                             \
     VK_FUNC_DECL(vkGetSemaphoreFdKHR)                                          \
     VK_FUNC_DECL(vkEnumeratePhysicalDeviceGroups)                              \
@@ -160,6 +162,7 @@
 #define vkDestroyImageView _vkDestroyImageView
 #define vkCreateImage _vkCreateImage
 #define vkGetImageMemoryRequirements _vkGetImageMemoryRequirements
+#define vkGetImageMemoryRequirements2KHR _vkGetImageMemoryRequirements2KHR
 #define vkDestroyImage _vkDestroyImage
 #define vkDestroyBuffer _vkDestroyBuffer
 #define vkDestroyPipeline _vkDestroyPipeline
@@ -175,6 +178,7 @@
 #define vkGetPhysicalDeviceFeatures _vkGetPhysicalDeviceFeatures
 #define vkGetPhysicalDeviceProperties2KHR _vkGetPhysicalDeviceProperties2KHR
 #define vkGetBufferMemoryRequirements _vkGetBufferMemoryRequirements
+#define vkGetBufferMemoryRequirements2KHR _vkGetBufferMemoryRequirements2KHR
 #define vkGetMemoryFdKHR _vkGetMemoryFdKHR
 #define vkGetSemaphoreFdKHR _vkGetSemaphoreFdKHR
 #define vkEnumeratePhysicalDeviceGroups _vkEnumeratePhysicalDeviceGroups

--- a/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
@@ -75,7 +75,7 @@
     VK_FUNC_DECL(vkDestroyImageView)                                           \
     VK_FUNC_DECL(vkCreateImage)                                                \
     VK_FUNC_DECL(vkGetImageMemoryRequirements)                                 \
-    VK_FUNC_DECL(vkGetImageMemoryRequirements2KHR)                                \
+    VK_FUNC_DECL(vkGetImageMemoryRequirements2KHR)                             \
     VK_FUNC_DECL(vkDestroyImage)                                               \
     VK_FUNC_DECL(vkDestroyBuffer)                                              \
     VK_FUNC_DECL(vkDestroyPipeline)                                            \

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
@@ -141,14 +141,13 @@ VulkanDescriptorSetLayoutBindingList::VulkanDescriptorSetLayoutBindingList(
 
 VulkanDescriptorSetLayoutBindingList::VulkanDescriptorSetLayoutBindingList() {}
 
-void VulkanDescriptorSetLayoutBindingList::addBinding(size_t binding,
-                VulkanDescriptorType descriptorType,
-                uint32_t descriptorCount,
-                VulkanShaderStage shaderStage)
+void VulkanDescriptorSetLayoutBindingList::addBinding(
+    size_t binding, VulkanDescriptorType descriptorType,
+    uint32_t descriptorCount, VulkanShaderStage shaderStage)
 {
     VulkanDescriptorSetLayoutBinding *descriptorSetLayoutBinding =
-            new VulkanDescriptorSetLayoutBinding(binding, descriptorType,
-                                                 descriptorCount, shaderStage);
+        new VulkanDescriptorSetLayoutBinding(binding, descriptorType,
+                                             descriptorCount, shaderStage);
     add(*descriptorSetLayoutBinding);
 }
 

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
@@ -141,6 +141,17 @@ VulkanDescriptorSetLayoutBindingList::VulkanDescriptorSetLayoutBindingList(
 
 VulkanDescriptorSetLayoutBindingList::VulkanDescriptorSetLayoutBindingList() {}
 
+void VulkanDescriptorSetLayoutBindingList::addBinding(size_t binding,
+                VulkanDescriptorType descriptorType,
+                uint32_t descriptorCount,
+                VulkanShaderStage shaderStage)
+{
+    VulkanDescriptorSetLayoutBinding *descriptorSetLayoutBinding =
+            new VulkanDescriptorSetLayoutBinding(binding, descriptorType,
+                                                 descriptorCount, shaderStage);
+    add(*descriptorSetLayoutBinding);
+}
+
 VulkanDescriptorSetLayoutBindingList::VulkanDescriptorSetLayoutBindingList(
     size_t numDescriptorSetLayoutBindings, VulkanDescriptorType descriptorType,
     uint32_t descriptorCount, VulkanShaderStage shaderStage)

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.cpp
@@ -278,6 +278,7 @@ VulkanImage2DList::VulkanImage2DList(
     size_t numImages, std::vector<VulkanDeviceMemory *> &deviceMemory,
     uint64_t baseOffset, uint64_t interImageOffset, const VulkanDevice &device,
     VulkanFormat format, uint32_t width, uint32_t height, uint32_t mipLevels,
+    VulkanImageTiling vulkanImageTiling,
     VulkanExternalMemoryHandleType externalMemoryHandleType,
     VulkanImageCreateFlag imageCreateFlag, VulkanImageUsage imageUsage,
     VulkanSharingMode sharingMode)
@@ -285,8 +286,8 @@ VulkanImage2DList::VulkanImage2DList(
     for (size_t i2DIdx = 0; i2DIdx < numImages; i2DIdx++)
     {
         VulkanImage2D *image2D = new VulkanImage2D(
-            device, format, width, height, mipLevels, externalMemoryHandleType,
-            imageCreateFlag, imageUsage, sharingMode);
+            device, format, width, height, vulkanImageTiling, mipLevels,
+            externalMemoryHandleType, imageCreateFlag, imageUsage, sharingMode);
         add(*image2D);
         deviceMemory[i2DIdx]->bindImage(
             *image2D, baseOffset + (i2DIdx * interImageOffset));
@@ -295,16 +296,16 @@ VulkanImage2DList::VulkanImage2DList(
 
 VulkanImage2DList::VulkanImage2DList(
     size_t numImages, const VulkanDevice &device, VulkanFormat format,
-    uint32_t width, uint32_t height, uint32_t mipLevels,
-    VulkanExternalMemoryHandleType externalMemoryHandleType,
+    uint32_t width, uint32_t height, VulkanImageTiling vulkanImageTiling,
+    uint32_t mipLevels, VulkanExternalMemoryHandleType externalMemoryHandleType,
     VulkanImageCreateFlag imageCreateFlag, VulkanImageUsage imageUsage,
     VulkanSharingMode sharingMode)
 {
     for (size_t bIdx = 0; bIdx < numImages; bIdx++)
     {
         VulkanImage2D *image2D = new VulkanImage2D(
-            device, format, width, height, mipLevels, externalMemoryHandleType,
-            imageCreateFlag, imageUsage, sharingMode);
+            device, format, width, height, vulkanImageTiling, mipLevels,
+            externalMemoryHandleType, imageCreateFlag, imageUsage, sharingMode);
         add(*image2D);
     }
 }

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
@@ -212,6 +212,7 @@ public:
         uint64_t baseOffset, uint64_t interImageOffset,
         const VulkanDevice &device, VulkanFormat format, uint32_t width,
         uint32_t height, uint32_t mipLevels,
+        VulkanImageTiling vulkanImageTiling,
         VulkanExternalMemoryHandleType externalMemoryHandleType =
             VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
         VulkanImageCreateFlag imageCreateFlag = VULKAN_IMAGE_CREATE_FLAG_NONE,
@@ -220,7 +221,8 @@ public:
         VulkanSharingMode sharingMode = VULKAN_SHARING_MODE_EXCLUSIVE);
     VulkanImage2DList(
         size_t numImages, const VulkanDevice &device, VulkanFormat format,
-        uint32_t width, uint32_t height, uint32_t mipLevels = 1,
+        uint32_t width, uint32_t height, VulkanImageTiling vulkanImageTiling,
+        uint32_t mipLevels = 1,
         VulkanExternalMemoryHandleType externalMemoryHandleType =
             VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
         VulkanImageCreateFlag imageCreateFlag = VULKAN_IMAGE_CREATE_FLAG_NONE,

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
@@ -154,10 +154,10 @@ public:
         VulkanDescriptorType descriptorType0, uint32_t descriptorCount0,
         VulkanDescriptorType descriptorType1, uint32_t descriptorCount1,
         VulkanShaderStage shaderStage = VULKAN_SHADER_STAGE_COMPUTE);
-    void addBinding(size_t binding,
-                    VulkanDescriptorType descriptorType,
-                    uint32_t descriptorCount,
-                    VulkanShaderStage shaderStage = VULKAN_SHADER_STAGE_COMPUTE);
+    void
+    addBinding(size_t binding, VulkanDescriptorType descriptorType,
+               uint32_t descriptorCount,
+               VulkanShaderStage shaderStage = VULKAN_SHADER_STAGE_COMPUTE);
     virtual ~VulkanDescriptorSetLayoutBindingList();
 };
 

--- a/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_list_map.hpp
@@ -154,6 +154,10 @@ public:
         VulkanDescriptorType descriptorType0, uint32_t descriptorCount0,
         VulkanDescriptorType descriptorType1, uint32_t descriptorCount1,
         VulkanShaderStage shaderStage = VULKAN_SHADER_STAGE_COMPUTE);
+    void addBinding(size_t binding,
+                    VulkanDescriptorType descriptorType,
+                    uint32_t descriptorCount,
+                    VulkanShaderStage shaderStage = VULKAN_SHADER_STAGE_COMPUTE);
     virtual ~VulkanDescriptorSetLayoutBindingList();
 };
 

--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <set>
 #include <string>
+#include <algorithm>
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 #if defined(_WIN32) || defined(_WIN64)

--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
@@ -33,7 +33,7 @@
 const VulkanInstance& getVulkanInstance();
 const VulkanPhysicalDevice& getVulkanPhysicalDevice();
 const VulkanQueueFamily&
-getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_MASK_ALL);
+getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_GRAPHICS | VULKAN_QUEUE_FLAG_COMPUTE);
 const VulkanMemoryType&
 getVulkanMemoryType(const VulkanDevice& device,
                     VulkanMemoryTypeProperty memoryTypeProperty);

--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
@@ -33,7 +33,8 @@
 const VulkanInstance& getVulkanInstance();
 const VulkanPhysicalDevice& getVulkanPhysicalDevice();
 const VulkanQueueFamily&
-getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_GRAPHICS | VULKAN_QUEUE_FLAG_COMPUTE);
+getVulkanQueueFamily(uint32_t queueFlags = VULKAN_QUEUE_FLAG_GRAPHICS
+                         | VULKAN_QUEUE_FLAG_COMPUTE);
 const VulkanMemoryType&
 getVulkanMemoryType(const VulkanDevice& device,
                     VulkanMemoryTypeProperty memoryTypeProperty);

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -74,7 +74,7 @@ VulkanInstance::VulkanInstance(): m_vkInstance(VK_NULL_HANDLE)
     const char *vulkanLoaderLibraryName = "vulkan-1.dll";
 #elif defined(__ANDROID__)
     const char *vulkanLoaderLibraryName = "libvulkan.so";
-#elif defined(__linux__)
+#else
     const char *vulkanLoaderLibraryName = "libvulkan.so.1";
 #endif
 #ifdef _WIN32
@@ -1013,12 +1013,12 @@ void VulkanDescriptorPool::VulkanDescriptorPoolCommon(
                 == vkDescriptorTypeToDescriptorCountMap.end())
             {
                 vkDescriptorTypeToDescriptorCountMap
-                    [vkDescriptorSetLayoutBinding.descriptorType] = 1;
+                    [vkDescriptorSetLayoutBinding.descriptorType] = vkDescriptorSetLayoutBinding.descriptorCount;
             }
             else
             {
                 vkDescriptorTypeToDescriptorCountMap
-                    [vkDescriptorSetLayoutBinding.descriptorType]++;
+                    [vkDescriptorSetLayoutBinding.descriptorType] += vkDescriptorSetLayoutBinding.descriptorCount;
             }
         }
 
@@ -1159,6 +1159,33 @@ void VulkanDescriptorSet::update(uint32_t binding, const VulkanBuffer &buffer)
     vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
 }
 
+void VulkanDescriptorSet::updateArray(uint32_t binding, unsigned numBuffers, const VulkanBufferList &buffers)
+{
+    VkDescriptorBufferInfo *vkDescriptorBufferInfo =
+            (VkDescriptorBufferInfo *)calloc(numBuffers, sizeof(VkDescriptorBufferInfo));
+    for(unsigned  i = 0; i < numBuffers; i++)
+    {
+        vkDescriptorBufferInfo[i].buffer = buffers[i];
+        vkDescriptorBufferInfo[i].offset = 0;
+        vkDescriptorBufferInfo[i].range = VK_WHOLE_SIZE;
+    }
+
+    VkWriteDescriptorSet vkWriteDescriptorSet = {};
+    vkWriteDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    vkWriteDescriptorSet.pNext = NULL;
+    vkWriteDescriptorSet.dstSet = m_vkDescriptorSet;
+    vkWriteDescriptorSet.dstBinding = binding;
+    vkWriteDescriptorSet.dstArrayElement = 0;
+    vkWriteDescriptorSet.descriptorCount = numBuffers;
+    vkWriteDescriptorSet.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    vkWriteDescriptorSet.pImageInfo = NULL;
+    vkWriteDescriptorSet.pBufferInfo = vkDescriptorBufferInfo;
+    vkWriteDescriptorSet.pTexelBufferView = NULL;
+
+    vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
+    free(vkDescriptorBufferInfo);
+}
+
 void VulkanDescriptorSet::update(uint32_t binding,
                                  const VulkanImageView &imageView)
 {
@@ -1180,6 +1207,33 @@ void VulkanDescriptorSet::update(uint32_t binding,
     vkWriteDescriptorSet.pTexelBufferView = NULL;
 
     vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
+}
+
+void VulkanDescriptorSet::updateArray(uint32_t binding,
+                                 const VulkanImageViewList &imageViewList)
+{
+    VkDescriptorImageInfo *vkDescriptorImageInfo = new VkDescriptorImageInfo[imageViewList.size()];
+    for(size_t i = 0; i < imageViewList.size(); i++)
+    {
+        vkDescriptorImageInfo[i].sampler = VK_NULL_HANDLE;
+        vkDescriptorImageInfo[i].imageView = imageViewList[i];
+        vkDescriptorImageInfo[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    }
+
+    VkWriteDescriptorSet vkWriteDescriptorSet = {};
+    vkWriteDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    vkWriteDescriptorSet.pNext = NULL;
+    vkWriteDescriptorSet.dstSet = m_vkDescriptorSet;
+    vkWriteDescriptorSet.dstBinding = binding;
+    vkWriteDescriptorSet.dstArrayElement = 0;
+    vkWriteDescriptorSet.descriptorCount = imageViewList.size();
+    vkWriteDescriptorSet.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    vkWriteDescriptorSet.pImageInfo = vkDescriptorImageInfo;
+    vkWriteDescriptorSet.pBufferInfo = NULL;
+    vkWriteDescriptorSet.pTexelBufferView = NULL;
+
+    vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
+    delete [] vkDescriptorImageInfo;
 }
 
 VulkanDescriptorSet::operator VkDescriptorSet() const

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -1013,12 +1013,14 @@ void VulkanDescriptorPool::VulkanDescriptorPoolCommon(
                 == vkDescriptorTypeToDescriptorCountMap.end())
             {
                 vkDescriptorTypeToDescriptorCountMap
-                    [vkDescriptorSetLayoutBinding.descriptorType] = vkDescriptorSetLayoutBinding.descriptorCount;
+                    [vkDescriptorSetLayoutBinding.descriptorType] =
+                        vkDescriptorSetLayoutBinding.descriptorCount;
             }
             else
             {
                 vkDescriptorTypeToDescriptorCountMap
-                    [vkDescriptorSetLayoutBinding.descriptorType] += vkDescriptorSetLayoutBinding.descriptorCount;
+                    [vkDescriptorSetLayoutBinding.descriptorType] +=
+                    vkDescriptorSetLayoutBinding.descriptorCount;
             }
         }
 
@@ -1159,11 +1161,13 @@ void VulkanDescriptorSet::update(uint32_t binding, const VulkanBuffer &buffer)
     vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
 }
 
-void VulkanDescriptorSet::updateArray(uint32_t binding, unsigned numBuffers, const VulkanBufferList &buffers)
+void VulkanDescriptorSet::updateArray(uint32_t binding, unsigned numBuffers,
+                                      const VulkanBufferList &buffers)
 {
     VkDescriptorBufferInfo *vkDescriptorBufferInfo =
-            (VkDescriptorBufferInfo *)calloc(numBuffers, sizeof(VkDescriptorBufferInfo));
-    for(unsigned  i = 0; i < numBuffers; i++)
+        (VkDescriptorBufferInfo *)calloc(numBuffers,
+                                         sizeof(VkDescriptorBufferInfo));
+    for (unsigned i = 0; i < numBuffers; i++)
     {
         vkDescriptorBufferInfo[i].buffer = buffers[i];
         vkDescriptorBufferInfo[i].offset = 0;
@@ -1210,10 +1214,11 @@ void VulkanDescriptorSet::update(uint32_t binding,
 }
 
 void VulkanDescriptorSet::updateArray(uint32_t binding,
-                                 const VulkanImageViewList &imageViewList)
+                                      const VulkanImageViewList &imageViewList)
 {
-    VkDescriptorImageInfo *vkDescriptorImageInfo = new VkDescriptorImageInfo[imageViewList.size()];
-    for(size_t i = 0; i < imageViewList.size(); i++)
+    VkDescriptorImageInfo *vkDescriptorImageInfo =
+        new VkDescriptorImageInfo[imageViewList.size()];
+    for (size_t i = 0; i < imageViewList.size(); i++)
     {
         vkDescriptorImageInfo[i].sampler = VK_NULL_HANDLE;
         vkDescriptorImageInfo[i].imageView = imageViewList[i];
@@ -1233,7 +1238,7 @@ void VulkanDescriptorSet::updateArray(uint32_t binding,
     vkWriteDescriptorSet.pTexelBufferView = NULL;
 
     vkUpdateDescriptorSets(m_device, 1, &vkWriteDescriptorSet, 0, NULL);
-    delete [] vkDescriptorImageInfo;
+    delete[] vkDescriptorImageInfo;
 }
 
 VulkanDescriptorSet::operator VkDescriptorSet() const
@@ -1559,10 +1564,7 @@ VulkanBuffer::VulkanBuffer(const VulkanBuffer &buffer)
       m_memoryTypeList(buffer.m_memoryTypeList)
 {}
 
-bool VulkanBuffer::isDedicated() const
-{
-    return m_dedicated;
-}
+bool VulkanBuffer::isDedicated() const { return m_dedicated; }
 
 VulkanBuffer::VulkanBuffer(
     const VulkanDevice &device, uint64_t size,
@@ -1616,20 +1618,23 @@ VulkanBuffer::VulkanBuffer(
     vkCreateBuffer(m_device, &vkBufferCreateInfo, NULL, &m_vkBuffer);
 
     VkMemoryDedicatedRequirements vkMemoryDedicatedRequirements = {};
-    vkMemoryDedicatedRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
+    vkMemoryDedicatedRequirements.sType =
+        VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
     vkMemoryDedicatedRequirements.pNext = NULL;
 
     VkMemoryRequirements2 vkMemoryRequirements = {};
     vkMemoryRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     vkMemoryRequirements.pNext = &vkMemoryDedicatedRequirements;
 
-    VkBufferMemoryRequirementsInfo2 vkMemoryRequirementsInfo ={};
+    VkBufferMemoryRequirementsInfo2 vkMemoryRequirementsInfo = {};
 
-    vkMemoryRequirementsInfo.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2;
+    vkMemoryRequirementsInfo.sType =
+        VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2;
     vkMemoryRequirementsInfo.buffer = m_vkBuffer;
     vkMemoryRequirementsInfo.pNext = NULL;
 
-    vkGetBufferMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo, &vkMemoryRequirements);
+    vkGetBufferMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo,
+                                      &vkMemoryRequirements);
 
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
 
@@ -1640,7 +1645,8 @@ VulkanBuffer::VulkanBuffer(
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];
-        if ((1 << memoryTypeIndex) & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
+        if ((1 << memoryTypeIndex)
+            & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
         {
             m_memoryTypeList.add(memoryTypeList[mtIdx]);
         }
@@ -1717,20 +1723,23 @@ VulkanImage::VulkanImage(
     VulkanImageCreateInfo = vkImageCreateInfo;
 
     VkMemoryDedicatedRequirements vkMemoryDedicatedRequirements = {};
-    vkMemoryDedicatedRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
+    vkMemoryDedicatedRequirements.sType =
+        VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
     vkMemoryDedicatedRequirements.pNext = NULL;
 
     VkMemoryRequirements2 vkMemoryRequirements = {};
     vkMemoryRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     vkMemoryRequirements.pNext = &vkMemoryDedicatedRequirements;
 
-    VkImageMemoryRequirementsInfo2 vkMemoryRequirementsInfo ={};
+    VkImageMemoryRequirementsInfo2 vkMemoryRequirementsInfo = {};
 
-    vkMemoryRequirementsInfo.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2;
+    vkMemoryRequirementsInfo.sType =
+        VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2;
     vkMemoryRequirementsInfo.image = m_vkImage;
     vkMemoryRequirementsInfo.pNext = NULL;
 
-    vkGetImageMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo, &vkMemoryRequirements);
+    vkGetImageMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo,
+                                     &vkMemoryRequirements);
     m_size = vkMemoryRequirements.memoryRequirements.size;
     m_alignment = vkMemoryRequirements.memoryRequirements.alignment;
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
@@ -1740,7 +1749,8 @@ VulkanImage::VulkanImage(
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];
-        if ((1 << memoryTypeIndex) & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
+        if ((1 << memoryTypeIndex)
+            & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
         {
             m_memoryTypeList.add(memoryTypeList[mtIdx]);
         }
@@ -1981,7 +1991,8 @@ VulkanDeviceMemory::VulkanDeviceMemory(
     const VulkanDevice &device, const VulkanImage &image,
     const VulkanMemoryType &memoryType,
     VulkanExternalMemoryHandleType externalMemoryHandleType, const void *name)
-    : m_device(device), m_size(image.getSize()), m_isDedicated(image.isDedicated())
+    : m_device(device), m_size(image.getSize()),
+      m_isDedicated(image.isDedicated())
 {
 #if defined(_WIN32) || defined(_WIN64)
     WindowsSecurityAttributes winSecurityAttributes;
@@ -2029,10 +2040,11 @@ VulkanDeviceMemory::VulkanDeviceMemory(
 }
 
 VulkanDeviceMemory::VulkanDeviceMemory(
-        const VulkanDevice &device, const VulkanBuffer &buffer,
-        const VulkanMemoryType &memoryType,
-        VulkanExternalMemoryHandleType externalMemoryHandleType, const void *name)
-        : m_device(device), m_size(buffer.getSize()), m_isDedicated(buffer.isDedicated())
+    const VulkanDevice &device, const VulkanBuffer &buffer,
+    const VulkanMemoryType &memoryType,
+    VulkanExternalMemoryHandleType externalMemoryHandleType, const void *name)
+    : m_device(device), m_size(buffer.getSize()),
+      m_isDedicated(buffer.isDedicated())
 {
 #if defined(_WIN32) || defined(_WIN64)
     WindowsSecurityAttributes winSecurityAttributes;
@@ -2050,7 +2062,7 @@ VulkanDeviceMemory::VulkanDeviceMemory(
 
     VkExportMemoryAllocateInfoKHR vkExportMemoryAllocateInfoKHR = {};
     vkExportMemoryAllocateInfoKHR.sType =
-            VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR;
+        VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR;
 #if defined(_WIN32) || defined(_WIN64)
     vkExportMemoryAllocateInfoKHR.pNext = externalMemoryHandleType
             & VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT
@@ -2060,25 +2072,26 @@ VulkanDeviceMemory::VulkanDeviceMemory(
     vkExportMemoryAllocateInfoKHR.pNext = NULL;
 #endif
     vkExportMemoryAllocateInfoKHR.handleTypes =
-            (VkExternalMemoryHandleTypeFlagsKHR)externalMemoryHandleType;
+        (VkExternalMemoryHandleTypeFlagsKHR)externalMemoryHandleType;
 
     VkMemoryDedicatedAllocateInfo vkMemoryDedicatedAllocateInfo = {};
     vkMemoryDedicatedAllocateInfo.sType =
-            VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+        VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
     vkMemoryDedicatedAllocateInfo.pNext =
-            externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+        externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
     vkMemoryDedicatedAllocateInfo.image = VK_NULL_HANDLE;
     vkMemoryDedicatedAllocateInfo.buffer = buffer;
 
     VkMemoryAllocateInfo vkMemoryAllocateInfo = {};
     vkMemoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    vkMemoryAllocateInfo.pNext = m_isDedicated ? &vkMemoryDedicatedAllocateInfo : nullptr;
+    vkMemoryAllocateInfo.pNext =
+        m_isDedicated ? &vkMemoryDedicatedAllocateInfo : nullptr;
     vkMemoryAllocateInfo.allocationSize = m_size;
     vkMemoryAllocateInfo.memoryTypeIndex = (uint32_t)memoryType;
 
-    VkResult res = vkAllocateMemory(m_device, &vkMemoryAllocateInfo, NULL, &m_vkDeviceMemory);
+    VkResult res = vkAllocateMemory(m_device, &vkMemoryAllocateInfo, NULL,
+                                    &m_vkDeviceMemory);
     ASSERT_SUCCESS(res, "Failed to allocate device memory");
-
 }
 
 VulkanDeviceMemory::~VulkanDeviceMemory()
@@ -2147,18 +2160,20 @@ void VulkanDeviceMemory::unmap() { vkUnmapMemory(m_device, m_vkDeviceMemory); }
 
 void VulkanDeviceMemory::bindBuffer(const VulkanBuffer &buffer, uint64_t offset)
 {
-    if(buffer.isDedicated() && !m_isDedicated)
+    if (buffer.isDedicated() && !m_isDedicated)
     {
-        throw std::runtime_error("Buffer requires dedicated memory.  Failed to bind");
+        throw std::runtime_error(
+            "Buffer requires dedicated memory.  Failed to bind");
     }
     vkBindBufferMemory(m_device, buffer, m_vkDeviceMemory, offset);
 }
 
 void VulkanDeviceMemory::bindImage(const VulkanImage &image, uint64_t offset)
 {
-    if(image.isDedicated() && !m_isDedicated)
+    if (image.isDedicated() && !m_isDedicated)
     {
-        throw std::runtime_error("Image requires dedicated memory.  Failed to bind");
+        throw std::runtime_error(
+            "Image requires dedicated memory.  Failed to bind");
     }
     vkBindImageMemory(m_device, image, m_vkDeviceMemory, offset);
 }

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -276,13 +276,13 @@ VulkanPhysicalDevice::VulkanPhysicalDevice(VkPhysicalDevice vkPhysicalDevice)
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR;
     vkPhysicalDeviceIDPropertiesKHR.pNext = NULL;
 
-    VkPhysicalDeviceProperties2KHR vkPhysicalDeviceProperties2KHR = {};
-    vkPhysicalDeviceProperties2KHR.sType =
+    VkPhysicalDeviceProperties2 vkPhysicalDeviceProperties2 = {};
+    vkPhysicalDeviceProperties2.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
-    vkPhysicalDeviceProperties2KHR.pNext = &vkPhysicalDeviceIDPropertiesKHR;
+    vkPhysicalDeviceProperties2.pNext = &vkPhysicalDeviceIDPropertiesKHR;
 
-    vkGetPhysicalDeviceProperties2KHR(m_vkPhysicalDevice,
-                                      &vkPhysicalDeviceProperties2KHR);
+    vkGetPhysicalDeviceProperties2(m_vkPhysicalDevice,
+                                   &vkPhysicalDeviceProperties2);
 
     memcpy(m_vkDeviceUUID, vkPhysicalDeviceIDPropertiesKHR.deviceUUID,
            sizeof(m_vkDeviceUUID));
@@ -1633,8 +1633,8 @@ VulkanBuffer::VulkanBuffer(
     vkMemoryRequirementsInfo.buffer = m_vkBuffer;
     vkMemoryRequirementsInfo.pNext = NULL;
 
-    vkGetBufferMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo,
-                                      &vkMemoryRequirements);
+    vkGetBufferMemoryRequirements2(m_device, &vkMemoryRequirementsInfo,
+                                   &vkMemoryRequirements);
 
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
 
@@ -1738,8 +1738,8 @@ VulkanImage::VulkanImage(
     vkMemoryRequirementsInfo.image = m_vkImage;
     vkMemoryRequirementsInfo.pNext = NULL;
 
-    vkGetImageMemoryRequirements2KHR(m_device, &vkMemoryRequirementsInfo,
-                                     &vkMemoryRequirements);
+    vkGetImageMemoryRequirements2(m_device, &vkMemoryRequirementsInfo,
+                                  &vkMemoryRequirements);
     m_size = vkMemoryRequirements.memoryRequirements.size;
     m_alignment = vkMemoryRequirements.memoryRequirements.alignment;
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -1797,14 +1797,14 @@ VulkanImage2D::VulkanImage2D(const VulkanImage2D &image2D): VulkanImage(image2D)
 
 VulkanImage2D::VulkanImage2D(
     const VulkanDevice &device, VulkanFormat format, uint32_t width,
-    uint32_t height, uint32_t numMipLevels,
+    uint32_t height, VulkanImageTiling imageTiling, uint32_t numMipLevels,
     VulkanExternalMemoryHandleType externalMemoryHandleType,
     VulkanImageCreateFlag imageCreateFlag, VulkanImageUsage imageUsage,
     VulkanSharingMode sharingMode)
     : VulkanImage(device, VULKAN_IMAGE_TYPE_2D, format,
                   VulkanExtent3D(width, height, 1), numMipLevels, 1,
-                  externalMemoryHandleType, imageCreateFlag,
-                  VULKAN_IMAGE_TILING_OPTIMAL, imageUsage, sharingMode)
+                  externalMemoryHandleType, imageCreateFlag, imageTiling,
+                  imageUsage, sharingMode)
 {}
 
 VulkanImage2D::~VulkanImage2D() {}

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -2025,16 +2025,26 @@ VulkanDeviceMemory::VulkanDeviceMemory(
     VkMemoryDedicatedAllocateInfo vkMemoryDedicatedAllocateInfo = {};
     vkMemoryDedicatedAllocateInfo.sType =
         VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
-    vkMemoryDedicatedAllocateInfo.pNext =
-        externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    vkMemoryDedicatedAllocateInfo.pNext = NULL;
     vkMemoryDedicatedAllocateInfo.image = image;
     vkMemoryDedicatedAllocateInfo.buffer = VK_NULL_HANDLE;
 
     VkMemoryAllocateInfo vkMemoryAllocateInfo = {};
     vkMemoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    vkMemoryAllocateInfo.pNext = &vkMemoryDedicatedAllocateInfo;
     vkMemoryAllocateInfo.allocationSize = m_size;
     vkMemoryAllocateInfo.memoryTypeIndex = (uint32_t)memoryType;
+
+    if (m_isDedicated)
+    {
+        vkMemoryAllocateInfo.pNext = &vkMemoryDedicatedAllocateInfo;
+        vkMemoryDedicatedAllocateInfo.pNext =
+            externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    }
+    else
+    {
+        vkMemoryAllocateInfo.pNext =
+            externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    }
 
     vkAllocateMemory(m_device, &vkMemoryAllocateInfo, NULL, &m_vkDeviceMemory);
 }
@@ -2077,17 +2087,27 @@ VulkanDeviceMemory::VulkanDeviceMemory(
     VkMemoryDedicatedAllocateInfo vkMemoryDedicatedAllocateInfo = {};
     vkMemoryDedicatedAllocateInfo.sType =
         VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
-    vkMemoryDedicatedAllocateInfo.pNext =
-        externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    vkMemoryDedicatedAllocateInfo.pNext = NULL;
     vkMemoryDedicatedAllocateInfo.image = VK_NULL_HANDLE;
     vkMemoryDedicatedAllocateInfo.buffer = buffer;
 
     VkMemoryAllocateInfo vkMemoryAllocateInfo = {};
     vkMemoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    vkMemoryAllocateInfo.pNext =
-        m_isDedicated ? &vkMemoryDedicatedAllocateInfo : nullptr;
     vkMemoryAllocateInfo.allocationSize = m_size;
     vkMemoryAllocateInfo.memoryTypeIndex = (uint32_t)memoryType;
+
+    if (m_isDedicated)
+    {
+        vkMemoryAllocateInfo.pNext = &vkMemoryDedicatedAllocateInfo;
+        vkMemoryDedicatedAllocateInfo.pNext =
+            externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    }
+    else
+    {
+        vkMemoryAllocateInfo.pNext =
+            externalMemoryHandleType ? &vkExportMemoryAllocateInfoKHR : NULL;
+    }
+
 
     VkResult res = vkAllocateMemory(m_device, &vkMemoryAllocateInfo, NULL,
                                     &m_vkDeviceMemory);

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -328,7 +328,9 @@ public:
                         const VulkanDescriptorSetLayout &descriptorSetLayout);
     virtual ~VulkanDescriptorSet();
     void update(uint32_t binding, const VulkanBuffer &buffer);
+    void updateArray(uint32_t binding, unsigned numBuffers, const VulkanBufferList &buffers);
     void update(uint32_t binding, const VulkanImageView &imageView);
+    void updateArray(uint32_t binding, const VulkanImageViewList &imageViewList);
     operator VkDescriptorSet() const;
 };
 

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -498,7 +498,8 @@ protected:
 public:
     VulkanImage2D(
         const VulkanDevice &device, VulkanFormat format, uint32_t width,
-        uint32_t height, uint32_t numMipLevels = 1,
+        uint32_t height, VulkanImageTiling imageTiling,
+        uint32_t numMipLevels = 1,
         VulkanExternalMemoryHandleType externalMemoryHandleType =
             VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
         VulkanImageCreateFlag imageCreateFlag = VULKAN_IMAGE_CREATE_FLAG_NONE,

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -426,6 +426,7 @@ protected:
     VkBuffer m_vkBuffer;
     uint64_t m_size;
     uint64_t m_alignment;
+    bool     m_dedicated;
     VulkanMemoryTypeList m_memoryTypeList;
 
     VulkanBuffer(const VulkanBuffer &buffer);
@@ -443,6 +444,7 @@ public:
     uint64_t getSize() const;
     uint64_t getAlignment() const;
     const VulkanMemoryTypeList &getMemoryTypeList() const;
+    bool isDedicated() const;
     operator VkBuffer() const;
 };
 
@@ -454,6 +456,7 @@ protected:
     const VulkanFormat m_format;
     const uint32_t m_numMipLevels;
     const uint32_t m_numLayers;
+    bool m_dedicated;
     VkImage m_vkImage;
     uint64_t m_size;
     uint64_t m_alignment;
@@ -480,6 +483,7 @@ public:
     uint32_t getNumLayers() const;
     uint64_t getSize() const;
     uint64_t getAlignment() const;
+    bool isDedicated() const;
     const VulkanMemoryTypeList &getMemoryTypeList() const;
     VkImageCreateInfo getVkImageCreateInfo() const;
     operator VkImage() const;
@@ -488,8 +492,6 @@ public:
 class VulkanImage2D : public VulkanImage {
 protected:
     VkImageView m_vkImageView;
-
-    VulkanImage2D(const VulkanImage2D &image2D);
 
 public:
     VulkanImage2D(
@@ -503,6 +505,8 @@ public:
         VulkanSharingMode sharingMode = VULKAN_SHARING_MODE_EXCLUSIVE);
     virtual ~VulkanImage2D();
     virtual VulkanExtent3D getExtent3D(uint32_t mipLevel = 0) const;
+
+    VulkanImage2D(const VulkanImage2D &image2D);
 };
 
 class VulkanImageView {
@@ -542,6 +546,11 @@ public:
                        const VulkanMemoryType &memoryType,
                        VulkanExternalMemoryHandleType externalMemoryHandleType =
                            VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
+                       const void *name = NULL);
+    VulkanDeviceMemory(const VulkanDevice &device, const VulkanBuffer &buffer,
+                       const VulkanMemoryType &memoryType,
+                       VulkanExternalMemoryHandleType externalMemoryHandleType =
+                       VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
                        const void *name = NULL);
     virtual ~VulkanDeviceMemory();
     uint64_t getSize() const;

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -328,9 +328,11 @@ public:
                         const VulkanDescriptorSetLayout &descriptorSetLayout);
     virtual ~VulkanDescriptorSet();
     void update(uint32_t binding, const VulkanBuffer &buffer);
-    void updateArray(uint32_t binding, unsigned numBuffers, const VulkanBufferList &buffers);
+    void updateArray(uint32_t binding, unsigned numBuffers,
+                     const VulkanBufferList &buffers);
     void update(uint32_t binding, const VulkanImageView &imageView);
-    void updateArray(uint32_t binding, const VulkanImageViewList &imageViewList);
+    void updateArray(uint32_t binding,
+                     const VulkanImageViewList &imageViewList);
     operator VkDescriptorSet() const;
 };
 
@@ -426,7 +428,7 @@ protected:
     VkBuffer m_vkBuffer;
     uint64_t m_size;
     uint64_t m_alignment;
-    bool     m_dedicated;
+    bool m_dedicated;
     VulkanMemoryTypeList m_memoryTypeList;
 
     VulkanBuffer(const VulkanBuffer &buffer);
@@ -550,7 +552,7 @@ public:
     VulkanDeviceMemory(const VulkanDevice &device, const VulkanBuffer &buffer,
                        const VulkanMemoryType &memoryType,
                        VulkanExternalMemoryHandleType externalMemoryHandleType =
-                       VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
+                           VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_NONE,
                        const void *name = NULL);
     virtual ~VulkanDeviceMemory();
     uint64_t getSize() const;

--- a/test_conformance/vulkan/main.cpp
+++ b/test_conformance/vulkan/main.cpp
@@ -185,7 +185,6 @@ bool useSingleImageKernel = false;
 bool useDeviceLocal = false;
 bool disableNTHandleType = false;
 bool enableOffset = false;
-bool non_dedicated = false;
 
 static void printUsage(const char *execName)
 {
@@ -231,10 +230,6 @@ size_t parseParams(int argc, const char *argv[], const char **argList)
             if (!strcmp(argv[i], "--enableOffset"))
             {
                 enableOffset = true;
-            }
-            if (!strcmp(argv[i], "--non_dedicated"))
-            {
-                non_dedicated = true;
             }
             if (strcmp(argv[i], "-h") == 0)
             {

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -83,8 +83,9 @@ int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
 
     VulkanBufferList vkBufferList(1, vkDevice, bufferSize,
                                   vkExternalMemoryHandleType);
-    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
-        vkDevice, vkBufferList[0], memoryTypeList[0], vkExternalMemoryHandleType);
+    VulkanDeviceMemory* vkDeviceMem =
+        new VulkanDeviceMemory(vkDevice, vkBufferList[0], memoryTypeList[0],
+                               vkExternalMemoryHandleType);
 
     vkDeviceMem->bindBuffer(vkBufferList[0], 0);
 
@@ -231,8 +232,9 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
 
     VulkanExternalMemoryHandleType vkExternalMemoryHandleType =
         getSupportedVulkanExternalMemoryHandleTypeList()[0];
-    VulkanImage2D vkImage2D = VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height,
-                          1, vkExternalMemoryHandleType);
+    VulkanImage2D vkImage2D =
+        VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height, 1,
+                      vkExternalMemoryHandleType);
 
     const VulkanMemoryTypeList& memoryTypeList = vkImage2D.getMemoryTypeList();
     uint64_t totalImageMemSize = vkImage2D.getSize();
@@ -242,9 +244,8 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
              memoryTypeList[0].getMemoryTypeProperty());
     log_info("Image size : %d\n", totalImageMemSize);
 
-    VulkanDeviceMemory* vkDeviceMem =
-        new VulkanDeviceMemory(vkDevice, vkImage2D, memoryTypeList[0],
-                               vkExternalMemoryHandleType);
+    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
+        vkDevice, vkImage2D, memoryTypeList[0], vkExternalMemoryHandleType);
     vkDeviceMem->bindImage(vkImage2D, 0);
 
     void* handle = NULL;

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -81,10 +81,10 @@ int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
     const VulkanMemoryTypeList& memoryTypeList =
         vkDummyBuffer.getMemoryTypeList();
 
-    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
-        vkDevice, bufferSize, memoryTypeList[0], vkExternalMemoryHandleType);
     VulkanBufferList vkBufferList(1, vkDevice, bufferSize,
                                   vkExternalMemoryHandleType);
+    VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
+        vkDevice, vkBufferList[0], memoryTypeList[0], vkExternalMemoryHandleType);
 
     vkDeviceMem->bindBuffer(vkBufferList[0], 0);
 
@@ -231,12 +231,11 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
 
     VulkanExternalMemoryHandleType vkExternalMemoryHandleType =
         getSupportedVulkanExternalMemoryHandleTypeList()[0];
-    VulkanImage2D* vkImage2D =
-        new VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height,
+    VulkanImage2D vkImage2D = VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height,
                           1, vkExternalMemoryHandleType);
 
-    const VulkanMemoryTypeList& memoryTypeList = vkImage2D->getMemoryTypeList();
-    uint64_t totalImageMemSize = vkImage2D->getSize();
+    const VulkanMemoryTypeList& memoryTypeList = vkImage2D.getMemoryTypeList();
+    uint64_t totalImageMemSize = vkImage2D.getSize();
 
     log_info("Memory type index: %lu\n", (uint32_t)memoryTypeList[0]);
     log_info("Memory type property: %d\n",
@@ -244,9 +243,9 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
     log_info("Image size : %d\n", totalImageMemSize);
 
     VulkanDeviceMemory* vkDeviceMem =
-        new VulkanDeviceMemory(vkDevice, totalImageMemSize, memoryTypeList[0],
+        new VulkanDeviceMemory(vkDevice, vkImage2D, memoryTypeList[0],
                                vkExternalMemoryHandleType);
-    vkDeviceMem->bindImage(*vkImage2D, 0);
+    vkDeviceMem->bindImage(vkImage2D, 0);
 
     void* handle = NULL;
     int fd;
@@ -299,7 +298,7 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
     extMemProperties.push_back(0);
 
     const VkImageCreateInfo VulkanImageCreateInfo =
-        vkImage2D->getVkImageCreateInfo();
+        vkImage2D.getVkImageCreateInfo();
 
     errNum = getCLImageInfoFromVkImageInfo(
         &VulkanImageCreateInfo, totalImageMemSize, &img_format, &image_desc);

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -232,9 +232,15 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
 
     VulkanExternalMemoryHandleType vkExternalMemoryHandleType =
         getSupportedVulkanExternalMemoryHandleTypeList()[0];
+
+    VulkanImageTiling vulkanImageTiling =
+        vkClExternalMemoryHandleTilingAssumption(
+            deviceID, vkExternalMemoryHandleType, &errNum);
+    ASSERT_SUCCESS(errNum, "Failed to query OpenCL tiling mode");
+
     VulkanImage2D vkImage2D =
-        VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height, 1,
-                      vkExternalMemoryHandleType);
+        VulkanImage2D(vkDevice, VULKAN_FORMAT_R8G8B8A8_UNORM, width, height,
+                      vulkanImageTiling, 1, vkExternalMemoryHandleType);
 
     const VulkanMemoryTypeList& memoryTypeList = vkImage2D.getMemoryTypeList();
     uint64_t totalImageMemSize = vkImage2D.getSize();

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -127,8 +127,10 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
-    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -190,9 +192,9 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
 
             for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
             {
-                vkBufferListDeviceMemory.push_back(
-                    new VulkanDeviceMemory(vkDevice, vkBufferList[bIdx], memoryType,
-                                           vkExternalMemoryHandleType));
+                vkBufferListDeviceMemory.push_back(new VulkanDeviceMemory(
+                    vkDevice, vkBufferList[bIdx], memoryType,
+                    vkExternalMemoryHandleType));
                 externalMemory.push_back(new clExternalMemory(
                     vkBufferListDeviceMemory[bIdx], vkExternalMemoryHandleType,
                     0, bufferSize, context, deviceId));
@@ -455,8 +457,10 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
     std::vector<char> vkBufferShader = readFile("buffer.spv");
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
-    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -519,9 +523,9 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
 
             for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
             {
-                vkBufferListDeviceMemory.push_back(
-                    new VulkanDeviceMemory(vkDevice, vkBufferList[bIdx], memoryType,
-                                           vkExternalMemoryHandleType));
+                vkBufferListDeviceMemory.push_back(new VulkanDeviceMemory(
+                    vkDevice, vkBufferList[bIdx], memoryType,
+                    vkExternalMemoryHandleType));
                 externalMemory.push_back(new clExternalMemory(
                     vkBufferListDeviceMemory[bIdx], vkExternalMemoryHandleType,
                     0, bufferSize, context, deviceId));
@@ -758,8 +762,10 @@ int run_test_with_multi_import_same_ctx(
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
-    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -126,8 +126,9 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
     std::vector<char> vkBufferShader = readFile("buffer.spv");
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
-    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(
-        MAX_BUFFERS + 1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -210,8 +211,8 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                 vkBufferListDeviceMemory[bIdx]->bindBuffer(vkBufferList[bIdx],
                                                            0);
                 buffers[bIdx] = externalMemory[bIdx]->getExternalMemoryBuffer();
-                vkDescriptorSet.update((uint32_t)bIdx + 1, vkBufferList[bIdx]);
             }
+            vkDescriptorSet.updateArray(1, numBuffers, vkBufferList);
             vkCommandBuffer.begin();
             vkCommandBuffer.bindPipeline(vkComputePipeline);
             vkCommandBuffer.bindDescriptorSets(
@@ -453,8 +454,9 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
 
     std::vector<char> vkBufferShader = readFile("buffer.spv");
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
-    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(
-        MAX_BUFFERS + 1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -538,8 +540,9 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                 vkBufferListDeviceMemory[bIdx]->bindBuffer(vkBufferList[bIdx],
                                                            0);
                 buffers[bIdx] = externalMemory[bIdx]->getExternalMemoryBuffer();
-                vkDescriptorSet.update((uint32_t)bIdx + 1, vkBufferList[bIdx]);
             }
+            vkDescriptorSet.updateArray(1, vkBufferList.size(), vkBufferList);
+
             vkCommandBuffer.begin();
             vkCommandBuffer.bindPipeline(vkComputePipeline);
             vkCommandBuffer.bindDescriptorSets(
@@ -754,8 +757,9 @@ int run_test_with_multi_import_same_ctx(
     std::vector<char> vkBufferShader = readFile("buffer.spv");
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
-    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(
-        MAX_BUFFERS + 1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_BUFFERS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -880,9 +884,8 @@ int run_test_with_multi_import_same_ctx(
                             externalMemory[bIdx][cl_bIdx]
                                 ->getExternalMemoryBuffer();
                     }
-                    vkDescriptorSet.update((uint32_t)bIdx + 1,
-                                           vkBufferList[bIdx]);
                 }
+                vkDescriptorSet.updateArray(1, numBuffers, vkBufferList);
                 vkCommandBuffer.begin();
                 vkCommandBuffer.bindPipeline(vkComputePipeline);
                 vkCommandBuffer.bindDescriptorSets(

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -191,7 +191,7 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
             for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
             {
                 vkBufferListDeviceMemory.push_back(
-                    new VulkanDeviceMemory(vkDevice, bufferSize, memoryType,
+                    new VulkanDeviceMemory(vkDevice, vkBufferList[bIdx], memoryType,
                                            vkExternalMemoryHandleType));
                 externalMemory.push_back(new clExternalMemory(
                     vkBufferListDeviceMemory[bIdx], vkExternalMemoryHandleType,
@@ -520,7 +520,7 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
             for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
             {
                 vkBufferListDeviceMemory.push_back(
-                    new VulkanDeviceMemory(vkDevice, bufferSize, memoryType,
+                    new VulkanDeviceMemory(vkDevice, vkBufferList[bIdx], memoryType,
                                            vkExternalMemoryHandleType));
                 externalMemory.push_back(new clExternalMemory(
                     vkBufferListDeviceMemory[bIdx], vkExternalMemoryHandleType,
@@ -840,7 +840,7 @@ int run_test_with_multi_import_same_ctx(
                     if (withOffset == 0)
                     {
                         vkBufferListDeviceMemory.push_back(
-                            new VulkanDeviceMemory(vkDevice, pBufferSize,
+                            new VulkanDeviceMemory(vkDevice, vkBufferList[bIdx],
                                                    memoryType,
                                                    vkExternalMemoryHandleType));
                     }

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -255,10 +255,10 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
     clCl2VkExternalSemaphore = new clExternalSemaphore(
         vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
 
-    std::vector<VulkanDeviceMemory *> vkNonDedicatedImage2DListDeviceMemory1;
-    std::vector<VulkanDeviceMemory *> vkNonDedicatedImage2DListDeviceMemory2;
-    std::vector<clExternalMemoryImage *> nonDedicatedExternalMemory1;
-    std::vector<clExternalMemoryImage *> nonDedicatedExternalMemory2;
+    std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;
+    std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory2;
+    std::vector<clExternalMemoryImage *> externalMemory1;
+    std::vector<clExternalMemoryImage *> externalMemory2;
     std::vector<char> vkImage2DShader;
 
     for (size_t fIdx = 0; fIdx < vkFormatList.size(); fIdx++)
@@ -396,94 +396,66 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                     ROUND_UP(vkImage2D.getSize(),
                                              vkImage2D.getAlignment());
                             }
-                            VulkanImage2DList vkNonDedicatedImage2DList(
+                            VulkanImage2DList vkImage2DList(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
-                                if (non_dedicated)
-                                {
-                                    vkNonDedicatedImage2DListDeviceMemory1
-                                        .push_back(new VulkanDeviceMemory(
-                                            vkDevice, totalImageMemSize,
-                                            memoryType,
-                                            vkExternalMemoryHandleType));
-                                }
-                                else
-                                {
-                                    vkNonDedicatedImage2DListDeviceMemory1
-                                        .push_back(new VulkanDeviceMemory(
+                                vkImage2DListDeviceMemory1
+                                    .push_back(new VulkanDeviceMemory(
                                             vkDevice,
-                                            vkNonDedicatedImage2DList[bIdx],
+                                            vkImage2DList[bIdx],
                                             memoryType,
                                             vkExternalMemoryHandleType));
-                                }
-                                vkNonDedicatedImage2DListDeviceMemory1[bIdx]
-                                    ->bindImage(vkNonDedicatedImage2DList[bIdx],
+                                vkImage2DListDeviceMemory1[bIdx]
+                                    ->bindImage(vkImage2DList[bIdx],
                                                 0);
-                                nonDedicatedExternalMemory1.push_back(
+                                externalMemory1.push_back(
                                     new clExternalMemoryImage(
-                                        *vkNonDedicatedImage2DListDeviceMemory1
+                                            *vkImage2DListDeviceMemory1
                                             [bIdx],
-                                        vkExternalMemoryHandleType, context,
-                                        totalImageMemSize, width, height, 0,
-                                        vkNonDedicatedImage2DList[bIdx],
-                                        deviceId));
+                                            vkExternalMemoryHandleType, context,
+                                            totalImageMemSize, width, height, 0,
+                                            vkImage2DList[bIdx],
+                                            deviceId));
                             }
-                            VulkanImageViewList vkNonDedicatedImage2DViewList(
-                                vkDevice, vkNonDedicatedImage2DList);
-                            VulkanImage2DList vkNonDedicatedImage2DList2(
+                            VulkanImageViewList vkImage2DViewList(
+                                    vkDevice, vkImage2DList);
+                            VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
-                                if (non_dedicated)
-                                {
-                                    vkNonDedicatedImage2DListDeviceMemory2
-                                        .push_back(new VulkanDeviceMemory(
-                                            vkDevice, totalImageMemSize,
-                                            memoryType,
-                                            vkExternalMemoryHandleType));
-                                }
-                                else
-                                {
-                                    vkNonDedicatedImage2DListDeviceMemory2
-                                        .push_back(new VulkanDeviceMemory(
+                                vkImage2DListDeviceMemory2
+                                    .push_back(new VulkanDeviceMemory(
                                             vkDevice,
-                                            vkNonDedicatedImage2DList2[bIdx],
+                                            vkImage2DList2[bIdx],
                                             memoryType,
                                             vkExternalMemoryHandleType));
-                                }
-                                vkNonDedicatedImage2DListDeviceMemory2[bIdx]
+                                vkImage2DListDeviceMemory2[bIdx]
                                     ->bindImage(
-                                        vkNonDedicatedImage2DList2[bIdx], 0);
-                                nonDedicatedExternalMemory2.push_back(
+                                            vkImage2DList2[bIdx], 0);
+                                externalMemory2.push_back(
                                     new clExternalMemoryImage(
-                                        *vkNonDedicatedImage2DListDeviceMemory2
+                                            *vkImage2DListDeviceMemory2
                                             [bIdx],
-                                        vkExternalMemoryHandleType, context,
-                                        totalImageMemSize, width, height, 0,
-                                        vkNonDedicatedImage2DList2[bIdx],
-                                        deviceId));
+                                            vkExternalMemoryHandleType, context,
+                                            totalImageMemSize, width, height, 0,
+                                            vkImage2DList2[bIdx],
+                                            deviceId));
                             }
-                            VulkanImageViewList vkDedicatedImage2DViewList(
-                                vkDevice, vkNonDedicatedImage2DList2);
 
                             cl_mem external_mem_image1[5];
                             cl_mem external_mem_image2[5];
                             for (int i = 0; i < num2DImages; i++)
                             {
                                 external_mem_image1[i] =
-                                    nonDedicatedExternalMemory1[i]
+                                    externalMemory1[i]
                                         ->getExternalMemoryImage();
                                 external_mem_image2[i] =
-                                    nonDedicatedExternalMemory2[i]
+                                    externalMemory2[i]
                                         ->getExternalMemoryImage();
                             }
-                            VulkanImage2DList &vkImage2DList =
-                                vkNonDedicatedImage2DList;
-                            VulkanImageViewList &vkImage2DViewList =
-                                vkNonDedicatedImage2DViewList;
 
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
@@ -730,28 +702,28 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             for (int i = 0; i < num2DImages; i++)
                             {
-                                delete vkNonDedicatedImage2DListDeviceMemory1
+                                delete vkImage2DListDeviceMemory1
                                     [i];
-                                delete vkNonDedicatedImage2DListDeviceMemory2
+                                delete vkImage2DListDeviceMemory2
                                     [i];
-                                delete nonDedicatedExternalMemory1[i];
-                                delete nonDedicatedExternalMemory2[i];
+                                delete externalMemory1[i];
+                                delete externalMemory2[i];
                             }
-                            vkNonDedicatedImage2DListDeviceMemory1.erase(
-                                vkNonDedicatedImage2DListDeviceMemory1.begin(),
-                                vkNonDedicatedImage2DListDeviceMemory1.begin()
+                            vkImage2DListDeviceMemory1.erase(
+                                    vkImage2DListDeviceMemory1.begin(),
+                                    vkImage2DListDeviceMemory1.begin()
                                     + num2DImages);
-                            vkNonDedicatedImage2DListDeviceMemory2.erase(
-                                vkNonDedicatedImage2DListDeviceMemory2.begin(),
-                                vkNonDedicatedImage2DListDeviceMemory2.begin()
+                            vkImage2DListDeviceMemory2.erase(
+                                    vkImage2DListDeviceMemory2.begin(),
+                                    vkImage2DListDeviceMemory2.begin()
                                     + num2DImages);
-                            nonDedicatedExternalMemory1.erase(
-                                nonDedicatedExternalMemory1.begin(),
-                                nonDedicatedExternalMemory1.begin()
+                            externalMemory1.erase(
+                                    externalMemory1.begin(),
+                                    externalMemory1.begin()
                                     + num2DImages);
-                            nonDedicatedExternalMemory2.erase(
-                                nonDedicatedExternalMemory2.begin(),
-                                nonDedicatedExternalMemory2.begin()
+                            externalMemory2.erase(
+                                    externalMemory2.begin(),
+                                    externalMemory2.begin()
                                     + num2DImages);
                             if (CL_SUCCESS != err)
                             {
@@ -838,10 +810,10 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
     clCl2VkExternalSemaphore = new clExternalSemaphore(
         vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
 
-    std::vector<VulkanDeviceMemory *> vkNonDedicatedImage2DListDeviceMemory1;
-    std::vector<VulkanDeviceMemory *> vkNonDedicatedImage2DListDeviceMemory2;
-    std::vector<clExternalMemoryImage *> nonDedicatedExternalMemory1;
-    std::vector<clExternalMemoryImage *> nonDedicatedExternalMemory2;
+    std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;
+    std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory2;
+    std::vector<clExternalMemoryImage *> externalMemory1;
+    std::vector<clExternalMemoryImage *> externalMemory2;
     std::vector<char> vkImage2DShader;
 
     for (size_t fIdx = 0; fIdx < vkFormatList.size(); fIdx++)
@@ -978,74 +950,69 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                     ROUND_UP(vkImage2D.getSize(),
                                              vkImage2D.getAlignment());
                             }
-                            VulkanImage2DList vkNonDedicatedImage2DList(
+                            VulkanImage2DList vkImage2DList(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0;
-                                 bIdx < vkNonDedicatedImage2DList.size();
+                                 bIdx < vkImage2DList.size();
                                  bIdx++)
                             {
                                 // Create list of Vulkan device memories and
                                 // bind the list of Vulkan images.
-                                vkNonDedicatedImage2DListDeviceMemory1
+                                vkImage2DListDeviceMemory1
                                     .push_back(new VulkanDeviceMemory(
-                                        vkDevice, totalImageMemSize, memoryType,
-                                        vkExternalMemoryHandleType));
-                                vkNonDedicatedImage2DListDeviceMemory1[bIdx]
-                                    ->bindImage(vkNonDedicatedImage2DList[bIdx],
+                                            vkDevice, vkImage2DList[bIdx], memoryType,
+                                            vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory1[bIdx]
+                                    ->bindImage(vkImage2DList[bIdx],
                                                 0);
-                                nonDedicatedExternalMemory1.push_back(
+                                externalMemory1.push_back(
                                     new clExternalMemoryImage(
-                                        *vkNonDedicatedImage2DListDeviceMemory1
+                                            *vkImage2DListDeviceMemory1
                                             [bIdx],
-                                        vkExternalMemoryHandleType, context,
-                                        totalImageMemSize, width, height, 0,
-                                        vkNonDedicatedImage2DList[bIdx],
-                                        deviceId));
+                                            vkExternalMemoryHandleType, context,
+                                            totalImageMemSize, width, height, 0,
+                                            vkImage2DList[bIdx],
+                                            deviceId));
                             }
-                            VulkanImageViewList vkNonDedicatedImage2DViewList(
-                                vkDevice, vkNonDedicatedImage2DList);
+                            VulkanImageViewList vkImage2DViewList(
+                                    vkDevice, vkImage2DList);
 
-                            VulkanImage2DList vkNonDedicatedImage2DList2(
+                            VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0;
-                                 bIdx < vkNonDedicatedImage2DList2.size();
+                                 bIdx < vkImage2DList2.size();
                                  bIdx++)
                             {
-                                vkNonDedicatedImage2DListDeviceMemory2
+                                vkImage2DListDeviceMemory2
                                     .push_back(new VulkanDeviceMemory(
-                                        vkDevice, totalImageMemSize, memoryType,
-                                        vkExternalMemoryHandleType));
-                                vkNonDedicatedImage2DListDeviceMemory2[bIdx]
+                                            vkDevice, vkImage2DList2[bIdx], memoryType,
+                                            vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory2[bIdx]
                                     ->bindImage(
-                                        vkNonDedicatedImage2DList2[bIdx], 0);
-                                nonDedicatedExternalMemory2.push_back(
+                                            vkImage2DList2[bIdx], 0);
+                                externalMemory2.push_back(
                                     new clExternalMemoryImage(
-                                        *vkNonDedicatedImage2DListDeviceMemory2
+                                            *vkImage2DListDeviceMemory2
                                             [bIdx],
-                                        vkExternalMemoryHandleType, context,
-                                        totalImageMemSize, width, height, 0,
-                                        vkNonDedicatedImage2DList2[bIdx],
-                                        deviceId));
+                                            vkExternalMemoryHandleType, context,
+                                            totalImageMemSize, width, height, 0,
+                                            vkImage2DList2[bIdx],
+                                            deviceId));
                             }
-                            VulkanImageViewList vkDedicatedImage2DViewList(
-                                vkDevice, vkNonDedicatedImage2DList2);
+
                             cl_mem external_mem_image1[4];
                             cl_mem external_mem_image2[4];
                             for (int i = 0; i < num2DImages; i++)
                             {
                                 external_mem_image1[i] =
-                                    nonDedicatedExternalMemory1[i]
+                                    externalMemory1[i]
                                         ->getExternalMemoryImage();
                                 external_mem_image2[i] =
-                                    nonDedicatedExternalMemory2[i]
+                                    externalMemory2[i]
                                         ->getExternalMemoryImage();
                             }
-                            VulkanImage2DList &vkImage2DList =
-                                vkNonDedicatedImage2DList;
-                            VulkanImageViewList &vkImage2DViewList =
-                                vkNonDedicatedImage2DViewList;
 
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
@@ -1248,28 +1215,28 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             for (int i = 0; i < num2DImages; i++)
                             {
-                                delete vkNonDedicatedImage2DListDeviceMemory1
+                                delete vkImage2DListDeviceMemory1
                                     [i];
-                                delete vkNonDedicatedImage2DListDeviceMemory2
+                                delete vkImage2DListDeviceMemory2
                                     [i];
-                                delete nonDedicatedExternalMemory1[i];
-                                delete nonDedicatedExternalMemory2[i];
+                                delete externalMemory1[i];
+                                delete externalMemory2[i];
                             }
-                            vkNonDedicatedImage2DListDeviceMemory1.erase(
-                                vkNonDedicatedImage2DListDeviceMemory1.begin(),
-                                vkNonDedicatedImage2DListDeviceMemory1.begin()
+                            vkImage2DListDeviceMemory1.erase(
+                                    vkImage2DListDeviceMemory1.begin(),
+                                    vkImage2DListDeviceMemory1.begin()
                                     + num2DImages);
-                            vkNonDedicatedImage2DListDeviceMemory2.erase(
-                                vkNonDedicatedImage2DListDeviceMemory2.begin(),
-                                vkNonDedicatedImage2DListDeviceMemory2.begin()
+                            vkImage2DListDeviceMemory2.erase(
+                                    vkImage2DListDeviceMemory2.begin(),
+                                    vkImage2DListDeviceMemory2.begin()
                                     + num2DImages);
-                            nonDedicatedExternalMemory1.erase(
-                                nonDedicatedExternalMemory1.begin(),
-                                nonDedicatedExternalMemory1.begin()
+                            externalMemory1.erase(
+                                    externalMemory1.begin(),
+                                    externalMemory1.begin()
                                     + num2DImages);
-                            nonDedicatedExternalMemory2.erase(
-                                nonDedicatedExternalMemory2.begin(),
-                                nonDedicatedExternalMemory2.begin()
+                            externalMemory2.erase(
+                                    externalMemory2.begin(),
+                                    externalMemory2.begin()
                                     + num2DImages);
                             if (CL_SUCCESS != err)
                             {

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -354,8 +354,6 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                         VulkanExternalMemoryHandleType
                             vkExternalMemoryHandleType =
                                 vkExternalMemoryHandleTypeList[emhtIdx];
-                        log_info("External memory handle type: %d \n",
-                                 vkExternalMemoryHandleType);
                         if ((true == disableNTHandleType)
                             && (VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT
                                 == vkExternalMemoryHandleType))
@@ -363,9 +361,19 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             // Skip running for WIN32 NT handle.
                             continue;
                         }
+                        log_info("External memory handle type: %d \n",
+                                 vkExternalMemoryHandleType);
+                        VulkanImageTiling vulkanImageTiling =
+                            vkClExternalMemoryHandleTilingAssumption(
+                                deviceId,
+                                vkExternalMemoryHandleTypeList[emhtIdx], &err);
+                        ASSERT_SUCCESS(err,
+                                       "Failed to query OpenCL tiling mode");
+
                         VulkanImage2D vkDummyImage2D(
                             vkDevice, vkFormatList[0], widthList[0],
-                            heightList[0], 1, vkExternalMemoryHandleType);
+                            heightList[0], vulkanImageTiling, 1,
+                            vkExternalMemoryHandleType);
                         const VulkanMemoryTypeList &memoryTypeList =
                             vkDummyImage2D.getMemoryTypeList();
 
@@ -392,7 +400,8 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             {
                                 VulkanImage2D vkImage2D(
                                     vkDevice, vkFormat, width, height,
-                                    numMipLevels, vkExternalMemoryHandleType);
+                                    vulkanImageTiling, numMipLevels,
+                                    vkExternalMemoryHandleType);
                                 ASSERT_LEQ(vkImage2D.getSize(), maxImage2DSize);
                                 totalImageMemSize =
                                     ROUND_UP(vkImage2D.getSize(),
@@ -400,7 +409,8 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             VulkanImage2DList vkImage2DList(
                                 num2DImages, vkDevice, vkFormat, width, height,
-                                numMipLevels, vkExternalMemoryHandleType);
+                                vulkanImageTiling, numMipLevels,
+                                vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
                                 vkImage2DListDeviceMemory1.push_back(
@@ -421,7 +431,8 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                 vkDevice, vkImage2DList);
                             VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
-                                numMipLevels, vkExternalMemoryHandleType);
+                                vulkanImageTiling, numMipLevels,
+                                vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
                                 vkImage2DListDeviceMemory2.push_back(
@@ -909,9 +920,18 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             // Skip running for WIN32 NT handle.
                             continue;
                         }
+
+                        VulkanImageTiling vulkanImageTiling =
+                            vkClExternalMemoryHandleTilingAssumption(
+                                deviceId,
+                                vkExternalMemoryHandleTypeList[emhtIdx], &err);
+                        ASSERT_SUCCESS(err,
+                                       "Failed to query OpenCL tiling mode");
+
                         VulkanImage2D vkDummyImage2D(
                             vkDevice, vkFormatList[0], widthList[0],
-                            heightList[0], 1, vkExternalMemoryHandleType);
+                            heightList[0], vulkanImageTiling, 1,
+                            vkExternalMemoryHandleType);
                         const VulkanMemoryTypeList &memoryTypeList =
                             vkDummyImage2D.getMemoryTypeList();
 
@@ -937,7 +957,8 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             {
                                 VulkanImage2D vkImage2D(
                                     vkDevice, vkFormat, width, height,
-                                    numMipLevels, vkExternalMemoryHandleType);
+                                    vulkanImageTiling, numMipLevels,
+                                    vkExternalMemoryHandleType);
                                 ASSERT_LEQ(vkImage2D.getSize(), maxImage2DSize);
                                 totalImageMemSize =
                                     ROUND_UP(vkImage2D.getSize(),
@@ -945,7 +966,8 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             VulkanImage2DList vkImage2DList(
                                 num2DImages, vkDevice, vkFormat, width, height,
-                                numMipLevels, vkExternalMemoryHandleType);
+                                vulkanImageTiling, numMipLevels,
+                                vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < vkImage2DList.size();
                                  bIdx++)
                             {
@@ -970,7 +992,8 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
 
                             VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
-                                numMipLevels, vkExternalMemoryHandleType);
+                                vulkanImageTiling, numMipLevels,
+                                vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < vkImage2DList2.size();
                                  bIdx++)
                             {

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -226,9 +226,9 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
     srcBufferPtr = (char *)malloc(maxImage2DSize);
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
-    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(
-        VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,
-        VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
+    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -488,20 +488,7 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
                             {
-                                for (size_t i2DIdx = 0;
-                                     i2DIdx < vkImage2DList.size(); i2DIdx++)
-                                {
-                                    for (uint32_t mipLevel = 0;
-                                         mipLevel < numMipLevels; mipLevel++)
-                                    {
-                                        uint32_t i2DvIdx =
-                                            (uint32_t)(i2DIdx * numMipLevels)
-                                            + mipLevel;
-                                        vkDescriptorSet.update(
-                                            1 + i2DvIdx,
-                                            vkImage2DViewList[i2DvIdx]);
-                                    }
-                                }
+                                vkDescriptorSet.updateArray(1, vkImage2DViewList);
                                 vkCopyCommandBuffer.begin();
                                 vkCopyCommandBuffer.pipelineBarrier(
                                     vkImage2DList,
@@ -822,9 +809,9 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
     srcBufferPtr = (char *)malloc(maxImage2DSize);
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
-    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(
-        VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,
-        VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
+    VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
+    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -1063,20 +1050,7 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
                             {
-                                for (size_t i2DIdx = 0;
-                                     i2DIdx < vkImage2DList.size(); i2DIdx++)
-                                {
-                                    for (uint32_t mipLevel = 0;
-                                         mipLevel < numMipLevels; mipLevel++)
-                                    {
-                                        uint32_t i2DvIdx =
-                                            (uint32_t)(i2DIdx * numMipLevels)
-                                            + mipLevel;
-                                        vkDescriptorSet.update(
-                                            1 + i2DvIdx,
-                                            vkImage2DViewList[i2DvIdx]);
-                                    }
-                                }
+                                vkDescriptorSet.updateArray(1, vkImage2DViewList);
                                 vkCopyCommandBuffer.begin();
                                 vkCopyCommandBuffer.pipelineBarrier(
                                     vkImage2DList,
@@ -1118,8 +1092,7 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                          i2DIdx < vkImage2DList.size();
                                          i2DIdx++)
                                     {
-                                        vkDescriptorSet.update(
-                                            1, vkImage2DViewList[i2DIdx]);
+                                        vkDescriptorSet.update(1, vkImage2DViewList[i2DIdx]);
                                         vkCopyCommandBuffer.begin();
                                         vkCopyCommandBuffer.pipelineBarrier(
                                             vkImage2DList,

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -227,8 +227,10 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
-    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -401,48 +403,40 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
-                                vkImage2DListDeviceMemory1
-                                    .push_back(new VulkanDeviceMemory(
-                                            vkDevice,
-                                            vkImage2DList[bIdx],
-                                            memoryType,
-                                            vkExternalMemoryHandleType));
-                                vkImage2DListDeviceMemory1[bIdx]
-                                    ->bindImage(vkImage2DList[bIdx],
-                                                0);
+                                vkImage2DListDeviceMemory1.push_back(
+                                    new VulkanDeviceMemory(
+                                        vkDevice, vkImage2DList[bIdx],
+                                        memoryType,
+                                        vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory1[bIdx]->bindImage(
+                                    vkImage2DList[bIdx], 0);
                                 externalMemory1.push_back(
                                     new clExternalMemoryImage(
-                                            *vkImage2DListDeviceMemory1
-                                            [bIdx],
-                                            vkExternalMemoryHandleType, context,
-                                            totalImageMemSize, width, height, 0,
-                                            vkImage2DList[bIdx],
-                                            deviceId));
+                                        *vkImage2DListDeviceMemory1[bIdx],
+                                        vkExternalMemoryHandleType, context,
+                                        totalImageMemSize, width, height, 0,
+                                        vkImage2DList[bIdx], deviceId));
                             }
                             VulkanImageViewList vkImage2DViewList(
-                                    vkDevice, vkImage2DList);
+                                vkDevice, vkImage2DList);
                             VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
                             for (size_t bIdx = 0; bIdx < num2DImages; bIdx++)
                             {
-                                vkImage2DListDeviceMemory2
-                                    .push_back(new VulkanDeviceMemory(
-                                            vkDevice,
-                                            vkImage2DList2[bIdx],
-                                            memoryType,
-                                            vkExternalMemoryHandleType));
-                                vkImage2DListDeviceMemory2[bIdx]
-                                    ->bindImage(
-                                            vkImage2DList2[bIdx], 0);
+                                vkImage2DListDeviceMemory2.push_back(
+                                    new VulkanDeviceMemory(
+                                        vkDevice, vkImage2DList2[bIdx],
+                                        memoryType,
+                                        vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory2[bIdx]->bindImage(
+                                    vkImage2DList2[bIdx], 0);
                                 externalMemory2.push_back(
                                     new clExternalMemoryImage(
-                                            *vkImage2DListDeviceMemory2
-                                            [bIdx],
-                                            vkExternalMemoryHandleType, context,
-                                            totalImageMemSize, width, height, 0,
-                                            vkImage2DList2[bIdx],
-                                            deviceId));
+                                        *vkImage2DListDeviceMemory2[bIdx],
+                                        vkExternalMemoryHandleType, context,
+                                        totalImageMemSize, width, height, 0,
+                                        vkImage2DList2[bIdx], deviceId));
                             }
 
                             cl_mem external_mem_image1[5];
@@ -460,7 +454,8 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
                             {
-                                vkDescriptorSet.updateArray(1, vkImage2DViewList);
+                                vkDescriptorSet.updateArray(1,
+                                                            vkImage2DViewList);
                                 vkCopyCommandBuffer.begin();
                                 vkCopyCommandBuffer.pipelineBarrier(
                                     vkImage2DList,
@@ -702,29 +697,25 @@ int run_test_with_two_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             for (int i = 0; i < num2DImages; i++)
                             {
-                                delete vkImage2DListDeviceMemory1
-                                    [i];
-                                delete vkImage2DListDeviceMemory2
-                                    [i];
+                                delete vkImage2DListDeviceMemory1[i];
+                                delete vkImage2DListDeviceMemory2[i];
                                 delete externalMemory1[i];
                                 delete externalMemory2[i];
                             }
                             vkImage2DListDeviceMemory1.erase(
-                                    vkImage2DListDeviceMemory1.begin(),
-                                    vkImage2DListDeviceMemory1.begin()
+                                vkImage2DListDeviceMemory1.begin(),
+                                vkImage2DListDeviceMemory1.begin()
                                     + num2DImages);
                             vkImage2DListDeviceMemory2.erase(
-                                    vkImage2DListDeviceMemory2.begin(),
-                                    vkImage2DListDeviceMemory2.begin()
+                                vkImage2DListDeviceMemory2.begin(),
+                                vkImage2DListDeviceMemory2.begin()
                                     + num2DImages);
-                            externalMemory1.erase(
-                                    externalMemory1.begin(),
-                                    externalMemory1.begin()
-                                    + num2DImages);
-                            externalMemory2.erase(
-                                    externalMemory2.begin(),
-                                    externalMemory2.begin()
-                                    + num2DImages);
+                            externalMemory1.erase(externalMemory1.begin(),
+                                                  externalMemory1.begin()
+                                                      + num2DImages);
+                            externalMemory2.erase(externalMemory2.begin(),
+                                                  externalMemory2.begin()
+                                                      + num2DImages);
                             if (CL_SUCCESS != err)
                             {
                                 goto CLEANUP;
@@ -782,8 +773,10 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
-    vkDescriptorSetLayoutBindingList.addBinding(0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    vkDescriptorSetLayoutBindingList.addBinding(1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    vkDescriptorSetLayoutBindingList.addBinding(
+        1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE, MAX_2D_IMAGE_DESCRIPTORS);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -953,53 +946,47 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             VulkanImage2DList vkImage2DList(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
-                            for (size_t bIdx = 0;
-                                 bIdx < vkImage2DList.size();
+                            for (size_t bIdx = 0; bIdx < vkImage2DList.size();
                                  bIdx++)
                             {
                                 // Create list of Vulkan device memories and
                                 // bind the list of Vulkan images.
-                                vkImage2DListDeviceMemory1
-                                    .push_back(new VulkanDeviceMemory(
-                                            vkDevice, vkImage2DList[bIdx], memoryType,
-                                            vkExternalMemoryHandleType));
-                                vkImage2DListDeviceMemory1[bIdx]
-                                    ->bindImage(vkImage2DList[bIdx],
-                                                0);
+                                vkImage2DListDeviceMemory1.push_back(
+                                    new VulkanDeviceMemory(
+                                        vkDevice, vkImage2DList[bIdx],
+                                        memoryType,
+                                        vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory1[bIdx]->bindImage(
+                                    vkImage2DList[bIdx], 0);
                                 externalMemory1.push_back(
                                     new clExternalMemoryImage(
-                                            *vkImage2DListDeviceMemory1
-                                            [bIdx],
-                                            vkExternalMemoryHandleType, context,
-                                            totalImageMemSize, width, height, 0,
-                                            vkImage2DList[bIdx],
-                                            deviceId));
+                                        *vkImage2DListDeviceMemory1[bIdx],
+                                        vkExternalMemoryHandleType, context,
+                                        totalImageMemSize, width, height, 0,
+                                        vkImage2DList[bIdx], deviceId));
                             }
                             VulkanImageViewList vkImage2DViewList(
-                                    vkDevice, vkImage2DList);
+                                vkDevice, vkImage2DList);
 
                             VulkanImage2DList vkImage2DList2(
                                 num2DImages, vkDevice, vkFormat, width, height,
                                 numMipLevels, vkExternalMemoryHandleType);
-                            for (size_t bIdx = 0;
-                                 bIdx < vkImage2DList2.size();
+                            for (size_t bIdx = 0; bIdx < vkImage2DList2.size();
                                  bIdx++)
                             {
-                                vkImage2DListDeviceMemory2
-                                    .push_back(new VulkanDeviceMemory(
-                                            vkDevice, vkImage2DList2[bIdx], memoryType,
-                                            vkExternalMemoryHandleType));
-                                vkImage2DListDeviceMemory2[bIdx]
-                                    ->bindImage(
-                                            vkImage2DList2[bIdx], 0);
+                                vkImage2DListDeviceMemory2.push_back(
+                                    new VulkanDeviceMemory(
+                                        vkDevice, vkImage2DList2[bIdx],
+                                        memoryType,
+                                        vkExternalMemoryHandleType));
+                                vkImage2DListDeviceMemory2[bIdx]->bindImage(
+                                    vkImage2DList2[bIdx], 0);
                                 externalMemory2.push_back(
                                     new clExternalMemoryImage(
-                                            *vkImage2DListDeviceMemory2
-                                            [bIdx],
-                                            vkExternalMemoryHandleType, context,
-                                            totalImageMemSize, width, height, 0,
-                                            vkImage2DList2[bIdx],
-                                            deviceId));
+                                        *vkImage2DListDeviceMemory2[bIdx],
+                                        vkExternalMemoryHandleType, context,
+                                        totalImageMemSize, width, height, 0,
+                                        vkImage2DList2[bIdx], deviceId));
                             }
 
                             cl_mem external_mem_image1[4];
@@ -1017,7 +1004,8 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             clCl2VkExternalSemaphore->signal(cmd_queue1);
                             if (!useSingleImageKernel)
                             {
-                                vkDescriptorSet.updateArray(1, vkImage2DViewList);
+                                vkDescriptorSet.updateArray(1,
+                                                            vkImage2DViewList);
                                 vkCopyCommandBuffer.begin();
                                 vkCopyCommandBuffer.pipelineBarrier(
                                     vkImage2DList,
@@ -1059,7 +1047,8 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                                          i2DIdx < vkImage2DList.size();
                                          i2DIdx++)
                                     {
-                                        vkDescriptorSet.update(1, vkImage2DViewList[i2DIdx]);
+                                        vkDescriptorSet.update(
+                                            1, vkImage2DViewList[i2DIdx]);
                                         vkCopyCommandBuffer.begin();
                                         vkCopyCommandBuffer.pipelineBarrier(
                                             vkImage2DList,
@@ -1215,29 +1204,25 @@ int run_test_with_one_queue(cl_context &context, cl_command_queue &cmd_queue1,
                             }
                             for (int i = 0; i < num2DImages; i++)
                             {
-                                delete vkImage2DListDeviceMemory1
-                                    [i];
-                                delete vkImage2DListDeviceMemory2
-                                    [i];
+                                delete vkImage2DListDeviceMemory1[i];
+                                delete vkImage2DListDeviceMemory2[i];
                                 delete externalMemory1[i];
                                 delete externalMemory2[i];
                             }
                             vkImage2DListDeviceMemory1.erase(
-                                    vkImage2DListDeviceMemory1.begin(),
-                                    vkImage2DListDeviceMemory1.begin()
+                                vkImage2DListDeviceMemory1.begin(),
+                                vkImage2DListDeviceMemory1.begin()
                                     + num2DImages);
                             vkImage2DListDeviceMemory2.erase(
-                                    vkImage2DListDeviceMemory2.begin(),
-                                    vkImage2DListDeviceMemory2.begin()
+                                vkImage2DListDeviceMemory2.begin(),
+                                vkImage2DListDeviceMemory2.begin()
                                     + num2DImages);
-                            externalMemory1.erase(
-                                    externalMemory1.begin(),
-                                    externalMemory1.begin()
-                                    + num2DImages);
-                            externalMemory2.erase(
-                                    externalMemory2.begin(),
-                                    externalMemory2.begin()
-                                    + num2DImages);
+                            externalMemory1.erase(externalMemory1.begin(),
+                                                  externalMemory1.begin()
+                                                      + num2DImages);
+                            externalMemory2.erase(externalMemory2.begin(),
+                                                  externalMemory2.begin()
+                                                      + num2DImages);
                             if (CL_SUCCESS != err)
                             {
                                 goto CLEANUP;

--- a/test_conformance/vulkan/vulkan_interop_common.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common.hpp
@@ -45,6 +45,5 @@ extern bool useDeviceLocal;
 extern bool disableNTHandleType;
 // Enable offset for multiImport of vulkan device memory
 extern bool enableOffset;
-extern bool non_dedicated;
 
 #endif // _vulkan_interop_common_hpp_


### PR DESCRIPTION
Fix Vulkan spec violation issues:

- Program Vulkan descriptor set layouts as arrays where appropriate:

Vulkan shader code binds images and buffers as arrays:
layout(binding = 1) buffer Buffer
{
     uint8_t ptr[];
} bufferPtrList[MAX_BUFFERS];

bufferPtrList is an array of size MAX_BUFFERS at binding 1.

This requires a VkDescriptorSetLayoutBinding with binding=1, and descriptorCount=MAX_BUFFERS.

From the Khronos spec "descriptorCount is the number of descriptors contained in the binding, accessed in a shader as an array"

The test previously assumed bufferPtrList[i] maps to binding site 1 + i, with descriptorCount=1.  This is not valid, and not portable.

See https://registry.khronos.org/vulkan/specs/1.1-extensions/html/vkspec.html#descriptorsets-sets


- Change VULKAN_QUEUE_FLAG_MASK_ALL to VULKAN_QUEUE_FLAG_GRAPHICS | VULKAN_QUEUE_FLAG_COMPUTE. The VULKAN_QUEUE_TRANSFER_BIT is implied by either the graphics or compute bit, implementations are not required to report it.

- Implementations may require dedicated memory for images.  This can be queried with https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMemoryDedicatedRequirements.html. This query must be done by default, and not enabled by a command line switch.  The conformance test should run on all platforms without extra options.  Suggest a follow up gerrit to add a debugging “disable dedicated memory” switch if manual control of the behavior is needed.