### PR TITLE
Minor fixes in mutable dispatch tests.

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -664,8 +664,8 @@ struct MutableDispatchSVMArguments : public BasicMutableCommandBufferTest
 
         // Allocate and initialize SVM for modified execution
 
-        cl_int *newWrapper =
-            (cl_int *)clSVMAlloc(context, CL_MEM_READ_WRITE, sizeof(cl_int), 0);
+        cl_int *newWrapper = (cl_int *)clSVMAlloc(context, CL_MEM_READ_WRITE,
+                                                  sizeof(cl_int *), 0);
         cl_int *newBuffer = (cl_int *)clSVMAlloc(
             context, CL_MEM_READ_WRITE, num_elements * sizeof(cl_int), 0);
         test_assert_error(newWrapper != nullptr && newBuffer != nullptr,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -207,7 +207,7 @@ struct Dimensions : public InfoMutableCommandBufferTest
     {
         cl_int error = clCommandNDRangeKernelKHR(
             command_buffer, nullptr, nullptr, kernel, dimensions, nullptr,
-            &global_work_size, nullptr, 0, nullptr, nullptr, &command);
+            global_work_size_3d, nullptr, 0, nullptr, nullptr, &command);
         test_error(error, "clCommandNDRangeKernelKHR failed");
 
         cl_uint test_dimensions = 0;
@@ -231,6 +231,7 @@ struct Dimensions : public InfoMutableCommandBufferTest
 
     cl_mutable_command_khr command = nullptr;
     const size_t dimensions = 3;
+    const size_t global_work_size_3d[3] = { 64, 1, 1 };
 };
 
 struct InfoType : public InfoMutableCommandBufferTest


### PR DESCRIPTION
* Fix size of newWrapper in MutableDispatchSVMArguments.
* Fix errnoneus clCommandNDRangeKernelKHR call.