### PR TITLE
half: fix -Wformat warnings

### DIFF
--- a/test_conformance/half/Test_roundTrip.cpp
+++ b/test_conformance/half/Test_roundTrip.cpp
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "cl_utils.h"
 #include "tests.h"
@@ -232,7 +233,10 @@ int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue qu
                         if( IsHalfSubnormal(u2[j]) && ( (u1[j] == 0) || (u1[j] == 0x8000) ) )
                             continue;
 
-                        vlog_error( "%lld) (of %lld)  Failure at 0x%4.4x:  0x%4.4x   vector_size = %d \n", j, (uint64_t)count, u2[j], u1[j], (g_arrVecSizes[vectorSize]) );
+                        vlog_error("%" PRId64 ") (of %u)  Failure at 0x%4.4x:  "
+                                   "0x%4.4x   vector_size = %d \n",
+                                   j, count, u2[j], u1[j],
+                                   (g_arrVecSizes[vectorSize]));
                         gFailCount++;
                         error = -1;
                         goto exit;
@@ -282,7 +286,10 @@ int test_roundTrip( cl_device_id device, cl_context context, cl_command_queue qu
                             if( IsHalfSubnormal(u2[j]) && ( (u1[j] == 0) || (u1[j] == 0x8000) ) )
                                 continue;
 
-                            vlog_error( "%lld) Failure at 0x%4.4x:  0x%4.4x   vector_size = %d (double precsion)\n", j, u2[j], u1[j], (g_arrVecSizes[vectorSize]) );
+                            vlog_error(
+                                "%" PRId64 ") Failure at 0x%4.4x:  0x%4.4x   "
+                                "vector_size = %d (double precision)\n",
+                                j, u2[j], u1[j], (g_arrVecSizes[vectorSize]));
                             gFailCount++;
                             error = -1;
                             goto exit;

--- a/test_conformance/half/Test_vLoadHalf.cpp
+++ b/test_conformance/half/Test_vLoadHalf.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "cl_utils.h"
 #include "tests.h"
@@ -157,7 +158,8 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
 
         char local_buf_size[10];
 
-        sprintf(local_buf_size, "%lld", (uint64_t)((effectiveVectorSize))*gWorkGroupSize);
+        sprintf(local_buf_size, "%" PRIu64,
+                (uint64_t)(effectiveVectorSize)*gWorkGroupSize);
         const char *source_local1[] = {
             "__kernel void test( const __global half *p, __global float *f )\n"
             "{\n"
@@ -522,10 +524,17 @@ int Test_vLoadHalf_private( cl_device_id device, bool aligned )
                             continue;
                         if( u1[j] != u2[j])
                         {
-                            vlog_error( " %lld)  (of %lld) Failure at 0x%4.4x:  %a vs *%a  (0x%8.8x vs *0x%8.8x)  vector_size = %d (%s) address space = %s, load is %s\n",
-                                       j, (uint64_t)count, ((unsigned short*)gIn_half)[j], f1[j], f2[j], u1[j], u2[j], (g_arrVecSizes[vectorSize]),
-                                       vector_size_names[vectorSize], addressSpaceNames[addressSpace],
-                                       (aligned?"aligned":"unaligned"));
+                            vlog_error(
+                                " %" PRId64
+                                ")  (of %u) Failure at 0x%4.4x:  %a vs *%a  "
+                                "(0x%8.8x vs *0x%8.8x)  vector_size = %d (%s) "
+                                "address space = %s, load is %s\n",
+                                j, count, ((unsigned short *)gIn_half)[j],
+                                f1[j], f2[j], u1[j], u2[j],
+                                (g_arrVecSizes[vectorSize]),
+                                vector_size_names[vectorSize],
+                                addressSpaceNames[addressSpace],
+                                (aligned ? "aligned" : "unaligned"));
                             gFailCount++;
                             error = -1;
                             goto exit;

--- a/test_conformance/half/Test_vStoreHalf.cpp
+++ b/test_conformance/half/Test_vStoreHalf.cpp
@@ -433,7 +433,7 @@ int Test_vStoreHalf_private(cl_device_id device, f2h referenceFunc,
         };
 
         char local_buf_size[10];
-        sprintf(local_buf_size, "%lld", (uint64_t)gWorkGroupSize);
+        sprintf(local_buf_size, "%zu", gWorkGroupSize);
 
 
         const char *source_local_store[] = {
@@ -1308,7 +1308,7 @@ int Test_vStoreaHalf_private(cl_device_id device, f2h referenceFunc,
         };
 
         char local_buf_size[10];
-        sprintf(local_buf_size, "%lld", (uint64_t)gWorkGroupSize);
+        sprintf(local_buf_size, "%zu", gWorkGroupSize);
         const char *source_local[] = { "__kernel void test( __global float",
                                        vector_size_name_extensions[vectorSize],
                                        " *p, __global half *f )\n"

--- a/test_conformance/half/cl_utils.cpp
+++ b/test_conformance/half/cl_utils.cpp
@@ -100,7 +100,7 @@ test_status InitCL( cl_device_id device )
     gTestDouble ^= hasDouble;
 
     vlog( "%d compute devices at %f GHz\n", gComputeDevices, (double) gDeviceFrequency / 1000. );
-    vlog( "Max thread group size is %lld.\n", (uint64_t) gMaxThreadGroupSize );
+    vlog("Max thread group size is %zu.\n", gMaxThreadGroupSize);
 
     gContext = clCreateContext( NULL, 1, &device, notify_callback, NULL, &error );
     if( NULL == gContext )


### PR DESCRIPTION
Avoid casting to `uint64_t` in some places; instead keep the types as `size_t` and use the `%z` length modifier, or as
`uint32_t` and use the `%u` specifier.

For printing of 64-bit types, use the `PRI*64` macros from `<cinttypes>` to ensure portability across 32 and 64-bit builds.