### PR TITLE
Fix more -Wsign-compare warnings

### DIFF
--- a/test_conformance/basic/test_enqueue_map.cpp
+++ b/test_conformance/basic/test_enqueue_map.cpp
@@ -54,7 +54,8 @@ int test_enqueue_map_buffer(cl_device_id deviceID, cl_context context,
     BufferOwningPtr<cl_char> referenceData{ malloc(bufferSize) };
     BufferOwningPtr<cl_char> finalData{ malloc(bufferSize) };
 
-    for (int src_flag_id = 0; src_flag_id < ARRAY_SIZE(flag_set); src_flag_id++)
+    for (size_t src_flag_id = 0; src_flag_id < ARRAY_SIZE(flag_set);
+         src_flag_id++)
     {
         clMemWrapper memObject;
         log_info("Testing with cl_mem_flags src: %s\n",
@@ -155,7 +156,8 @@ int test_enqueue_map_image(cl_device_id deviceID, cl_context context,
     BufferOwningPtr<cl_uint> finalData{ malloc(imageDataSize) };
 
     MTdataHolder d{ gRandomSeed };
-    for (int src_flag_id = 0; src_flag_id < ARRAY_SIZE(flag_set); src_flag_id++)
+    for (size_t src_flag_id = 0; src_flag_id < ARRAY_SIZE(flag_set);
+         src_flag_id++)
     {
         clMemWrapper memObject;
         log_info("Testing with cl_mem_flags src: %s\n",

--- a/test_conformance/basic/test_fpmath.cpp
+++ b/test_conformance/basic/test_fpmath.cpp
@@ -94,7 +94,7 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
 {
     auto &inA = input[0];
     auto &inB = input[1];
-    for (int i = 0; i < output.size(); i++)
+    for (size_t i = 0; i < output.size(); i++)
     {
         bool nan_test = false;
 
@@ -106,7 +106,7 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
         if (r != output[i] && nan_test)
         {
             log_error("FP math test for type: %s, vec size: %zu, failed at "
-                      "index %d, %a '%c' %a, expected %a, get %a\n",
+                      "index %zu, %a '%c' %a, expected %a, get %a\n",
                       test.type_str.c_str(), test.vec_size, i, toDouble(inA[i]),
                       test.op, toDouble(inB[i]), toDouble(r),
                       toDouble(output[i]));
@@ -238,13 +238,13 @@ struct TypesIterator
 
             generate_random_inputs<T>(inputs);
 
-            for (int i = 0; i < ARRAY_SIZE(streams); i++)
+            for (size_t i = 0; i < ARRAY_SIZE(streams); i++)
             {
                 streams[i] = clCreateBuffer(context, CL_MEM_READ_WRITE, length,
                                             NULL, &err);
                 test_error(err, "clCreateBuffer failed.");
             }
-            for (int i = 0; i < ARRAY_SIZE(inputs); i++)
+            for (size_t i = 0; i < ARRAY_SIZE(inputs); i++)
             {
                 err =
                     clEnqueueWriteBuffer(queue, streams[i], CL_TRUE, 0, length,
@@ -264,7 +264,7 @@ struct TypesIterator
 
             test_error(err, "create_single_kernel_helper failed");
 
-            for (int i = 0; i < ARRAY_SIZE(streams); i++)
+            for (size_t i = 0; i < ARRAY_SIZE(streams); i++)
             {
                 err =
                     clSetKernelArg(kernel, i, sizeof(streams[i]), &streams[i]);

--- a/test_conformance/basic/test_intmath.cpp
+++ b/test_conformance/basic/test_intmath.cpp
@@ -123,7 +123,7 @@ int test_intmath(cl_device_id device, cl_context context,
     size_t datasize = sizeof(T) * num_elements * N;
 
     // Create device buffers.
-    for (int i = 0; i < ARRAY_SIZE(streams); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(streams); i++)
     {
         streams[i] =
             clCreateBuffer(context, CL_MEM_READ_WRITE, datasize, NULL, &err);
@@ -175,7 +175,7 @@ int test_intmath(cl_device_id device, cl_context context,
         test_error(err, "clEnqueueReadBuffer failed\n");
 
         // Verify results
-        for (int i = 0; i < num_elements * N; i++)
+        for (unsigned i = 0; i < num_elements * N; i++)
         {
             T r = test.ref(inputA[i], inputB[i], inputC[i]);
             if (r != output[i])

--- a/test_conformance/basic/test_vector_creation.cpp
+++ b/test_conformance/basic/test_vector_creation.cpp
@@ -260,7 +260,7 @@ int test_vector_creation(cl_device_id deviceID, cl_context context,
     std::vector<char> output_data;
 
     // Iterate over all the types
-    for (int type_index = 0; type_index < vecType.size(); type_index++)
+    for (size_t type_index = 0; type_index < vecType.size(); type_index++)
     {
 
         if (!gHasLong
@@ -336,7 +336,7 @@ int test_vector_creation(cl_device_id deviceID, cl_context context,
         }
 
         // Iterate over all the vector sizes.
-        for (int size_index = 1; size_index < vecSizes.size(); size_index++)
+        for (size_t size_index = 1; size_index < vecSizes.size(); size_index++)
         {
             size_t global[] = { 1, 1, 1 };
             int number_generated = -1;

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -3145,7 +3145,7 @@ public:
     }
 
 private:
-    int _subCaseId;
+    size_t _subCaseId;
     struct TestDefinition _subCase;
 };
 

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
@@ -136,7 +136,7 @@ struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
 
         // We can not check if this is the right queue because this is an opaque
         // object, test against NULL.
-        for (int i = 0; i < queue_list.size(); i++)
+        for (size_t i = 0; i < queue_list.size(); i++)
         {
             test_assert_error(
                 queue_list[i] == queue,

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_profiling.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_profiling.cpp
@@ -160,7 +160,7 @@ struct CommandBufferProfiling : public BasicCommandBufferTest
 
         // verify the results by comparing timestamps
         bool all_vals_0 = prof_params.front().value != 0;
-        for (int i = 1; i < prof_params.size(); i++)
+        for (size_t i = 1; i < prof_params.size(); i++)
         {
             all_vals_0 = (prof_params[i].value != 0) ? false : all_vals_0;
             if (prof_params[i - 1].value > prof_params[i].value)

--- a/test_conformance/pipes/test_pipe_limits.cpp
+++ b/test_conformance/pipes/test_pipe_limits.cpp
@@ -274,8 +274,7 @@ int test_pipe_max_packet_size(cl_device_id deviceID, cl_context context, cl_comm
     size_t global_work_size[3];
     cl_int err;
     size_t size;
-    int num_pipe_elements = 1024;
-    int i;
+    cl_uint num_pipe_elements = 1024;
     cl_uint max_pipe_packet_size;
     clEventWrapper producer_sync_event = NULL;
     clEventWrapper consumer_sync_event = NULL;
@@ -287,7 +286,7 @@ int test_pipe_max_packet_size(cl_device_id deviceID, cl_context context, cl_comm
 
     size_t min_alignment = get_min_alignment(context);
 
-    global_work_size[0] = (cl_uint)num_pipe_elements;
+    global_work_size[0] = num_pipe_elements;
 
     std::stringstream source;
 
@@ -312,7 +311,8 @@ int test_pipe_max_packet_size(cl_device_id deviceID, cl_context context, cl_comm
 
     inptr = (cl_char *)align_malloc(size, min_alignment);
 
-    for(i = 0; i < size; i++){
+    for (size_t i = 0; i < size; i++)
+    {
         inptr[i] = (char)genrand_int32(d);
     }
     BufferInPtr.reset(inptr, nullptr, 0, size, true);
@@ -412,7 +412,7 @@ int test_pipe_max_active_reservations(cl_device_id deviceID, cl_context context,
     clMemWrapper buf_reserve_id_t_size_aligned;
     cl_int *inptr;
     void *outptr;
-    int size, i;
+    int size;
     clProgramWrapper program;
     clKernelWrapper kernel[3];
     size_t global_work_size[3];
@@ -565,7 +565,8 @@ int test_pipe_max_active_reservations(cl_device_id deviceID, cl_context context,
     size = sizeof(cl_int) * max_active_reservations;
     inptr = (cl_int *)align_malloc(size, min_alignment);
 
-    for(i = 0; i < max_active_reservations; i++){
+    for (cl_uint i = 0; i < max_active_reservations; i++)
+    {
         inptr[i] = (int)genrand_int32(d);
     }
     BufferInPtr.reset(inptr, nullptr, 0, size, true);

--- a/test_conformance/select/test_select.cpp
+++ b/test_conformance/select/test_select.cpp
@@ -119,34 +119,32 @@ static void initSrcBuffer(void* src1, Type stype, MTdata d)
         s1[i]   = genrand_int32(d);
 }
 
-static void initCmpBuffer(void* cmp, Type cmptype, uint64_t start, size_t count) {
-    int i;
+static void initCmpBuffer(void *cmp, Type cmptype, uint64_t start, size_t count)
+{
     assert(cmptype != kfloat);
     switch (type_size[cmptype]) {
         case 1: {
             uint8_t* ub = (uint8_t *)cmp;
-            for (i=0; i < count; ++i)
-                ub[i] = (uint8_t)start++;
+            for (size_t i = 0; i < count; ++i) ub[i] = (uint8_t)start++;
             break;
         }
         case 2: {
             uint16_t* us = (uint16_t *)cmp;
-            for (i=0; i < count; ++i)
-                us[i] = (uint16_t)start++;
+            for (size_t i = 0; i < count; ++i) us[i] = (uint16_t)start++;
             break;
         }
         case 4: {
             if (!s_wimpy_mode) {
                 uint32_t* ui = (uint32_t *)cmp;
-                for (i=0; i < count; ++i)
-                    ui[i] = (uint32_t)start++;
+                for (size_t i = 0; i < count; ++i) ui[i] = (uint32_t)start++;
             }
             else {
                 // The short test doesn't iterate over the entire 32 bit space so
                 // we alternate between positive and negative values
                 int32_t* ui = (int32_t *)cmp;
                 int32_t sign = 1;
-                for (i=0; i < count; ++i, ++start) {
+                for (size_t i = 0; i < count; ++i, ++start)
+                {
                     ui[i] = (int32_t)start*sign;
                     sign = sign * -1;
                 }
@@ -158,7 +156,8 @@ static void initCmpBuffer(void* cmp, Type cmptype, uint64_t start, size_t count)
             // selects, we want to test positive and negative values
             int64_t* ll = (int64_t *)cmp;
             int64_t sign = 1;
-            for (i=0; i < count; ++i, ++start) {
+            for (size_t i = 0; i < count; ++i, ++start)
+            {
                 ll[i] = start*sign;
                 sign = sign * -1;
             }


### PR DESCRIPTION
Fix `-Wsign-compare` warnings in multiple tests.  Most of these are trivial `for`-loop iterator type changes.