### PR TITLE
c11_atomics: fix uninitialized member accesses

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -644,8 +644,8 @@ public:
     }
 
 private:
-    TExplicitMemoryOrderType _memoryOrder;
-    TExplicitMemoryScopeType _memoryScope;
+    TExplicitMemoryOrderType _memoryOrder = MEMORY_ORDER_EMPTY;
+    TExplicitMemoryScopeType _memoryScope = MEMORY_SCOPE_EMPTY;
 };
 
 template <typename HostAtomicType, typename HostDataType>


### PR DESCRIPTION
Initialize the `_memoryOrder` and `_memoryScope` members to avoid `CBasicTestMemOrderScope::MaxHostThreads()` accessing uninitialized data.