### PR TITLE
subgroups: Add missing algorithm header

### DIFF
--- a/test_conformance/subgroups/subhelpers.cpp
+++ b/test_conformance/subgroups/subhelpers.cpp
@@ -16,6 +16,7 @@
 
 #include "subhelpers.h"
 
+#include <algorithm>
 #include <random>
 
 // Define operator<< for cl_ types, accessing the .s member.


### PR DESCRIPTION
* Was causing a build error with GN
* fill_and_shuffle_safe_values() in subhelpers.cpp calls std::shuffle()
* std::shuffle is defined in <algorithm>