### PR TITLE
Fix -Wformat warnings in multiple tests

### DIFF
--- a/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
+++ b/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
@@ -126,8 +126,10 @@ int launch_kernels_and_verify(clContextWrapper &context, clCommandQueueWrapper* 
   // each device and the host inserted all of the pixels, check that none are missing.
   if(num_items != num_pixels * (num_devices + 1) )
   {
-    log_error("The hash table is not correct, num items %d, expected num items: %d\n", num_items, num_pixels * (num_devices + 1));
-    return -1; // test did not pass
+      log_error("The hash table is not correct, num items %d, expected num "
+                "items: %zu\n",
+                num_items, num_pixels * (num_devices + 1));
+      return -1; // test did not pass
   }
   return 0;
 }

--- a/test_conformance/compiler/test_pragma_unroll.cpp
+++ b/test_conformance/compiler/test_pragma_unroll.cpp
@@ -284,8 +284,10 @@ int test_pragma_unroll(cl_device_id deviceID, cl_context context, cl_command_que
 
     for (size_t i = 0; i < ELEMENT_NUM; ++i) {
       if (results[i] != i) {
-        log_error("Kernel %d returned invalid result. Test: %d, expected: %d\n", kernelIdx + 1, results[i], i);
-        return -1;
+          log_error(
+              "Kernel %zu returned invalid result. Test: %d, expected: %zu\n",
+              kernelIdx + 1, results[i], i);
+          return -1;
       }
     }
   }

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1392,7 +1392,7 @@ int test_computeinfo(cl_device_id deviceID, cl_context context,
             for (size_t onDevice = 0;
                  onDevice < device_infos[onInfo].num_devices; onDevice++)
             {
-                log_info("%s Device %d of %d Info:\n",
+                log_info("%s Device %zu of %d Info:\n",
                          device_infos[onInfo].device_type_name, onDevice + 1,
                          device_infos[onInfo].num_devices);
                 total_errors +=

--- a/test_conformance/gl/test_image_methods.cpp
+++ b/test_conformance/gl/test_image_methods.cpp
@@ -170,7 +170,7 @@ int test_image_format_methods(cl_device_id device, cl_context context,
     }
 
     // Construct testing source
-    log_info(" - Creating image %d by %d...\n", width, height);
+    log_info(" - Creating image %zu by %zu...\n", width, height);
     // Create a CL image from the supplied GL texture
     image = (*clCreateFromGLTexture_ptr)(context, CL_MEM_READ_ONLY, target, 0,
                                          glTexture, &error);

--- a/test_conformance/spir/run_services.cpp
+++ b/test_conformance/spir/run_services.cpp
@@ -762,7 +762,9 @@ bool compare_results( const TestResult& lhs, const TestResult& rhs, float ulps )
     {
         if( ! lhs.kernelArgs().getArg(i)->compare( *rhs.kernelArgs().getArg(i), ulps ) )
         {
-            log_error("the kernel parameter (%d) is different between SPIR and CL version of the kernel\n", i);
+            log_error("the kernel parameter (%zu) is different between SPIR "
+                      "and CL version of the kernel\n",
+                      i);
             return false;
         }
     }

--- a/test_conformance/subgroups/subgroup_common_templates.h
+++ b/test_conformance/subgroups/subgroup_common_templates.h
@@ -549,7 +549,7 @@ template <typename Ty, ShuffleOp operation> struct SHF
                         if (!compare(rr, tr))
                         {
                             log_error("ERROR: sub_group_%s(%s) mismatch for "
-                                      "local id %d in sub group %d in group "
+                                      "local id %zu in sub group %zu in group "
                                       "%d\n",
                                       operation_names(operation),
                                       TypeManager<Ty>::name(), i, j, k);

--- a/test_conformance/workgroups/test_wg_broadcast.cpp
+++ b/test_conformance/workgroups/test_wg_broadcast.cpp
@@ -76,7 +76,9 @@ verify_wg_broadcast_1D(float *inptr, float *outptr, size_t n, size_t wg_size)
         {
             if ( broadcast_result != outptr[i+j] )
             {
-                log_info("work_group_broadcast: Error at %u: expected = %f, got = %f\n", i+j, broadcast_result, outptr[i+j]);
+                log_info("work_group_broadcast: Error at %zu: expected = %f, "
+                         "got = %f\n",
+                         i + j, broadcast_result, outptr[i + j]);
                 return -1;
             }
         }
@@ -107,7 +109,10 @@ verify_wg_broadcast_2D(float *inptr, float *outptr, size_t nx, size_t ny, size_t
                     size_t indx = (i + _i) * nx + (j + _j);
                     if ( broadcast_result != outptr[indx] )
                     {
-                        log_info("work_group_broadcast: Error at (%u, %u): expected = %f, got = %f\n", j+_j, i+_i, broadcast_result, outptr[indx]);
+                        log_info("work_group_broadcast: Error at (%zu, %zu): "
+                                 "expected = %f, got = %f\n",
+                                 j + _j, i + _i, broadcast_result,
+                                 outptr[indx]);
                         return -1;
                     }
                 }
@@ -146,7 +151,10 @@ verify_wg_broadcast_3D(float *inptr, float *outptr, size_t nx, size_t ny, size_t
                             size_t indx = (i + _i) * ny * nx + (j + _j) * nx + (k + _k);
                             if ( broadcast_result != outptr[indx] )
                             {
-                                log_info("work_group_broadcast: Error at (%u, %u, %u): expected = %f, got = %f\n", k+_k, j+_j, i+_i, broadcast_result, outptr[indx]);
+                                log_info("work_group_broadcast: Error at (%zu, "
+                                         "%zu, %zu): expected = %f, got = %f\n",
+                                         k + _k, j + _j, i + _i,
+                                         broadcast_result, outptr[indx]);
                                 return -1;
                             }
                         }


### PR DESCRIPTION
All of these warnings stem from printing `size_t` types, which should be done using the `z` length modifier.