### PR TITLE
Fix failing image tests for CL_UNORM_INT_101010_2

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -286,6 +286,7 @@ uint32_t get_pixel_size(const cl_image_format *format)
 
         case CL_FLOAT:
             return get_format_channel_count(format) * sizeof(cl_float);
+        case CL_UNORM_INT_101010_2: return 4;
 
         default: return 0;
     }


### PR DESCRIPTION
Add support for `CL_UNORM_INT_101010_2` in the `get_pixel_size` helper function. 

This fixes the following tests:
-  memInfo_image_from_buffer_positive
- image_from_buffer_alignment_negative
- imageInfo_image_from_buffer_positive