### PR TITLE
basic/int2fp: fix missing include

### DIFF
--- a/test_conformance/basic/test_int2fp.cpp
+++ b/test_conformance/basic/test_int2fp.cpp
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
With GCC 13 some headers are no longer included transitively through C++ Standard Library headers.