### PR TITLE
switch to the new memory and semaphore specific device handle lists

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -25,6 +25,19 @@
 #define ASSERT(x) assert((x))
 #define GB(x) ((unsigned long long)(x) << 30)
 
+#if !defined(CL_MEM_DEVICE_HANDLE_LIST_KHR)
+#pragma message(                                                               \
+    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external memory, please update your headers!")
+#define CL_MEM_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#define CL_MEM_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
+#endif
+#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+#pragma message(                                                               \
+    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
+#endif
+
 pfnclCreateSemaphoreWithPropertiesKHR clCreateSemaphoreWithPropertiesKHRptr;
 pfnclEnqueueWaitSemaphoresKHR clEnqueueWaitSemaphoresKHRptr;
 pfnclEnqueueSignalSemaphoresKHR clEnqueueSignalSemaphoresKHRptr;
@@ -595,10 +608,11 @@ clExternalMemory::clExternalMemory(
         throw std::runtime_error("Unsupported external memory type\n ");
     }
 
-    extMemProperties.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR);
+    extMemProperties.push_back(
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR);
     extMemProperties.push_back((cl_mem_properties)devList[0]);
     extMemProperties.push_back(
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR);
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_END_KHR);
     extMemProperties.push_back(0);
 
     m_externalMemory = clCreateBufferWithProperties(
@@ -691,10 +705,11 @@ clExternalMemoryImage::clExternalMemoryImage(
         throw std::runtime_error("getCLImageInfoFromVkImageInfo failed!!!");
     }
 
-    extMemProperties1.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR);
+    extMemProperties1.push_back(
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR);
     extMemProperties1.push_back((cl_mem_properties)devList[0]);
     extMemProperties1.push_back(
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR);
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_END_KHR);
     extMemProperties1.push_back(0);
     m_externalMemory = clCreateImageWithProperties(
         context, extMemProperties1.data(), CL_MEM_READ_WRITE, &img_format,
@@ -846,10 +861,10 @@ clExternalSemaphore::clExternalSemaphore(
     }
 
     sema_props.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR);
     sema_props.push_back((cl_semaphore_properties_khr)devList[0]);
     sema_props.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_END_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR);
     sema_props.push_back(0);
     m_externalSemaphore =
         clCreateSemaphoreWithPropertiesKHRptr(context, sema_props.data(), &err);

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -25,19 +25,6 @@
 #define ASSERT(x) assert((x))
 #define GB(x) ((unsigned long long)(x) << 30)
 
-#if !defined(CL_MEM_DEVICE_HANDLE_LIST_KHR)
-#pragma message(                                                               \
-    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external memory, please update your headers!")
-#define CL_MEM_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#define CL_MEM_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
-#endif
-#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
-#pragma message(                                                               \
-    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
-#endif
-
 pfnclCreateSemaphoreWithPropertiesKHR clCreateSemaphoreWithPropertiesKHRptr;
 pfnclEnqueueWaitSemaphoresKHR clEnqueueWaitSemaphoresKHRptr;
 pfnclEnqueueSignalSemaphoresKHR clEnqueueSignalSemaphoresKHRptr;

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -5,13 +5,6 @@
 #include <thread>
 #include <chrono>
 
-#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
-#pragma message(                                                               \
-    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
-#endif
-
 #define FLUSH_DELAY_S 5
 
 #define SEMAPHORE_PARAM_TEST(param_name, param_type, expected)                 \

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -5,6 +5,13 @@
 #include <thread>
 #include <chrono>
 
+#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+#pragma message(                                                               \
+    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
+#endif
+
 #define FLUSH_DELAY_S 5
 
 #define SEMAPHORE_PARAM_TEST(param_name, param_type, expected)                 \
@@ -120,7 +127,8 @@ int test_external_semaphores_queries(cl_device_id deviceID, cl_context context,
     SEMAPHORE_PARAM_TEST(CL_SEMAPHORE_TYPE_KHR, cl_semaphore_type_khr,
                          CL_SEMAPHORE_TYPE_BINARY_KHR);
 
-    SEMAPHORE_PARAM_TEST(CL_DEVICE_HANDLE_LIST_KHR, cl_device_id, deviceID);
+    SEMAPHORE_PARAM_TEST(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, cl_device_id,
+                         deviceID);
 
     SEMAPHORE_PARAM_TEST(
         CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR, cl_uint,

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -33,19 +33,6 @@
 #include "harness/typeWrappers.h"
 #include "harness/deviceInfo.h"
 
-#if !defined(CL_MEM_DEVICE_HANDLE_LIST_KHR)
-#pragma message(                                                               \
-    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external memory, please update your headers!")
-#define CL_MEM_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#define CL_MEM_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
-#endif
-#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
-#pragma message(                                                               \
-    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
-#endif
-
 int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
                                      cl_command_queue _queue, int num_elements)
 {

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -33,6 +33,19 @@
 #include "harness/typeWrappers.h"
 #include "harness/deviceInfo.h"
 
+#if !defined(CL_MEM_DEVICE_HANDLE_LIST_KHR)
+#pragma message(                                                               \
+    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external memory, please update your headers!")
+#define CL_MEM_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#define CL_MEM_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
+#endif
+#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+#pragma message(                                                               \
+    "Using old CL_DEVICE_HANDLE_LIST_KHR enum for external semaphores, please update your headers!")
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR CL_DEVICE_HANDLE_LIST_END_KHR
+#endif
+
 int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
                                      cl_command_queue _queue, int num_elements)
 {
@@ -93,9 +106,9 @@ int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
     int fd;
 
     std::vector<cl_mem_properties> extMemProperties{
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
         (cl_mem_properties)devList[0],
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_END_KHR,
     };
     cl_external_memory_handle_type_khr type;
     switch (vkExternalMemoryHandleType)
@@ -162,9 +175,9 @@ int test_consistency_external_buffer(cl_device_id deviceID, cl_context _context,
         (cl_mem_properties)type,
         (cl_mem_properties)-64, // Passing random invalid fd
 #endif
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
         (cl_mem_properties)devList[0],
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_END_KHR,
         0
     };
     buffer = clCreateBufferWithProperties(context, extMemProperties2.data(), 1,
@@ -257,9 +270,9 @@ int test_consistency_external_image(cl_device_id deviceID, cl_context _context,
     void* handle = NULL;
     int fd;
     std::vector<cl_mem_properties> extMemProperties{
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
         (cl_mem_properties)devList[0],
-        (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR,
+        (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_END_KHR,
     };
     switch (vkExternalMemoryHandleType)
     {
@@ -484,15 +497,15 @@ int test_consistency_external_semaphore(cl_device_id deviceID,
             "Unsupported external sempahore handle type\n ");
     }
     sema_props1.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR);
     sema_props1.push_back((cl_semaphore_properties_khr)devList[0]);
     sema_props1.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_END_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR);
     sema_props2.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR);
     sema_props2.push_back((cl_semaphore_properties_khr)devList[0]);
     sema_props2.push_back(
-        (cl_semaphore_properties_khr)CL_DEVICE_HANDLE_LIST_END_KHR);
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR);
     sema_props1.push_back(0);
     sema_props2.push_back(0);
 


### PR DESCRIPTION
fixes #1807 

Switches to the new specific device handle list enums for external memory and semaphores, rather then the old overloaded device handle list enum.

I've added some preprocessor checks at the top of each file so these tests will continue to build with older headers, for now at least.  I'd be fine removing these checks right now, in this PR, or we could remove them at some point in the future once the header changes are in place (see: https://github.com/KhronosGroup/OpenCL-Headers/pull/240).