### PR TITLE
device_execution: fix -Wformat warnings

### DIFF
--- a/test_conformance/device_execution/enqueue_block.cpp
+++ b/test_conformance/device_execution/enqueue_block.cpp
@@ -641,7 +641,9 @@ int test_enqueue_block(cl_device_id device, cl_context context, cl_command_queue
         if (!gKernelName.empty() && gKernelName != sources_enqueue_block[i].kernel_name)
             continue;
 
-        log_info("Running '%s' kernel (%d of %d) ...\n", sources_enqueue_block[i].kernel_name, i + 1, num_kernels_enqueue_block);
+        log_info("Running '%s' kernel (%d of %zu) ...\n",
+                 sources_enqueue_block[i].kernel_name, i + 1,
+                 num_kernels_enqueue_block);
         err_ret = run_n_kernel_args(context, queue, sources_enqueue_block[i].lines, sources_enqueue_block[i].num_lines, sources_enqueue_block[i].kernel_name, local_size, global_size, kernel_results, sizeof(kernel_results), 0, NULL);
         if(check_error(err_ret, "'%s' kernel execution failed", sources_enqueue_block[i].kernel_name)) { ++failCnt; res = -1; }
         else if((n = check_kernel_results(kernel_results, arr_size(kernel_results))) >= 0 && check_error(-1, "'%s' kernel results validation failed: [%d] returned %d expected 0", sources_enqueue_block[i].kernel_name, n, kernel_results[n])) res = -1;
@@ -650,7 +652,8 @@ int test_enqueue_block(cl_device_id device, cl_context context, cl_command_queue
 
     if (failCnt > 0)
     {
-      log_error("ERROR: %d of %d kernels failed.\n", failCnt, num_kernels_enqueue_block);
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  num_kernels_enqueue_block);
     }
 
     return res;

--- a/test_conformance/device_execution/enqueue_flags.cpp
+++ b/test_conformance/device_execution/enqueue_flags.cpp
@@ -714,7 +714,9 @@ int test_enqueue_flags(cl_device_id device, cl_context context, cl_command_queue
         if (!gKernelName.empty() && gKernelName != sources_enqueue_block_flags[i].kernel_name)
             continue;
 
-        log_info("Running '%s' kernel (%d of %d) ...\n", sources_enqueue_block_flags[i].kernel_name, i + 1, num_enqueue_block_flags);
+        log_info("Running '%s' kernel (%d of %zu) ...\n",
+                 sources_enqueue_block_flags[i].kernel_name, i + 1,
+                 num_enqueue_block_flags);
 
         clMemWrapper mem = clCreateBuffer(context, CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR, global_size * BITS_DEPTH * sizeof(cl_int), buff, &err_ret);
         test_error(err_ret, "clCreateBuffer() failed");
@@ -749,7 +751,8 @@ int test_enqueue_flags(cl_device_id device, cl_context context, cl_command_queue
 
     if (failCnt > 0)
     {
-        log_error("ERROR: %d of %d kernels failed.\n", failCnt, num_enqueue_block_flags);
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  num_enqueue_block_flags);
     }
 
     return res;

--- a/test_conformance/device_execution/enqueue_ndrange.cpp
+++ b/test_conformance/device_execution/enqueue_ndrange.cpp
@@ -700,7 +700,9 @@ int test_enqueue_ndrange(cl_device_id device, cl_context context, cl_command_que
             { sizeof(cl_mem), &mem4 },
         };
 
-        log_info("Running '%s' kernel (%d of %d) ...\n",  sources_ndrange_Xd[i].src.kernel_name, i + 1, num_kernels_ndrange_Xd);
+        log_info("Running '%s' kernel (%d of %zu) ...\n",
+                 sources_ndrange_Xd[i].src.kernel_name, i + 1,
+                 num_kernels_ndrange_Xd);
         err_ret = run_single_kernel_args(context, queue, sources_ndrange_Xd[i].src.lines, sources_ndrange_Xd[i].src.num_lines, sources_ndrange_Xd[i].src.kernel_name, kernel_results, sizeof(kernel_results), arr_size(args), args);
 
         cl_int *ptr = (cl_int *)clEnqueueMapBuffer(queue, mem3, CL_TRUE, CL_MAP_READ, 0, glob_results.size() * sizeof(cl_int), 0, 0, 0, &err_ret);
@@ -718,7 +720,8 @@ int test_enqueue_ndrange(cl_device_id device, cl_context context, cl_command_que
 
     if (failCnt > 0)
     {
-        log_error("ERROR: %d of %d kernels failed.\n", failCnt, num_kernels_ndrange_Xd);
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  num_kernels_ndrange_Xd);
     }
 
     return res;

--- a/test_conformance/device_execution/enqueue_wg_size.cpp
+++ b/test_conformance/device_execution/enqueue_wg_size.cpp
@@ -68,13 +68,15 @@ static int check_single(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if(i == 0 && results[i] != nestingLevel)
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], nestingLevel, i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], nestingLevel, i);
             return (int)i;
         }
 
         if(i > 0 && results[i] != 0)
         {
-            log_error("ERROR: Kernel returned %d vs. expected 0, index: %d\n", results[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected 0, index: %zu\n",
+                      results[i], i);
             return (int)i;
         }
     }
