### PR TITLE
spirv_new: fix -Wformat warnings

### DIFF
--- a/test_conformance/spirv_new/test_decorate.cpp
+++ b/test_conformance/spirv_new/test_decorate.cpp
@@ -439,9 +439,12 @@ int test_fp_rounding(cl_device_id deviceID,
     {
         if (h_res[i] != h_out[i])
         {
-            log_error("Values do not match at location %d. Original :%lf, "
-                      "Expected: %ld, Found %ld\n",
-                      i, h_in[i], h_out[i], h_res[i]);
+            std::stringstream sstr;
+            sstr << "Values do not match at location " << i << ". "
+                 << "Original: " << h_in[i] << ", "
+                 << "Expected: " << h_out[i] << ", "
+                 << "Found: " << h_res[i];
+            log_error("%s\n", sstr.str().c_str());
             return -1;
         }
     }

--- a/test_conformance/spirv_new/test_op_spec_constant.cpp
+++ b/test_conformance/spirv_new/test_op_spec_constant.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#include <sstream>
+
 #include "testBase.h"
 #include "types.hpp"
 
@@ -63,8 +65,10 @@ int run_case(cl_device_id deviceID, cl_context context, cl_command_queue queue,
     use_spec_constant ? reference = final_value : reference = init_buffer;
     if (device_results != reference)
     {
-        log_error("Values do not match. Expected %d obtained %d\n", reference,
-                  device_results);
+        std::stringstream sstr;
+        sstr << "Values do not match. Expected " << reference << " obtained "
+             << device_results;
+        log_error("%s\n", sstr.str().c_str());
         err = -1;
     }
     return err;


### PR DESCRIPTION
`log_error` was invoked from a template function, but the format specifiers weren't adjusted for the template parameter types.  Use a stringstream for printing instead.