### PR TITLE
select: using clEnqueueReadBuffer rather than clEnqueueMapBuffer

### DIFF
--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -363,14 +363,30 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
     dest = clCreateBuffer( context, CL_MEM_WRITE_ONLY, BUFFER_SIZE, NULL, &err );
     if( err ) { log_error( "Error: could not allocate dest buffer\n" );  ++s_test_fail; goto exit; }
 
-    src1_host = malloc( BUFFER_SIZE );
-    if( NULL == src1_host ){ log_error("Error: could not allocate src1_host buffer\n" ); goto exit; }
-    src2_host = malloc( BUFFER_SIZE );
-    if( NULL == src2_host ){ log_error("Error: could not allocate src2_host buffer\n" ); goto exit; }
-    cmp_host = malloc( BUFFER_SIZE );
-    if( NULL == cmp_host ){ log_error("Error: could not allocate cmp_host buffer\n" ); goto exit; }
-    dest_host = malloc( BUFFER_SIZE );
-    if( NULL == dest_host ){ log_error("Error: could not allocate dest_host buffer\n" ); goto exit; }
+    src1_host = malloc(BUFFER_SIZE);
+    if (NULL == src1_host)
+    {
+        log_error("Error: could not allocate src1_host buffer\n");
+        goto exit;
+    }
+    src2_host = malloc(BUFFER_SIZE);
+    if (NULL == src2_host)
+    {
+        log_error("Error: could not allocate src2_host buffer\n");
+        goto exit;
+    }
+    cmp_host = malloc(BUFFER_SIZE);
+    if (NULL == cmp_host)
+    {
+        log_error("Error: could not allocate cmp_host buffer\n");
+        goto exit;
+    }
+    dest_host = malloc(BUFFER_SIZE);
+    if (NULL == dest_host)
+    {
+        log_error("Error: could not allocate dest_host buffer\n");
+        goto exit;
+    }
 
     // We block the test as we are running over the range of compare values
     // "block the test" means "break the test into blocks"
@@ -407,17 +423,37 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
         { log_error( "Error: coult not unmap cmp\n" );  ++s_test_fail; goto exit; }
 
         // Create the reference result
-        err = clEnqueueReadBuffer( queue, src1, CL_TRUE, 0, BUFFER_SIZE, src1_host, 0, NULL, NULL);
-        if( err ){ log_error( "Error: Reading buffer from src1 to src1_host failed\n" );  ++s_test_fail; goto exit; }
-        err = clEnqueueReadBuffer( queue, src2, CL_TRUE, 0, BUFFER_SIZE, src2_host, 0, NULL, NULL);
-        if( err ){ log_error( "Error: Reading buffer from src2 to src2_host failed\n" );  ++s_test_fail; goto exit; }
-        err = clEnqueueReadBuffer( queue, cmp, CL_TRUE, 0, BUFFER_SIZE, cmp_host, 0, NULL, NULL);
-        if( err ){ log_error( "Error: Reading buffer from cmp to cmp_host failed\n" );  ++s_test_fail; goto exit; }
+        err = clEnqueueReadBuffer(queue, src1, CL_TRUE, 0, BUFFER_SIZE,
+                                  src1_host, 0, NULL, NULL);
+        if (err)
+        {
+            log_error("Error: Reading buffer from src1 to src1_host failed\n");
+            ++s_test_fail;
+            goto exit;
+        }
+        err = clEnqueueReadBuffer(queue, src2, CL_TRUE, 0, BUFFER_SIZE,
+                                  src2_host, 0, NULL, NULL);
+        if (err)
+        {
+            log_error("Error: Reading buffer from src2 to src2_host failed\n");
+            ++s_test_fail;
+            goto exit;
+        }
+        err = clEnqueueReadBuffer(queue, cmp, CL_TRUE, 0, BUFFER_SIZE, cmp_host,
+                                  0, NULL, NULL);
+        if (err)
+        {
+            log_error("Error: Reading buffer from cmp to cmp_host failed\n");
+            ++s_test_fail;
+            goto exit;
+        }
 
