### PR TITLE
configure depdendabot github actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
see #1920 

This sets up dependabot updates to GitHub actions.

I have been using a similar config file in my repos and it has been working well.  Currently, it is setup to check for updates monthly, but we can check for updates more or less frequently as needed.