### PR TITLE
harness: add missing stdexcept header

### DIFF
--- a/test_common/harness/stringHelpers.h
+++ b/test_common/harness/stringHelpers.h
@@ -18,6 +18,7 @@
 #define STRING_HELPERS_H
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 inline std::string concat_kernel(const char *sstr[], int num)


### PR DESCRIPTION
Required for std::runtime_error.