### PR TITLE
Test CL_COMMAND_BUFFER_CONTEXT_KHR

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
@@ -26,6 +26,7 @@ enum class CombufInfoTestMode
     CITM_REF_COUNT,
     CITM_STATE,
     CITM_PROP_ARRAY,
+    CITM_CONTEXT,
 };
 
 namespace {
@@ -38,6 +39,7 @@ namespace {
 // -test case for CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR query
 // -test case for CL_COMMAND_BUFFER_STATE_KHR query
 // -test case for CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR query
+// -test case for CL_COMMAND_BUFFER_CONTEXT_KHR query
 
 template <CombufInfoTestMode test_mode>
 struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
@@ -69,6 +71,10 @@ struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
             case CombufInfoTestMode::CITM_PROP_ARRAY:
                 error = RunPropArrayInfoTest();
                 test_error(error, "RunPropArrayInfoTest failed");
+                break;
+            case CombufInfoTestMode::CITM_CONTEXT:
+                error = RunContextInfoTest();
+                test_error(error, "RunContextInfoTest failed");
                 break;
         }
 
@@ -315,6 +321,46 @@ struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
         return TEST_FAIL;
     }
 
+    cl_int RunContextInfoTest()
+    {
+        cl_int error = TEST_PASS;
+
+        // record command buffers
+        error = RecordCommandBuffer();
+        test_error(error, "RecordCommandBuffer failed");
+
+        size_t ret_value_size = 0;
+        error = clGetCommandBufferInfoKHR(command_buffer,
+                                          CL_COMMAND_BUFFER_CONTEXT_KHR, 0,
+                                          nullptr, &ret_value_size);
+        test_error(error, "clGetCommandBufferInfoKHR failed");
+
+        test_assert_error(
+            ret_value_size == sizeof(cl_context),
+            "Unexpected result of CL_COMMAND_BUFFER_CONTEXT_KHR query!");
+
+        cl_context ret_context = nullptr;
+        error = clGetCommandBufferInfoKHR(
+            command_buffer, CL_COMMAND_BUFFER_CONTEXT_KHR, sizeof(cl_context),
+            &ret_context, nullptr);
+        test_error(error, "clGetCommandBufferInfoKHR failed");
+        test_assert_error(
+            ret_context != nullptr,
+            "Unexpected result of CL_COMMAND_BUFFER_CONTEXT_KHR query!");
+
+        cl_context expected_context = nullptr;
+        error =
+            clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(cl_context),
+                                  &expected_context, nullptr);
+        test_error(error, "clGetCommandQueueInfo failed");
+
+        test_assert_error(
+            ret_context == expected_context,
+            "Unexpected result of CL_COMMAND_BUFFER_CONTEXT_KHR query!");
+
+        return TEST_PASS;
+    }
+
     const cl_int pattern = 0xE;
 };
 
@@ -350,5 +396,13 @@ int test_info_prop_array(cl_device_id device, cl_context context,
 {
     return MakeAndRunTest<
         CommandBufferGetCommandBufferInfo<CombufInfoTestMode::CITM_PROP_ARRAY>>(
+        device, context, queue, num_elements);
+}
+
+int test_info_context(cl_device_id device, cl_context context,
+                      cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<
+        CommandBufferGetCommandBufferInfo<CombufInfoTestMode::CITM_CONTEXT>>(
         device, context, queue, num_elements);
 }

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -26,6 +26,7 @@ test_definition test_list[] = {
     ADD_TEST(info_ref_count),
     ADD_TEST(info_state),
     ADD_TEST(info_prop_array),
+    ADD_TEST(info_context),
     ADD_TEST(basic_profiling),
     ADD_TEST(simultaneous_profiling),
     ADD_TEST(regular_wait_for_command_buffer),

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -41,6 +41,8 @@ extern int test_info_state(cl_device_id device, cl_context context,
                            cl_command_queue queue, int num_elements);
 extern int test_info_prop_array(cl_device_id device, cl_context context,
                                 cl_command_queue queue, int num_elements);
+extern int test_info_context(cl_device_id device, cl_context context,
+                             cl_command_queue queue, int num_elements);
 extern int test_basic_set_kernel_arg(cl_device_id device, cl_context context,
                                      cl_command_queue queue, int num_elements);
 extern int test_pending_set_kernel_arg(cl_device_id device, cl_context context,


### PR DESCRIPTION
Test coverage for spec PR https://github.com/KhronosGroup/OpenCL-Docs/pull/899 which introduces a new cl_khr_command_buffer query for the cl_context.