-        Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0] : vrefSelects[stype][1];
+        Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0]
+                                                : vrefSelects[stype][1];
         (*sfunc)(ref, src1_host, src2_host, cmp_host, block_elements);
 
-        sfunc = (cmptype == ctype[stype][0]) ? refSelects[stype][0] : refSelects[stype][1];
+        sfunc = (cmptype == ctype[stype][0]) ? refSelects[stype][0]
+                                             : refSelects[stype][1];
         (*sfunc)(sref, src1_host, src2_host, cmp_host, block_elements);
 
         for (vecsize = 0; vecsize < VECTOR_SIZE_COUNT; ++vecsize)
@@ -447,13 +483,23 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
                 goto exit;
             }
 
-            err = clEnqueueReadBuffer( queue, dest, CL_TRUE, 0, BUFFER_SIZE, dest_host, 0, NULL, NULL);
-            if( err ){ log_error( "Error: Reading buffer from dest to dest_host failed\n" );  ++s_test_fail; goto exit; }
-
-            if ((*checkResults[stype])(dest_host, vecsize == 0 ? sref : ref, block_elements, element_count[vecsize])!=0){
-                log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
+            err = clEnqueueReadBuffer(queue, dest, CL_TRUE, 0, BUFFER_SIZE,
+                                      dest_host, 0, NULL, NULL);
+            if (err)
+            {
+                log_error(
+                    "Error: Reading buffer from dest to dest_host failed\n");
                 ++s_test_fail;
                 goto exit;
+            }
+
+            if ((*checkResults[stype])(dest_host, vecsize == 0 ? sref : ref,
+                                       block_elements, element_count[vecsize])
+                != 0)
+            {
+                     log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
+                     ++s_test_fail;
+                     goto exit;
             }
         } // for vecsize
     } // for i
@@ -470,10 +516,10 @@ exit:
     if( dest)   clReleaseMemObject( dest );
     if( ref )   free(ref );
     if( sref )  free(sref );
-    if( src1_host )  free( src1_host );
-    if( src2_host )  free( src2_host );
-    if( cmp_host )   free( cmp_host );
-    if( dest_host )  free( dest_host );
+    if (src1_host) free(src1_host);
+    if (src2_host) free(src2_host);
+    if (cmp_host) free(cmp_host);
+    if (dest_host) free(dest_host);
 
     for (vecsize = 0; vecsize < VECTOR_SIZE_COUNT; vecsize++) {
         clReleaseKernel(kernels[vecsize]);

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -303,6 +303,10 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
     cl_mem dest = NULL;
     void *ref = NULL;
     void *sref = NULL;
+    void *src1_host = NULL;
+    void *src2_host = NULL;
+    void *cmp_host = NULL;
+    void *dest_host = NULL;
 
     cl_ulong blocks = type_size[stype] * 0x100000000ULL / BUFFER_SIZE;
     size_t block_elements = BUFFER_SIZE / type_size[stype];
@@ -359,6 +363,14 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
     dest = clCreateBuffer( context, CL_MEM_WRITE_ONLY, BUFFER_SIZE, NULL, &err );
     if( err ) { log_error( "Error: could not allocate dest buffer\n" );  ++s_test_fail; goto exit; }
 
+    src1_host = malloc( BUFFER_SIZE );
+    if( NULL == src1_host ){ log_error("Error: could not allocate src1_host buffer\n" ); goto exit; }
+    src2_host = malloc( BUFFER_SIZE );
+    if( NULL == src2_host ){ log_error("Error: could not allocate src2_host buffer\n" ); goto exit; }
+    cmp_host = malloc( BUFFER_SIZE );
+    if( NULL == cmp_host ){ log_error("Error: could not allocate cmp_host buffer\n" ); goto exit; }
+    dest_host = malloc( BUFFER_SIZE );
+    if( NULL == dest_host ){ log_error("Error: could not allocate dest_host buffer\n" ); goto exit; }
 
     // We block the test as we are running over the range of compare values
     // "block the test" means "break the test into blocks"
@@ -387,19 +399,26 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
         // Setup the input data to change for each block
         initCmpBuffer(s3, cmptype, i * cmp_stride, block_elements);
 
-        // Create the reference result
-        Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0] : vrefSelects[stype][1];
-        (*sfunc)(ref, s1, s2, s3, block_elements);
-
-        sfunc = (cmptype == ctype[stype][0]) ? refSelects[stype][0] : refSelects[stype][1];
-        (*sfunc)(sref, s1, s2, s3, block_elements);
-
         if( (err = clEnqueueUnmapMemObject( queue, src1, s1, 0, NULL, NULL )))
         { log_error( "Error: coult not unmap src1\n" );  ++s_test_fail; goto exit; }
         if( (err = clEnqueueUnmapMemObject( queue, src2, s2, 0, NULL, NULL )))
         { log_error( "Error: coult not unmap src2\n" );  ++s_test_fail; goto exit; }
         if( (err = clEnqueueUnmapMemObject( queue, cmp, s3, 0, NULL, NULL )))
         { log_error( "Error: coult not unmap cmp\n" );  ++s_test_fail; goto exit; }
