### PR TITLE
Fix some Wformat size_t warnings

### DIFF
--- a/test_conformance/basic/test_get_linear_ids.cpp
+++ b/test_conformance/basic/test_get_linear_ids.cpp
@@ -104,15 +104,19 @@ test_get_linear_ids(cl_device_id device, cl_context context, cl_command_queue qu
 
         switch (dims) {
         case 1:
-            log_info("  testing offset=%u global=%u local=%u...\n", gwo[0], gws[0], lws[0]);
+            log_info("  testing offset=%zu global=%zu local=%zu...\n", gwo[0],
+                     gws[0], lws[0]);
             break;
         case 2:
-            log_info("  testing offset=(%u,%u) global=(%u,%u) local=(%u,%u)...\n",
-                    gwo[0], gwo[1], gws[0], gws[1], lws[0], lws[1]);
+            log_info("  testing offset=(%zu,%zu) global=(%zu,%zu) "
+                     "local=(%zu,%zu)...\n",
+                     gwo[0], gwo[1], gws[0], gws[1], lws[0], lws[1]);
             break;
         case 3:
-            log_info("  testing offset=(%u,%u,%u) global=(%u,%u,%u) local=(%u,%u,%u)...\n",
-                    gwo[0], gwo[1], gwo[2], gws[0], gws[1], gws[2], lws[0], lws[1], lws[2]);
+            log_info("  testing offset=(%zu,%zu,%zu) global=(%zu,%zu,%zu) "
+                     "local=(%zu,%zu,%zu)...\n",
+                     gwo[0], gwo[1], gwo[2], gws[0], gws[1], gws[2], lws[0],
+                     lws[1], lws[2]);
             break;
         }
 

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -28,7 +28,7 @@
     {                                                                          \
         if (reference != result)                                               \
         {                                                                      \
-            log_error("Expected %d was %d at index %u\n", reference, result,   \
+            log_error("Expected %d was %d at index %zu\n", reference, result,  \
                       index);                                                  \
             return TEST_FAIL;                                                  \
         }                                                                      \


### PR DESCRIPTION
Printing a `size_t` requires the `%zu` specifier.