### PR TITLE
math_brute_force: don't set/restore FTZ mode twice

### DIFF
--- a/test_conformance/math_brute_force/i_unary_double.cpp
+++ b/test_conformance/math_brute_force/i_unary_double.cpp
@@ -50,11 +50,6 @@ int TestFunc_Int_Double(const Func *f, MTdata d, bool relaxedMode)
 
     logFunctionInfo(f->name, sizeof(cl_double), relaxedMode);
 
-    // This test is not using ThreadPool so we need to disable FTZ here
-    // for reference computations
-    FPU_mode_type oldMode;
-    DisableFTZ(&oldMode);
-
     Force64BitFPUPrecision();
 
     // Init the kernels
@@ -227,6 +222,5 @@ int TestFunc_Int_Double(const Func *f, MTdata d, bool relaxedMode)
     vlog("\n");
 
 exit:
-    RestoreFPState(&oldMode);
     return error;
 }

--- a/test_conformance/math_brute_force/i_unary_float.cpp
+++ b/test_conformance/math_brute_force/i_unary_float.cpp
@@ -49,11 +49,6 @@ int TestFunc_Int_Float(const Func *f, MTdata d, bool relaxedMode)
 
     logFunctionInfo(f->name, sizeof(cl_float), relaxedMode);
 
-    // This test is not using ThreadPool so we need to disable FTZ here
-    // for reference computations
-    FPU_mode_type oldMode;
-    DisableFTZ(&oldMode);
-
     Force64BitFPUPrecision();
 
     // Init the kernels
@@ -225,6 +220,5 @@ int TestFunc_Int_Float(const Func *f, MTdata d, bool relaxedMode)
     vlog("\n");
 
 exit:
-    RestoreFPState(&oldMode);
     return error;
 }


### PR DESCRIPTION
The suite's `main()` function already disables the FTZ mode prior to invoking `runTestHarnessWithCheck` and restores the FP state afterwards, so tests don't have to do so themselves.