### PR TITLE
fix macos builds by avoiding double compilation of function_list.cpp for test_spir

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -38,11 +38,14 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev libglew-dev
       - name: Setup MSVC with Ninja
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Get System Info
+        uses: kenchan0130/actions-system-info@master
+        id: system-info
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           variant: sccache
-          key: ${{ matrix.os }}-${{ matrix.arch }}
+          key: ${{ matrix.os }}-${{ steps.system-info.outputs.release }}-${{ matrix.arch }}
       - name: Fetch OpenCL Headers
         shell: bash
         run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -38,14 +38,11 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev libglew-dev
       - name: Setup MSVC with Ninja
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Get System Info
-        uses: kenchan0130/actions-system-info@master
-        id: system-info
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           variant: sccache
-          key: ${{ matrix.os }}-${{ steps.system-info.outputs.release }}-${{ matrix.arch }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}
       - name: Fetch OpenCL Headers
         shell: bash
         run: |

--- a/test_conformance/spir/CMakeLists.txt
+++ b/test_conformance/spir/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Import function list from math_brute_force
-add_definitions(-DFUNCTION_LIST_ULPS_ONLY)
-
 set(SPIR_OUT ${CONFORMANCE_PREFIX}spir${CONFORMANCE_SUFFIX})
 
 set (SPIR_SOURCES
@@ -16,18 +13,15 @@ add_executable(${SPIR_OUT}
     ${SPIR_SOURCES})
 
 if(UNIX)
-    set_target_properties(${SPIR_OUT} PROPERTIES
-       COMPILE_FLAGS "-fexceptions -frtti")
+    target_compile_options(${SPIR_OUT} PRIVATE -fexceptions -frtti)
 elseif(MSVC)
-    set_target_properties(${SPIR_OUT} PROPERTIES
-       COMPILE_FLAGS "/GR /EHs /EHc")
+    target_compile_options(${SPIR_OUT} PRIVATE /GR /EHs /EHc)
 endif()
 
-TARGET_LINK_LIBRARIES(${SPIR_OUT} harness
-    ${CLConform_LIBRARIES})
+# Import function list from math_brute_force
+target_compile_definitions(${SPIR_OUT} PRIVATE FUNCTION_LIST_ULPS_ONLY)
 
-
-set_source_files_properties(${SPIR_SOURCES} PROPERTIES LANGUAGE CXX)
+target_link_libraries(${SPIR_OUT} harness ${CLConform_LIBRARIES})
 
 # Need to copy the spir zips to sit beside the executable
 

--- a/test_conformance/spir/CMakeLists.txt
+++ b/test_conformance/spir/CMakeLists.txt
@@ -6,7 +6,6 @@ set (SPIR_SOURCES
     run_build_test.cpp
     run_services.cpp
     kernelargs.cpp
-    ../math_brute_force/function_list.cpp
 )
 
 add_executable(${SPIR_OUT}
@@ -17,9 +16,6 @@ if(UNIX)
 elseif(MSVC)
     target_compile_options(${SPIR_OUT} PRIVATE /GR /EHs /EHc)
 endif()
-
-# Import function list from math_brute_force
-target_compile_definitions(${SPIR_OUT} PRIVATE FUNCTION_LIST_ULPS_ONLY)
 
 target_link_libraries(${SPIR_OUT} harness ${CLConform_LIBRARIES})
 

--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -13,6 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+// Import function list from math_brute_force
+#define FUNCTION_LIST_ULPS_ONLY
+#include "../math_brute_force/function_list.cpp"
+
 #include "harness/compat.h"
 
 #include <stdio.h>


### PR DESCRIPTION
fixes #1862 

This PR modernizes the CMakeLists.txt for test_spir.  It uses target specific commands to add compile options and compile definitions vs. setting COMPILE_FLAGS and adding definitions globally.  This fixes the macos builds, which broke when the runner updated to a new version of CMake.