### PR TITLE
[NFC] subgroups: clarify bs128 to uint4 conversion

### DIFF
--- a/test_conformance/subgroups/subhelpers.cpp
+++ b/test_conformance/subgroups/subhelpers.cpp
@@ -102,8 +102,9 @@ cl_uint4 generate_bit_mask(cl_uint subgroup_local_id,
         if (mask_type == "gt") mask128.reset(pos);
     }
 
-    // convert std::bitset<128> to uint4
-    auto const uint_mask = bs128{ static_cast<unsigned long>(-1) };
+    // convert std::bitset<128> to uint4.
+    // Use a mask to avoid std::overflow_error from to_ulong().
+    auto const uint_mask = bs128{ 0xffffffff };
     mask.s0 = (mask128 & uint_mask).to_ulong();
     mask128 >>= 32;
     mask.s1 = (mask128 & uint_mask).to_ulong();


### PR DESCRIPTION
There appears to have been some confusion over `uint_mask` during the initial reviews of the subgroup tests.  Add a comment to clarify the purpose of the mask.

Use a 32-bit all-ones mask (`0xffffffff`) instead of a 64-bit all-ones mask to further clarify the intent, that is, don't delay discarding the upper 32 bits until the assignment but mask them out immediately.

Fixes https://github.com/KhronosGroup/OpenCL-CTS/issues/1203