### PR TITLE
[CI] Build Vulkan loader with USE_GAS=ON

### DIFF
--- a/presubmit.sh
+++ b/presubmit.sh
@@ -77,7 +77,6 @@ cmake .. -G Ninja \
       -DBUILD_WSI_XLIB_SUPPORT=OFF \
       -DBUILD_WSI_XCB_SUPPORT=OFF \
       -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
-      -DUSE_GAS=OFF \
       -C helper.cmake ..
 cmake --build . -j2
 


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Loader/pull/1212 broke builds that set `USE_GAS=OFF`.

It was originally added to fix aarch64 builds by @nikhiljnv 
>    Disable USE_GAS for Vulkan Loader build to fix aarch64 build.

but it seems we no longer need it.