### PR TITLE
Bump clang-format version to 14

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install packages
-        run: sudo apt install -y clang-format clang-format-11
+        run: sudo apt install -y clang-format clang-format-14
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/check-format.sh
+++ b/check-format.sh
@@ -2,7 +2,7 @@
 
 # Arg used to specify non-'origin/main' comparison branch
 ORIGIN_BRANCH=${1:-"origin/main"}
-CLANG_BINARY=${2:-"`which clang-format-11`"}
+CLANG_BINARY=${2:-"`which clang-format-14`"}
 
 # Run git-clang-format to check for violations
 CLANG_FORMAT_OUTPUT=$(git-clang-format --diff $ORIGIN_BRANCH --extensions c,cpp,h,hpp --binary $CLANG_BINARY)


### PR DESCRIPTION
Default version coming with Ubuntu 22.04 that the CI now uses.