### PR TITLE
Fix cross-context semaphore signals

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
@@ -17,7 +17,7 @@
 
 test_definition test_list[] = {
     ADD_TEST(external_semaphores_queries),
-    ADD_TEST(external_semaphores_multi_context),
+    ADD_TEST(external_semaphores_cross_context),
     ADD_TEST(external_semaphores_simple_1),
     // ADD_TEST(external_semaphores_simple_2),
     ADD_TEST(external_semaphores_reuse),

--- a/test_conformance/extensions/cl_khr_external_semaphore/procs.h
+++ b/test_conformance/extensions/cl_khr_external_semaphore/procs.h
@@ -24,7 +24,7 @@ extern int test_external_semaphores_queries(cl_device_id deviceID,
                                             cl_context context,
                                             cl_command_queue defaultQueue,
                                             int num_elements);
-extern int test_external_semaphores_multi_context(cl_device_id deviceID,
+extern int test_external_semaphores_cross_context(cl_device_id deviceID,
                                                   cl_context context,
                                                   cl_command_queue defaultQueue,
                                                   int num_elements);


### PR DESCRIPTION
Multi-context test was not correctly testing cross-context functionality. Use semaphore import/export mechanism to signal across contexts.  Also add missing acquire/release calls. Fixes outstanding #1588 issues.