### PR TITLE
[NFC] conversions: reenable Wunused-but-set-variable

### DIFF
--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -16,6 +16,6 @@ set_source_files_properties(
         COMPILE_FLAGS -march=i686)
 endif(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
 
-set_gnulike_module_compile_flags("-Wno-unused-but-set-variable -Wno-sign-compare")
+set_gnulike_module_compile_flags("-Wno-sign-compare")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/conversions/fplib.cpp
+++ b/test_conformance/conversions/fplib.cpp
@@ -198,7 +198,6 @@ float qcom_u64_2_f32(uint64_t data, bool sat, roundingMode rnd)
                 return as_float(result);
         }
         case qcomRTN: {
-            int inExact = 0;
             if (!data)
                 return 0.0f;
             uint32_t  exponent    = (127 + 64 - clz(data) - 1) << (FLT_MANT_DIG - 1); //add 1 for the implied 1.0 in normalized fp32 numbers
@@ -206,8 +205,6 @@ float qcom_u64_2_f32(uint64_t data, bool sat, roundingMode rnd)
             uint32_t  mantissa;
             if (mantShift >= 0){
                 uint64_t temp = (uint64_t)data >> mantShift;
-                if (temp << mantShift != data)
-                    inExact = 1;
                 mantissa = (uint32_t)temp;
             }
             else


### PR DESCRIPTION
Remove an assigned-to but unused variable.

Reenable the Wunused-but-set-variable warning for the conversions
suite, as it now compiles cleanly with this warning enabled.