### PR TITLE
device_execution: fix CL_QUEUE_* in error messages

### DIFF
--- a/test_conformance/device_execution/device_queue.cpp
+++ b/test_conformance/device_execution/device_queue.cpp
@@ -84,7 +84,7 @@ static int check_device_queues(cl_device_id device, cl_context context, cl_uint 
     for(i = 0; i < num_queues; ++i)
     {
         queue[i] = clCreateCommandQueueWithProperties(context, device, properties, &err_ret);
-        test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE) failed");
+        test_error(err_ret, "clCreateCommandQueueWithProperties failed");
     }
 
     // Validate all queues
@@ -128,7 +128,9 @@ int test_device_queue(cl_device_id device, cl_context context, cl_command_queue 
     if(max_queues > MAX_QUEUES) max_queues = MAX_QUEUES;
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     err_ret = check_device_queue(device, context, dev_queue, preffered_size);
     if(check_error(err_ret, "Default device queue validation failed")) res = -1;

--- a/test_conformance/device_execution/enqueue_block.cpp
+++ b/test_conformance/device_execution/enqueue_block.cpp
@@ -623,7 +623,9 @@ int test_enqueue_block(cl_device_id device, cl_context context, cl_command_queue
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     size_t global_size = MAX_GWS;
     size_t local_size = (max_local_size > global_size/16) ? global_size/16 : max_local_size;

--- a/test_conformance/device_execution/enqueue_flags.cpp
+++ b/test_conformance/device_execution/enqueue_flags.cpp
@@ -696,7 +696,9 @@ int test_enqueue_flags(cl_device_id device, cl_context context, cl_command_queue
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     size_t global_size = MAX_GWS;
     size_t local_size = (max_local_size > global_size/16) ? global_size/16 : max_local_size;

--- a/test_conformance/device_execution/enqueue_multi_queue.cpp
+++ b/test_conformance/device_execution/enqueue_multi_queue.cpp
@@ -123,7 +123,9 @@ int test_enqueue_multi_queue(cl_device_id device, cl_context context, cl_command
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     if(max_queues > 1)
     {
@@ -141,7 +143,9 @@ int test_enqueue_multi_queue(cl_device_id device, cl_context context, cl_command
         for(i = 0; i < n; ++i)
         {
             queues[i] = clCreateCommandQueueWithProperties(context, device, queue_prop, &err_ret);
-            test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE) failed");
+            test_error(err_ret,
+                       "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE) "
+                       "failed");
             q[i] = queues[i];
         }
 

--- a/test_conformance/device_execution/enqueue_ndrange.cpp
+++ b/test_conformance/device_execution/enqueue_ndrange.cpp
@@ -641,7 +641,9 @@ int test_enqueue_ndrange(cl_device_id device, cl_context context, cl_command_que
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     max_local_size = (max_local_size > MAX_GWS)? MAX_GWS: max_local_size;
     if(gWimpyMode)

--- a/test_conformance/device_execution/enqueue_profiling.cpp
+++ b/test_conformance/device_execution/enqueue_profiling.cpp
@@ -66,8 +66,8 @@ int test_enqueue_profiling(cl_device_id device, cl_context context,
     dev_queue = clCreateCommandQueueWithProperties(
         context, device, dev_queue_prop_def, &err_ret);
     test_error(err_ret,
-               "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_"
-               "DEFAULT) failed");
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     cl_queue_properties host_queue_prop_def[] = { CL_QUEUE_PROPERTIES,
                                                   CL_QUEUE_PROFILING_ENABLE,
@@ -75,9 +75,9 @@ int test_enqueue_profiling(cl_device_id device, cl_context context,
 
     host_queue = clCreateCommandQueueWithProperties(
         context, device, host_queue_prop_def, &err_ret);
-    test_error(err_ret,
-               "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_"
-               "DEFAULT) failed");
+    test_error(
+        err_ret,
+        "clCreateCommandQueueWithProperties(CL_QUEUE_PROFILING_ENABLE) failed");
 
     cl_int status;
     size_t size = 1;

--- a/test_conformance/device_execution/enqueue_wg_size.cpp
+++ b/test_conformance/device_execution/enqueue_wg_size.cpp
@@ -1659,7 +1659,9 @@ int test_enqueue_wg_size(cl_device_id device, cl_context context, cl_command_que
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
 
     size_t failCnt = 0;

--- a/test_conformance/device_execution/host_multi_queue.cpp
+++ b/test_conformance/device_execution/host_multi_queue.cpp
@@ -157,7 +157,9 @@ int test_host_multi_queue(cl_device_id device, cl_context context, cl_command_qu
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     cl_uint n = num_kernels_multi_queue_block; // Number of host queues
     std::vector<clCommandQueueWrapper> queues(n);

--- a/test_conformance/device_execution/host_queue_order.cpp
+++ b/test_conformance/device_execution/host_queue_order.cpp
@@ -117,7 +117,9 @@ int test_host_queue_order(cl_device_id device, cl_context context, cl_command_qu
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     cl_int status;
     size_t size = 1;

--- a/test_conformance/device_execution/nested_blocks.cpp
+++ b/test_conformance/device_execution/nested_blocks.cpp
@@ -335,7 +335,9 @@ int test_enqueue_nested_blocks(cl_device_id device, cl_context context, cl_comma
     };
 
     dev_queue = clCreateCommandQueueWithProperties(context, device, queue_prop_def, &err_ret);
-    test_error(err_ret, "clCreateCommandQueueWithProperties(CL_QUEUE_DEVICE|CL_QUEUE_DEFAULT) failed");
+    test_error(err_ret,
+               "clCreateCommandQueueWithProperties(CL_QUEUE_ON_DEVICE | "
+               "CL_QUEUE_ON_DEVICE_DEFAULT) failed");
 
     kernel_arg args[] =
     {


### PR DESCRIPTION
When reporting errors from `clCreateCommandQueueWithProperties`, report the correct property names.  In particular:

`CL_QUEUE_DEVICE` should be `CL_QUEUE_ON_DEVICE`.
`CL_QUEUE_DEFAULT` should be `CL_QUEUE_ON_DEVICE_DEFAULT`.