### PR TITLE
fix the type used for bitfield_extract_signed

### DIFF
--- a/test_conformance/integer_ops/test_extended_bit_ops_extract.cpp
+++ b/test_conformance/integer_ops/test_extended_bit_ops_extract.cpp
@@ -44,7 +44,7 @@ template <typename T>
 static typename std::make_unsigned<T>::type
 cpu_bit_extract_signed(T tbase, cl_uint offset, cl_uint count)
 {
-    typedef typename std::make_signed<T>::type unsigned_t;
+    typedef typename std::make_unsigned<T>::type unsigned_t;
 
     assert(offset <= sizeof(T) * 8);
     assert(count <= sizeof(T) * 8);


### PR DESCRIPTION
We compute the reference values using unsigned types exclusively, even when the input type is signed.  This fixes one place where an signed type was inadvertently used.