@@ -142,7 +144,8 @@ static int check_some_eq_1D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -216,7 +219,8 @@ static int check_some_diff_1D(cl_int* results, cl_int maxGlobalWorkSize, cl_int 
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -278,7 +282,8 @@ static int check_all_eq_1D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -346,7 +351,8 @@ static int check_all_diff_1D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -455,7 +461,8 @@ static int check_some_eq_2D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -535,7 +542,8 @@ static int check_some_diff_2D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -603,7 +611,8 @@ static int check_all_eq_2D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -677,7 +686,8 @@ static int check_all_diff_2D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -794,7 +804,8 @@ static int check_some_eq_3D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -879,7 +890,8 @@ static int check_some_diff_3D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -952,7 +964,8 @@ static int check_all_eq_3D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1031,7 +1044,8 @@ static int check_all_diff_3D(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1217,7 +1231,8 @@ static int check_some_eq_mix(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1346,7 +1361,8 @@ static int check_some_diff_mix(cl_int* results, cl_int len, cl_int nesting_level
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1462,7 +1478,8 @@ static int check_all_eq_mix(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1584,7 +1601,8 @@ static int check_all_diff_mix(cl_int* results, cl_int len, cl_int nesting_level)
     {
         if (results[i] != referenceResults[i])
         {
-            log_error("ERROR: Kernel returned %d vs. expected %d, index: %d\n", results[i], referenceResults[i], i);
+            log_error("ERROR: Kernel returned %d vs. expected %d, index: %zu\n",
+                      results[i], referenceResults[i], i);
             return (int)i;
         }
     }
@@ -1670,7 +1688,9 @@ int test_enqueue_wg_size(cl_device_id device, cl_context context, cl_command_que
         if (!gKernelName.empty() && gKernelName != sources_enqueue_wg_size[k].src.kernel_name)
             continue;
 
-        log_info("Running '%s' kernel (%d of %d) ...\n", sources_enqueue_wg_size[k].src.kernel_name, k + 1, arr_size(sources_enqueue_wg_size));
+        log_info("Running '%s' kernel (%d of %zu) ...\n",
+                 sources_enqueue_wg_size[k].src.kernel_name, k + 1,
+                 arr_size(sources_enqueue_wg_size));
         for(i = 0; i < MAX_GLOBAL_WORK_SIZE; ++i)
         {
             kernel_results[i] = 0;
@@ -1714,7 +1734,8 @@ int test_enqueue_wg_size(cl_device_id device, cl_context context, cl_command_que
 
     if (failCnt > 0)
     {
-        log_error("ERROR: %d of %d kernels failed.\n", failCnt, arr_size(sources_enqueue_wg_size));
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  arr_size(sources_enqueue_wg_size));
     }
 
     free_mtdata(d);

--- a/test_conformance/device_execution/execute_block.cpp
+++ b/test_conformance/device_execution/execute_block.cpp
@@ -1031,7 +1031,9 @@ int test_execute_block(cl_device_id device, cl_context context, cl_command_queue
         if (!gKernelName.empty() && gKernelName != sources_execute_block[i].kernel_name)
             continue;
 
-        log_info("Running '%s' kernel (%d of %d) ...\n", sources_execute_block[i].kernel_name, i + 1, num_kernels_execute_block);
+        log_info("Running '%s' kernel (%zu of %zu) ...\n",
+                 sources_execute_block[i].kernel_name, i + 1,
+                 num_kernels_execute_block);
         err_ret = run_n_kernel_args(context, queue, sources_execute_block[i].lines, sources_execute_block[i].num_lines, sources_execute_block[i].kernel_name, local_size, global_size, kernel_results, sizeof(kernel_results), 0, NULL);
         if(check_error(err_ret, "'%s' kernel execution failed", sources_execute_block[i].kernel_name)) { ++failCnt; res = -1; }
         else if((n = check_kernel_results(kernel_results, arr_size(kernel_results))) >= 0 && check_error(-1, "'%s' kernel results validation failed: [%d] returned %d expected 0", sources_execute_block[i].kernel_name, n, kernel_results[n])) { ++failCnt; res = -1; }
@@ -1040,7 +1042,8 @@ int test_execute_block(cl_device_id device, cl_context context, cl_command_queue
 
     if (failCnt > 0)
     {
-      log_error("ERROR: %d of %d kernels failed.\n", failCnt, num_kernels_execute_block);
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  num_kernels_execute_block);
     }
 
     return res;

--- a/test_conformance/device_execution/nested_blocks.cpp
+++ b/test_conformance/device_execution/nested_blocks.cpp
@@ -350,7 +350,9 @@ int test_enqueue_nested_blocks(cl_device_id device, cl_context context, cl_comma
         if (!gKernelName.empty() && gKernelName != sources_nested_blocks[k].src.kernel_name)
             continue;
 
-        log_info("Running '%s' kernel (%d of %d) ...\n", sources_nested_blocks[k].src.kernel_name, k + 1, arr_size(sources_nested_blocks));
+        log_info("Running '%s' kernel (%d of %zu) ...\n",
+                 sources_nested_blocks[k].src.kernel_name, k + 1,
+                 arr_size(sources_nested_blocks));
         for(i = 0; i < MAX_GLOBAL_WORK_SIZE; ++i) kernel_results[i] = 0;
 
         err_ret = run_n_kernel_args(context, queue, sources_nested_blocks[k].src.lines, sources_nested_blocks[k].src.num_lines, sources_nested_blocks[k].src.kernel_name, 0, MAX_GLOBAL_WORK_SIZE, kernel_results, sizeof(kernel_results), arr_size(args), args);
@@ -366,7 +368,8 @@ int test_enqueue_nested_blocks(cl_device_id device, cl_context context, cl_comma
 
     if (failCnt > 0)
     {
-        log_error("ERROR: %d of %d kernels failed.\n", failCnt, arr_size(sources_nested_blocks));
+        log_error("ERROR: %zu of %zu kernels failed.\n", failCnt,
+                  arr_size(sources_nested_blocks));
     }
 
     return res;


### PR DESCRIPTION
Printing of a `size_t` requires the `%zu` specifier.