### PR TITLE
test_vulkan: don't throw from destructors

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -853,7 +853,7 @@ clExternalImportableSemaphore::~clExternalImportableSemaphore()
     cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
     if (err != CL_SUCCESS)
     {
-        throw std::runtime_error("clReleaseSemaphoreKHR failed!");
+        log_error("clReleaseSemaphoreKHR failed with %d\n", err);
     }
 }
 
@@ -935,7 +935,7 @@ clExternalExportableSemaphore::~clExternalExportableSemaphore()
     cl_int err = clReleaseSemaphoreKHRptr(m_externalSemaphore);
     if (err != CL_SUCCESS)
     {
-        throw std::runtime_error("clReleaseSemaphoreKHR failed!");
+        log_error("clReleaseSemaphoreKHR failed with %d\n", err);
     }
 }
 


### PR DESCRIPTION
Only report an error (and include the error code), but don't throw an exception as that would call `terminate`.  Failure to release resources is not fatal in other parts of the CTS.

This fixes `-Wterminate` warnings:

    warning: ‘throw’ will always call ‘terminate’ [-Wterminate]
    note: in C++11 destructors default to ‘noexcept’