### PR TITLE
cmake: Enable -Wall for non-release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,11 +98,20 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
     add_cxx_flag_if_supported(-Wmisleading-indentation)
     add_cxx_flag_if_supported(-Wunused-function)
     add_cxx_flag_if_supported(-Wunused-variable)
+    add_cxx_flag_if_supported(-Werror)
+    if(NOT CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo|MinSizeRel")
+        # Enable more warnings if not doing a release build.
+        add_cxx_flag_if_supported(-Wall)
+        # Suppress warnings that currently trigger on the code base.
+        # This list should shrink over time when warnings are fixed.
+        add_cxx_flag_if_supported(-Wno-unused-but-set-variable)
+        add_cxx_flag_if_supported(-Wno-sometimes-uninitialized)
+        add_cxx_flag_if_supported(-Wno-sign-compare)
+    endif()
     add_cxx_flag_if_supported(-Wno-narrowing)
     add_cxx_flag_if_supported(-Wno-format)
-    add_cxx_flag_if_supported(-Werror)
     add_cxx_flag_if_supported(-Wno-error=cpp) # Allow #warning directive
-    add_cxx_flag_if_supported(-Wno-error=unknown-pragmas) # Issue #785
+    add_cxx_flag_if_supported(-Wno-unknown-pragmas) # Issue #785
     add_cxx_flag_if_supported(-Wno-error=asm-operand-widths) # Issue #784
 
     # -msse -mfpmath=sse to force gcc to use sse for float math,


### PR DESCRIPTION
Enable a larger set of compiler warnings globally for gcc/clang-like compilers.  This should help catch issues early and result in better code quality.  These warnings are primarily aimed at OpenCL-CTS developers, so only enable them for non-release builds.

Ensure `-Wall` and `-Werror` are set before any `-Wno-...` options, as the `-Wall`/`-Werror` flags undo `-Wno-...` for some compilers.

The code base does not compile cleanly with `-Wall` yet, so disable some warnings.  Do this globally for now, to keep this patch small and localized.

Silence `-Wunknown-pragmas` (instead of only making them non-fatal), to avoid verbose warning logs.