### PR TITLE
basic: workaround MSVC compiler bug with post-increment operator

### DIFF
--- a/test_conformance/basic/test_vector_swizzle.cpp
+++ b/test_conformance/basic/test_vector_swizzle.cpp
@@ -516,8 +516,7 @@ static void makeReference(std::vector<T>& ref)
     // single channel lvalue
     for (size_t i = 0; i < N; i++)
     {
-        ref[dstIndex * S + i] = 0;
-        ++dstIndex;
+        ref[dstIndex++ * S + i] = 0;
     }
 
     // normal lvalue


### PR DESCRIPTION
Prevent the compiler from optimizing away initialization loops