### PR TITLE
fix return code when readwrite image is not supported

### DIFF
--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -202,7 +202,7 @@ static int doTest( cl_device_id device, cl_context context, cl_command_queue que
     if ((testTypesToRun & kReadWriteTests)
         && checkForReadWriteImageSupport(device))
     {
-        return TEST_SKIPPED_ITSELF;
+        return ret;
     }
 
     if( ( testTypesToRun & kReadWriteTests ) && !gTestMipmaps )


### PR DESCRIPTION
This function (do_test) starts by testing write and read individually. Both of them can have errors.

When readwrite image is not supported, the function returns TEST_SKIPPED_ITSELF potentially masking errors leading to the test returning EXIT_SUCCESS even with errors along the way.