### PR TITLE
cmake: do not suppress -Wsometimes-uninitialized globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
         add_cxx_flag_if_supported(-Wall)
         # Suppress warnings that currently trigger on the code base.
         # This list should shrink over time when warnings are fixed.
-        add_cxx_flag_if_supported(-Wno-sometimes-uninitialized)
         add_cxx_flag_if_supported(-Wno-sign-compare)
     endif()
     add_cxx_flag_if_supported(-Wno-narrowing)

--- a/test_conformance/SVM/CMakeLists.txt
+++ b/test_conformance/SVM/CMakeLists.txt
@@ -17,4 +17,6 @@ set(${MODULE_NAME}_SOURCES
     test_migrate.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sometimes-uninitialized")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/mem_host_flags/checker.h
+++ b/test_conformance/mem_host_flags/checker.h
@@ -219,7 +219,7 @@ cl_int cBuffer_checker<T>::SetupASSubBuffer(cl_mem_flags parent_buffer_flag)
         err = CL_SUCCESS;
     }
 
-    cl_mem_flags f;
+    cl_mem_flags f = 0;
     if (parent_buffer_flag & CL_MEM_HOST_READ_ONLY)
         f = CL_MEM_HOST_READ_ONLY;
     else if (parent_buffer_flag & CL_MEM_HOST_WRITE_ONLY)


### PR DESCRIPTION
Fix an instance of this warning in mem_host_flags.

Only disable `-Wsometimes-uninitialized` for the SVM test, which does not compile cleanly with this warning enabled.  Re-enable the warning for the other tests, so that it can catch any new occurrences.