### PR TITLE
Updated semaphore tests to use clSemaphoreReImportSyncFdKHR.

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -757,7 +757,7 @@ int clExternalSemaphore::wait(cl_command_queue cmd_queue)
     return CL_INVALID_OPERATION;
 }
 
-clExternalSemaphore::~clExternalSemaphore() noexcept(false) = default;
+clExternalSemaphore::~clExternalSemaphore() = default;
 
 clExternalImportableSemaphore::clExternalImportableSemaphore(
     const VulkanSemaphore &semaphore, cl_context context,
@@ -851,7 +851,7 @@ clExternalImportableSemaphore::clExternalImportableSemaphore(
     }
 }
 
-clExternalImportableSemaphore::~clExternalImportableSemaphore() noexcept(false)
+clExternalImportableSemaphore::~clExternalImportableSemaphore()
 {
     cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
     if (err != CL_SUCCESS)
@@ -927,7 +927,7 @@ clExternalExportableSemaphore::clExternalExportableSemaphore(
     }
 }
 
-clExternalExportableSemaphore::~clExternalExportableSemaphore() noexcept(false)
+clExternalExportableSemaphore::~clExternalExportableSemaphore()
 {
     cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
     if (err != CL_SUCCESS)

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -36,7 +36,8 @@ pfnclReleaseSemaphoreKHR clReleaseSemaphoreKHRptr;
 pfnclGetSemaphoreHandleForTypeKHR clGetSemaphoreHandleForTypeKHRptr;
 pfnclReImportSemaphoreSyncFdKHR clReImportSemaphoreSyncFdKHRptr;
 
-void init_cl_vk_ext(cl_platform_id opencl_platform)
+void init_cl_vk_ext(cl_platform_id opencl_platform, cl_uint num_devices,
+                    cl_device_id *deviceIds)
 {
     clEnqueueWaitSemaphoresKHRptr =
         (pfnclEnqueueWaitSemaphoresKHR)clGetExtensionFunctionAddressForPlatform(
@@ -81,13 +82,19 @@ void init_cl_vk_ext(cl_platform_id opencl_platform)
                                  "clGetSemaphoreHandleForTypeKHRptr!");
     }
 
+    // Required only if cl_khr_external_semaphore_sync_fd is reported
     clReImportSemaphoreSyncFdKHRptr = (pfnclReImportSemaphoreSyncFdKHR)
         clGetExtensionFunctionAddressForPlatform(
             opencl_platform, "clReImportSemaphoreSyncFdKHR");
-    if (NULL == clReImportSemaphoreSyncFdKHRptr)
+    for (cl_uint i = 0; i < num_devices; i++)
     {
-        throw std::runtime_error("Failed to get the function pointer of "
-                                 "clReImportSemaphoreSyncFdKHRptr!");
+        if (is_extension_available(deviceIds[i],
+                                   "cl_khr_external_semaphore_sync_fd")
+            && (NULL == clReImportSemaphoreSyncFdKHRptr))
+        {
+            throw std::runtime_error("Failed to get the function pointer of "
+                                     "clReImportSemaphoreSyncFdKHR!");
+        }
     }
 }
 

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -757,6 +757,8 @@ int clExternalSemaphore::wait(cl_command_queue cmd_queue)
     return CL_INVALID_OPERATION;
 }
 
