### PR TITLE
Import OpenCL exported semaphore in Vulkan 

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -508,7 +508,8 @@ cl_int check_external_memory_handle_type(
 
 cl_int check_external_semaphore_handle_type(
     cl_device_id deviceID,
-    cl_external_semaphore_handle_type_khr requiredHandleType)
+    cl_external_semaphore_handle_type_khr requiredHandleType,
+    cl_device_info queryParamName)
 {
     unsigned int i;
     cl_external_semaphore_handle_type_khr *handle_type;
@@ -516,18 +517,27 @@ cl_int check_external_semaphore_handle_type(
     cl_int errNum = CL_SUCCESS;
 
     errNum =
-        clGetDeviceInfo(deviceID, CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR,
+        clGetDeviceInfo(deviceID, queryParamName,
                         0, NULL, &handle_type_size);
+
+    if (handle_type_size == 0)
+    {
+        log_error("Device does not support %s semaphore\n",
+                  queryParamName == CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR
+                  ? "importing"
+                  : "exporting");
+        return CL_INVALID_VALUE;
+    }
+
     handle_type =
         (cl_external_semaphore_handle_type_khr *)malloc(handle_type_size);
 
     errNum =
-        clGetDeviceInfo(deviceID, CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR,
+        clGetDeviceInfo(deviceID, queryParamName,
                         handle_type_size, handle_type, NULL);
 
-    test_error(
-        errNum,
-        "Unable to query CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR \n");
+    test_error(errNum,
+               "Unable to query supported device semaphore handle types list");
 
     for (i = 0; i < handle_type_size; i++)
     {

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -517,27 +517,26 @@ cl_int check_external_semaphore_handle_type(
     cl_int errNum = CL_SUCCESS;
 
     errNum =
-        clGetDeviceInfo(deviceID, queryParamName,
-                        0, NULL, &handle_type_size);
+        clGetDeviceInfo(deviceID, queryParamName, 0, NULL, &handle_type_size);
 
     if (handle_type_size == 0)
     {
         log_error("Device does not support %s semaphore\n",
                   queryParamName == CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR
-                  ? "importing"
-                  : "exporting");
+                      ? "importing"
+                      : "exporting");
         return CL_INVALID_VALUE;
     }
 
     handle_type =
         (cl_external_semaphore_handle_type_khr *)malloc(handle_type_size);
 
-    errNum =
-        clGetDeviceInfo(deviceID, queryParamName,
-                        handle_type_size, handle_type, NULL);
+    errNum = clGetDeviceInfo(deviceID, queryParamName, handle_type_size,
+                             handle_type, NULL);
 
-    test_error(errNum,
-               "Unable to query supported device semaphore handle types list");
+    test_error(
+        errNum,
+        "Unable to query supported device semaphore handle types list\n");
 
     for (i = 0; i < handle_type_size; i++)
     {
@@ -907,6 +906,8 @@ clExternalExportableSemaphore::clExternalExportableSemaphore(
 
     cl_int err = 0;
     cl_device_id devList[] = { deviceId, NULL };
+    cl_external_semaphore_handle_type_khr clSemaphoreHandleType =
+        getCLSemaphoreTypeFromVulkanType(externalSemaphoreHandleType);
     m_externalHandleType = externalSemaphoreHandleType;
     m_externalSemaphore = nullptr;
     m_device = deviceId;
@@ -918,9 +919,7 @@ clExternalExportableSemaphore::clExternalExportableSemaphore(
     };
     sema_props.push_back(
         (cl_semaphore_properties_khr)CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR);
-    sema_props.push_back(
-        (cl_semaphore_properties_khr)getCLSemaphoreTypeFromVulkanType(
-            externalSemaphoreHandleType));
+    sema_props.push_back((cl_semaphore_properties_khr)clSemaphoreHandleType);
     sema_props.push_back((cl_semaphore_properties_khr)
                              CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR);
     sema_props.push_back(
@@ -939,66 +938,82 @@ clExternalExportableSemaphore::clExternalExportableSemaphore(
             "clCreateSemaphoreWithPropertiesKHRptr failed! ");
     }
 
-    if (m_externalHandleType == VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD)
+    switch (m_externalHandleType)
     {
-        err = clGetSemaphoreHandleForTypeKHRptr(
-            m_externalSemaphore, m_device, CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
-            sizeof(int), &fd, nullptr);
-        if (err != CL_SUCCESS)
-        {
-            throw std::runtime_error("Failed to export OpenCL semaphore\n");
-        }
+        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD: {
+            err = clGetSemaphoreHandleForTypeKHRptr(
+                m_externalSemaphore, m_device, clSemaphoreHandleType,
+                sizeof(int), &fd, nullptr);
+            if (err != CL_SUCCESS)
+            {
+                throw std::runtime_error("Failed to export OpenCL semaphore\n");
+            }
 
-        VkImportSemaphoreFdInfoKHR vkImportSemaphoreFdInfoKHR = {};
-        vkImportSemaphoreFdInfoKHR.sType =
-            VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
-        vkImportSemaphoreFdInfoKHR.semaphore = m_deviceSemaphore;
-        vkImportSemaphoreFdInfoKHR.fd = fd;
-        vkImportSemaphoreFdInfoKHR.pNext = nullptr;
-        vkImportSemaphoreFdInfoKHR.handleType =
-            VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
-        vkImportSemaphoreFdInfoKHR.flags = 0;
+            VkImportSemaphoreFdInfoKHR vkImportSemaphoreFdInfoKHR = {};
+            vkImportSemaphoreFdInfoKHR.sType =
+                VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+            vkImportSemaphoreFdInfoKHR.semaphore = m_deviceSemaphore;
+            vkImportSemaphoreFdInfoKHR.fd = fd;
+            vkImportSemaphoreFdInfoKHR.pNext = nullptr;
+            vkImportSemaphoreFdInfoKHR.handleType =
+                VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+            vkImportSemaphoreFdInfoKHR.flags = 0;
 
-        if (vkImportSemaphoreFdKHR(m_deviceSemaphore.getDevice(),
-                                   &vkImportSemaphoreFdInfoKHR)
-            != VK_SUCCESS)
-        {
-            throw std::runtime_error("Failed to import semaphore in Vulkan\n");
+            if (vkImportSemaphoreFdKHR(m_deviceSemaphore.getDevice(),
+                                       &vkImportSemaphoreFdInfoKHR)
+                != VK_SUCCESS)
+            {
+                throw std::runtime_error(
+                    "Failed to import semaphore in Vulkan\n");
+            }
+            break;
         }
-    }
+        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT:
+        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_NT: {
+            err = clGetSemaphoreHandleForTypeKHRptr(
+                m_externalSemaphore, m_device, clSemaphoreHandleType,
+                sizeof(void *), (void *)&handle, nullptr);
+            if (err != CL_SUCCESS)
+            {
+                throw std::runtime_error("Failed to export OpenCL semaphore\n");
+            }
+
 #ifdef _WIN32
-    else
-    {
-        err = clGetSemaphoreHandleForTypeKHRptr(
-            m_externalSemaphore, m_device,
-            getCLSemaphoreTypeFromVulkanType(m_externalHandleType),
-            sizeof(void*), (void*)&handle, nullptr);
-        if (err != CL_SUCCESS)
-        {
-            throw std::runtime_error("Failed to export OpenCL semaphore\n");
-        }
+            VkImportSemaphoreWin32HandleInfoKHR
+                vkImportSemaphoreWin32HandleInfoKHR = {};
+            vkImportSemaphoreWin32HandleInfoKHR.sType =
+                VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR;
+            vkImportSemaphoreWin32HandleInfoKHR.pNext = nullptr;
+            vkImportSemaphoreWin32HandleInfoKHR.semaphore = m_deviceSemaphore;
+            vkImportSemaphoreWin32HandleInfoKHR.flags = 0;
+            vkImportSemaphoreWin32HandleInfoKHR.handleType =
+                (VkExternalSemaphoreHandleTypeFlagBits)m_externalHandleType;
+            vkImportSemaphoreWin32HandleInfoKHR.handle = (HANDLE)handle;
+            vkImportSemaphoreWin32HandleInfoKHR.name = nullptr;
 
-        VkImportSemaphoreWin32HandleInfoKHR
-            vkImportSemaphoreWin32HandleInfoKHR = {};
-        vkImportSemaphoreWin32HandleInfoKHR.sType =
-            VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR;
-        vkImportSemaphoreWin32HandleInfoKHR.pNext = nullptr;
-        vkImportSemaphoreWin32HandleInfoKHR.semaphore = m_deviceSemaphore;
-        vkImportSemaphoreWin32HandleInfoKHR.flags = 0;
-        vkImportSemaphoreWin32HandleInfoKHR.handleType =
-            (VkExternalSemaphoreHandleTypeFlagsKHR)m_externalHandleType;
-        vkImportSemaphoreWin32HandleInfoKHR.handle = (HANDLE)handle;
-        vkImportSemaphoreWin32HandleInfoKHR.name = nullptr;
-
-        if (vkImportSemaphoreWin32HandleKHR(
-                m_deviceSemaphore.getDevice(),
-                &vkImportSemaphoreWin32HandleInfoKHR)
-            != VK_SUCCESS)
-        {
-            throw std::runtime_error("Failed to import semaphore in Vulkan\n");
-        }
-    }
+            if (vkImportSemaphoreWin32HandleKHR(
+                    m_deviceSemaphore.getDevice(),
+                    &vkImportSemaphoreWin32HandleInfoKHR)
+                != VK_SUCCESS)
+            {
+                throw std::runtime_error(
+                    "Failed to import semaphore in Vulkan\n");
+            }
+#else
+            log_error(
+                "Opaque D3DKMT and NT handles are only supported on Windows\n");
+            ASSERT(0);
 #endif
+            break;
+        }
+        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD:
+            // Do nothing, imported after each signal from OpenCL
+            break;
+        default:
+            log_error("Unsupported external semaphore handle type\n");
+            ASSERT(0);
+            break;
+    }
 }
 
 clExternalExportableSemaphore::~clExternalExportableSemaphore()

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -76,7 +76,9 @@ cl_int check_external_memory_handle_type(
     cl_external_memory_handle_type_khr requiredHandleType);
 cl_int check_external_semaphore_handle_type(
     cl_device_id deviceID,
-    cl_external_semaphore_handle_type_khr requiredHandleType);
+    cl_external_semaphore_handle_type_khr requiredHandleType,
+    cl_device_info queryParamName =
+        CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR);
 cl_int setMaxImageDimensions(cl_device_id deviceID, size_t &width,
                              size_t &height);
 

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -26,6 +26,23 @@
 #include <OpenCL/cl_ext.h>
 #endif
 
+#define CREATE_OPENCL_SEMAPHORE(clSemaphore, vkSemaphore, ctx, handleType,     \
+                                devIdx, createExportable)                      \
+    if (!(createExportable                                                     \
+          && (check_external_semaphore_handle_type(                            \
+                  devIdx, getCLSemaphoreTypeFromVulkanType(handleType),        \
+                  CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR)                 \
+              == CL_SUCCESS)))                                                 \
+    {                                                                          \
+        clSemaphore = new clExternalImportableSemaphore(vkSemaphore, ctx,      \
+                                                        handleType, devIdx);   \
+    }                                                                          \
+    else                                                                       \
+    {                                                                          \
+        clSemaphore = new clExternalExportableSemaphore(vkSemaphore, ctx,      \
+                                                        handleType, devIdx);   \
+    }
+
 typedef cl_semaphore_khr (*pfnclCreateSemaphoreWithPropertiesKHR)(
     cl_context context, cl_semaphore_properties_khr *sema_props,
     cl_int *errcode_ret);

--- a/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
@@ -103,7 +103,8 @@
     VK_FUNC_DECL(vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)
 #define VK_WINDOWS_FUNC_LIST                                                   \
     VK_FUNC_DECL(vkGetMemoryWin32HandleKHR)                                    \
-    VK_FUNC_DECL(vkGetSemaphoreWin32HandleKHR)
+    VK_FUNC_DECL(vkGetSemaphoreWin32HandleKHR)                                 \
+    VK_FUNC_DECL(vkImportSemaphoreWin32HandleKHR)
 
 #define vkEnumerateInstanceVersion _vkEnumerateInstanceVersion
 #define vkEnumerateInstanceExtensionProperties                                 \
@@ -198,5 +199,6 @@
     _vkGetPhysicalDeviceExternalSemaphorePropertiesKHR
 #define vkGetMemoryWin32HandleKHR _vkGetMemoryWin32HandleKHR
 #define vkGetSemaphoreWin32HandleKHR _vkGetSemaphoreWin32HandleKHR
+#define vkImportSemaphoreWin32HandleKHR _vkImportSemaphoreWin32HandleKHR
 
 #endif //_vulkan_api_list_hpp_

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -140,10 +140,12 @@ int run_test_with_two_queue(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, false);
+        CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, true);
     }
 
     const uint32_t maxIter = innerIterations;
@@ -453,10 +455,12 @@ int run_test_with_one_queue(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, false);
+        CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, true);
     }
 
     const uint32_t maxIter = innerIterations;
