### PR TITLE
[NFC] api: Fix sign-compare warnings

### DIFF
--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -647,7 +647,7 @@ int test_consistency_read_write_images(cl_device_id deviceID,
         CL_MEM_OBJECT_IMAGE2D,       CL_MEM_OBJECT_IMAGE3D,
         CL_MEM_OBJECT_IMAGE1D_ARRAY, CL_MEM_OBJECT_IMAGE2D_ARRAY,
     };
-    for (int i = 0; i < ARRAY_SIZE(image_types); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(image_types); i++)
     {
         cl_uint numImageFormats = 0;
         error = clGetSupportedImageFormats(
@@ -801,7 +801,7 @@ int test_consistency_depth_images(cl_device_id deviceID, cl_context context,
         CL_MEM_READ_WRITE,
         CL_MEM_KERNEL_READ_AND_WRITE,
     };
-    for (int i = 0; i < ARRAY_SIZE(mem_flags); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(mem_flags); i++)
     {
         cl_uint numImageFormats = 0;
         error = clGetSupportedImageFormats(context, mem_flags[i],
@@ -1114,7 +1114,7 @@ int test_consistency_3d_image_writes(cl_device_id deviceID, cl_context context,
         CL_MEM_READ_WRITE,
         CL_MEM_KERNEL_READ_AND_WRITE,
     };
-    for (int i = 0; i < ARRAY_SIZE(mem_flags); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(mem_flags); i++)
     {
         cl_uint numImageFormats = 0;
         error = clGetSupportedImageFormats(context, mem_flags[i],

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -2290,7 +2290,7 @@ int test_min_max_device_version(cl_device_id deviceID, cl_context context,
     {
         log_info("Checking for required extensions for OpenCL 1.1 and later "
                  "devices...\n");
-        for (int i = 0; i < ARRAY_SIZE(requiredExtensions11); i++)
+        for (size_t i = 0; i < ARRAY_SIZE(requiredExtensions11); i++)
         {
             if (!is_extension_available(deviceID, requiredExtensions11[i]))
             {
@@ -2335,7 +2335,7 @@ int test_min_max_device_version(cl_device_id deviceID, cl_context context,
         {
             log_info("Checking for required extensions for OpenCL 2.0, 2.1 and "
                      "2.2 devices...\n");
-            for (int i = 0; i < ARRAY_SIZE(requiredExtensions2x); i++)
+            for (size_t i = 0; i < ARRAY_SIZE(requiredExtensions2x); i++)
             {
                 if (!is_extension_available(deviceID, requiredExtensions2x[i]))
                 {

--- a/test_conformance/api/test_kernel_arg_info.cpp
+++ b/test_conformance/api/test_kernel_arg_info.cpp
@@ -178,7 +178,7 @@ static std::string generate_kernel(const std::vector<KernelArgInfo>& all_args,
         ret += "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n";
     }
     ret += "kernel void get_kernel_arg_info(\n";
-    for (int i = 0; i < all_args.size(); ++i)
+    for (size_t i = 0; i < all_args.size(); ++i)
     {
         ret += generate_argument(all_args[i]);
         if (i == all_args.size() - 1)
@@ -492,7 +492,7 @@ compare_kernel_with_expected(cl_context context, cl_device_id deviceID,
         context, &program, &kernel, 1, &kernel_src, "get_kernel_arg_info",
         get_build_options(deviceID).c_str());
     test_error(err, "create_single_kernel_helper_with_build_options");
-    for (int i = 0; i < expected_args.size(); ++i)
+    for (size_t i = 0; i < expected_args.size(); ++i)
     {
         KernelArgInfo actual;
         err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_ADDRESS_QUALIFIER,

--- a/test_conformance/api/test_min_image_formats.cpp
+++ b/test_conformance/api/test_min_image_formats.cpp
@@ -71,11 +71,11 @@ int test_min_image_formats(cl_device_id device, cl_context context,
     int supports_3D_image_writes =
         is_extension_available(device, "cl_khr_3d_image_writes");
 
-    for (int t = 0; t < ARRAY_SIZE(image_types); t++)
+    for (size_t t = 0; t < ARRAY_SIZE(image_types); t++)
     {
         const cl_mem_object_type type = image_types[t];
         log_info("    testing %s...\n", convert_image_type_to_string(type));
-        for (int f = 0; f < ARRAY_SIZE(mem_flags); f++)
+        for (size_t f = 0; f < ARRAY_SIZE(mem_flags); f++)
         {
             const cl_mem_flags flags = mem_flags[f];
             const char* testTypeString = flags == CL_MEM_READ_ONLY

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -162,8 +162,8 @@ static cl_filter_mode filter_mode_values[] = { CL_FILTER_NEAREST,
                                                CL_FILTER_LINEAR };
 
 int test_sampler_params(cl_device_id deviceID, cl_context context,
-                        bool is_compatibility, int norm_coord_num,
-                        int addr_mod_num, int filt_mod_num)
+                        bool is_compatibility, size_t norm_coord_num,
+                        size_t addr_mod_num, size_t filt_mod_num)
 {
     cl_uint refCount;
     size_t size;
@@ -272,10 +272,10 @@ int test_sampler_params(cl_device_id deviceID, cl_context context,
 int get_sampler_info_params(cl_device_id deviceID, cl_context context,
                             bool is_compatibility)
 {
-    for (int norm_coord_num = 0;
+    for (size_t norm_coord_num = 0;
          norm_coord_num < ARRAY_SIZE(normalized_coord_values); norm_coord_num++)
     {
-        for (int addr_mod_num = 0;
+        for (size_t addr_mod_num = 0;
              addr_mod_num < ARRAY_SIZE(addressing_mode_values); addr_mod_num++)
         {
             if ((normalized_coord_values[norm_coord_num] == CL_FALSE)
@@ -285,7 +285,7 @@ int get_sampler_info_params(cl_device_id deviceID, cl_context context,
             {
                 continue;
             }
-            for (int filt_mod_num = 0;
+            for (size_t filt_mod_num = 0;
                  filt_mod_num < ARRAY_SIZE(filter_mode_values); filt_mod_num++)
             {
                 int err = test_sampler_params(deviceID, context,

--- a/test_conformance/api/test_queue_properties.cpp
+++ b/test_conformance/api/test_queue_properties.cpp
@@ -60,7 +60,7 @@ int enqueue_kernel(cl_context context, const cl_queue_properties_khr *queue_prop
     clCommandQueueWrapper queue = clCreateCommandQueueWithPropertiesKHR(context, deviceID, queue_prop_def, &error);
     test_error(error, "clCreateCommandQueueWithPropertiesKHR failed");
 
-    for (int i = 0; i < num_elements; ++i)
+    for (size_t i = 0; i < num_elements; ++i)
     {
         buf[i] = i;
     }
@@ -85,9 +85,9 @@ int enqueue_kernel(cl_context context, const cl_queue_properties_khr *queue_prop
     error = clEnqueueReadBuffer(queue, streams[1], CL_TRUE, 0, num_elements, buf.data(), 0, NULL, NULL);
     test_error( error, "clEnqueueReadBuffer failed." );
 
-    for (int i = 0; i < num_elements; ++i)
+    for (size_t i = 0; i < num_elements; ++i)
     {
-        if (buf[i] != i)
+        if (static_cast<size_t>(buf[i]) != i)
         {
             log_error("ERROR: Incorrect vector copy result.");
             return -1;


### PR DESCRIPTION
Fix sign-compare warnings in the api tests.  Most of these come from comparing an `int` iterator with the result of the `ARRAY_SIZE` macro, which "returns" a `size_t`.