### PR TITLE
cl_khr_kernel_clock: use create_single_kernel_helper

### DIFF
--- a/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
+++ b/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
@@ -117,9 +117,6 @@ public:
                                      sizeof(cl_uint), nullptr, &error);
             test_error(error, "clCreateBuffer failed");
 
-            kernel = clCreateKernel(program, "SampleClock", &error);
-            test_error(error, "Failed to create kernel");
-
             error = clSetKernelArg(kernel, 0, sizeof(out_mem), &out_mem);
             test_error(error, "clSetKernelArg failed");
 

--- a/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
+++ b/test_conformance/extensions/cl_khr_kernel_clock/kernel_clock.cpp
@@ -109,13 +109,9 @@ public:
 
             ptr = kernel_src;
 
-            error = create_single_kernel_helper_create_program(
-                context, &program, 1, &ptr);
+            error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                                &ptr, "SampleClock");
             test_error(error, "Failed to create program with source");
-
-            error =
-                clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
-            test_error(error, "Failed to build program");
 
             out_mem = clCreateBuffer(context, CL_MEM_WRITE_ONLY,
                                      sizeof(cl_uint), nullptr, &error);


### PR DESCRIPTION
`create_single_kernel_helper` invokes `clBuildProgram` and sets `-cl-std` to the latest version supported by the context.

The vast majority of tests are using `create_single_kernel_helper` instead of the `..._create_program` variant, so use the former for the sake of consistency.