+
+        // Create the reference result
+        err = clEnqueueReadBuffer( queue, src1, CL_TRUE, 0, BUFFER_SIZE, src1_host, 0, NULL, NULL);
+        if( err ){ log_error( "Error: Reading buffer from src1 to src1_host failed\n" );  ++s_test_fail; goto exit; }
+        err = clEnqueueReadBuffer( queue, src2, CL_TRUE, 0, BUFFER_SIZE, src2_host, 0, NULL, NULL);
+        if( err ){ log_error( "Error: Reading buffer from src2 to src2_host failed\n" );  ++s_test_fail; goto exit; }
+        err = clEnqueueReadBuffer( queue, cmp, CL_TRUE, 0, BUFFER_SIZE, cmp_host, 0, NULL, NULL);
+        if( err ){ log_error( "Error: Reading buffer from cmp to cmp_host failed\n" );  ++s_test_fail; goto exit; }
+
+        Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0] : vrefSelects[stype][1];
+        (*sfunc)(ref, src1_host, src2_host, cmp_host, block_elements);
+
+        sfunc = (cmptype == ctype[stype][0]) ? refSelects[stype][0] : refSelects[stype][1];
+        (*sfunc)(sref, src1_host, src2_host, cmp_host, block_elements);
 
         for (vecsize = 0; vecsize < VECTOR_SIZE_COUNT; ++vecsize)
         {
@@ -415,7 +434,6 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
             if((err = clSetKernelArg(kernels[vecsize], 3,  sizeof cmp, &cmp) ))
             { log_error( "Error: Cannot set kernel arg dest! %d\n", err ); ++s_test_fail; goto exit; }
 
-
             // Wipe destination
             void *d = clEnqueueMapBuffer( queue, dest, CL_TRUE, CL_MAP_WRITE, 0, BUFFER_SIZE, 0, NULL, NULL, &err );
             if( err ){ log_error( "Error: Could not map dest" );  ++s_test_fail; goto exit; }
@@ -429,18 +447,11 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
                 goto exit;
             }
 
-            d = clEnqueueMapBuffer( queue, dest, CL_TRUE, CL_MAP_READ, 0, BUFFER_SIZE, 0, NULL, NULL, &err );
-            if( err ){ log_error( "Error: Could not map dest # 2" );  ++s_test_fail; goto exit; }
+            err = clEnqueueReadBuffer( queue, dest, CL_TRUE, 0, BUFFER_SIZE, dest_host, 0, NULL, NULL);
+            if( err ){ log_error( "Error: Reading buffer from dest to dest_host failed\n" );  ++s_test_fail; goto exit; }
 
