### PR TITLE
Fix bug of conversion from long to double

### DIFF
--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -423,10 +423,10 @@ void DataInfoSpec<InType, OutType>::conv(OutType *out, InType *in)
             cl_float outVal = 0.f;
 
 #if defined(_MSC_VER) && defined(_M_X64)
-            cl_ulong l = ((cl_ulong *)in)[0];
             float result;
             if (std::is_same<cl_ulong, InType>::value)
             {
+                cl_ulong l = ((cl_ulong *)in)[0];
                 cl_long sl = ((cl_long)l < 0) ? (cl_long)((l >> 1) | (l & 1))
                                               : (cl_long)l;
                 _mm_store_ss(&result, _mm_cvtsi64_ss(_mm_setzero_ps(), sl));
@@ -435,6 +435,7 @@ void DataInfoSpec<InType, OutType>::conv(OutType *out, InType *in)
             }
             else
             {
+                cl_long l = ((cl_long *)in)[0];
                 _mm_store_ss(&result, _mm_cvtsi64_ss(_mm_setzero_ps(), l));
                 outVal = (l == 0 ? 0.0f : result); // Per IEEE-754-2008 5.4.1,
                                                    // 0's always convert to +0.0

--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -385,11 +385,11 @@ void DataInfoSpec<InType, OutType>::conv(OutType *out, InType *in)
         if (std::is_same<cl_double, OutType>::value)
         {
 #if defined(_MSC_VER)
-            cl_ulong l = ((cl_ulong *)in)[0];
             double result;
 
             if (std::is_same<cl_ulong, InType>::value)
             {
+                cl_ulong l = ((cl_ulong *)in)[0];
                 cl_long sl = ((cl_long)l < 0) ? (cl_long)((l >> 1) | (l & 1))
                                               : (cl_long)l;
 #if defined(_M_X64)
@@ -402,6 +402,7 @@ void DataInfoSpec<InType, OutType>::conv(OutType *out, InType *in)
             }
             else
             {
+                cl_long l = ((cl_long *)in)[0];
 #if defined(_M_X64)
                 _mm_store_sd(&result, _mm_cvtsi64_sd(_mm_setzero_pd(), l));
 #else


### PR DESCRIPTION
If the input is long type, it should be load as long type, not ulong.