### PR TITLE
cl_khr_kernel_clock: fix builtin function names

### DIFF
--- a/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
+++ b/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
@@ -96,13 +96,13 @@ public:
                     break;
                 }
                 case CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR: {
-                    sprintf(kernel_src, kernel_sources[i], "workgroup",
-                            "workgroup");
+                    sprintf(kernel_src, kernel_sources[i], "work_group",
+                            "work_group");
                     break;
                 }
                 case CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR: {
-                    sprintf(kernel_src, kernel_sources[i], "subgroup",
-                            "subgroup");
+                    sprintf(kernel_src, kernel_sources[i], "sub_group",
+                            "sub_group");
                     break;
                 }
             }


### PR DESCRIPTION
According to the [specification](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#kernel-clock-functions), the work_group and sub_group variants have an `_` in them.