### PR TITLE
[NFC] cmake: do not suppress -Wunused-but-set-variable globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
         add_cxx_flag_if_supported(-Wall)
         # Suppress warnings that currently trigger on the code base.
         # This list should shrink over time when warnings are fixed.
-        add_cxx_flag_if_supported(-Wno-unused-but-set-variable)
         add_cxx_flag_if_supported(-Wno-sometimes-uninitialized)
         add_cxx_flag_if_supported(-Wno-sign-compare)
     endif()

--- a/test_conformance/basic/CMakeLists.txt
+++ b/test_conformance/basic/CMakeLists.txt
@@ -70,4 +70,6 @@ if(APPLE)
     list(APPEND ${MODULE_NAME}_SOURCES test_queue_priority.cpp)
 endif(APPLE)
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -16,4 +16,6 @@ set_source_files_properties(
         COMPILE_FLAGS -march=i686)
 endif(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/device_timer/CMakeLists.txt
+++ b/test_conformance/device_timer/CMakeLists.txt
@@ -5,4 +5,6 @@ set(${MODULE_NAME}_SOURCES
     test_device_timer.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/images/clCopyImage/CMakeLists.txt
+++ b/test_conformance/images/clCopyImage/CMakeLists.txt
@@ -15,5 +15,7 @@ set(${MODULE_NAME}_SOURCES
     ../common.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../../CMakeCommon.txt)
 

--- a/test_conformance/images/clReadWriteImage/CMakeLists.txt
+++ b/test_conformance/images/clReadWriteImage/CMakeLists.txt
@@ -11,5 +11,7 @@ set(${MODULE_NAME}_SOURCES
     ../common.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../../CMakeCommon.txt)
 

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -21,7 +21,7 @@ set(${MODULE_NAME}_SOURCES
 
 # Make unused variables not fatal in this module; see
 # https://github.com/KhronosGroup/OpenCL-CTS/issues/1484
-set_gnulike_module_compile_flags("-Wno-error=unused-variable")
+set_gnulike_module_compile_flags("-Wno-error=unused-variable -Wno-unused-but-set-variable")
 
 include(../../CMakeCommon.txt)
 

--- a/test_conformance/mem_host_flags/CMakeLists.txt
+++ b/test_conformance/mem_host_flags/CMakeLists.txt
@@ -6,4 +6,6 @@ set(${MODULE_NAME}_SOURCES
     mem_host_image.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/non_uniform_work_group/CMakeLists.txt
+++ b/test_conformance/non_uniform_work_group/CMakeLists.txt
@@ -10,6 +10,8 @@ set(${MODULE_NAME}_SOURCES
     tools.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+
 include(../CMakeCommon.txt)
 
 # end of file #


### PR DESCRIPTION
Only disable `-Wunused-but-set-variable` for tests that do not compile cleanly with this warning enabled.  This re-enables the warning for most other tests, so that it can catch any new occurrences.