### PR TITLE
Changes to make test suite compile on GCC 12.2.0

### DIFF
--- a/test_conformance/api/test_create_kernels.cpp
+++ b/test_conformance/api/test_create_kernels.cpp
@@ -406,8 +406,8 @@ int test_get_program_info_kernel_names( cl_device_id deviceID, cl_context contex
 
     if (i == sizeof( actual_names ) / sizeof( actual_names[0] ) )
     {
-        free(kernel_names);
         log_error( "Kernel names \"%s\" did not match:\n", kernel_names );
+        free(kernel_names);
         for( i = 0; i < sizeof( actual_names ) / sizeof( actual_names[0] ); i++ )
             log_error( "\t\t\"%s\"\n", actual_names[0] );
         return -1;

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -212,7 +212,7 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     clProgramWrapper program;
     clKernelWrapper kernels[2];
     clMemWrapper  stream;
-    clCommandQueueWrapper queues[MAX_QUEUES];
+    clCommandQueueWrapper queues[MAX_QUEUES] = {};
     size_t threads[1], localThreads[1];
     int data[TEST_SIZE];
     int outputData[TEST_SIZE];
@@ -225,8 +225,6 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     for (i=0; i<deviceCount; i++) {
         expectedResultsOneDevice[i] = expectedResultsOneDeviceArray + (i * TEST_SIZE);
     }
-
-    memset(queues, 0, sizeof(queues));
 
     RandomSeed seed( gRandomSeed );
 

--- a/test_conformance/multiple_device_context/test_multiple_devices.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_devices.cpp
@@ -42,15 +42,13 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     clProgramWrapper program;
     clKernelWrapper kernels[2];
     clMemWrapper      stream;
-    clCommandQueueWrapper queues[MAX_QUEUES];
+    clCommandQueueWrapper queues[MAX_QUEUES] = {};
     size_t    threads[1], localThreads[1];
     cl_uint data[TEST_SIZE];
     cl_uint outputData[TEST_SIZE];
     cl_uint expectedResults[TEST_SIZE];
     cl_uint expectedResultsOneDevice[MAX_DEVICES][TEST_SIZE];
     size_t i;
-
-  memset(queues, 0, sizeof(queues));
 
     RandomSeed seed( gRandomSeed );
 


### PR DESCRIPTION
Fixed use-after-free and class-memaccess errors when compiling with GCC 12.2.0.