### PR TITLE
[NFC] subgroups: remove unnecessary extern keywords

### DIFF
--- a/test_conformance/subgroups/procs.h
+++ b/test_conformance/subgroups/procs.h
@@ -21,67 +21,51 @@
 #include "harness/errorHelpers.h"
 #include "harness/conversions.h"
 #include "harness/typeWrappers.h"
-#include "harness/mt19937.h"
 
-extern MTdata gMTdata;
-
-extern int test_sub_group_info_ext(cl_device_id device, cl_context context,
-                                   cl_command_queue queue, int num_elements);
-extern int test_sub_group_info_core(cl_device_id device, cl_context context,
-                                    cl_command_queue queue, int num_elements);
-extern int test_work_item_functions_ext(cl_device_id device, cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_work_item_functions_core(cl_device_id device,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         int num_elements);
-extern int test_subgroup_functions_ext(cl_device_id device, cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_subgroup_functions_core(cl_device_id device, cl_context context,
-                                        cl_command_queue queue,
-                                        int num_elements);
-extern int test_barrier_functions_ext(cl_device_id device, cl_context context,
-                                      cl_command_queue queue, int num_elements);
-extern int test_barrier_functions_core(cl_device_id device, cl_context context,
-                                       cl_command_queue queue,
-                                       int num_elements);
-extern int test_pipe_functions(cl_device_id device, cl_context context,
+int test_sub_group_info_ext(cl_device_id device, cl_context context,
+                            cl_command_queue queue, int num_elements);
+int test_sub_group_info_core(cl_device_id device, cl_context context,
+                             cl_command_queue queue, int num_elements);
+int test_work_item_functions_ext(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+int test_work_item_functions_core(cl_device_id device, cl_context context,
+                                  cl_command_queue queue, int num_elements);
+int test_subgroup_functions_ext(cl_device_id device, cl_context context,
+                                cl_command_queue queue, int num_elements);
+int test_subgroup_functions_core(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, int num_elements);
+int test_barrier_functions_ext(cl_device_id device, cl_context context,
                                cl_command_queue queue, int num_elements);
-extern int test_ifp_ext(cl_device_id device, cl_context context,
-                        cl_command_queue queue, int num_elements);
-extern int test_ifp_core(cl_device_id device, cl_context context,
-                         cl_command_queue queue, int num_elements);
-extern int test_subgroup_functions_extended_types(cl_device_id device,
-                                                  cl_context context,
-                                                  cl_command_queue queue,
-                                                  int num_elements);
-extern int test_subgroup_functions_non_uniform_vote(cl_device_id device,
-                                                    cl_context context,
-                                                    cl_command_queue queue,
-                                                    int num_elements);
-extern int test_subgroup_functions_non_uniform_arithmetic(
-    cl_device_id device, cl_context context, cl_command_queue queue,
-    int num_elements);
-extern int test_subgroup_functions_ballot(cl_device_id device,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
-extern int test_subgroup_functions_clustered_reduce(cl_device_id device,
-                                                    cl_context context,
-                                                    cl_command_queue queue,
-                                                    int num_elements);
-extern int test_subgroup_functions_shuffle(cl_device_id device,
+int test_barrier_functions_core(cl_device_id device, cl_context context,
+                                cl_command_queue queue, int num_elements);
+int test_ifp_ext(cl_device_id device, cl_context context,
+                 cl_command_queue queue, int num_elements);
+int test_ifp_core(cl_device_id device, cl_context context,
+                  cl_command_queue queue, int num_elements);
+int test_subgroup_functions_extended_types(cl_device_id device,
                                            cl_context context,
                                            cl_command_queue queue,
                                            int num_elements);
-extern int test_subgroup_functions_shuffle_relative(cl_device_id device,
-                                                    cl_context context,
-                                                    cl_command_queue queue,
-                                                    int num_elements);
-extern int test_subgroup_functions_rotate(cl_device_id device,
-                                          cl_context context,
-                                          cl_command_queue queue,
-                                          int num_elements);
+int test_subgroup_functions_non_uniform_vote(cl_device_id device,
+                                             cl_context context,
+                                             cl_command_queue queue,
+                                             int num_elements);
+int test_subgroup_functions_non_uniform_arithmetic(cl_device_id device,
+                                                   cl_context context,
+                                                   cl_command_queue queue,
+                                                   int num_elements);
+int test_subgroup_functions_ballot(cl_device_id device, cl_context context,
+                                   cl_command_queue queue, int num_elements);
+int test_subgroup_functions_clustered_reduce(cl_device_id device,
+                                             cl_context context,
+                                             cl_command_queue queue,
+                                             int num_elements);
+int test_subgroup_functions_shuffle(cl_device_id device, cl_context context,
+                                    cl_command_queue queue, int num_elements);
+int test_subgroup_functions_shuffle_relative(cl_device_id device,
+                                             cl_context context,
+                                             cl_command_queue queue,
+                                             int num_elements);
+int test_subgroup_functions_rotate(cl_device_id device, cl_context context,
+                                   cl_command_queue queue, int num_elements);
 #endif /*_procs_h*/


### PR DESCRIPTION
In C and C++ all functions have external linkage by default.

Also remove the unused `gMTdata` and `test_pipe_functions` declarations.

Fixes https://github.com/KhronosGroup/OpenCL-CTS/issues/1137