### PR TITLE
Convert some if-else chains to switch statements

### DIFF
--- a/test_conformance/allocations/allocation_execute.cpp
+++ b/test_conformance/allocations/allocation_execute.cpp
@@ -79,20 +79,30 @@ int check_image(cl_command_queue queue, cl_mem mem) {
         return -1;
     }
 
-    if (type == CL_MEM_OBJECT_BUFFER) {
-        log_error("Expected image object, not buffer.\n");
-        return -1;
-    } else if (type == CL_MEM_OBJECT_IMAGE2D) {
-        error = clGetImageInfo(mem, CL_IMAGE_WIDTH, sizeof(width), &width, NULL);
-        if (error) {
-            print_error(error, "clGetMemObjectInfo failed for CL_IMAGE_WIDTH.");
+    switch (type)
+    {
+        case CL_MEM_OBJECT_BUFFER:
+            log_error("Expected image object, not buffer.\n");
             return -1;
-        }
-        error = clGetImageInfo(mem, CL_IMAGE_HEIGHT, sizeof(height), &height, NULL);
-        if (error) {
-            print_error(error, "clGetMemObjectInfo failed for CL_IMAGE_HEIGHT.");
-            return -1;
-        }
+        case CL_MEM_OBJECT_IMAGE2D:
+            error = clGetImageInfo(mem, CL_IMAGE_WIDTH, sizeof(width), &width,
+                                   NULL);
+            if (error)
+            {
+                print_error(error,
+                            "clGetMemObjectInfo failed for CL_IMAGE_WIDTH.");
+                return -1;
+            }
+            error = clGetImageInfo(mem, CL_IMAGE_HEIGHT, sizeof(height),
+                                   &height, NULL);
+            if (error)
+            {
+                print_error(error,
+                            "clGetMemObjectInfo failed for CL_IMAGE_HEIGHT.");
+                return -1;
+            }
+            break;
+        default: log_error("unexpected object type"); return -1;
     }
 
 

--- a/test_conformance/api/test_null_buffer_arg.cpp
+++ b/test_conformance/api/test_null_buffer_arg.cpp
@@ -64,16 +64,21 @@ static int test_setargs_and_execution(cl_command_queue queue, cl_kernel kernel,
     cl_int status;
     const char *typestr;
 
-    if (type == NON_NULL_PATH) {
-        status = clSetKernelArg(kernel, 0, sizeof(cl_mem), &test_buf);
-        typestr = "non-NULL";
-    } else if (type == ADDROF_NULL_PATH) {
-        test_buf = NULL;
-        status = clSetKernelArg(kernel, 0, sizeof(cl_mem), &test_buf);
-        typestr = "&NULL";
-    } else if (type == NULL_PATH) {
-        status = clSetKernelArg(kernel, 0, sizeof(cl_mem), NULL);
-        typestr = "NULL";
+    switch (type)
+    {
+        case NON_NULL_PATH:
+            status = clSetKernelArg(kernel, 0, sizeof(cl_mem), &test_buf);
+            typestr = "non-NULL";
+            break;
+        case ADDROF_NULL_PATH:
+            test_buf = NULL;
+            status = clSetKernelArg(kernel, 0, sizeof(cl_mem), &test_buf);
+            typestr = "&NULL";
+            break;
+        case NULL_PATH:
+            status = clSetKernelArg(kernel, 0, sizeof(cl_mem), NULL);
+            typestr = "NULL";
+            break;
     }
 
     log_info("Testing setKernelArgs with %s buffer.\n", typestr);

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -41,60 +41,52 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
         }
     }
 
-    if( testMethod == k1D )
+    switch (testMethod)
     {
-        name = "1D -> 1D";
-        imageType = CL_MEM_OBJECT_IMAGE1D;
-    }
-    else if( testMethod == k2D )
-    {
-        name = "2D -> 2D";
-        imageType = CL_MEM_OBJECT_IMAGE2D;
-    }
-    else if( testMethod == k3D )
-    {
-        name = "3D -> 3D";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
-    }
-    else if( testMethod == k1DArray )
-    {
-        name = "1D array -> 1D array";
-        imageType = CL_MEM_OBJECT_IMAGE1D_ARRAY;
-    }
-    else if( testMethod == k2DArray )
-    {
-        name = "2D array -> 2D array";
-        imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-    }
-    else if( testMethod == k2DTo3D )
-    {
-        name = "2D -> 3D";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
-    }
-    else if( testMethod == k3DTo2D )
-    {
-        name = "3D -> 2D";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
-    }
-    else if( testMethod == k2DArrayTo2D )
-    {
-        name = "2D array -> 2D";
-        imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-    }
-    else if( testMethod == k2DTo2DArray )
-    {
-        name = "2D -> 2D array";
-        imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-    }
-    else if( testMethod == k2DArrayTo3D )
-    {
-        name = "2D array -> 3D";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
-    }
-    else if( testMethod == k3DTo2DArray )
-    {
-        name = "3D -> 2D array";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
+        case k1D:
+            name = "1D -> 1D";
+            imageType = CL_MEM_OBJECT_IMAGE1D;
+            break;
+        case k2D:
+            name = "2D -> 2D";
+            imageType = CL_MEM_OBJECT_IMAGE2D;
+            break;
+        case k3D:
+            name = "3D -> 3D";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            break;
+        case k1DArray:
+            name = "1D array -> 1D array";
+            imageType = CL_MEM_OBJECT_IMAGE1D_ARRAY;
+            break;
+        case k2DArray:
+            name = "2D array -> 2D array";
+            imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+            break;
+        case k2DTo3D:
+            name = "2D -> 3D";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            break;
+        case k3DTo2D:
+            name = "3D -> 2D";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            break;
+        case k2DArrayTo2D:
+            name = "2D array -> 2D";
+            imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+            break;
+        case k2DTo2DArray:
+            name = "2D -> 2D array";
+            imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+            break;
+        case k2DArrayTo3D:
+            name = "2D array -> 3D";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            break;
+        case k3DTo2DArray:
+            name = "3D -> 2D array";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            break;
     }
 
     if(gTestMipmaps)

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -33,35 +33,34 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     cl_mem_object_type imageType;
     test_func test_fn;
 
-    if ( testMethod == k1D )
+    switch (testMethod)
     {
-        name = "1D Image Fill";
-        imageType = CL_MEM_OBJECT_IMAGE1D;
-        test_fn = &test_fill_image_set_1D;
-    }
-    else if ( testMethod == k2D )
-    {
-        name = "2D Image Fill";
-        imageType = CL_MEM_OBJECT_IMAGE2D;
-        test_fn = &test_fill_image_set_2D;
-    }
-    else if ( testMethod == k1DArray )
-    {
-        name = "1D Image Array Fill";
-        imageType = CL_MEM_OBJECT_IMAGE1D_ARRAY;
-        test_fn = &test_fill_image_set_1D_array;
-    }
-    else if ( testMethod == k2DArray )
-    {
-        name = "2D Image Array Fill";
-        imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-        test_fn = &test_fill_image_set_2D_array;
-    }
-    else if ( testMethod == k3D )
-    {
-        name = "3D Image Fill";
-        imageType = CL_MEM_OBJECT_IMAGE3D;
-        test_fn = &test_fill_image_set_3D;
+        case k1D:
+            name = "1D Image Fill";
+            imageType = CL_MEM_OBJECT_IMAGE1D;
+            test_fn = &test_fill_image_set_1D;
+            break;
+        case k2D:
+            name = "2D Image Fill";
+            imageType = CL_MEM_OBJECT_IMAGE2D;
+            test_fn = &test_fill_image_set_2D;
+            break;
+        case k1DArray:
+            name = "1D Image Array Fill";
+            imageType = CL_MEM_OBJECT_IMAGE1D_ARRAY;
+            test_fn = &test_fill_image_set_1D_array;
+            break;
+        case k2DArray:
+            name = "2D Image Array Fill";
+            imageType = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+            test_fn = &test_fill_image_set_2D_array;
+            break;
+        case k3D:
+            name = "3D Image Fill";
+            imageType = CL_MEM_OBJECT_IMAGE3D;
+            test_fn = &test_fill_image_set_3D;
+            break;
+        default: log_error("Unhandled method\n"); return -1;
     }
 
     log_info( "Running %s tests...\n", name );


### PR DESCRIPTION
All of these if-else chains compare against enums, which is better done using switch statements.  This helps avoid some `-Wsometimes-uninitialized` warnings of variables that are assigned inside the switch.