### PR TITLE
apply environment variable CL_PLATFORM_INDEX to test_compute_info

### DIFF
--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1256,9 +1256,30 @@ int test_computeinfo(cl_device_id deviceID, cl_context context,
     int err;
     int total_errors = 0;
     cl_platform_id platform;
-
-    err = clGetPlatformIDs(1, &platform, NULL);
-    test_error(err, "clGetPlatformIDs failed");
+    cl_uint platform_num;
+    
+    err = clGetPlatformIDs(0, NULL, &platform_num);
+    test_error(err, "clGetPlatformIDs failed in trying to get platform number");
+    
+    char *env_mode=getenv("CL_PLATFORM_INDEX");
+    if(env_mode == NULL)
+    {
+        err = clGetPlatformIDs(1, &platform, NULL);
+        test_error(err, "clGetPlatformIDs failed");
+    }
+    else{
+        cl_uint platform_index_env = atoi(env_mode);
+        if(platform_index_env >= platform_num)
+        {
+            test_error(CL_INVALID_PLATFORM, "platform index out of range");
+        }
+        cl_platform_id* platform_id_temp_buffer = new cl_platform_id[platform_num];
+        err = clGetPlatformIDs(platform_num, platform_id_temp_buffer, NULL);
+        test_error(err, "clGetPlatformIDs failed");
+        platform = platform_id_temp_buffer[platform_index_env];
+        delete [] platform_id_temp_buffer;
+    }
+    
 
     // print platform info
     log_info("\nclGetPlatformInfo:\n------------------\n");


### PR DESCRIPTION
The environment variable CL_PLATFORM_INDEX was meant to be used to specify the platform on which the conformance test should be run, but the compute_info test does not properly utilize this particular environment variable, which might cause unexpected test failure in a multi-platform environment. 
Previously in the test_compute_info function, the first clGetPlatformIDs call just passed constant value 1 as the first argument, which would only be able to get the ID of the first platform, regardless of the CL_PLATFORM_INDEX setting.
After the change, it would first be checked whether the CL_PLATFORM_INDEX is a valid platform index, and falls back to use the first platform if no environment variable is provided.
Similar function has already be implemented in the source file testHarness.cpp, but the current test_compute_info function lacks appropriate support for platform selection through the enviroment variable.