### PR TITLE
cl_khr_external_semaphore: No re-export

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
@@ -26,6 +26,8 @@ test_definition test_list[] = {
     ADD_TEST(external_semaphores_cross_queues_io2),
     ADD_TEST(external_semaphores_multi_signal),
     ADD_TEST(external_semaphores_multi_wait),
+    ADD_TEST(external_semaphores_no_re_export),
+    ADD_TEST(external_semaphores_multiple_export),
     // ADD_TEST(external_semaphores_order_1),
     // ADD_TEST(external_semaphores_order_2),
     // ADD_TEST(external_semaphores_order_3),

--- a/test_conformance/extensions/cl_khr_external_semaphore/procs.h
+++ b/test_conformance/extensions/cl_khr_external_semaphore/procs.h
@@ -79,4 +79,11 @@ extern int test_external_semaphores_invalid_command(cl_device_id deviceID,
                                                     cl_context context,
                                                     cl_command_queue queue,
                                                     int num_elements);
+extern int test_external_semaphores_no_re_export(cl_device_id deviceID,
+                                                 cl_context context,
+                                                 cl_command_queue defaultQueue,
+                                                 int num_elements);
+extern int test_external_semaphores_multiple_export(
+    cl_device_id deviceID, cl_context context, cl_command_queue defaultQueue,
+    int num_elements);
 #endif // CL_KHR_EXTERNAL_SEMAPHORE_PROCS_H


### PR DESCRIPTION
Add test for no re-exporting for imported
external semaphore handles.  See issue #975