### PR TITLE
Command buffer wait_for_sec_queue_event subtest, call clFinish in the correct order.

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
@@ -603,6 +603,9 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
                                     event_ptrs[1], nullptr);
         test_error(error, "clEnqueueReadBuffer failed");
 
+        error = clFlush(queue);
+        test_error(error, "clFlush failed");
+
         error = clFinish(queue_sec);
         test_error(error, "clFinish failed");
 

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
@@ -603,10 +603,10 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
                                     event_ptrs[1], nullptr);
         test_error(error, "clEnqueueReadBuffer failed");
 
-        error = clFinish(queue);
+        error = clFinish(queue_sec);
         test_error(error, "clFinish failed");
 
-        error = clFinish(queue_sec);
+        error = clFinish(queue);
         test_error(error, "clFinish failed");
 
         // verify the result - result buffer must contain initial pattern


### PR DESCRIPTION
queue has a command that depends on a command that resides in queue_sec, calling clFinish(queue) before clFinish(queue_sec) causes the test to hang as the queue_sec command never got a chance to finish.