### PR TITLE
Add NULL CL_MEM_HOST_PTR check for clGetMemObjectInfo

### DIFF
--- a/test_conformance/api/test_mem_object_info.cpp
+++ b/test_conformance/api/test_mem_object_info.cpp
@@ -217,6 +217,9 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
             // Create a buffer object to test against.
             bufferObject = clCreateBuffer( context, bufferFlags[ i ], addressAlign * 4, NULL, &error );
             test_error( error, "Unable to create buffer to test with" );
+            void *ptr;
+            TEST_MEM_OBJECT_PARAM(bufferObject, CL_MEM_HOST_PTR, ptr, NULL,
+                                  "host pointer", "%p", void *)
         }
 
         // Perform buffer object queries.


### PR DESCRIPTION
The spec requires implementations return NULL for CL_MEM_HOST_PTR when the flags passed at memory object creation time do not contain CL_MEM_USE_HOST_PTR

CTS was not checking this. Add the same check.

Fixes #1752