### PR TITLE
mem_host_flags: check returned pointer for NULL

### DIFF
--- a/test_conformance/mem_host_flags/CMakeLists.txt
+++ b/test_conformance/mem_host_flags/CMakeLists.txt
@@ -6,6 +6,4 @@ set(${MODULE_NAME}_SOURCES
     mem_host_image.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-unused-but-set-variable")
-
 include(../CMakeCommon.txt)

--- a/test_conformance/mem_host_flags/checker_image_mem_host_no_access.hpp
+++ b/test_conformance/mem_host_flags/checker_image_mem_host_no_access.hpp
@@ -135,6 +135,14 @@ cl_int cImage_check_mem_host_no_access<T>::verify_RW_Image_Mapping()
         err = FAILURE;
         return err;
     }
+    else if (dataPtr != nullptr)
+    {
+        log_error("Calling clEnqueueMapImage (CL_MAP_WRITE) on a memory object "
+                  "created with the CL_MEM_HOST_NO_ACCESS flag should fail "
+                  "and return NULL\n");
+        err = FAILURE;
+        return err;
+    }
     else
     {
         log_info("Test succeeded\n\n");
@@ -151,6 +159,14 @@ cl_int cImage_check_mem_host_no_access<T>::verify_RW_Image_Mapping()
         log_error("Calling clEnqueueMapImage (CL_MAP_READ) on a memory object "
                   "created with the CL_MEM_HOST_NO_ACCESS flag should not "
                   "return CL_SUCCESS\n");
+        err = FAILURE;
+        return err;
+    }
+    else if (dataPtr != nullptr)
+    {
+        log_error("Calling clEnqueueMapImage (CL_MAP_READ) on a memory object "
+                  "created with the CL_MEM_HOST_NO_ACCESS flag should fail "
+                  "and return NULL\n");
         err = FAILURE;
         return err;
     }

--- a/test_conformance/mem_host_flags/checker_mem_host_no_access.hpp
+++ b/test_conformance/mem_host_flags/checker_mem_host_no_access.hpp
@@ -190,6 +190,14 @@ cl_int cBuffer_check_mem_host_no_access<T>::verify_RW_Buffer_mapping()
         err = FAILURE;
         return FAILURE;
     }
+    else if (dataPtr != nullptr)
+    {
+        log_error("Calling clEnqueueMapBuffer (CL_MAP_READ) on a memory object "
+                  "created with the CL_MEM_HOST_NO_ACCESS flag should fail "
+                  "and return NULL\n");
+        err = FAILURE;
+        return err;
+    }
     else
     {
         log_info("Test succeeded\n\n");
@@ -206,6 +214,15 @@ cl_int cBuffer_check_mem_host_no_access<T>::verify_RW_Buffer_mapping()
                   "not return CL_SUCCESS\n");
         err = FAILURE;
         return FAILURE;
+    }
+    else if (dataPtr != nullptr)
+    {
+        log_error(
+            "Calling clEnqueueMapBuffer (CL_MAP_WRITE) on a memory object "
+            "created with the CL_MEM_HOST_NO_ACCESS flag should fail "
+            "and return NULL\n");
+        err = FAILURE;
+        return err;
     }
     else
     {


### PR DESCRIPTION
The specification states that `clEnqueueMapImage` and `clEnqueueMapBuffer` should return NULL on error.  Ensure this is checked.

This testing gap was caught by a compiler warning about `dataPtr` being written but not read.  With this fix, there are no more Wunused-but-set-variable warnings in this test, so reenable the warning.