### PR TITLE
Fixed incorrect usage of clGetDeviceIDs num_devices

### DIFF
--- a/test_conformance/events/test_event_dependencies.cpp
+++ b/test_conformance/events/test_event_dependencies.cpp
@@ -97,7 +97,7 @@ int test_event_enqueue_wait_for_events_run_test(
         error = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 2, two_device_ids,
                                &number_returned);
         test_error(error, "clGetDeviceIDs for CL_DEVICE_TYPE_ALL failed.");
-        if (number_returned != 2)
+        if (number_returned >= 2)
         {
             log_info("Failed to obtain two devices. Test can not run.\n");
             free(two_device_ids);

--- a/test_conformance/events/test_event_dependencies.cpp
+++ b/test_conformance/events/test_event_dependencies.cpp
@@ -97,7 +97,7 @@ int test_event_enqueue_wait_for_events_run_test(
         error = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 2, two_device_ids,
                                &number_returned);
         test_error(error, "clGetDeviceIDs for CL_DEVICE_TYPE_ALL failed.");
-        if (number_returned >= 2)
+        if (number_returned < 2)
         {
             log_info("Failed to obtain two devices. Test can not run.\n");
             free(two_device_ids);


### PR DESCRIPTION
clGetDeviceIDs 'num_devices' output parameter is described as:
> num_devices returns the number of OpenCL devices available that match device_type.

but the _test_events out_of_order_event_waitlist_multi_queue_multi_device_ test expects that after calling:
`clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 2, two_device_ids, &number_returned);`

the content of number_returned needs to be 2, but it should be valid to return a larger number.
