### PR TITLE
[NFC] api: remove duplicate and unused macros

### DIFF
--- a/test_conformance/api/test_kernel_arg_multi_setup.cpp
+++ b/test_conformance/api/test_kernel_arg_multi_setup.cpp
@@ -27,8 +27,6 @@ const char *multi_arg_kernel_source_pattern =
 "    dst3[tid] = src3[tid];\n"
 "}\n";
 
-#define MAX_ERROR_TOLERANCE 0.0005f
-
 int test_multi_arg_set(cl_device_id device, cl_context context, cl_command_queue queue,
                        ExplicitType vec1Type, int vec1Size,
                        ExplicitType vec2Type, int vec2Size,

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -507,20 +507,6 @@ int test_get_context_info(cl_device_id deviceID, cl_context context, cl_command_
     return -1;
 }
 
-#define TEST_MEM_OBJECT_PARAM( mem, paramName, val, expected, name, type, cast )    \
-error = clGetMemObjectInfo( mem, paramName, sizeof( val ), &val, &size );        \
-test_error( error, "Unable to get mem object " name );                            \
-if( val != expected )                                                                \
-{                                                                                    \
-log_error( "ERROR: Mem object " name " did not validate! (expected " type ", got " type ")\n", (cast)(expected), (cast)val );    \
-return -1;                                                                        \
-}            \
-if( size != sizeof( val ) )                \
-{                                        \
-log_error( "ERROR: Returned size of mem object " name " does not validate! (expected %d, got %d)\n", (int)sizeof( val ), (int)size );    \
-return -1;    \
-}
-
 void CL_CALLBACK mem_obj_destructor_callback( cl_mem, void *data )
 {
     free( data );

--- a/test_conformance/api/test_wg_suggested_local_work_size.cpp
+++ b/test_conformance/api/test_wg_suggested_local_work_size.cpp
@@ -24,19 +24,6 @@
 #include "procs.h"
 #include <CL/cl_ext.h>
 
-/** @brief Gets the number of elements of type s in a fixed length array of s */
-#define NELEMS(s) (sizeof(s) / sizeof((s)[0]))
-#define test_error_ret_and_free(errCode, msg, retValue, ptr)                   \
-    {                                                                          \
-        auto errCodeResult = errCode;                                          \
-        if (errCodeResult != CL_SUCCESS)                                       \
-        {                                                                      \
-            print_error(errCodeResult, msg);                                   \
-            free(ptr);                                                         \
-            return retValue;                                                   \
-        }                                                                      \
-    }
-
 const char* wg_scan_local_work_group_size = R"(
     bool is_zero_linear_id()
     {
@@ -107,7 +94,6 @@ bool is_not_even(size_t a) { return (is_prime(a) || (a % 2 == 1)); }
 
 bool is_not_odd(size_t a) { return (is_prime(a) || (a % 2 == 0)); }
 
-#define NELEMS(s) (sizeof(s) / sizeof((s)[0]))
 /* The value_range_nD contains numbers to be used for the experiments with 2D
    and 3D global work sizes. This is because we need smaller numbers so that the
    resulting number of work items is meaningful and does not become too large.
@@ -265,7 +251,7 @@ int do_test_work_group_suggested_local_size(
         // return error if no number is found due to the skip condition
         err = -1;
         unsigned int j = 0;
-        size_t num_elems = NELEMS(value_range_nD);
+        size_t num_elems = ARRAY_SIZE(value_range_nD);
         for (size_t i = start; i < end; i += incr)
         {
             if (skip_cond(i)) continue;


### PR DESCRIPTION
The removed macros were never used.

Use the more common `ARRAY_SIZE` macro instead of defining an identical `NELEMS` macro.