### PR TITLE
Increase the number of work items used by the allocations test

### DIFF
--- a/test_conformance/allocations/allocation_execute.cpp
+++ b/test_conformance/allocations/allocation_execute.cpp
@@ -140,7 +140,7 @@ int check_image(cl_command_queue queue, cl_mem mem) {
 }
 
 
-#define NUM_OF_WORK_ITEMS 8192*32
+#define NUM_OF_WORK_ITEMS (8192 * 32)
 
 int execute_kernel(cl_context context, cl_command_queue *queue, cl_device_id device_id, int test, cl_mem mems[], int number_of_mems_used, int verify_checksum) {
 

--- a/test_conformance/allocations/allocation_execute.cpp
+++ b/test_conformance/allocations/allocation_execute.cpp
@@ -140,7 +140,7 @@ int check_image(cl_command_queue queue, cl_mem mem) {
 }
 
 
-#define NUM_OF_WORK_ITEMS 8192*2
+#define NUM_OF_WORK_ITEMS 8192*32
 
 int execute_kernel(cl_context context, cl_command_queue *queue, cl_device_id device_id, int test, cl_mem mems[], int number_of_mems_used, int verify_checksum) {
 


### PR DESCRIPTION
The test uses a fixed number of work items to process very large buffers and images. As devices support more and more memory, this leads to an ever-increasing amount of work done in each work item. This results in some implementations and devices hitting timeout issues.

Furthermore, a greater number of work items can provide performance benefits on some devices.

Long term, this test should be redesigned to scale the number of threads dynamically as a function of the max allocation size.