### PR TITLE
fix a sporadic failure in the mutable_command_dimensions test

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -140,7 +140,7 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
         if (size != sizeof(props) || test_props[0] != props[0]
             || test_props[1] != props[1])
         {
-            log_error("ERROR: Incorrect command buffer returned from "
+            log_error("ERROR: Incorrect properties returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }
@@ -181,7 +181,7 @@ struct Kernel : public InfoMutableCommandBufferTest
         // opaque object.
         if (test_kernel != kernel)
         {
-            log_error("ERROR: Incorrect command buffer returned from "
+            log_error("ERROR: Incorrect kernel returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }
@@ -210,8 +210,7 @@ struct Dimensions : public InfoMutableCommandBufferTest
             &global_work_size, nullptr, 0, nullptr, nullptr, &command);
         test_error(error, "clCommandNDRangeKernelKHR failed");
 
-        size_t test_dimensions;
-
+        cl_uint test_dimensions = 0;
         error = clGetMutableCommandInfoKHR(
             command, CL_MUTABLE_DISPATCH_DIMENSIONS_KHR,
             sizeof(test_dimensions), &test_dimensions, nullptr);
@@ -219,7 +218,7 @@ struct Dimensions : public InfoMutableCommandBufferTest
 
         if (test_dimensions != dimensions)
         {
-            log_error("ERROR: Incorrect command buffer returned from "
+            log_error("ERROR: Incorrect dimensions returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }
@@ -330,7 +329,7 @@ struct InfoGlobalWorkOffset : public InfoMutableCommandBufferTest
 
         if (test_global_work_offset != global_work_offset)
         {
-            log_error("ERROR: Wrong size returned from "
+            log_error("ERROR: Wrong global work offset returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }
@@ -368,7 +367,7 @@ struct InfoGlobalWorkSize : public InfoMutableCommandBufferTest
 
         if (test_global_work_size != global_work_size)
         {
-            log_error("ERROR: Wrong size returned from "
+            log_error("ERROR: Wrong global work size returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }
@@ -405,7 +404,7 @@ struct InfoLocalWorkSize : public InfoMutableCommandBufferTest
 
         if (test_local_work_size != local_work_size)
         {
-            log_error("ERROR: Wrong size returned from "
+            log_error("ERROR: Wrong local work size returned from "
                       "clGetMutableCommandInfoKHR.");
             return TEST_FAIL;
         }


### PR DESCRIPTION
This change fixes a sporadic failure in the mutable_command_dimensions test.

The previous test passed an uninitialized `size_t` variable as the return location for the `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR` query, though this query only returns a `cl_uint`.  This meant that the test sometimes passes, especially for 32-bit builds, where `sizeof(size_t) == sizeof(cl_uint)`, but will frequently fail for larger values of `size_t` if the upper bits of the uninitialized variable are non-zero.  Changing to a `cl_uint` instead fixes the sporadic failures.

I also fixed a few ambiguous or incorrect error messages.

With these changes I'm seeing a 100% pass rate for the mutable dispatch tests with the command buffer emulation layer.