### PR TITLE
fix the reported platform information for math brute force

### DIFF
--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -769,10 +769,11 @@ test_status InitCL(cl_device_id device)
     IsTininessDetectedBeforeRounding();
 
     cl_platform_id platform;
-    int err = clGetPlatformIDs(1, &platform, NULL);
+    int err = clGetDeviceInfo(gDevice, CL_DEVICE_PLATFORM, sizeof(platform),
+                              &platform, NULL);
     if (err)
     {
-        print_error(err, "clGetPlatformIDs failed");
+        print_error(err, "clGetDeviceInfo for CL_DEVICE_PLATFORM failed");
         return TEST_FAIL;
     }
 


### PR DESCRIPTION
When the math brute force test printed the platform version it always printed information for the first platform in the system, which could be different than the platform for the passed-in device.  Fixed by querying the platform from the passed-in device instead.