### PR TITLE
Replace cl_queue_properties_khr with cl_command_queue_properties

### DIFF
--- a/test_conformance/api/test_queue_properties.cpp
+++ b/test_conformance/api/test_queue_properties.cpp
@@ -107,8 +107,9 @@ int test_queue_properties(cl_device_id deviceID, cl_context context, cl_command_
 
     clProgramWrapper program;
     clKernelWrapper kernel;
-    cl_queue_properties_khr device_props = 0;
-    cl_queue_properties_khr queue_prop_def[] = { CL_QUEUE_PROPERTIES, 0, 0 };
+    cl_command_queue_properties device_props = 0;
+    cl_command_queue_properties queue_prop_def[] = { CL_QUEUE_PROPERTIES, 0,
+                                                     0 };
 
     // Query extension
     if (!is_extension_available(deviceID, "cl_khr_create_command_queue"))


### PR DESCRIPTION
test_conformance/api/test_queue_properties.cpp uses a cl_queue_properties_khr value to query CL_DEVICE_QUEUE_PROPERTIES, however this should be a cl_command_queue_properties typed variable.

Fixes issue #1640