### PR TITLE
gl: fix sometimes-uninitialized warning

### DIFF
--- a/test_conformance/gl/test_images_write_common.cpp
+++ b/test_conformance/gl/test_images_write_common.cpp
@@ -571,6 +571,7 @@ static int test_image_format_write(cl_context context, cl_command_queue queue,
                       "%s (%s):%d",
                       GetGLTargetName(target), __FUNCTION__, __FILE__,
                       __LINE__);
+            return -1;
     }
 
     // If there was a problem during creation, make sure it isn't a known


### PR DESCRIPTION
Bail out when hitting the default case, so that we don't attempt to access the uninitialized `error` variable.