### PR TITLE
Fix minimum image size for cl_ext_image_requirements_info

### DIFF
--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_buffer.hpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_buffer.hpp
@@ -48,8 +48,10 @@ static inline size_t get_format_size(cl_context context,
     cl_image_desc image_desc = { 0 };
     image_desc.image_type = imageType;
 
-    /* Size 1 only to query element size */
-    image_desc.image_width = 1;
+    /* We use a width of 4 to query element size, as this is
+       the smallest possible value that satisfies the requirements
+       of all image formats (including extensions). */
+    image_desc.image_width = 4;
     if (CL_MEM_OBJECT_IMAGE1D_BUFFER != imageType
         && CL_MEM_OBJECT_IMAGE1D != imageType)
     {


### PR DESCRIPTION
Some new extension formats require the width to be a multiple of 4 or 2 (see cl_ext_image_raw10_raw12).
Change has not functional impact as the affected image is only used for generic queries.