### PR TITLE
fix memory leak from argList and from wrong ordering of free and return statement

### DIFF
--- a/test_conformance/allocations/main.cpp
+++ b/test_conformance/allocations/main.cpp
@@ -326,6 +326,7 @@ int main(int argc, const char *argv[])
         else if ( strcmp( argv[i], "--help" ) == 0 || strcmp( argv[i], "-h" ) == 0 )
         {
             printUsage( argv[0] );
+            free(argList);
             return -1;
         }
 

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -799,8 +799,8 @@ int test_kernel_required_group_size(cl_device_id deviceID, cl_context context, c
         test_error(error, "clFinish failed");
 
         if (max_dimensions == 2) {
-            return 0;
             free(source);
+            return 0;
         }
 
         local[1]--; local[2]++;


### PR DESCRIPTION
argList was not freed in else if statement.
have wrong ordering of free and return statement.