### PR TITLE
[Command-buffer] Test finalizing empty command-buffer

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${MODULE_NAME}_SOURCES
     command_buffer_test_copy.cpp
     command_buffer_test_barrier.cpp
     command_buffer_test_event_info.cpp
+    command_buffer_finalize.cpp
 )
 
 include(../../CMakeCommon.txt)

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_finalize.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_finalize.cpp
@@ -1,0 +1,85 @@
+//
+// Copyright (c) 2023 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "basic_command_buffer.h"
+#include "procs.h"
+
+namespace {
+
+// Test that finalizing a command-buffer that has already been finalized returns
+// the correct error code.
+struct FinalizeInvalid : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        // Finalizing an already finalized command-buffer must return
+        // CL_INVALID_OPERATION
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_failure_error_ret(
+            error, CL_INVALID_OPERATION,
+            "clFinalizeCommandBufferKHR should return CL_INVALID_OPERATION",
+            TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+};
+
+// Check that an empty command-buffer can be finalized and then executed.
+struct FinalizeEmpty : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override
+    {
+        // Finalize an empty command-buffer
+        cl_int error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        // Execute empty command-buffer and then wait to complete
+        clEventWrapper event;
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, &event);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clWaitForEvents(1, &event);
+        test_error(error, "clWaitForEvents failed");
+
+        return CL_SUCCESS;
+    }
+};
+} // anonymous namespace
+
+int test_finalize_invalid(cl_device_id device, cl_context context,
+                          cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<FinalizeInvalid>(device, context, queue,
+                                           num_elements);
+}
+
+int test_finalize_empty(cl_device_id device, cl_context context,
+                        cl_command_queue queue, int num_elements)
+{
+    return MakeAndRunTest<FinalizeEmpty>(device, context, queue, num_elements);
+}

--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -59,7 +59,9 @@ test_definition test_list[] = {
     ADD_TEST(event_info_command_queue),
     ADD_TEST(event_info_execution_status),
     ADD_TEST(event_info_context),
-    ADD_TEST(event_info_reference_count)
+    ADD_TEST(event_info_reference_count),
+    ADD_TEST(finalize_invalid),
+    ADD_TEST(finalize_empty)
 };
 
 int main(int argc, const char *argv[])

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -132,5 +132,9 @@ extern int test_event_info_reference_count(cl_device_id device,
                                            cl_context context,
                                            cl_command_queue queue,
                                            int num_elements);
+extern int test_finalize_invalid(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+extern int test_finalize_empty(cl_device_id device, cl_context context,
+                               cl_command_queue queue, int num_elements);
 
 #endif // CL_KHR_COMMAND_BUFFER_PROCS_H


### PR DESCRIPTION
This patch adds two test cases related to command-buffer finalization:

1) That it is an error to finalize and already finalized command-buffer. See https://github.com/KhronosGroup/OpenCL-Docs/pull/817

2) That it is not an error to create, finalize, and execute an empty command-buffer. Closes issue #1781