### PR TITLE
[NFC] cmake: do not suppress -Wsign-compare globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,9 +103,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
     if(NOT CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo|MinSizeRel")
         # Enable more warnings if not doing a release build.
         add_cxx_flag_if_supported(-Wall)
-        # Suppress warnings that currently trigger on the code base.
-        # This list should shrink over time when warnings are fixed.
-        add_cxx_flag_if_supported(-Wno-sign-compare)
     endif()
     add_cxx_flag_if_supported(-Wno-narrowing)
     add_cxx_flag_if_supported(-Wno-format)

--- a/test_conformance/SVM/CMakeLists.txt
+++ b/test_conformance/SVM/CMakeLists.txt
@@ -17,6 +17,6 @@ set(${MODULE_NAME}_SOURCES
     test_migrate.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-sometimes-uninitialized")
+set_gnulike_module_compile_flags("-Wno-sometimes-uninitialized -Wno-sign-compare")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/allocations/CMakeLists.txt
+++ b/test_conformance/allocations/CMakeLists.txt
@@ -8,4 +8,6 @@ set(${MODULE_NAME}_SOURCES
         allocation_utils.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/basic/CMakeLists.txt
+++ b/test_conformance/basic/CMakeLists.txt
@@ -68,4 +68,6 @@ if(APPLE)
     list(APPEND ${MODULE_NAME}_SOURCES test_queue_priority.cpp)
 endif(APPLE)
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/c11_atomics/CMakeLists.txt
+++ b/test_conformance/c11_atomics/CMakeLists.txt
@@ -7,4 +7,6 @@ set(${MODULE_NAME}_SOURCES
     test_atomics.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -16,6 +16,6 @@ set_source_files_properties(
         COMPILE_FLAGS -march=i686)
 endif(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
 
-set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
+set_gnulike_module_compile_flags("-Wno-unused-but-set-variable -Wno-sign-compare")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/device_execution/CMakeLists.txt
+++ b/test_conformance/device_execution/CMakeLists.txt
@@ -17,6 +17,6 @@ set(DEVICE_EXECUTION_SOURCES
     utils.cpp
 )
 
-include(../CMakeCommon.txt)
+set_gnulike_module_compile_flags("-Wno-sign-compare")
 
-# end of file #
+include(../CMakeCommon.txt)

--- a/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/CMakeLists.txt
@@ -17,6 +17,8 @@ set(${MODULE_NAME}_SOURCES
     command_buffer_finalize.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../../CMakeCommon.txt)
 
 add_subdirectory( cl_khr_command_buffer_mutable_dispatch )

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/CMakeLists.txt
@@ -12,4 +12,6 @@ set(${MODULE_NAME}_SOURCES
     ../basic_command_buffer.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../../../CMakeCommon.txt)

--- a/test_conformance/geometrics/CMakeLists.txt
+++ b/test_conformance/geometrics/CMakeLists.txt
@@ -6,5 +6,7 @@ set(${MODULE_NAME}_SOURCES
     test_geometrics.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-sign-compare")
+
 include(../CMakeCommon.txt)
 

--- a/test_conformance/images/kernel_read_write/CMakeLists.txt
+++ b/test_conformance/images/kernel_read_write/CMakeLists.txt
@@ -21,7 +21,7 @@ set(${MODULE_NAME}_SOURCES
 
 # Make unused variables not fatal in this module; see
 # https://github.com/KhronosGroup/OpenCL-CTS/issues/1484
-set_gnulike_module_compile_flags("-Wno-error=unused-variable -Wno-unused-but-set-variable")
+set_gnulike_module_compile_flags("-Wno-error=unused-variable -Wno-unused-but-set-variable -Wno-sign-compare")
 
 include(../../CMakeCommon.txt)
 


### PR DESCRIPTION
Only disable `-Wsign-compare` for tests that do not compile cleanly with this warning enabled.  Re-enable the warning for the other tests, so that it can catch any new occurrences.