### PR TITLE
api tests fix: Free MTdata object in test_get_image_info

### DIFF
--- a/test_conformance/api/test_mem_object_info.cpp
+++ b/test_conformance/api/test_mem_object_info.cpp
@@ -476,7 +476,8 @@ int test_get_image_info( cl_device_id deviceID, cl_context context, cl_mem_objec
         CL_MEM_HOST_NO_ACCESS | CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
         CL_MEM_HOST_NO_ACCESS | CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
     };
-    MTdata d;
+    MTdataHolder d_holder(gRandomSeed);
+    MTdata d = static_cast<MTdata>(d_holder);
 
     PASSIVE_REQUIRE_IMAGE_SUPPORT( deviceID )
 
@@ -494,8 +495,6 @@ int test_get_image_info( cl_device_id deviceID, cl_context context, cl_mem_objec
 #else
     imageInfo.buffer = NULL;
 #endif
-
-    d = init_genrand( gRandomSeed );
 
     for ( unsigned int i = 0; i < sizeof(imageFlags) / sizeof(cl_mem_flags); ++i )
     {


### PR DESCRIPTION
Add call of free_mtdata function in test_get_image_info. This fixes memory leak in api tests.

Fixes #1870.