### PR TITLE
[command-buffer] Remove deleted enum used to initialize variable

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
@@ -211,8 +211,7 @@ struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
 
         // lambda to verify given state
         auto verify_state = [&](const cl_command_buffer_state_khr &expected) {
-            cl_command_buffer_state_khr state =
-                CL_COMMAND_BUFFER_STATE_INVALID_KHR;
+            cl_command_buffer_state_khr state = ~cl_command_buffer_state_khr(0);
 
             cl_int error = clGetCommandBufferInfoKHR(
                 command_buffer, CL_COMMAND_BUFFER_STATE_KHR, sizeof(state),


### PR DESCRIPTION
The enum value `CL_COMMAND_BUFFER_STATE_INVALID_KHR` no longer exists:
* https://github.com/KhronosGroup/OpenCL-Headers/pull/235
* https://github.com/KhronosGroup/OpenCL-Docs/pull/885

Replace variable initialization using this enum with a value where all the bits are set, requiring the runtime to write to it in `clGetCommandBufferInfoKHR` for the test to pass.