### PR TITLE
conversions: fix undefined behaviour in DataInfoSpec

### DIFF
--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -150,13 +150,13 @@ DataInfoSpec<InType, OutType>::DataInfoSpec(const DataInitInfo &agg)
     else if (std::is_same<cl_long, OutType>::value)
         ranges = std::make_pair(CL_LONG_MIN, CL_LONG_MAX);
 
-    InType outMin = ((InType)ranges.first);
-    InType outMax = ((InType)ranges.second);
-
     // clang-format off
     // for readability sake keep this section unformatted
     if (std::is_floating_point<InType>::value)
     { // from float/double
+        InType outMin = static_cast<InType>(ranges.first);
+        InType outMax = static_cast<InType>(ranges.second);
+
         InType eps = std::is_same<InType, cl_float>::value ? (InType) FLT_EPSILON : (InType) DBL_EPSILON;
         if (std::is_integral<OutType>::value)
         { // to char/uchar/short/ushort/int/uint/long/ulong


### PR DESCRIPTION
For conversion from integers to floating point, the `DataInfoSpec` constructor tries to convert `CL_FLT_MAX` to an integer.  The float value cannot be represented as an integer, which is undefined behaviour.

Fix by only doing this conversion when `InType` is a floating point value.

The refactoring of the conversions test dropped the workaround added by 59a12047a ("Fix for test_conversions failure with Clang build on Linux #1057 (#1062)", 2021-05-11).

While at it, prefer `static_cast` for the conversions.