### PR TITLE
non_uniform_work_group: fix unused-but-set variables

### DIFF
--- a/test_conformance/non_uniform_work_group/CMakeLists.txt
+++ b/test_conformance/non_uniform_work_group/CMakeLists.txt
@@ -10,8 +10,6 @@ set(${MODULE_NAME}_SOURCES
     tools.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
-
 include(../CMakeCommon.txt)
 
 # end of file #

--- a/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
+++ b/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
@@ -448,12 +448,7 @@ void TestNonUniformWorkGroup::verifyData (DataContainerAttrib * reference, DataC
 }
 
 void TestNonUniformWorkGroup::calculateExpectedValues () {
-  size_t nonRemainderGlobalSize[MAX_DIMS];
   size_t numberOfPossibleRegions[MAX_DIMS];
-
-  nonRemainderGlobalSize[0] = _globalSize[0] - (_globalSize[0] % _enqueuedLocalSize[0]);
-  nonRemainderGlobalSize[1] = _globalSize[1] - (_globalSize[1] % _enqueuedLocalSize[1]);
-  nonRemainderGlobalSize[2] = _globalSize[2] - (_globalSize[2] % _enqueuedLocalSize[2]);
 
   numberOfPossibleRegions[0] = (_globalSize[0]>1)?2:1;
   numberOfPossibleRegions[1] = (_globalSize[1]>1)?2:1;
@@ -502,6 +497,11 @@ size_t TestNonUniformWorkGroup::getMaxLocalWorkgroupSize (const cl_device_id &de
   if (TestNonUniformWorkGroup::_maxLocalWorkgroupSize == 0) {
     err = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_GROUP_SIZE,
       sizeof(TestNonUniformWorkGroup::_maxLocalWorkgroupSize), &TestNonUniformWorkGroup::_maxLocalWorkgroupSize, NULL);
+    if (err)
+    {
+        log_error("clGetDeviceInfo failed\n");
+        return 0;
+    }
   }
 
   return TestNonUniformWorkGroup::_maxLocalWorkgroupSize;


### PR DESCRIPTION
Remove the unused `nonRemainderGlobalSize` array.  Inspect the result of the `clGetDeviceInfo` call.

As this fixes all occurrences of this warning, remove the suppression flag from this test's CMakeLists.txt.