### PR TITLE
subgroups: fix Wsign-compare warnings

### DIFF
--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -483,29 +483,30 @@ template <typename Ty, ShuffleOp operation> struct SHF
     static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,
                            const WorkGroupParams &test_params)
     {
-        int ii, i, j, k, n;
+        int ii, k;
+        size_t n;
         cl_uint l;
-        int nw = test_params.local_workgroup_size;
-        int ns = test_params.subgroup_size;
+        size_t nw = test_params.local_workgroup_size;
+        size_t ns = test_params.subgroup_size;
         int ng = test_params.global_workgroup_size;
-        int nj = (nw + ns - 1) / ns;
+        size_t nj = (nw + ns - 1) / ns;
         Ty tr, rr;
         ng = ng / nw;
 
         for (k = 0; k < ng; ++k)
         { // for each work_group
-            for (j = 0; j < nw; ++j)
+            for (size_t j = 0; j < nw; ++j)
             { // inside the work_group
                 mx[j] = x[j]; // read host inputs for work_group
                 my[j] = y[j]; // read device outputs for work_group
             }
 
-            for (j = 0; j < nj; ++j)
+            for (size_t j = 0; j < nj; ++j)
             { // for each subgroup
                 ii = j * ns;
                 n = ii + ns > nw ? nw - ii : ns;
 
-                for (i = 0; i < n; ++i)
+                for (size_t i = 0; i < n; ++i)
                 { // inside the subgroup
                   // shuffle index storage
                     int midx = 4 * ii + 4 * i + 2;

--- a/test_conformance/subgroups/subhelpers.cpp
+++ b/test_conformance/subgroups/subhelpers.cpp
@@ -206,7 +206,7 @@ void set_last_workgroup_params(int non_uniform_size, int &number_of_subgroups,
 }
 
 void fill_and_shuffle_safe_values(std::vector<cl_ulong> &safe_values,
-                                  int sb_size)
+                                  size_t sb_size)
 {
     // max product is 720, cl_half has enough precision for it
     const std::vector<cl_ulong> non_one_values{ 2, 3, 4, 5, 6 };

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -44,7 +44,7 @@ cl_uint4 generate_bit_mask(cl_uint subgroup_local_id,
 // for each subgroup values defined different values
 // for rest of workitems set 1 shuffle values
 void fill_and_shuffle_safe_values(std::vector<cl_ulong> &safe_values,
-                                  int sb_size);
+                                  size_t sb_size);
 
 struct WorkGroupParams
 {

--- a/test_conformance/subgroups/test_workitem.cpp
+++ b/test_conformance/subgroups/test_workitem.cpp
@@ -36,7 +36,7 @@ struct get_test_data
 };
 
 static int check_group(const get_test_data *result, int nw, cl_uint ensg,
-                       int maxwgs)
+                       size_t maxwgs)
 {
     int first = -1;
     int last = -1;
@@ -168,7 +168,7 @@ static int check_group(const get_test_data *result, int nw, cl_uint ensg,
 
         j = (result[first].subGroupSize + 31) / 32 * result[i].subGroupId
             + (result[i].subGroupLocalId >> 5);
-        if (j < sizeof(hit) / 4)
+        if (j < static_cast<int>(sizeof(hit) / 4))
         {
             cl_uint b = 1U << (result[i].subGroupLocalId & 0x1fU);
             if ((hit[j] & b) != 0)
@@ -191,7 +191,7 @@ int test_work_item_functions(cl_device_id device, cl_context context,
     static const size_t lsize = 200;
     int error;
     int i, j, k, q, r, nw;
-    int maxwgs;
+    size_t maxwgs;
     cl_uint ensg;
     size_t global;
     size_t local;
@@ -235,7 +235,7 @@ int test_work_item_functions(cl_device_id device, cl_context context,
     error = get_max_allowed_work_group_size(context, kernel, &local, NULL);
     if (error != 0) return error;
 
-    maxwgs = (int)local;
+    maxwgs = local;
 
     // Limit it a bit so we have muliple work groups
     // Ideally this will still be large enough to give us multiple subgroups


### PR DESCRIPTION
The subgroup and workgroup sizes reported by clGetKernelSubGroupInfo and clGetKernelWorkGroupInfo are of type `size_t`.  Avoid changing the values to an `int` type as they are propagated through the tests and then compared against `size_t` again.