### PR TITLE
Negative test for returning command-buffer mutable handle

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/main.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/main.cpp
@@ -63,7 +63,8 @@ test_definition test_list[] = {
     ADD_TEST(event_info_context),
     ADD_TEST(event_info_reference_count),
     ADD_TEST(finalize_invalid),
-    ADD_TEST(finalize_empty)
+    ADD_TEST(finalize_empty),
+    ADD_TEST(invalid_command_handle)
 };
 
 int main(int argc, const char *argv[])

--- a/test_conformance/extensions/cl_khr_command_buffer/procs.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/procs.h
@@ -141,4 +141,8 @@ extern int test_finalize_invalid(cl_device_id device, cl_context context,
 extern int test_finalize_empty(cl_device_id device, cl_context context,
                                cl_command_queue queue, int num_elements);
 
+extern int test_invalid_command_handle(cl_device_id device, cl_context context,
+                                       cl_command_queue queue,
+                                       int num_elements);
+
 #endif // CL_KHR_COMMAND_BUFFER_PROCS_H


### PR DESCRIPTION
See https://github.com/KhronosGroup/OpenCL-Docs/issues/1043 which clarifies that implementations are expected to return `CL_INVALID_VALUE` when an output command-handle is used without a layered extension supporting it.