### PR TITLE
relationals: add missing virtual destructor

### DIFF
--- a/test_conformance/relationals/test_comparisons_fp.h
+++ b/test_conformance/relationals/test_comparisons_fp.h
@@ -32,6 +32,7 @@ template <typename T> using VerifyFunc = bool (*)(const T &, const T &);
 struct RelTestBase
 {
     explicit RelTestBase(const ExplicitTypes &dt): dataType(dt) {}
+    virtual ~RelTestBase() = default;
     ExplicitTypes dataType;
 };
 


### PR DESCRIPTION
`RelationalsFPTest` contains a vector of `RelTestBase` pointers to `RelTestParams` instances, so the base class destructor should be virtual to avoid undefined behaviour.

Fixes https://github.com/KhronosGroup/OpenCL-CTS/issues/1731