### PR TITLE
fix bugs in negative command_buffer tests

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
@@ -40,6 +40,7 @@ struct CommandBufferBarrierNotNullQueue : public BasicCommandBufferTest
 
     bool Skip() override
     {
+        if (BasicCommandBufferTest::Skip()) return true;
         return is_extension_available(device,
                                       "cl_khr_command_buffer_multi_device");
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
@@ -37,6 +37,12 @@ struct CommandBufferBarrierNotNullQueue : public BasicCommandBufferTest
 
         return CL_SUCCESS;
     }
+
+    bool Skip() override
+    {
+        return is_extension_available(device,
+                                      "cl_khr_command_buffer_multi_device");
+    }
 };
 
 // CL_INVALID_COMMAND_BUFFER_KHR if command_buffer is not a valid

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
@@ -50,6 +50,12 @@ struct CommandBufferCommandSVMQueueNotNull : public BasicSVMCommandBufferTest
     }
 
     const cl_char pattern_1 = 0x14;
+
+    bool Skip() override
+    {
+        return is_extension_available(device,
+                                      "cl_khr_command_buffer_multi_device");
+    }
 };
 
 // CL_INVALID_SYNC_POINT_WAIT_LIST_KHR if sync_point_wait_list is NULL and

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
@@ -53,6 +53,7 @@ struct CommandBufferCommandSVMQueueNotNull : public BasicSVMCommandBufferTest
 
     bool Skip() override
     {
+        if (BasicSVMCommandBufferTest::Skip()) return true;
         return is_extension_available(device,
                                       "cl_khr_command_buffer_multi_device");
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
@@ -41,6 +41,7 @@ struct CommandNDRangeKernelQueueNotNull : public BasicCommandBufferTest
 
     bool Skip() override
     {
+        if (BasicCommandBufferTest::Skip()) return true;
         return is_extension_available(device,
                                       "cl_khr_command_buffer_multi_device");
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
@@ -38,6 +38,12 @@ struct CommandNDRangeKernelQueueNotNull : public BasicCommandBufferTest
 
         return CL_SUCCESS;
     }
+
+    bool Skip() override
+    {
+        return is_extension_available(device,
+                                      "cl_khr_command_buffer_multi_device");
+    }
 };
 
 // CL_INVALID_CONTEXT if the context associated with command_queue,
@@ -108,7 +114,7 @@ struct CommandNDRangeKerneSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
         cl_sync_point_khr* invalid_sync_points[] = { &invalid_point };
         cl_int error = clCommandNDRangeKernelKHR(
-            command_buffer, nullptr, nullptr, kernel, 0, nullptr, &num_elements,
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
             nullptr, 1, invalid_sync_points[0], nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
@@ -134,7 +140,7 @@ struct CommandNDRangeKerneSyncPointsNullOrNumZero
 
         cl_sync_point_khr* sync_points[] = { &point };
         error = clCommandNDRangeKernelKHR(
-            command_buffer, nullptr, nullptr, kernel, 0, nullptr, &num_elements,
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
             nullptr, 0, sync_points[0], nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,


### PR DESCRIPTION
- when calling command buffer APIs, test with `command_queue != NULL` should return `CL_INVALID_VALUE` only if the device doesn't support `cl_khr_command_buffer_multi_device` (added `Skip`)

- some tests enqueued commands with multiple invalid arguments, e.g. `clCommandCopyImageToBufferKHR` with two images and invalid sync points. AFAIK the order of argument checking is not defined, so implementation can return any valid error value for such API calls, but the tests assumed only one particular error would be returned. Fix the API calls to be unambiguous.