### PR TITLE
kernel_clock: Update function names to match spec

### DIFF
--- a/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
+++ b/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
@@ -96,13 +96,13 @@ public:
                     break;
                 }
                 case CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR: {
-                    sprintf(kernel_src, kernel_sources[i], "workgroup",
-                            "workgroup");
+                    sprintf(kernel_src, kernel_sources[i], "work_group",
+                            "work_group");
                     break;
                 }
                 case CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR: {
-                    sprintf(kernel_src, kernel_sources[i], "subgroup",
-                            "subgroup");
+                    sprintf(kernel_src, kernel_sources[i], "sub_group",
+                            "sub_group");
                     break;
                 }
             }


### PR DESCRIPTION
The spec has underscores in work_group and sub_group functions Fix the test to use that. 