@@ -742,10 +746,12 @@ int run_test_with_multi_import_same_ctx(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, false);
+        CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, true);
     }
 
     const uint32_t maxIter = innerIterations;
@@ -1071,17 +1077,19 @@ int run_test_with_multi_import_diff_ctx(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, false);
+        CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore,
+                                context, vkExternalSemaphoreHandleType,
+                                deviceId, false);
 
-        clVk2CLExternalSemaphore2 = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context2, vkExternalSemaphoreHandleType,
-            deviceId);
-        clCl2VkExternalSemaphore2 = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context2, vkExternalSemaphoreHandleType,
-            deviceId);
+        CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore2, vkVk2CLSemaphore,
+                                context2, vkExternalSemaphoreHandleType,
+                                deviceId, false);
+        CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore2, vkCl2VkSemaphore,
+                                context2, vkExternalSemaphoreHandleType,
+                                deviceId, false);
     }
 
     const uint32_t maxIter = innerIterations;

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -251,10 +251,10 @@ int run_test_with_two_queue(
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
 
-    clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-        vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-    clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-        vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+    CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore, context,
+                            vkExternalSemaphoreHandleType, deviceId, false);
+    CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore, context,
+                            vkExternalSemaphoreHandleType, deviceId, true);
 
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory2;
@@ -816,10 +816,10 @@ int run_test_with_one_queue(
     clExternalSemaphore *clVk2CLExternalSemaphore = NULL;
     clExternalSemaphore *clCl2VkExternalSemaphore = NULL;
 
-    clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-        vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
-    clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-        vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+    CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore, vkVk2CLSemaphore, context,
+                            vkExternalSemaphoreHandleType, deviceId, false);
+    CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore, context,
+                            vkExternalSemaphoreHandleType, deviceId, true);
 
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory1;
     std::vector<VulkanDeviceMemory *> vkImage2DListDeviceMemory2;


### PR DESCRIPTION
Except for SYNC_FD, current implementation doesn't import exported OpenCL semaphore in Vulkan and ends up doing signal and wait on essentially two unrelated semaphores (one created in OpenCL and one in Vulkan).
Since OpenCL exports the semaphore, import that in Vulkan to perform signal/wait on the same underlying payload.