### PR TITLE
add missing header

### DIFF
--- a/test_common/harness/integer_ops_test_info.h
+++ b/test_common/harness/integer_ops_test_info.h
@@ -20,6 +20,8 @@
 #include "conversions.h"
 #include "testHarness.h"
 
+#include <vector>
+
 // TODO: expand usage to other tests.
 
 template <typename T> struct TestInfo


### PR DESCRIPTION
test_common/harness/integer_ops_test_info.h is using std::vector but is not including the header.

This is breaking on Google internal CI.