### PR TITLE
relationals: fix -Wformat-truncation warning

### DIFF
--- a/test_conformance/relationals/test_shuffles.cpp
+++ b/test_conformance/relationals/test_shuffles.cpp
@@ -245,7 +245,7 @@ const char *get_order_string( ShuffleOrder &order, size_t vecSize, cl_uint lengt
 char * get_order_name( ExplicitType vecType, size_t inVecSize, size_t outVecSize, ShuffleOrder &inOrder, ShuffleOrder &outOrder, cl_uint lengthToUse, MTdata d, bool inUseNumerics, bool outUseNumerics )
 {
     static char orderName[ 512 ] = "";
-    char inOrderStr[ 512 ], outOrderStr[ 512 ];
+    char inOrderStr[64], outOrderStr[64];
 
     if( inVecSize == 1 )
         inOrderStr[ 0 ] = 0;


### PR DESCRIPTION
`inOrderStr` and `outOrderStr` are both written into `orderName` on line 261, which may not fit as all three are the same size.  Decrease the sizes of `inOrderStr` and `outOrderStr`.  The new sizes are still sufficiently large to hold the result of `get_order_string`.

This commit only affects the error path and does not change the printed output.  Error logs before and after this commit should not differ.