### PR TITLE
conversions: fix memory leak from excess gMTdata initialization

### DIFF
--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -118,7 +118,6 @@ const int test_num = ARRAY_SIZE(test_list);
 int main(int argc, const char **argv)
 {
     int error;
-    cl_uint seed = (cl_uint)time(NULL);
 
     argc = parseCustomParam(argc, argv);
     if (argc == -1)
@@ -145,8 +144,8 @@ int main(int argc, const char **argv)
 #endif
 
     vlog("===========================================================\n");
-    vlog("Random seed: %u\n", seed);
-    gMTdata = init_genrand(seed);
+    vlog("Random seed: %u\n", gRandomSeed);
+    gMTdata = init_genrand(gRandomSeed);
 
     const char *arg[] = { argv[0] };
     int ret =
@@ -474,8 +473,6 @@ test_status InitCL(cl_device_id device)
             return TEST_FAIL;
         }
     }
-
-    gMTdata = init_genrand(gRandomSeed);
 
     char c[1024];
     static const char *no_yes[] = { "NO", "YES" };


### PR DESCRIPTION
`gMTdata` was initialized twice, but freed only once.

Drop the first initialization with a local seed, and initialize with `gRandomSeed` instead.