### PR TITLE
Remove dead code

### DIFF
--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -8,14 +8,6 @@ if("${CLConform_TARGET_ARCH}" STREQUAL "ARM" OR "${CLConform_TARGET_ARCH}" STREQ
     list(APPEND ${MODULE_NAME}_SOURCES fplib.cpp)
 endif()
 
-if(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
-# -march is needed for CPU atomics, default arch on gcc is i386
-# that does not support atomics.
-set_source_files_properties(
-        ${MODULE_NAME}_SOURCES
-        COMPILE_FLAGS -march=i686)
-endif(NOT CMAKE_CL_64 AND NOT MSVC AND NOT ANDROID)
-
 set_gnulike_module_compile_flags("-Wno-sign-compare")
 
 include(../CMakeCommon.txt)


### PR DESCRIPTION
This is 7-year old CMake code that never did anything because the function invocation is missing the PROPERTIES keyword. Adding the keyword results in build errors, so just drop the dead code since everything seems to be working without it anyway.