### PR TITLE
Fix uninitialised memory use.

### DIFF
--- a/test_conformance/basic/test_async_copy2D.cpp
+++ b/test_conformance/basic/test_async_copy2D.cpp
@@ -141,7 +141,7 @@ int test_copy2D(const cl_device_id deviceID, const cl_context context,
     test_error(error,
                "clGetDeviceInfo for CL_DEVICE_MAX_MEM_ALLOC_SIZE failed.");
 
-    cl_long max_work_group_size;
+    size_t max_work_group_size;
     error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_WORK_GROUP_SIZE,
                             sizeof(max_work_group_size), &max_work_group_size,
                             NULL);

--- a/test_conformance/basic/test_async_copy3D.cpp
+++ b/test_conformance/basic/test_async_copy3D.cpp
@@ -193,7 +193,7 @@ int test_copy3D(const cl_device_id deviceID, const cl_context context,
     test_error(error,
                "clGetDeviceInfo failed for CL_DEVICE_MAX_WORK_ITEM_SIZES");
 
-    cl_long max_work_group_size;
+    size_t max_work_group_size;
     error = clGetDeviceInfo(deviceID, CL_DEVICE_MAX_WORK_GROUP_SIZE,
                             sizeof(max_work_group_size), &max_work_group_size,
                             NULL);


### PR DESCRIPTION
CL_DEVICE_MAX_WORK_GROUP_SIZE is specified to fill in a size_t. By asking it to fill in an uninitialised cl_long, on platforms where size_t is smaller than cl_long, the high bits of the cl_long remain uninitialised.