-            if ((*checkResults[stype])(d, vecsize == 0 ? sref : ref, block_elements, element_count[vecsize])!=0){
+            if ((*checkResults[stype])(dest_host, vecsize == 0 ? sref : ref, block_elements, element_count[vecsize])!=0){
                 log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
-                ++s_test_fail;
-                goto exit;
-            }
-
-            if( (err = clEnqueueUnmapMemObject( queue, dest, d, 0, NULL, NULL ) ) )
-            {
-                log_error( "Error: Could not unmap dest" );
                 ++s_test_fail;
                 goto exit;
             }
@@ -459,6 +470,10 @@ exit:
     if( dest)   clReleaseMemObject( dest );
     if( ref )   free(ref );
     if( sref )  free(sref );
+    if( src1_host )  free( src1_host );
+    if( src2_host )  free( src2_host );
+    if( cmp_host )   free( cmp_host );
+    if( dest_host )  free( dest_host );
 
     for (vecsize = 0; vecsize < VECTOR_SIZE_COUNT; vecsize++) {
         clReleaseKernel(kernels[vecsize]);

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -449,7 +449,7 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
         }
 
         Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0]
-                                                : vrefSelects[stype][1];
+                                                    : vrefSelects[stype][1];
         (*sfunc)(ref, src1_host, src2_host, cmp_host, block_elements);
 
         sfunc = (cmptype == ctype[stype][0]) ? refSelects[stype][0]
@@ -497,9 +497,9 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
                                        block_elements, element_count[vecsize])
                 != 0)
             {
-                     log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
-                     ++s_test_fail;
-                     goto exit;
+                 log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
+                 ++s_test_fail;
+                 goto exit;
             }
         } // for vecsize
     } // for i

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -497,7 +497,8 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
                                        block_elements, element_count[vecsize])
                 != 0)
             {
-                log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
+                log_error("vec_size:%d indx: 0x%16.16llx\n",
+                          (int)element_count[vecsize], i);
                 ++s_test_fail;
                 goto exit;
             }

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -497,9 +497,9 @@ static int doTest(cl_command_queue queue, cl_context context, Type stype, Type c
                                        block_elements, element_count[vecsize])
                 != 0)
             {
-                 log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
-                 ++s_test_fail;
-                 goto exit;
+                log_error("vec_size:%d indx: 0x%16.16llx\n", (int)element_count[vecsize], i);
+                ++s_test_fail;
+                goto exit;
             }
         } // for vecsize
     } // for i


### PR DESCRIPTION
In this PR, I'd propose to replace clEnqueueMapBuffer with clEnqueueReadBuffer while reading data from buffers.

In my opinion:
- clEnqueueMapBuffer should be used to read/write small data randomly.
- clEnqueueReadBuffer should be used to read the whole data from the buffer **frequently**.

Vendors implement the clEnqueueMapBuffer API differently. If the buffer is located on the device, and clEnqueueMapBuffer is returning a CPU virtual address of it, the reading speed vary. For example, PCIe writing is asynchronous while PCIe reading is synchronous. This results a gap between the speed of reading and writing to the memory/pointer returned by clEnqueueMapBuffer.

Loading the buffer back to CPU using clEnqueueReadBuffer ensures the frequent data reading always happen on CPU, and it will increase the speed of creating reference result and comparing/checking result. For example, on my test machine, the runtime of test_select program **reduced from 82 hours to 45 minutes**. This is also relevant to the ticket here: #1054 .

Also, the clEnqueueMapBuffer function used for creating reference result is actaully created for "writing" (CL_MAP_WRITE), and later we used it for "reading" as well.
```
void *s3 = clEnqueueMapBuffer( queue, cmp, CL_TRUE, CL_MAP_WRITE, 0, BUFFER_SIZE, 0, NULL, NULL, &err );
if( err ){ log_error( "Error: Could not map cmp" ); goto exit; }
// Setup the input data to change for each block
initCmpBuffer(s3, cmptype, i * cmp_stride, block_elements);

// Create the reference result
Select sfunc = (cmptype == ctype[stype][0]) ? vrefSelects[stype][0] : vrefSelects[stype][1];
(*sfunc)(ref, s1, s2, s3, block_elements);
```
I've tested the patch with Nvidia RTX 3090 (Driver Version: 530.30.02, CUDA version 12.1) as well, the correctness is okay. It won't reduce the runtime of their test_select, but I'd guess they have an optimized implementation for clEnqueueMapBuffer. 