### PR TITLE
compiler: fix memory leak

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -472,8 +472,13 @@ int test_compiler_defines_for_extensions(cl_device_id device, cl_context context
     // cleanup
     free(data);
     free(kernel_code);
-    for(i=0; i<num_of_supported_extensions; i++) {
-      free(extensions_supported[i]);
+    for (i = 0; i < num_of_supported_extensions; i++)
+    {
+        free(extensions_supported[i]);
+    }
+    for (i = 0; i < num_not_supported_extensions; i++)
+    {
+        free(extensions_not_supported[i]);
     }
     free(extensions);
 


### PR DESCRIPTION
The `test_compiler compiler_defines_for_extensions` test did not free all `malloc`'ed memory.