+clExternalSemaphore::~clExternalSemaphore() noexcept(false) = default;
+
 clExternalImportableSemaphore::clExternalImportableSemaphore(
     const VulkanSemaphore &semaphore, cl_context context,
     VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -34,6 +34,7 @@ pfnclEnqueueReleaseExternalMemObjectsKHR
     clEnqueueReleaseExternalMemObjectsKHRptr;
 pfnclReleaseSemaphoreKHR clReleaseSemaphoreKHRptr;
 pfnclGetSemaphoreHandleForTypeKHR clGetSemaphoreHandleForTypeKHRptr;
+pfnclReImportSemaphoreSyncFdKHR clReImportSemaphoreSyncFdKHRptr;
 
 void init_cl_vk_ext(cl_platform_id opencl_platform)
 {
@@ -78,6 +79,15 @@ void init_cl_vk_ext(cl_platform_id opencl_platform)
     {
         throw std::runtime_error("Failed to get the function pointer of "
                                  "clGetSemaphoreHandleForTypeKHRptr!");
+    }
+
+    clReImportSemaphoreSyncFdKHRptr = (pfnclReImportSemaphoreSyncFdKHR)
+        clGetExtensionFunctionAddressForPlatform(
+            opencl_platform, "clReImportSemaphoreSyncFdKHR");
+    if (NULL == clReImportSemaphoreSyncFdKHRptr)
+    {
+        throw std::runtime_error("Failed to get the function pointer of "
+                                 "clReImportSemaphoreSyncFdKHRptr!");
     }
 }
 
@@ -669,7 +679,6 @@ clExternalMemoryImage::clExternalMemoryImage(
             break;
 #elif !defined(__APPLE__)
         case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
-            log_info(" Opaque file descriptors are not supported on Windows\n");
             fd = (int)deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(
                 devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
@@ -738,7 +747,17 @@ clExternalMemoryImage::clExternalMemoryImage() {}
 // clExternalSemaphore implementation //
 //////////////////////////////////////////
 
-clExternalSemaphore::clExternalSemaphore(
+int clExternalSemaphore::signal(cl_command_queue cmd_queue)
+{
+    return CL_INVALID_OPERATION;
+}
+
+int clExternalSemaphore::wait(cl_command_queue cmd_queue)
+{
+    return CL_INVALID_OPERATION;
+}
+
+clExternalImportableSemaphore::clExternalImportableSemaphore(
     const VulkanSemaphore &semaphore, cl_context context,
     VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
     cl_device_id deviceId)
@@ -759,17 +778,12 @@ clExternalSemaphore::clExternalSemaphore(
     switch (externalSemaphoreHandleType)
     {
         case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD:
-#ifdef _WIN32
-            ASSERT(0);
-#else
-            log_info(" Opaque file descriptors are not supported on Windows\n");
             fd = (int)semaphore.getHandle(externalSemaphoreHandleType);
             err = check_external_semaphore_handle_type(
                 devList[0], CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
             sema_props.push_back(
                 (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
             sema_props.push_back((cl_semaphore_properties_khr)fd);
-#endif
             break;
         case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_NT:
 #ifndef _WIN32
@@ -802,12 +816,10 @@ clExternalSemaphore::clExternalSemaphore(
         case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD:
             err = check_external_semaphore_handle_type(
                 devList[0], CL_SEMAPHORE_HANDLE_SYNC_FD_KHR);
-            sema_props.push_back(static_cast<cl_semaphore_properties_khr>(
-                CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR));
+
             sema_props.push_back(static_cast<cl_semaphore_properties_khr>(
                 CL_SEMAPHORE_HANDLE_SYNC_FD_KHR));
-            sema_props.push_back(static_cast<cl_semaphore_properties_khr>(
-                CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR));
+            sema_props.push_back(static_cast<cl_semaphore_properties_khr>(-1));
             break;
         default:
             ASSERT(0);
@@ -837,7 +849,7 @@ clExternalSemaphore::clExternalSemaphore(
     }
 }
 
-clExternalSemaphore::~clExternalSemaphore() noexcept(false)
+clExternalImportableSemaphore::~clExternalImportableSemaphore() noexcept(false)
 {
     cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
     if (err != CL_SUCCESS)
@@ -846,7 +858,83 @@ clExternalSemaphore::~clExternalSemaphore() noexcept(false)
     }
 }
 
-int clExternalSemaphore::signal(cl_command_queue cmd_queue)
+int clExternalImportableSemaphore::wait(cl_command_queue cmd_queue)
+{
+    int err = CL_SUCCESS;
+    if (m_externalHandleType == VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD)
+    {
+        cl_int err = 0;
+        fd = (int)m_deviceSemaphore.getHandle(m_externalHandleType);
+        err = clReImportSemaphoreSyncFdKHRptr(m_externalSemaphore, nullptr, fd);
+        if (err != CL_SUCCESS)
+        {
+            return err;
+        }
+    }
+
+    err = clEnqueueWaitSemaphoresKHRptr(cmd_queue, 1, &m_externalSemaphore,
+                                        NULL, 0, NULL, NULL);
+    return err;
+}
+
+cl_semaphore_khr &clExternalImportableSemaphore::getCLSemaphore()
+{
+    return m_externalSemaphore;
+}
+
+
+clExternalExportableSemaphore::clExternalExportableSemaphore(
+    const VulkanSemaphore &semaphore, cl_context context,
+    VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
+    cl_device_id deviceId)
+    : m_deviceSemaphore(semaphore)
+{
+
+    cl_int err = 0;
+    cl_device_id devList[] = { deviceId, NULL };
+    m_externalHandleType = externalSemaphoreHandleType;
+    m_externalSemaphore = nullptr;
+    m_device = deviceId;
+    m_context = context;
+
+    std::vector<cl_semaphore_properties_khr> sema_props{
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR,
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,
+    };
+    sema_props.push_back(
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR);
+    sema_props.push_back(
+        (cl_semaphore_properties_khr)getCLSemaphoreTypeFromVulkanType(
+            externalSemaphoreHandleType));
+    sema_props.push_back((cl_semaphore_properties_khr)
+                             CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR);
+    sema_props.push_back(
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR);
+    sema_props.push_back((cl_semaphore_properties_khr)devList[0]);
+    sema_props.push_back(
+        (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR);
+    sema_props.push_back(0);
+    m_externalSemaphore =
+        clCreateSemaphoreWithPropertiesKHRptr(context, sema_props.data(), &err);
+    if (CL_SUCCESS != err)
+    {
+        log_error("clCreateSemaphoreWithPropertiesKHRptr failed with %d\n",
+                  err);
+        throw std::runtime_error(
+            "clCreateSemaphoreWithPropertiesKHRptr failed! ");
+    }
+}
+
+clExternalExportableSemaphore::~clExternalExportableSemaphore() noexcept(false)
+{
+    cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
+    if (err != CL_SUCCESS)
+    {
+        throw std::runtime_error("clReleaseSemaphoreKHR failed!");
+    }
+}
+
+int clExternalExportableSemaphore::signal(cl_command_queue cmd_queue)
 {
     int err = clEnqueueSignalSemaphoresKHRptr(
         cmd_queue, 1, &m_externalSemaphore, NULL, 0, NULL, nullptr);
@@ -886,60 +974,7 @@ int clExternalSemaphore::signal(cl_command_queue cmd_queue)
     return err;
 }
 
-int clExternalSemaphore::wait(cl_command_queue cmd_queue)
-{
-    int err = CL_SUCCESS;
-    if (m_externalHandleType == VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD)
-    {
-        cl_int err = 0;
-        cl_device_id devList[] = { m_device, NULL };
-        std::vector<cl_semaphore_properties_khr> sema_props{
-            (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR,
-            (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,
-        };
-        fd = (int)m_deviceSemaphore.getHandle(m_externalHandleType);
-
-        err = check_external_semaphore_handle_type(
-            devList[0], CL_SEMAPHORE_HANDLE_SYNC_FD_KHR);
-        if (CL_SUCCESS != err)
-        {
-            log_error("CL_SEMAPHORE_HANDLE_SYNC_FD_KHR not supported\n");
-            return err;
-        }
-
-        sema_props.push_back(
-            (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_SYNC_FD_KHR);
-        sema_props.push_back((cl_semaphore_properties_khr)fd);
-
-        sema_props.push_back(0);
-
-        if (m_externalSemaphore)
-        {
-            err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
-            if (err != CL_SUCCESS)
-            {
-                log_error("Failed to release CL external semaphore\n");
-                return err;
-            }
-            m_externalSemaphore = nullptr;
-        }
-
-        m_externalSemaphore = clCreateSemaphoreWithPropertiesKHRptr(
-            m_context, sema_props.data(), &err);
-        if (CL_SUCCESS != err)
-        {
-            log_error("clCreateSemaphoreWithPropertiesKHRptr failed with %d\n",
-                      err);
-            return err;
-        }
-    }
-
-    err = clEnqueueWaitSemaphoresKHRptr(cmd_queue, 1, &m_externalSemaphore,
-                                        NULL, 0, NULL, NULL);
-    return err;
-}
-
-cl_semaphore_khr &clExternalSemaphore::getCLSemaphore()
+cl_semaphore_khr &clExternalExportableSemaphore::getCLSemaphore()
 {
     return m_externalSemaphore;
 }

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -754,16 +754,6 @@ clExternalMemoryImage::clExternalMemoryImage() {}
 // clExternalSemaphore implementation //
 //////////////////////////////////////////
 
-int clExternalSemaphore::signal(cl_command_queue cmd_queue)
-{
-    return CL_INVALID_OPERATION;
-}
-
-int clExternalSemaphore::wait(cl_command_queue cmd_queue)
-{
-    return CL_INVALID_OPERATION;
-}
-
 clExternalSemaphore::~clExternalSemaphore() = default;
 
 clExternalImportableSemaphore::clExternalImportableSemaphore(
@@ -886,6 +876,12 @@ int clExternalImportableSemaphore::wait(cl_command_queue cmd_queue)
     return err;
 }
 
+int clExternalImportableSemaphore::signal(cl_command_queue cmd_queue)
+{
+    return clEnqueueSignalSemaphoresKHRptr(cmd_queue, 1, &m_externalSemaphore,
+                                           NULL, 0, NULL, NULL);
+}
+
 cl_semaphore_khr &clExternalImportableSemaphore::getCLSemaphore()
 {
     return m_externalSemaphore;
@@ -981,6 +977,12 @@ int clExternalExportableSemaphore::signal(cl_command_queue cmd_queue)
     }
 
     return err;
+}
+
+int clExternalExportableSemaphore::wait(cl_command_queue command_queue)
+{
+    return clEnqueueWaitSemaphoresKHRptr(command_queue, 1, &m_externalSemaphore,
+                                         NULL, 0, NULL, nullptr);
 }
 
 cl_semaphore_khr &clExternalExportableSemaphore::getCLSemaphore()

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -119,7 +119,7 @@ public:
     virtual int signal(cl_command_queue command_queue);
     virtual int wait(cl_command_queue command_queue);
     virtual cl_semaphore_khr &getCLSemaphore() = 0;
-    virtual ~clExternalSemaphore() noexcept(false) = default;
+    virtual ~clExternalSemaphore() noexcept(false) = 0;
 };
 
 

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -116,8 +116,8 @@ public:
 
 class clExternalSemaphore {
 public:
-    virtual int signal(cl_command_queue command_queue);
-    virtual int wait(cl_command_queue command_queue);
+    virtual int signal(cl_command_queue command_queue) = 0;
+    virtual int wait(cl_command_queue command_queue) = 0;
     virtual cl_semaphore_khr &getCLSemaphore() = 0;
     virtual ~clExternalSemaphore() = 0;
 };
@@ -140,6 +140,7 @@ public:
         cl_device_id deviceId);
     ~clExternalImportableSemaphore() override;
     int wait(cl_command_queue command_queue) override;
+    int signal(cl_command_queue command_queue) override;
     cl_semaphore_khr &getCLSemaphore() override;
 };
 
@@ -160,6 +161,7 @@ public:
         cl_device_id deviceId);
     ~clExternalExportableSemaphore() override;
     int signal(cl_command_queue command_queue) override;
+    int wait(cl_command_queue command_queue) override;
     cl_semaphore_khr &getCLSemaphore() override;
 };
 

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -54,6 +54,9 @@ typedef cl_int (*pfnclGetSemaphoreHandleForTypeKHR)(
     cl_semaphore_khr sema_object, cl_device_id device,
     cl_external_semaphore_handle_type_khr handleType, size_t handle_size,
     void *handle, size_t *handleSize);
+typedef cl_int (*pfnclReImportSemaphoreSyncFdKHR)(
+    cl_semaphore_khr sema_object,
+    cl_semaphore_reimport_properties_khr *reimport_props, int fd);
 
 extern pfnclCreateSemaphoreWithPropertiesKHR
     clCreateSemaphoreWithPropertiesKHRptr;
@@ -64,6 +67,7 @@ extern pfnclEnqueueAcquireExternalMemObjectsKHR
 extern pfnclEnqueueReleaseExternalMemObjectsKHR
     clEnqueueReleaseExternalMemObjectsKHRptr;
 extern pfnclReleaseSemaphoreKHR clReleaseSemaphoreKHRptr;
+extern pfnclReImportSemaphoreSyncFdKHR pfnclReImportSemaphoreSyncFdKHRptr;
 
 cl_int getCLImageInfoFromVkImageInfo(const VkImageCreateInfo *, size_t,
                                      cl_image_format *, cl_image_desc *);
@@ -97,7 +101,6 @@ protected:
     cl_mem m_externalMemory;
     int fd;
     void *handle;
-    cl_command_queue cmd_queue;
     clExternalMemoryImage();
 
 public:
@@ -112,6 +115,15 @@ public:
 };
 
 class clExternalSemaphore {
+public:
+    virtual int signal(cl_command_queue command_queue);
+    virtual int wait(cl_command_queue command_queue);
+    virtual cl_semaphore_khr &getCLSemaphore() = 0;
+    virtual ~clExternalSemaphore() noexcept(false) = default;
+};
+
+
+class clExternalImportableSemaphore : public virtual clExternalSemaphore {
 protected:
     cl_semaphore_khr m_externalSemaphore;
     VulkanExternalSemaphoreHandleType m_externalHandleType;
@@ -122,15 +134,33 @@ protected:
     void *handle;
 
 public:
-    clExternalSemaphore(
+    clExternalImportableSemaphore(
         const VulkanSemaphore &deviceSemaphore, cl_context context,
         VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
         cl_device_id deviceId);
-    virtual ~clExternalSemaphore() noexcept(false);
-    int signal(cl_command_queue command_queue);
-    int wait(cl_command_queue command_queue);
-    cl_semaphore_khr &getCLSemaphore();
-    // operator openclExternalSemaphore_t() const;
+    ~clExternalImportableSemaphore() noexcept(false) override;
+    int wait(cl_command_queue command_queue) override;
+    cl_semaphore_khr &getCLSemaphore() override;
+};
+
+class clExternalExportableSemaphore : public virtual clExternalSemaphore {
+protected:
+    cl_semaphore_khr m_externalSemaphore;
+    VulkanExternalSemaphoreHandleType m_externalHandleType;
+    cl_device_id m_device;
+    cl_context m_context;
+    const VulkanSemaphore &m_deviceSemaphore;
+    int fd;
+    void *handle;
+
+public:
+    clExternalExportableSemaphore(
+        const VulkanSemaphore &deviceSemaphore, cl_context context,
+        VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
+        cl_device_id deviceId);
+    ~clExternalExportableSemaphore() noexcept(false) override;
+    int signal(cl_command_queue command_queue) override;
+    cl_semaphore_khr &getCLSemaphore() override;
 };
 
 extern void init_cl_vk_ext(cl_platform_id);

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -163,7 +163,8 @@ public:
     cl_semaphore_khr &getCLSemaphore() override;
 };
 
-extern void init_cl_vk_ext(cl_platform_id);
+extern void init_cl_vk_ext(cl_platform_id, cl_uint num_devices,
+                           cl_device_id *deviceIds);
 
 VulkanImageTiling vkClExternalMemoryHandleTilingAssumption(
     cl_device_id deviceId,

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -119,7 +119,7 @@ public:
     virtual int signal(cl_command_queue command_queue);
     virtual int wait(cl_command_queue command_queue);
     virtual cl_semaphore_khr &getCLSemaphore() = 0;
-    virtual ~clExternalSemaphore() noexcept(false) = 0;
+    virtual ~clExternalSemaphore() = 0;
 };
 
 
@@ -138,7 +138,7 @@ public:
         const VulkanSemaphore &deviceSemaphore, cl_context context,
         VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
         cl_device_id deviceId);
-    ~clExternalImportableSemaphore() noexcept(false) override;
+    ~clExternalImportableSemaphore() override;
     int wait(cl_command_queue command_queue) override;
     cl_semaphore_khr &getCLSemaphore() override;
 };
@@ -158,7 +158,7 @@ public:
         const VulkanSemaphore &deviceSemaphore, cl_context context,
         VulkanExternalSemaphoreHandleType externalSemaphoreHandleType,
         cl_device_id deviceId);
-    ~clExternalExportableSemaphore() noexcept(false) override;
+    ~clExternalExportableSemaphore() override;
     int signal(cl_command_queue command_queue) override;
     cl_semaphore_khr &getCLSemaphore() override;
 };

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -130,8 +130,8 @@ int test_external_semaphores_queries(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalImportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         // Needed by the macro
         cl_semaphore_khr sema = sema_ext.getCLSemaphore();
@@ -219,10 +219,11 @@ int test_external_semaphores_multi_context(cl_device_id deviceID,
             return TEST_FAIL;
         }
 
-        clExternalSemaphore sema_ext_1(vkVk2CLSemaphore, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
-        clExternalSemaphore sema_ext_2(vkVk2CLSemaphore, context2,
-                                       vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_1(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore, context2,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
 
         clCommandQueueWrapper queue1 =
             clCreateCommandQueue(context, deviceID, 0, &err);
@@ -313,8 +314,8 @@ static int semaphore_external_cross_queue_helper(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         // Obtain pointers to semaphore's API
         GET_PFN(deviceID, clEnqueueSignalSemaphoresKHR);
@@ -392,8 +393,8 @@ int test_external_semaphores_simple_1(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         cl_int err = CL_SUCCESS;
 
@@ -468,8 +469,8 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         cl_int err = CL_SUCCESS;
 
@@ -574,8 +575,8 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         cl_int err = CL_SUCCESS;
 
@@ -697,8 +698,8 @@ static int external_semaphore_cross_queue_helper(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext(vkVk2CLSemaphore, context,
-                                     vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
 
         cl_int err = CL_SUCCESS;
 
@@ -823,10 +824,11 @@ int test_external_semaphores_cross_queues_io2(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext_1(vkVk2CLSemaphore, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
-        clExternalSemaphore sema_ext_2(vkVk2CLSemaphore, context2,
-                                       vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_1(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore, context2,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
 
         clCommandQueueWrapper queue1 =
             clCreateCommandQueue(context, deviceID, 0, &err);
@@ -922,10 +924,12 @@ int test_external_semaphores_multi_signal(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore2(vkDevice,
                                           vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
-        clExternalSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
+        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
 
         cl_int err = CL_SUCCESS;
 
@@ -1011,10 +1015,12 @@ int test_external_semaphores_multi_wait(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore2(vkDevice,
                                           vkExternalSemaphoreHandleType);
 
-        clExternalSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
-        clExternalSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
-                                       vkExternalSemaphoreHandleType, deviceID);
+        clExternalExportableSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
+        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
+                                                 vkExternalSemaphoreHandleType,
+                                                 deviceID);
 
         cl_int err = CL_SUCCESS;
 

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -64,7 +64,7 @@ static void log_info_semaphore_type(
     log_info("%s", semaphore_type_description.str().c_str());
 }
 
-static int init_vuikan_device()
+static int init_vuikan_device(cl_uint num_devices, cl_device_id* deviceIds)
 {
     cl_platform_id platform = nullptr;
 
@@ -77,7 +77,7 @@ static int init_vuikan_device()
         return err;
     }
 
-    init_cl_vk_ext(platform);
+    init_cl_vk_ext(platform, num_devices, deviceIds);
 
     return CL_SUCCESS;
 }
@@ -101,7 +101,7 @@ int test_external_semaphores_queries(cl_device_id deviceID, cl_context context,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -181,7 +181,7 @@ int test_external_semaphores_multi_context(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -289,7 +289,7 @@ static int semaphore_external_cross_queue_helper(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -363,7 +363,7 @@ int test_external_semaphores_simple_1(cl_device_id deviceID, cl_context context,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -440,7 +440,7 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -546,7 +546,7 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -669,7 +669,7 @@ static int external_semaphore_cross_queue_helper(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -786,7 +786,7 @@ int test_external_semaphores_cross_queues_io2(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -893,7 +893,7 @@ int test_external_semaphores_multi_signal(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");
@@ -984,7 +984,7 @@ int test_external_semaphores_multi_wait(cl_device_id deviceID,
         return TEST_SKIPPED_ITSELF;
     }
 
-    if (init_vuikan_device())
+    if (init_vuikan_device(1, &deviceID))
     {
         log_info("Cannot initialise Vulkan. "
                  "Skipping test.\n");

--- a/test_conformance/vulkan/main.cpp
+++ b/test_conformance/vulkan/main.cpp
@@ -369,7 +369,7 @@ int main(int argc, const char *argv[])
         log_info(" TEST SKIPPED\n");
         return CL_SUCCESS;
     }
-    init_cl_vk_ext(platform);
+    init_cl_vk_ext(platform, num_devices, devices);
 
     // Execute tests.
     // Note: don't use the entire harness, because we have a different way of

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -89,10 +89,10 @@ int run_test_with_two_queue(
 {
     int err = CL_SUCCESS;
     size_t global_work_size[1];
-    uint8_t *error_2;
-    cl_mem error_1;
-    cl_kernel update_buffer_kernel;
-    cl_kernel kernel_cq;
+    uint8_t *error_2 = nullptr;
+    cl_mem error_1 = nullptr;
+    cl_kernel update_buffer_kernel = nullptr;
+    cl_kernel kernel_cq = nullptr;
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
     const char *program_source_const = kernel_text_numbuffer_2;
@@ -140,9 +140,9 @@ int run_test_with_two_queue(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalSemaphore(
+        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
             vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalSemaphore(
+        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
             vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
     }
 
@@ -413,8 +413,8 @@ int run_test_with_one_queue(
 {
     log_info("RUNNING TEST WITH ONE QUEUE...... \n\n");
     size_t global_work_size[1];
-    uint8_t *error_2;
-    cl_mem error_1;
+    uint8_t *error_2 = nullptr;
+    cl_mem error_1 = nullptr;
     cl_kernel update_buffer_kernel;
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
@@ -453,9 +453,9 @@ int run_test_with_one_queue(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalSemaphore(
+        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
             vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalSemaphore(
+        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
             vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
     }
 
@@ -699,8 +699,8 @@ int run_test_with_multi_import_same_ctx(
     VulkanExternalSemaphoreHandleType vkExternalSemaphoreHandleType)
 {
     size_t global_work_size[1];
-    uint8_t *error_2;
-    cl_mem error_1;
+    uint8_t *error_2 = nullptr;
+    cl_mem error_1 = nullptr;
     int numImports = numBuffers;
     cl_kernel update_buffer_kernel;
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
@@ -742,9 +742,9 @@ int run_test_with_multi_import_same_ctx(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalSemaphore(
+        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
             vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalSemaphore(
+        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
             vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
     }
 
@@ -1025,9 +1025,9 @@ int run_test_with_multi_import_diff_ctx(
     VulkanExternalSemaphoreHandleType vkExternalSemaphoreHandleType)
 {
     size_t global_work_size[1];
-    uint8_t *error_3;
-    cl_mem error_1;
-    cl_mem error_2;
+    uint8_t *error_3 = nullptr;
+    cl_mem error_1 = nullptr;
+    cl_mem error_2 = nullptr;
     int numImports = numBuffers;
     cl_kernel update_buffer_kernel1[MAX_IMPORTS];
     cl_kernel update_buffer_kernel2[MAX_IMPORTS];
@@ -1071,17 +1071,17 @@ int run_test_with_multi_import_diff_ctx(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalSemaphore(
+        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
             vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalSemaphore(
+        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
             vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
 
-        clVk2CLExternalSemaphore2 =
-            new clExternalSemaphore(vkVk2CLSemaphore, context2,
-                                    vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore2 =
-            new clExternalSemaphore(vkCl2VkSemaphore, context2,
-                                    vkExternalSemaphoreHandleType, deviceId);
+        clVk2CLExternalSemaphore2 = new clExternalImportableSemaphore(
+            vkVk2CLSemaphore, context2, vkExternalSemaphoreHandleType,
+            deviceId);
+        clCl2VkExternalSemaphore2 = new clExternalExportableSemaphore(
+            vkCl2VkSemaphore, context2, vkExternalSemaphoreHandleType,
+            deviceId);
     }
 
     const uint32_t maxIter = innerIterations;

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -251,9 +251,9 @@ int run_test_with_two_queue(
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
 
-    clVk2CLExternalSemaphore = new clExternalSemaphore(
+    clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
         vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-    clCl2VkExternalSemaphore = new clExternalSemaphore(
+    clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
         vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
 
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;
@@ -816,9 +816,9 @@ int run_test_with_one_queue(
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
 
-    clVk2CLExternalSemaphore = new clExternalSemaphore(
+    clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
         vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-    clCl2VkExternalSemaphore = new clExternalSemaphore(
+    clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
         vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
 
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;


### PR DESCRIPTION
Additionally updated common semaphore code to handle spec updates that restrict simultaneous importing/exporting of handles.

See docs issue #939