### PR TITLE
math_brute_force: fix exp/exp2 rlx ULP calculation

### DIFF
--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -303,15 +303,14 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
 
                     if (strcmp(fname, "exp") == 0 || strcmp(fname, "exp2") == 0)
                     {
-                        float exp_error = ulps;
-
+                        // For full profile, ULP depends on input value.
+                        // For embedded profile, ULP comes from functionList.
                         if (!gIsEmbedded)
                         {
-                            exp_error += floor(fabs(2 * s[j]));
+                            ulps = 3.0f + floor(fabs(2 * s[j]));
                         }
 
-                        fail = !(fabsf(err) <= exp_error);
-                        ulps = exp_error;
+                        fail = !(fabsf(err) <= ulps);
                     }
                     if (strcmp(fname, "tan") == 0)
                     {


### PR DESCRIPTION
Fix the ULP error calculation for the `exp` and `exp2` builtins in relaxed math mode for the full profile.

Previously, the `ulps` value kept being added to while verifying the result buffer in a loop.  `ulps` could even become a `NaN` when the input argument being tested was a `NaN`.