### PR TITLE
relationals: fix out of bounds accesses in shuffle test

### DIFF
--- a/test_conformance/relationals/test_shuffles.cpp
+++ b/test_conformance/relationals/test_shuffles.cpp
@@ -882,7 +882,8 @@ int test_shuffle_random(cl_device_id device, cl_context context, cl_command_queu
                 int numTests = NUM_TESTS*NUM_ITERATIONS_PER_TEST;
                 for( int i = 0; i < numTests /*&& error == 0*/; i++ )
                 {
-                    ShuffleOrder src, dst;
+                    ShuffleOrder src{ 0 };
+                    ShuffleOrder dst;
                     if( shuffleMode == kBuiltInFnMode )
                     {
                         build_random_shuffle_order( dst, vecSizes[ dstIdx ], vecSizes[ srcIdx ], true, d );


### PR DESCRIPTION
The values in `src` are indices into an array in `get_order_string()`. Not initializing `src` resulted in out of bounds accesses there.

It seems that when the out of bounds accesses happened, the result of `get_order_string()` was not actually used, so at least the test was not using random data.  Fix the issue as it prevents a clean run of this test with e.g. AddressSanitizer.