### PR TITLE
a few fixes (thread safety & cl_khr_command_buffer UB)

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
@@ -583,7 +583,7 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
 
         // process secondary queue
         error =
-            clEnqueueFillBuffer(queue_sec, in_mem, &pattern_pri, sizeof(cl_int),
+            clEnqueueFillBuffer(queue_sec, in_mem, &pattern_sec, sizeof(cl_int),
                                 0, data_size(), 0, nullptr, nullptr);
         test_error(error, "clEnqueueFillBuffer failed");
 
@@ -593,8 +593,9 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
                    "clEnqueueCommandBufferKHR in secondary queue failed");
 
         // process primary queue
-        error = clEnqueueFillBuffer(queue, in_mem, &pattern_pri, sizeof(cl_int),
-                                    0, data_size(), 0, nullptr, event_ptrs[0]);
+        error =
+            clEnqueueFillBuffer(queue, in_mem, &pattern_pri, sizeof(cl_int), 0,
+                                data_size(), 1, &test_event, event_ptrs[0]);
         test_error(error, "clEnqueueFillBuffer failed");
 
         cl_event wait_list[] = { test_event,

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
@@ -93,6 +93,9 @@ struct BarrierWithWaitListKHR : public BasicCommandBufferTest
                                 0, data_size(), 0, nullptr, nullptr);
         test_error(error, "clEnqueueFillBufferKHR failed");
 
+        error = clFinish(queue);
+        test_error(error, "clFinish");
+
         error = clEnqueueCommandBufferKHR(
             0, nullptr, out_of_order_command_buffer, 0, nullptr, &event);
         test_error(error, "clEnqueueCommandBufferKHR failed");


### PR DESCRIPTION
some fixes we've been carrying in our CTS fork:

* fix UB in `command_buffer_event_sync.cpp`: enqueue of two commands in two separate queues, with both using the same buffer argument, and no synchronization between the commands.
* fix UB in `command_buffer_test_barrier.cpp`: missing synchronization between zeroing command and command-buffer using two separate queues
* make `test_thread_dimensions.cpp` thread-safe to avoid spurious errors.