### PR TITLE
test_common: fix -Wsign-compare warnings

### DIFF
--- a/test_common/gl/helpers.cpp
+++ b/test_common/gl/helpers.cpp
@@ -1715,7 +1715,7 @@ void * CreateGLRenderbuffer( GLsizei width, GLsizei height,
         // Reverse and reorder to validate since in the
         // kernel the read_imagef() call always returns RGBA
         cl_uchar *p = (cl_uchar *)buffer;
-        for( size_t i = 0; i < (size_t)width * height; i++ )
+        for (GLsizei i = 0; i < width * height; i++)
         {
             cl_uchar uc0 = p[i * 4 + 0];
             cl_uchar uc1 = p[i * 4 + 1];
@@ -1733,7 +1733,7 @@ void * CreateGLRenderbuffer( GLsizei width, GLsizei height,
       // Reverse and reorder to validate since in the
       // kernel the read_imagef() call always returns RGBA
       cl_uchar *p = (cl_uchar *)buffer;
-      for( size_t i = 0; i < width * height; i++ )
+      for (GLsizei i = 0; i < width * height; i++)
       {
         cl_uchar uc0 = p[i * 4 + 0];
         cl_uchar uc1 = p[i * 4 + 1];

--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -835,9 +835,9 @@ void callTestFunctions(test_definition testList[],
         std::vector<std::thread *> threads;
         test_harness_state state = { testList, resultTestList, deviceToUse,
                                      config };
-        for (int i = 0; i < config.numWorkerThreads; i++)
+        for (unsigned i = 0; i < config.numWorkerThreads; i++)
         {
-            log_info("Spawning worker thread %i\n", i);
+            log_info("Spawning worker thread %u\n", i);
             threads.push_back(new std::thread(test_function_runner, &state));
         }
 


### PR DESCRIPTION
In preparation of re-enabling `-Wsign-compare` globally, avoid mixing signed and unsigned integers in comparisons in test_common.