### PR TITLE
Check that CL_DEVICE_COMPILER_AVAILABLE is CL_TRUE for FULL_PROFILE

### DIFF
--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -649,6 +649,13 @@ int test_get_device_info(cl_device_id deviceID, cl_context context, cl_command_q
     }
     log_info( "\tReported device profile: %s \n", profile );
 
+    if (strcmp(profile, "FULL_PROFILE") == 0 && compilerAvail != CL_TRUE)
+    {
+        log_error("ERROR: Returned profile of device is FULL , but "
+                  "CL_DEVICE_COMPILER_AVAILABLE is not CL_TRUE as required by "
+                  "OpenCL 1.2!");
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
OpenCL FULL profile requires that online compiler be available. OpenCL-CTS currently queries profile as well as online compiler availability via device queries, but doesn't check for the consistency.

Check for consistency that if CL_DEVICE_PROFILE is "FULL_PROFILE" (or technically is not "EMBEDDED_PROFILE") then CL_DEVICE_COMPILER_AVAILABLE is CL_TRUE for that device.

Fixes #1763