### PR TITLE
integer_ops: fix -Wformat warnings

### DIFF
--- a/test_conformance/integer_ops/test_abs.cpp
+++ b/test_conformance/integer_ops/test_abs.cpp
@@ -15,6 +15,8 @@
 //
 #include "harness/compat.h"
 
+#include <cinttypes>
+
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
@@ -35,7 +37,7 @@ static int verify_abs_char( const void *p, const void *q, size_t n, const char *
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -52,7 +54,7 @@ static int verify_abs_short( const void *p, const void *q, size_t n, const char 
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -68,7 +70,7 @@ static int verify_abs_int( const void *p, const void *q, size_t n, const char *s
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -84,7 +86,7 @@ static int verify_abs_long( const void *p, const void *q, size_t n, const char *
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (long%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -100,7 +102,7 @@ static int verify_abs_uchar( const void *p, const void *q, size_t n, const char 
     {
         cl_uchar r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -115,7 +117,7 @@ static int verify_abs_ushort( const void *p, const void *q, size_t n, const char
     {
         cl_ushort r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -129,7 +131,7 @@ static int verify_abs_uint( const void *p, const void *q, size_t n, const char *
     {
         cl_uint r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -143,7 +145,7 @@ static int verify_abs_ulong( const void *p, const void *q, size_t n, const char 
     {
         cl_ulong r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for abs( (long%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for abs( (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_abs.cpp
+++ b/test_conformance/integer_ops/test_abs.cpp
@@ -37,7 +37,12 @@ static int verify_abs_char( const void *p, const void *q, size_t n, const char *
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (char%s) 0x%2.2x) = *0x%2.2x vs "
+                     "0x%2.2x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -54,7 +59,12 @@ static int verify_abs_short( const void *p, const void *q, size_t n, const char 
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs "
+                     "0x%4.4x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -70,7 +80,12 @@ static int verify_abs_int( const void *p, const void *q, size_t n, const char *s
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs "
+                     "0x%8.8x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -86,7 +101,12 @@ static int verify_abs_long( const void *p, const void *q, size_t n, const char *
         if( inA[i] < 0 )
             r = -inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (long%s) 0x%16.16" PRIx64
+                     ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -102,7 +122,12 @@ static int verify_abs_uchar( const void *p, const void *q, size_t n, const char 
     {
         cl_uchar r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (uchar%s) 0x%2.2x) = *0x%2.2x vs "
+                     "0x%2.2x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -117,7 +142,12 @@ static int verify_abs_ushort( const void *p, const void *q, size_t n, const char
     {
         cl_ushort r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (short%s) 0x%4.4x) = *0x%4.4x vs "
+                     "0x%4.4x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -131,7 +161,12 @@ static int verify_abs_uint( const void *p, const void *q, size_t n, const char *
     {
         cl_uint r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (int%s) 0x%2.2x) = *0x%8.8x vs "
+                     "0x%8.8x\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -145,7 +180,12 @@ static int verify_abs_ulong( const void *p, const void *q, size_t n, const char 
     {
         cl_ulong r = inA[i];
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for abs( (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i],r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for abs( (long%s) 0x%16.16" PRIx64
+                     ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_absdiff.cpp
+++ b/test_conformance/integer_ops/test_absdiff.cpp
@@ -20,6 +20,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "procs.h"
 
 template <class Integer>
@@ -43,7 +45,7 @@ static int verify_absdiff_char( const void *p, const void *q, const void *r, siz
     {
         cl_uchar r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (char%s) 0x%2.2x, (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (char%s) 0x%2.2x, (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -58,7 +60,7 @@ static int verify_absdiff_uchar( const void *p, const void *q, const void *r, si
     {
         cl_uchar r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (uchar%s) 0x%2.2x, (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (uchar%s) 0x%2.2x, (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -73,7 +75,7 @@ static int verify_absdiff_short( const void *p, const void *q, const void *r, si
     {
         cl_ushort r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (short%s) 0x%4.4x, (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (short%s) 0x%4.4x, (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -88,7 +90,7 @@ static int verify_absdiff_ushort( const void *p, const void *q, const void *r, s
     {
         cl_ushort r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (ushort%s) 0x%4.4x, (ushort%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (ushort%s) 0x%4.4x, (ushort%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -104,7 +106,7 @@ static int verify_absdiff_int( const void *p, const void *q, const void *r, size
         cl_uint r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
         {
-            log_info( "%ld) Failure for absdiff( (int%s) 0x%8.8x, (int%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] );
+            log_info( "%zu) Failure for absdiff( (int%s) 0x%8.8x, (int%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] );
             return -1;
         }
     }
@@ -121,7 +123,7 @@ static int verify_absdiff_uint( const void *p, const void *q, const void *r, siz
     {
         cl_uint r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (uint%s) 0x%8.8x, (uint%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (uint%s) 0x%8.8x, (uint%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -136,7 +138,7 @@ static int verify_absdiff_long( const void *p, const void *q, const void *r, siz
     {
         cl_ulong r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (long%s) 0x%16.16llx, (long%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -151,7 +153,7 @@ static int verify_absdiff_ulong( const void *p, const void *q, const void *r, si
     {
         cl_ulong r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%ld) Failure for absdiff( (ulong%s) 0x%16.16llx, (ulong%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%zu) Failure for absdiff( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_absdiff.cpp
+++ b/test_conformance/integer_ops/test_absdiff.cpp
@@ -45,7 +45,12 @@ static int verify_absdiff_char( const void *p, const void *q, const void *r, siz
     {
         cl_uchar r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (char%s) 0x%2.2x, (char%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (char%s) 0x%2.2x, (char%s) "
+                     "0x%2.2x) = *0x%2.2x vs 0x%2.2x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -60,7 +65,12 @@ static int verify_absdiff_uchar( const void *p, const void *q, const void *r, si
     {
         cl_uchar r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (uchar%s) 0x%2.2x, (uchar%s) 0x%2.2x) = *0x%2.2x vs 0x%2.2x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (uchar%s) 0x%2.2x, (uchar%s) "
+                     "0x%2.2x) = *0x%2.2x vs 0x%2.2x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -75,7 +85,12 @@ static int verify_absdiff_short( const void *p, const void *q, const void *r, si
     {
         cl_ushort r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (short%s) 0x%4.4x, (short%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (short%s) 0x%4.4x, (short%s) "
+                     "0x%4.4x) = *0x%4.4x vs 0x%4.4x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -90,7 +105,12 @@ static int verify_absdiff_ushort( const void *p, const void *q, const void *r, s
     {
         cl_ushort r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (ushort%s) 0x%4.4x, (ushort%s) 0x%4.4x) = *0x%4.4x vs 0x%4.4x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (ushort%s) 0x%4.4x, (ushort%s) "
+                     "0x%4.4x) = *0x%4.4x vs 0x%4.4x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -106,7 +126,9 @@ static int verify_absdiff_int( const void *p, const void *q, const void *r, size
         cl_uint r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
         {
-            log_info( "%zu) Failure for absdiff( (int%s) 0x%8.8x, (int%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] );
+            log_info("%zu) Failure for absdiff( (int%s) 0x%8.8x, (int%s) "
+                     "0x%8.8x) = *0x%8.8x vs 0x%8.8x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
             return -1;
         }
     }
@@ -123,7 +145,12 @@ static int verify_absdiff_uint( const void *p, const void *q, const void *r, siz
     {
         cl_uint r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (uint%s) 0x%8.8x, (uint%s) 0x%8.8x) = *0x%8.8x vs 0x%8.8x\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (uint%s) 0x%8.8x, (uint%s) "
+                     "0x%8.8x) = *0x%8.8x vs 0x%8.8x\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -138,7 +165,13 @@ static int verify_absdiff_long( const void *p, const void *q, const void *r, siz
     {
         cl_ulong r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (long%s) 0x%16.16" PRIx64
+                     ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -153,7 +186,13 @@ static int verify_absdiff_ulong( const void *p, const void *q, const void *r, si
     {
         cl_ulong r = abs_diff(inA[i], inB[i]);
         if( r != outptr[i] )
-        { log_info( "%zu) Failure for absdiff( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%zu) Failure for absdiff( (ulong%s) 0x%16.16" PRIx64
+                     ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_add_sat.cpp
+++ b/test_conformance/integer_ops/test_add_sat.cpp
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "procs.h"
 
@@ -140,7 +141,7 @@ static int verify_addsat_long( const cl_long *inA, const cl_long *inB, const cl_
                 r = CL_LONG_MIN;
         }
         if( r != outptr[i] )
-        { log_info( "%d) Failure for add_sat( (long%s) 0x%16.16llx, (long%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%d) Failure for add_sat( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -154,7 +155,7 @@ static int verify_addsat_ulong( const cl_ulong *inA, const cl_ulong *inB, const 
         if( r < inA[i] )
             r = CL_ULONG_MAX;
         if( r != outptr[i] )
-        { log_info( "%d) Failure for add_sat( (ulong%s) 0x%16.16llx, (ulong%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%d) Failure for add_sat( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_add_sat.cpp
+++ b/test_conformance/integer_ops/test_add_sat.cpp
@@ -141,7 +141,13 @@ static int verify_addsat_long( const cl_long *inA, const cl_long *inB, const cl_
                 r = CL_LONG_MIN;
         }
         if( r != outptr[i] )
-        { log_info( "%d) Failure for add_sat( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%d) Failure for add_sat( (long%s) 0x%16.16" PRIx64
+                     ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -155,7 +161,13 @@ static int verify_addsat_ulong( const cl_ulong *inA, const cl_ulong *inB, const 
         if( r < inA[i] )
             r = CL_ULONG_MAX;
         if( r != outptr[i] )
-        { log_info( "%d) Failure for add_sat( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%d) Failure for add_sat( (ulong%s) 0x%16.16" PRIx64
+                     ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_integers.cpp
+++ b/test_conformance/integer_ops/test_integers.cpp
@@ -199,13 +199,23 @@ int test_single_param_integer_kernel(cl_command_queue queue, cl_context context,
 
                     case 8:
                         if( useOpKernel )
-                            log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
-                                      (int)i, (int)j, ((cl_ulong*)&expected)[0], *( (cl_ulong *)p ),
-                                      *( (cl_ulong *)in ), *( (cl_ulong *)in2 ) );
+                            log_error("ERROR: Data sample %d:%d does not "
+                                      "validate! Expected (0x%16.16" PRIx64
+                                      "), got (0x%16.16" PRIx64
+                                      "), sources (0x%16.16" PRIx64
+                                      ", 0x%16.16" PRIx64 ")\n",
+                                      (int)i, (int)j,
+                                      ((cl_ulong *)&expected)[0],
+                                      *((cl_ulong *)p), *((cl_ulong *)in),
+                                      *((cl_ulong *)in2));
                         else
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ")\n",
-                                  (int)i, (int)j, ((cl_ulong*)&expected)[0], *( (cl_ulong *)p ),
-                                            *( (cl_ulong *)in ) );
+                            log_error("ERROR: Data sample %d:%d does not "
+                                      "validate! Expected (0x%16.16" PRIx64
+                                      "), got (0x%16.16" PRIx64
+                                      "), sources (0x%16.16" PRIx64 ")\n",
+                                      (int)i, (int)j,
+                                      ((cl_ulong *)&expected)[0],
+                                      *((cl_ulong *)p), *((cl_ulong *)in));
                         break;
                 }
                 return -1;
@@ -751,10 +761,14 @@ int test_two_param_integer_kernel(cl_command_queue queue, cl_context context, co
                         break;
 
                     case 8:
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
-                                  (int)i, (int)j, ((cl_ulong*)&expected)[ 0 ], *( (cl_ulong *)out ),
-                                            *( (cl_ulong *)inA ),
-                                            *( (cl_ulong *)inB ) );
+                        log_error("ERROR: Data sample %d:%d does not validate! "
+                                  "Expected (0x%16.16" PRIx64
+                                  "), got (0x%16.16" PRIx64
+                                  "), sources (0x%16.16" PRIx64
+                                  ", 0x%16.16" PRIx64 ")\n",
+                                  (int)i, (int)j, ((cl_ulong *)&expected)[0],
+                                  *((cl_ulong *)out), *((cl_ulong *)inA),
+                                  *((cl_ulong *)inB));
                         break;
                 }
                 return -1;
@@ -1418,11 +1432,14 @@ int test_three_param_integer_kernel(cl_command_queue queue, cl_context context, 
                         break;
 
                     case 8:
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
-                                  (int)i, (int)j, ((cl_ulong*)&expected)[ 0 ], *( (cl_ulong *)out ),
-                                            *( (cl_ulong *)inA ),
-                                            *( (cl_ulong *)inB ),
-                                            *( (cl_ulong *)inC ) );
+                        log_error("ERROR: Data sample %d:%d does not validate! "
+                                  "Expected (0x%16.16" PRIx64
+                                  "), got (0x%16.16" PRIx64
+                                  "), sources (0x%16.16" PRIx64
+                                  ", 0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
+                                  (int)i, (int)j, ((cl_ulong *)&expected)[0],
+                                  *((cl_ulong *)out), *((cl_ulong *)inA),
+                                  *((cl_ulong *)inB), *((cl_ulong *)inC));
                         break;
                 }
                 return -1;

--- a/test_conformance/integer_ops/test_integers.cpp
+++ b/test_conformance/integer_ops/test_integers.cpp
@@ -17,6 +17,7 @@
 #include "harness/conversions.h"
 
 #include <algorithm>
+#include <cinttypes>
 
 #define TEST_SIZE 512
 
@@ -198,11 +199,11 @@ int test_single_param_integer_kernel(cl_command_queue queue, cl_context context,
 
                     case 8:
                         if( useOpKernel )
-                            log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16llx), got (0x%16.16llx), sources (0x%16.16llx, 0x%16.16llx)\n",
+                            log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
                                       (int)i, (int)j, ((cl_ulong*)&expected)[0], *( (cl_ulong *)p ),
                                       *( (cl_ulong *)in ), *( (cl_ulong *)in2 ) );
                         else
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16llx), got (0x%16.16llx), sources (0x%16.16llx)\n",
+                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ")\n",
                                   (int)i, (int)j, ((cl_ulong*)&expected)[0], *( (cl_ulong *)p ),
                                             *( (cl_ulong *)in ) );
                         break;
@@ -750,7 +751,7 @@ int test_two_param_integer_kernel(cl_command_queue queue, cl_context context, co
                         break;
 
                     case 8:
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16llx), got (0x%16.16llx), sources (0x%16.16llx, 0x%16.16llx)\n",
+                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
                                   (int)i, (int)j, ((cl_ulong*)&expected)[ 0 ], *( (cl_ulong *)out ),
                                             *( (cl_ulong *)inA ),
                                             *( (cl_ulong *)inB ) );
@@ -1417,7 +1418,7 @@ int test_three_param_integer_kernel(cl_command_queue queue, cl_context context, 
                         break;
 
                     case 8:
-                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16llx), got (0x%16.16llx), sources (0x%16.16llx, 0x%16.16llx, 0x%16.16llx)\n",
+                        log_error( "ERROR: Data sample %d:%d does not validate! Expected (0x%16.16" PRIx64 "), got (0x%16.16" PRIx64 "), sources (0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ", 0x%16.16" PRIx64 ")\n",
                                   (int)i, (int)j, ((cl_ulong*)&expected)[ 0 ], *( (cl_ulong *)out ),
                                             *( (cl_ulong *)inA ),
                                             *( (cl_ulong *)inB ),

--- a/test_conformance/integer_ops/test_intmad24.cpp
+++ b/test_conformance/integer_ops/test_intmad24.cpp
@@ -139,7 +139,7 @@ verify_int_mad24(int *inptrA, int *inptrB, int *inptrC, int *outptr, size_t n, s
         r = a * b + inptrC[i];
         if (r != outptr[i])
         {
-            log_error( "Failed at %ld)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
+            log_error( "Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
              return -1;
         }
     }
@@ -160,7 +160,7 @@ verify_uint_mad24(cl_uint *inptrA, cl_uint *inptrB, cl_uint *inptrC, cl_uint *ou
         r = a * b + inptrC[i];
         if (r != outptr[i])
         {
-            log_error( "Failed at %ld)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
+            log_error( "Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
              return -1;
         }
     }

--- a/test_conformance/integer_ops/test_intmad24.cpp
+++ b/test_conformance/integer_ops/test_intmad24.cpp
@@ -139,8 +139,10 @@ verify_int_mad24(int *inptrA, int *inptrB, int *inptrC, int *outptr, size_t n, s
         r = a * b + inptrC[i];
         if (r != outptr[i])
         {
-            log_error( "Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
-             return -1;
+            log_error("Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x "
+                      "vs 0x%8.8x\n",
+                      i, a, b, inptrC[i], r, outptr[i]);
+            return -1;
         }
     }
 
@@ -160,8 +162,10 @@ verify_uint_mad24(cl_uint *inptrA, cl_uint *inptrB, cl_uint *inptrC, cl_uint *ou
         r = a * b + inptrC[i];
         if (r != outptr[i])
         {
-            log_error( "Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, a, b, inptrC[i], r, outptr[i] );
-             return -1;
+            log_error("Failed at %zu)  0x%8.8x * 0x%8.8x + 0x%8.8x = *0x%8.8x "
+                      "vs 0x%8.8x\n",
+                      i, a, b, inptrC[i], r, outptr[i]);
+            return -1;
         }
     }
 

--- a/test_conformance/integer_ops/test_intmul24.cpp
+++ b/test_conformance/integer_ops/test_intmul24.cpp
@@ -153,7 +153,7 @@ verify_uint_mul24(cl_uint *inptrA, cl_uint *inptrB, cl_uint *outptr, size_t n, s
         r = (inptrA[i] & 0xffffffU) * (inptrB[i] & 0xffffffU);
         if (r != outptr[i])
         {
-            log_error( "failed at %ld: 0x%8.8x * 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, inptrA[i], inptrB[i], r, outptr[i] );
+            log_error( "failed at %zu: 0x%8.8x * 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, inptrA[i], inptrB[i], r, outptr[i] );
              return -1;
         }
     }

--- a/test_conformance/integer_ops/test_intmul24.cpp
+++ b/test_conformance/integer_ops/test_intmul24.cpp
@@ -153,8 +153,10 @@ verify_uint_mul24(cl_uint *inptrA, cl_uint *inptrB, cl_uint *outptr, size_t n, s
         r = (inptrA[i] & 0xffffffU) * (inptrB[i] & 0xffffffU);
         if (r != outptr[i])
         {
-            log_error( "failed at %zu: 0x%8.8x * 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i, inptrA[i], inptrB[i], r, outptr[i] );
-             return -1;
+            log_error(
+                "failed at %zu: 0x%8.8x * 0x%8.8x = *0x%8.8x vs 0x%8.8x\n", i,
+                inptrA[i], inptrB[i], r, outptr[i]);
+            return -1;
         }
     }
 

--- a/test_conformance/integer_ops/test_popcount.cpp
+++ b/test_conformance/integer_ops/test_popcount.cpp
@@ -38,26 +38,29 @@
         } \
     }
 
-#define __verify_popcount_func(__T) \
-    static int verify_popcount_##__T( const void *p, const void *r, size_t n, const char *sizeName, size_t vecSize ) \
-    { \
-        const __T *inA = (const __T *) p; \
-        const __T *outptr = (const __T *) r; \
-        size_t i; \
-        int _n = sizeof(__T)*8; \
-        __T ref; \
-        for(i = 0; i < n; i++) \
-        { \
-            __T x = inA[i]; \
-            __T res = outptr[i]; \
-            __popcnt(x, __T, _n, ref); \
-            if(res != ref) \
-            { \
-                log_info( "%zu) Failure for popcount( (%s%s) 0x%x ) = *%d vs %d\n", i, str(__T), sizeName, (int)x, (int)ref, (int)res ); \
-                return -1; \
-            }\
-        } \
-        return 0; \
+#define __verify_popcount_func(__T)                                            \
+    static int verify_popcount_##__T(const void *p, const void *r, size_t n,   \
+                                     const char *sizeName, size_t vecSize)     \
+    {                                                                          \
+        const __T *inA = (const __T *)p;                                       \
+        const __T *outptr = (const __T *)r;                                    \
+        size_t i;                                                              \
+        int _n = sizeof(__T) * 8;                                              \
+        __T ref;                                                               \
+        for (i = 0; i < n; i++)                                                \
+        {                                                                      \
+            __T x = inA[i];                                                    \
+            __T res = outptr[i];                                               \
+            __popcnt(x, __T, _n, ref);                                         \
+            if (res != ref)                                                    \
+            {                                                                  \
+                log_info(                                                      \
+                    "%zu) Failure for popcount( (%s%s) 0x%x ) = *%d vs %d\n",  \
+                    i, str(__T), sizeName, (int)x, (int)ref, (int)res);        \
+                return -1;                                                     \
+            }                                                                  \
+        }                                                                      \
+        return 0;                                                              \
     }
 
 __verify_popcount_func(cl_char);

--- a/test_conformance/integer_ops/test_popcount.cpp
+++ b/test_conformance/integer_ops/test_popcount.cpp
@@ -20,6 +20,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "procs.h"
 
 #define str(s) #s
@@ -51,7 +53,7 @@
             __popcnt(x, __T, _n, ref); \
             if(res != ref) \
             { \
-                log_info( "%ld) Failure for popcount( (%s%s) 0x%x ) = *%d vs %d\n", i, str(__T), sizeName, x, (int)ref, (int)res ); \
+                log_info( "%zu) Failure for popcount( (%s%s) 0x%x ) = *%d vs %d\n", i, str(__T), sizeName, (int)x, (int)ref, (int)res ); \
                 return -1; \
             }\
         } \

--- a/test_conformance/integer_ops/test_sub_sat.cpp
+++ b/test_conformance/integer_ops/test_sub_sat.cpp
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "procs.h"
 
@@ -140,7 +141,7 @@ static int verify_subsat_long( const cl_long *inA, const cl_long *inB, const cl_
                 r = CL_LONG_MIN;
         }
         if( r != outptr[i] )
-        { log_info( "%d) Failure for sub_sat( (long%s) 0x%16.16llx, (long%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%d) Failure for sub_sat( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }
@@ -154,7 +155,7 @@ static int verify_subsat_ulong( const cl_ulong *inA, const cl_ulong *inB, const 
         if(  inA[i] < inB[i] )
             r = 0;
         if( r != outptr[i] )
-        { log_info( "%d) Failure for sub_sat( (ulong%s) 0x%16.16llx, (ulong%s) 0x%16.16llx) = *0x%16.16llx vs 0x%16.16llx\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        { log_info( "%d) Failure for sub_sat( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_sub_sat.cpp
+++ b/test_conformance/integer_ops/test_sub_sat.cpp
@@ -141,7 +141,13 @@ static int verify_subsat_long( const cl_long *inA, const cl_long *inB, const cl_
                 r = CL_LONG_MIN;
         }
         if( r != outptr[i] )
-        { log_info( "%d) Failure for sub_sat( (long%s) 0x%16.16" PRIx64 ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%d) Failure for sub_sat( (long%s) 0x%16.16" PRIx64
+                     ", (long%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }
@@ -155,7 +161,13 @@ static int verify_subsat_ulong( const cl_ulong *inA, const cl_ulong *inB, const 
         if(  inA[i] < inB[i] )
             r = 0;
         if( r != outptr[i] )
-        { log_info( "%d) Failure for sub_sat( (ulong%s) 0x%16.16" PRIx64 ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64 " vs 0x%16.16" PRIx64 "\n", i, sizeName, inA[i], sizeName, inB[i], r, outptr[i] ); return -1; }
+        {
+            log_info("%d) Failure for sub_sat( (ulong%s) 0x%16.16" PRIx64
+                     ", (ulong%s) 0x%16.16" PRIx64 ") = *0x%16.16" PRIx64
+                     " vs 0x%16.16" PRIx64 "\n",
+                     i, sizeName, inA[i], sizeName, inB[i], r, outptr[i]);
+            return -1;
+        }
     }
     return 0;
 }

--- a/test_conformance/integer_ops/test_unary_ops.cpp
+++ b/test_conformance/integer_ops/test_unary_ops.cpp
@@ -73,8 +73,8 @@ int test_unary_op( cl_command_queue queue, cl_context context, OpKonstants which
     }
     else
     {
-        sprintf( loadLine, "vload%zu( tid, inOut )", vecSize );
-        sprintf( storeLine, "vstore%zu( inOutVal, tid, inOut )", vecSize );
+        sprintf(loadLine, "vload%zu( tid, inOut )", vecSize);
+        sprintf(storeLine, "vstore%zu( inOutVal, tid, inOut )", vecSize);
     }
 
     char sizeNames[][4] = { "", "", "2", "3", "4", "", "", "", "8", "", "", "", "", "", "", "", "16" };
@@ -161,8 +161,9 @@ template<typename T> int VerifyFn( void * actualPtr, void * inputPtr, size_t vec
 
             if( actualData[ index ] != nextVal )
             {
-                log_error( "ERROR: Validation failed on vector %zu:%zu (expected %" PRId64 ", got %" PRId64 ")", i, j,
-                          (cl_long)nextVal, (cl_long)actualData[ index ] );
+                log_error("ERROR: Validation failed on vector %zu:%zu "
+                          "(expected %" PRId64 ", got %" PRId64 ")",
+                          i, j, (cl_long)nextVal, (cl_long)actualData[index]);
                 return -1;
             }
         }

--- a/test_conformance/integer_ops/test_unary_ops.cpp
+++ b/test_conformance/integer_ops/test_unary_ops.cpp
@@ -16,6 +16,8 @@
 #include "testBase.h"
 #include "harness/conversions.h"
 
+#include <cinttypes>
+
 #define TEST_SIZE 512
 
 enum OpKonstants
@@ -71,8 +73,8 @@ int test_unary_op( cl_command_queue queue, cl_context context, OpKonstants which
     }
     else
     {
-        sprintf( loadLine, "vload%ld( tid, inOut )", vecSize );
-        sprintf( storeLine, "vstore%ld( inOutVal, tid, inOut )", vecSize );
+        sprintf( loadLine, "vload%zu( tid, inOut )", vecSize );
+        sprintf( storeLine, "vstore%zu( inOutVal, tid, inOut )", vecSize );
     }
 
     char sizeNames[][4] = { "", "", "2", "3", "4", "", "", "", "8", "", "", "", "", "", "", "", "16" };
@@ -159,7 +161,7 @@ template<typename T> int VerifyFn( void * actualPtr, void * inputPtr, size_t vec
 
             if( actualData[ index ] != nextVal )
             {
-                log_error( "ERROR: Validation failed on vector %ld:%ld (expected %lld, got %lld)", i, j,
+                log_error( "ERROR: Validation failed on vector %zu:%zu (expected %" PRId64 ", got %" PRId64 ")", i, j,
                           (cl_long)nextVal, (cl_long)actualData[ index ] );
                 return -1;
             }

--- a/test_conformance/integer_ops/test_upsample.cpp
+++ b/test_conformance/integer_ops/test_upsample.cpp
@@ -213,7 +213,7 @@ void * create_upsample_data( ExplicitType type, void *sourceA, void *sourceB, si
             }
             break;
         default:
-            log_error( "ERROR: unknown type size: %ld\n", tSize );
+            log_error( "ERROR: unknown type size: %zu\n", tSize );
             return NULL;
     }
 

--- a/test_conformance/integer_ops/test_upsample.cpp
+++ b/test_conformance/integer_ops/test_upsample.cpp
@@ -213,7 +213,7 @@ void * create_upsample_data( ExplicitType type, void *sourceA, void *sourceB, si
             }
             break;
         default:
-            log_error( "ERROR: unknown type size: %zu\n", tSize );
+            log_error("ERROR: unknown type size: %zu\n", tSize);
             return NULL;
     }
 

--- a/test_conformance/integer_ops/verification_and_generation_functions.cpp
+++ b/test_conformance/integer_ops/verification_and_generation_functions.cpp
@@ -229,20 +229,50 @@ verify_long(int test, size_t vector_size, cl_long *inptrA, cl_long *inptrB, cl_l
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_long Verification failed at element %zu of %zu : 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Vector shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
+                    log_error("cl_long Verification failed at element %zu of "
+                              "%zu : 0x%" PRIx64 " %s 0x%" PRIx64
+                              " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n",
+                              i, n, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error(
+                        "\t1) Vector shift failure at element %zu: original is "
+                        "0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n",
+                        i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the "
+                              "final shift amount %" PRId64 " (0x%" PRIx64
+                              ").\n",
+                              (int)log2(sizeof(cl_long) * 8),
+                              inptrB[i] & shift_mask, inptrB[i] & shift_mask);
                 }
                 else if (test == 10 || test == 11) {
 
-                    log_error("cl_long Verification failed at element %zu of %zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
+                    log_error("cl_long Verification failed at element %zu of "
+                              "%zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64
+                              " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n",
+                              i, n, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error(
+                        "\t1) Scalar shift failure at element %zu: original is "
+                        "0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n",
+                        i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the "
+                              "final shift amount %" PRId64 " (0x%" PRIx64
+                              ").\n",
+                              (int)log2(sizeof(cl_long) * 8),
+                              inptrB[j] & shift_mask, inptrB[j] & shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%" PRIx64 " < 0x%" PRIx64 ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error("cl_int Verification failed at element %zu "
+                              "(%zu): (0x%" PRIx64 " < 0x%" PRIx64
+                              ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64
+                              ", got 0x%" PRIx64 "\n",
+                              i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i],
+                              r, outptr[i]);
                 } else {
-                    log_error("cl_long Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_long Verification failed at element %zu of "
+                              "%zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64
+                              ", got 0x%" PRIx64 "\n",
+                              i, n, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -425,19 +455,49 @@ verify_ulong(int test, size_t vector_size, cl_ulong *inptrA, cl_ulong *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_ulong Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRIu64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_ulong)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
+                    log_error("cl_ulong Verification failed at element %zu of "
+                              "%zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64
+                              ", got 0x%" PRIx64 "\n",
+                              i, n, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the "
+                              "final shift amount %" PRIu64 " (0x%" PRIx64
+                              ").\n",
+                              (int)log2(sizeof(cl_ulong) * 8),
+                              inptrB[i] & shift_mask, inptrB[i] & shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_ulong Verification failed at element %zu of %zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
+                    log_error("cl_ulong Verification failed at element %zu of "
+                              "%zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64
+                              " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n",
+                              i, n, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error(
+                        "\t1) Scalar shift failure at element %zu: original is "
+                        "0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n",
+                        i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the "
+                              "final shift amount %" PRId64 " (0x%" PRIx64
+                              ").\n",
+                              (int)log2(sizeof(cl_long) * 8),
+                              inptrB[j] & shift_mask, inptrB[j] & shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu of %zu (%zu): (0x%" PRIx64 " < 0x%" PRIx64 ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error("cl_int Verification failed at element %zu of "
+                              "%zu (%zu): (0x%" PRIx64 " < 0x%" PRIx64
+                              ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64
+                              ", got 0x%" PRIx64 "\n",
+                              i, n, j, inptrA[j], inptrB[j], inptrA[i],
+                              inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_ulong Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_ulong Verification failed at element %zu of "
+                              "%zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64
+                              ", got 0x%" PRIx64 "\n",
+                              i, n, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -626,19 +686,37 @@ verify_int(int test, size_t vector_size, cl_int *inptrA, cl_int *inptrB, cl_int 
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_int Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_int Verification failed at element %zu: 0x%x "
+                              "%s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_int)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_int Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_int Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_int)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_int Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_int Verification failed at element %zu: 0x%x "
+                              "%s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -821,19 +899,37 @@ verify_uint(int test, size_t vector_size, cl_uint *inptrA, cl_uint *inptrB, cl_u
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_uint Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_uint Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uint)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_uint Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_uint Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uint)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_uint Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_uint Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1017,19 +1113,37 @@ verify_short(int test, size_t vector_size, cl_short *inptrA, cl_short *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_short Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_short Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_short)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_short Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_short Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_short)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_short Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_short Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1215,19 +1329,37 @@ verify_ushort(int test, size_t vector_size, cl_ushort *inptrA, cl_ushort *inptrB
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_ushort Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_ushort Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_ushort)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_ushort Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_ushort Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_ushort)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_ushort Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_ushort Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1415,19 +1547,37 @@ verify_char(int test, size_t vector_size, cl_char *inptrA, cl_char *inptrB, cl_c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_char Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_char Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_char)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_char Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_char Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_char Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_char Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1621,19 +1771,37 @@ verify_uchar(int test, size_t vector_size, cl_uchar *inptrA, cl_uchar *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_uchar Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_uchar Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is "
+                              "0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[i],
+                              inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uchar)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_uchar Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_uchar Verification failed at element %zu "
+                              "(%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, j, inptrA[i], tests[test], inptrB[j], r,
+                              outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: "
+                              "original is 0x%x %s %d (0x%x)\n",
+                              i, inptrA[i], tests[test], (int)inptrB[j],
+                              inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uchar)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
-                              inptrA[i], inptrB[i], r, outptr[i]);
+                    log_error(
+                        "cl_int Verification failed at element %zu (%zu): "
+                        "(0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n",
+                        i, j, inptrA[j], inptrB[j], inptrA[i], inptrB[i], r,
+                        outptr[i]);
                 } else {
-                    log_error("cl_uchar Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_uchar Verification failed at element %zu: "
+                              "0x%x %s 0x%x = 0x%x, got 0x%x\n",
+                              i, inptrA[i], tests[test], inptrB[i], r,
+                              outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {

--- a/test_conformance/integer_ops/verification_and_generation_functions.cpp
+++ b/test_conformance/integer_ops/verification_and_generation_functions.cpp
@@ -20,6 +20,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "procs.h"
 #include "harness/conversions.h"
 
@@ -227,20 +229,20 @@ verify_long(int test, size_t vector_size, cl_long *inptrA, cl_long *inptrB, cl_l
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_long Verification failed at element %ld of %ld : 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Vector shift failure at element %ld: original is 0x%llx %s %d (0x%llx)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %lld (0x%llx).\n", (int)log2(sizeof(cl_long)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
+                    log_error("cl_long Verification failed at element %zu of %zu : 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Vector shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
 
-                    log_error("cl_long Verification failed at element %ld of %ld (%ld): 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%llx %s %d (0x%llx)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %lld (0x%llx).\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
+                    log_error("cl_long Verification failed at element %zu of %zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%llx < 0x%llx) ? 0x%llx : 0x%llx = 0x%llx, got 0x%llx\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%" PRIx64 " < 0x%" PRIx64 ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_long Verification failed at element %ld of %ld: 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_long Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -423,19 +425,19 @@ verify_ulong(int test, size_t vector_size, cl_ulong *inptrA, cl_ulong *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_ulong Verification failed at element %ld of %ld: 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%llx %s %d (0x%llx)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %llu (0x%llx).\n", (int)log2(sizeof(cl_ulong)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
+                    log_error("cl_ulong Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRIu64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_ulong)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_ulong Verification failed at element %ld of %ld (%ld): 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%llx %s %d (0x%llx)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
-                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %lld (0x%llx).\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
+                    log_error("cl_ulong Verification failed at element %zu of %zu (%zu): 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%" PRIx64 " %s %d (0x%" PRIx64 ")\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %" PRId64 " (0x%" PRIx64 ").\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld of %ld (%ld): (0x%llx < 0x%llx) ? 0x%llx : 0x%llx = 0x%llx, got 0x%llx\n", i, n, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu of %zu (%zu): (0x%" PRIx64 " < 0x%" PRIx64 ") ? 0x%" PRIx64 " : 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_ulong Verification failed at element %ld of %ld: 0x%llx %s 0x%llx = 0x%llx, got 0x%llx\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_ulong Verification failed at element %zu of %zu: 0x%" PRIx64 " %s 0x%" PRIx64 " = 0x%" PRIx64 ", got 0x%" PRIx64 "\n", i, n, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -624,19 +626,19 @@ verify_int(int test, size_t vector_size, cl_int *inptrA, cl_int *inptrB, cl_int 
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_int Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_int Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_int)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_int Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_int Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_int)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_int Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_int Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -819,19 +821,19 @@ verify_uint(int test, size_t vector_size, cl_uint *inptrA, cl_uint *inptrB, cl_u
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_uint Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_uint Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uint)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_uint Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_uint Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uint)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_uint Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_uint Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1015,19 +1017,19 @@ verify_short(int test, size_t vector_size, cl_short *inptrA, cl_short *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_short Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_short Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_short)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_short Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_short Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_short)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_short Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_short Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1213,19 +1215,19 @@ verify_ushort(int test, size_t vector_size, cl_ushort *inptrA, cl_ushort *inptrB
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_ushort Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_ushort Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_ushort)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_ushort Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_ushort Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_ushort)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_ushort Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_ushort Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1413,19 +1415,19 @@ verify_char(int test, size_t vector_size, cl_char *inptrA, cl_char *inptrB, cl_c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_char Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_char Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_char)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_char Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_char Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_long)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_char Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_char Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {
@@ -1619,19 +1621,19 @@ verify_uchar(int test, size_t vector_size, cl_uchar *inptrA, cl_uchar *inptrB, c
             if (r != outptr[i]) {
                 // Shift is tricky
                 if (test == 8 || test == 9) {
-                    log_error("cl_uchar Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
-                    log_error("\t1) Shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
+                    log_error("cl_uchar Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("\t1) Shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[i], inptrB[i]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uchar)*8),  inptrB[i]&shift_mask, inptrB[i]&shift_mask);
                 }
                 else if (test == 10 || test == 11) {
-                    log_error("cl_uchar Verification failed at element %ld (%ld): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
-                    log_error("\t1) Scalar shift failure at element %ld: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
+                    log_error("cl_uchar Verification failed at element %zu (%zu): 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[i], tests[test], inptrB[j], r, outptr[i]);
+                    log_error("\t1) Scalar shift failure at element %zu: original is 0x%x %s %d (0x%x)\n", i, inptrA[i], tests[test], (int)inptrB[j], inptrB[j]);
                     log_error("\t2) Take the %d LSBs of the shift to get the final shift amount %d (0x%x).\n", (int)log2(sizeof(cl_uchar)*8),  inptrB[j]&shift_mask, inptrB[j]&shift_mask);
                 } else if (test == 13) {
-                    log_error("cl_int Verification failed at element %ld (%ld): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
+                    log_error("cl_int Verification failed at element %zu (%zu): (0x%x < 0x%x) ? 0x%x : 0x%x = 0x%x, got 0x%x\n", i, j, inptrA[j], inptrB[j],
                               inptrA[i], inptrB[i], r, outptr[i]);
                 } else {
-                    log_error("cl_uchar Verification failed at element %ld: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
+                    log_error("cl_uchar Verification failed at element %zu: 0x%x %s 0x%x = 0x%x, got 0x%x\n", i, inptrA[i], tests[test], inptrB[i], r, outptr[i]);
                 }
                 count++;
                 if (count >= MAX_ERRORS_TO_PRINT) {


### PR DESCRIPTION
The main sources of warnings were:

 * Printing of a `size_t` which requires the `%zu` specifier.

 * Printing of `cl_long`/`cl_ulong` which is now done using the `PRI*64` macros to ensure portability across 32 and 64-bit builds.

I've split out the clang-formatting of my changes into a separate commit to ease reviewing.