### PR TITLE
image_streams: fix -Wformat warnings

### DIFF
--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -17,6 +17,7 @@
 #include <float.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #if defined( __APPLE__ )
     #include <signal.h>
@@ -1481,8 +1482,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         char *imagePtr = (char *)imageValues + nextLevelOffset;
         if( gTestMipmaps )
         {
-            if(gDebugTrace)
-                log_info("\t- Working at mip level %d\n", lod);
+            if (gDebugTrace) log_info("\t- Working at mip level %zu\n", lod);
             error = clSetKernelArg( kernel, idx, sizeof(float), &lod_float);
         }
 
@@ -1723,7 +1723,10 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
         do
         {
             if( gDebugTrace )
-                log_info( "   at size %d,%d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, (int)imageInfo.height, gRoundingStartValue, typeRange );
+                log_info("   at size %d,%d, starting round ramp at %" PRIu64
+                         " for range %" PRIu64 "\n",
+                         (int)imageInfo.width, (int)imageInfo.height,
+                         gRoundingStartValue, typeRange);
             int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -18,6 +18,7 @@
 #include <float.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #if defined( __APPLE__ )
     #include <signal.h>
@@ -1151,7 +1152,9 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
         do
         {
             if( gDebugTrace )
-                log_info( "   at size %d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, gRoundingStartValue, typeRange );
+                log_info("   at size %d, starting round ramp at %" PRIu64
+                         " for range %" PRIu64 "\n",
+                         (int)imageInfo.width, gRoundingStartValue, typeRange);
             int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -17,6 +17,7 @@
 #include <float.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #if defined( __APPLE__ )
 #include <signal.h>
@@ -1261,7 +1262,10 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
         do
         {
             if( gDebugTrace )
-                log_info( "   at size %d,%d, starting round ramp at %llu for range %llu\n", (int)imageInfo.width, (int)imageInfo.arraySize, gRoundingStartValue, typeRange );
+                log_info("   at size %d,%d, starting round ramp at %" PRIu64
+                         " for range %" PRIu64 "\n",
+                         (int)imageInfo.width, (int)imageInfo.arraySize,
+                         gRoundingStartValue, typeRange);
             int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
             if( retCode )
                 return retCode;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -542,8 +542,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
         float lod_float = (float)lod;
         if( gTestMipmaps )
         {
-            if(gDebugTrace)
-                log_info(" - Working at mip level %d\n", lod);
+            if (gDebugTrace) log_info(" - Working at mip level %zu\n", lod);
             error = clSetKernelArg( kernel, idx, sizeof(float), &lod_float);
         }
     for( int q = 0; q < loopCount; q++ )

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -472,7 +472,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x3F,
                                                   (test_value[0] >> 11) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;
@@ -497,7 +497,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x1F,
                                                   (test_value[0] >> 10) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -493,7 +493,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x3F,
                                                   (test_value[0] >> 11) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;
@@ -518,7 +518,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x1F,
                                                   (test_value[0] >> 10) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -525,7 +525,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                                 (test_value[0] >> 5) & 0x3F,
                                                 (test_value[0] >> 11) & 0x1F);
                                             log_error(
-                                                "    Error:    %f %f %f %f\n",
+                                                "    Error:    %f %f %f\n",
                                                 errors[0], errors[1],
                                                 errors[2]);
                                             break;
@@ -554,7 +554,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                                 (test_value[0] >> 5) & 0x1F,
                                                 (test_value[0] >> 10) & 0x1F);
                                             log_error(
-                                                "    Error:    %f %f %f %f\n",
+                                                "    Error:    %f %f %f\n",
                                                 errors[0], errors[1],
                                                 errors[2]);
                                             break;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -532,7 +532,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                                 (test_value[0] >> 5) & 0x3F,
                                                 (test_value[0] >> 11) & 0x1F);
                                             log_error(
-                                                "    Error:    %f %f %f %f\n",
+                                                "    Error:    %f %f %f\n",
                                                 errors[0], errors[1],
                                                 errors[2]);
                                             break;
@@ -561,7 +561,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                                 (test_value[0] >> 5) & 0x1F,
                                                 (test_value[0] >> 10) & 0x1F);
                                             log_error(
-                                                "    Error:    %f %f %f %f\n",
+                                                "    Error:    %f %f %f\n",
                                                 errors[0], errors[1],
                                                 errors[2]);
                                             break;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -592,7 +592,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x3F,
                                                   (test_value[0] >> 11) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;
@@ -618,7 +618,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                                   test_value[0] & 0x1F,
                                                   (test_value[0] >> 5) & 0x1F,
                                                   (test_value[0] >> 10) & 0x1F);
-                                        log_error("    Error:    %f %f %f %f\n",
+                                        log_error("    Error:    %f %f %f\n",
                                                   errors[0], errors[1],
                                                   errors[2]);
                                         break;


### PR DESCRIPTION
The main sources of warnings were:

 * Printing of a `size_t` which requires the `%zu` specifier.

 * Printing of 64-bit values which is now done using the `PRI*64` macros to ensure portability across 32 and 64-bit builds.

 * Calling log_error with a format string of `"%f %f %f %f"` but specifying only three arguments.