### PR TITLE
math_brute_force: always initialize oldMode

### DIFF
--- a/test_conformance/math_brute_force/unary_two_results_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_float.cpp
@@ -189,12 +189,11 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
         // Get that moving
         if ((error = clFlush(gQueue))) vlog("clFlush failed\n");
 
-        FPU_mode_type oldMode;
+        FPU_mode_type oldMode = 0;
         RoundingMode oldRoundMode = kRoundToNearestEven;
         if (isFract)
         {
             // Calculate the correctly rounded reference result
-            memset(&oldMode, 0, sizeof(oldMode));
             if (ftz || relaxedMode) ForceFTZ(&oldMode);
 
             // Set the rounding mode to match the device


### PR DESCRIPTION
Avoid a maybe-uninitialized warning by ensuring that `oldMode` is always initialized to 0.  There is no need to use `memset` for this, as `FPU_mode_type` is either an `int` or an `int64_t`.