### PR TITLE
Array based clUpdateMutableCommandsKHR changes

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -164,32 +164,6 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
 
         cl_mutable_dispatch_arg_khr arg{ 1, sizeof(dst_buf_1), &dst_buf_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            &arg /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -209,11 +183,9 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -315,17 +287,10 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
                                           nullptr, nullptr);
         test_error(error, "clEnqueueCommandBufferKHR failed");
 
-        error = clFinish(queue);
-        test_error(error, "clFinish failed.");
-
         cl_mutable_dispatch_arg_khr arg_1{ 1, sizeof(cl_mem), nullptr };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
             command,
             1 /* num_args */,
             0 /* num_svm_arg */,
@@ -337,39 +302,19 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
             nullptr /* global_work_offset */,
             nullptr /* global_work_size */,
             nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
         };
 
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
-        cl_mutable_dispatch_config_khr dispatch_config{
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
+        error = clFinish(queue);
+        test_error(error, "clFinish failed.");
 
         cl_uint num_configs = 1;
         cl_command_buffer_update_type_khr config_types[1] = {
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error =
             clEnqueueReadBuffer(queue, streams[1], CL_TRUE, 0, size_to_allocate,
@@ -475,18 +420,11 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
                                           nullptr, nullptr);
         test_error(error, "clEnqueueCommandBufferKHR failed");
 
-        error = clFinish(queue);
-        test_error(error, "clFinish failed.");
-
         int_arg = 20;
         cl_mutable_dispatch_arg_khr arg_1{ 1, sizeof(cl_int), &int_arg };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
             command,
             1 /* num_args */,
             0 /* num_svm_arg */,
@@ -498,39 +436,19 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
             nullptr /* global_work_offset */,
             nullptr /* global_work_size */,
             nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
         };
 
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
-        cl_mutable_dispatch_config_khr dispatch_config{
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
+        error = clFinish(queue);
+        test_error(error, "clFinish failed.");
 
         cl_uint num_configs = 1;
         cl_command_buffer_update_type_khr config_types[1] = {
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueReadBuffer(queue, stream, CL_TRUE, 0, size_to_allocate,
                                     result_data.data(), 0, nullptr, nullptr);
@@ -652,33 +570,6 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
 
         // Modify and execute the command buffer
         cl_mutable_dispatch_arg_khr arg{ 0, sizeof(cl_mem), nullptr };
-
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            &arg /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -698,11 +589,9 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -881,25 +770,6 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
         exec_info.param_value_size = sizeof(new_buffer);
         exec_info.param_value = &new_buffer;
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-
-        cl_mutable_dispatch_config_khr dispatch_config{};
-        dispatch_config.type = CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR;
-        dispatch_config.command = command;
-        dispatch_config.num_svm_args = 1;
-        dispatch_config.arg_svm_list = &arg_svm;
-        dispatch_config.num_exec_infos = 1;
-        dispatch_config.exec_info_list = &exec_info;
-
-        cl_mutable_base_config_khr mutable_config{};
-        mutable_config.type = CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR;
-        mutable_config.num_mutable_dispatch = 1;
-        mutable_config.mutable_dispatch_list = &dispatch_config;
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{};
         dispatch_config.num_svm_args = 1;
         dispatch_config.arg_svm_list = &arg_svm;
@@ -911,11 +781,9 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -164,6 +164,8 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
 
         cl_mutable_dispatch_arg_khr arg{ 1, sizeof(dst_buf_1), &dst_buf_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -187,6 +189,31 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            &arg /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -288,9 +315,14 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
                                           nullptr, nullptr);
         test_error(error, "clEnqueueCommandBufferKHR failed");
 
+        error = clFinish(queue);
+        test_error(error, "clFinish failed.");
+
         cl_mutable_dispatch_arg_khr arg_1{ 1, sizeof(cl_mem), nullptr };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -311,11 +343,33 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
             &dispatch_config
         };
 
-        error = clFinish(queue);
-        test_error(error, "clFinish failed.");
-
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error =
             clEnqueueReadBuffer(queue, streams[1], CL_TRUE, 0, size_to_allocate,
@@ -421,10 +475,15 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
                                           nullptr, nullptr);
         test_error(error, "clEnqueueCommandBufferKHR failed");
 
+        error = clFinish(queue);
+        test_error(error, "clFinish failed.");
+
         int_arg = 20;
         cl_mutable_dispatch_arg_khr arg_1{ 1, sizeof(cl_int), &int_arg };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -445,11 +504,33 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
             &dispatch_config
         };
 
-        error = clFinish(queue);
-        test_error(error, "clFinish failed.");
-
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueReadBuffer(queue, stream, CL_TRUE, 0, size_to_allocate,
                                     result_data.data(), 0, nullptr, nullptr);
@@ -571,6 +652,9 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
 
         // Modify and execute the command buffer
         cl_mutable_dispatch_arg_khr arg{ 0, sizeof(cl_mem), nullptr };
+
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -594,6 +678,31 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            &arg /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -772,6 +881,9 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
         exec_info.param_value_size = sizeof(new_buffer);
         exec_info.param_value = &new_buffer;
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
+
         cl_mutable_dispatch_config_khr dispatch_config{};
         dispatch_config.type = CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR;
         dispatch_config.command = command;
@@ -787,6 +899,23 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{};
+        dispatch_config.num_svm_args = 1;
+        dispatch_config.arg_svm_list = &arg_svm;
+        dispatch_config.num_exec_infos = 1;
+        dispatch_config.exec_info_list = &exec_info;
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_basic.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_basic.h
@@ -80,6 +80,22 @@ struct BasicMutableCommandBufferTest : BasicCommandBufferTest
                                    "cl_khr_command_buffer_mutable_dispatch")
             == true;
 
+        if (extension_avaliable) {
+         // API breaking changes occur at revision 0.9.2, check implementation
+         // matches tested API
+         Version device_version = get_device_cl_version(device);
+         if ((device_version >= Version(3, 0))
+            || is_extension_available(device, "cl_khr_extended_versioning")) {
+
+           cl_version extension_version =
+            get_extension_version(device, "cl_khr_command_buffer_mutable_dispatch");
+
+          if (extension_version < CL_MAKE_VERSION(0, 9, 2)) {
+            extension_avaliable = false;
+          }
+         }
+        }
+
         cl_mutable_dispatch_fields_khr mutable_capabilities;
 
         bool mutable_support =

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -334,6 +334,8 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
             test_error(error, "clEnqueueFillBuffer failed");
         }
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         // Modify and execute the command buffer
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
@@ -350,6 +352,22 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
             nullptr /* global_work_size */,
             nullptr /* local_work_size */
         };
+#else
+        // Modify and execute the command buffer
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            0 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            nullptr /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         cl_mutable_dispatch_arg_khr arg0{ 0 };
         cl_mutable_dispatch_arg_khr arg1{ 0 };
@@ -395,6 +413,8 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
             dispatch_config.local_work_size = &group_size;
         }
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_base_config_khr mutable_config{
             CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
             &dispatch_config
@@ -402,6 +422,17 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
@@ -87,6 +87,8 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -109,6 +111,32 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            0 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            nullptr /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            &update_global_offset /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
+
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
@@ -87,31 +87,6 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            0 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            nullptr /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            &update_global_offset /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             0 /* num_args */,
@@ -131,12 +106,9 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
-
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
@@ -86,32 +86,6 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            0 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            nullptr /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            &update_global_size /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
-
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             0 /* num_args */,
@@ -131,12 +105,9 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
-
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
@@ -86,6 +86,8 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -108,6 +110,33 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            0 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            nullptr /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            &update_global_size /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
+
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
@@ -161,6 +161,8 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         cl_mutable_dispatch_arg_khr arg_2{ 2, sizeof(cl_mem), &new_image };
         cl_mutable_dispatch_arg_khr args[] = { arg_2 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -182,6 +184,31 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         };
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -359,6 +386,8 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
         cl_mutable_dispatch_arg_khr arg_2{ 2, sizeof(cl_mem), &new_image };
         cl_mutable_dispatch_arg_khr args[] = { arg_2 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -380,6 +409,32 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
         };
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
+
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
@@ -161,30 +161,6 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         cl_mutable_dispatch_arg_khr arg_2{ 2, sizeof(cl_mem), &new_image };
         cl_mutable_dispatch_arg_khr args[] = { arg_2 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -204,11 +180,9 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);
@@ -386,30 +360,6 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
         cl_mutable_dispatch_arg_khr arg_2{ 2, sizeof(cl_mem), &new_image };
         cl_mutable_dispatch_arg_khr args[] = { arg_2 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -429,12 +379,9 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
-
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_iterative_arg_update.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_iterative_arg_update.cpp
@@ -151,32 +151,6 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
         // apply dispatch for mutable arguments
         cl_mutable_dispatch_arg_khr args = { 0, sizeof(cl_int), &pattern_sec };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            &args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -196,11 +170,9 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // update parameter of previous mutable dispatch by using the same
         // arguments list variable but this time modify other kernel argument
@@ -208,15 +180,9 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
         args.arg_size = sizeof(new_out_mem);
         args.arg_value = &new_out_mem;
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueFillBuffer(queue, new_out_mem, &pattern_pri,
                                     sizeof(cl_int), 0, data_size(), 0, nullptr,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_iterative_arg_update.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_iterative_arg_update.cpp
@@ -151,6 +151,8 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
         // apply dispatch for mutable arguments
         cl_mutable_dispatch_arg_khr args = { 0, sizeof(cl_int), &pattern_sec };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -174,6 +176,31 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            &args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // update parameter of previous mutable dispatch by using the same
         // arguments list variable but this time modify other kernel argument
@@ -181,8 +208,15 @@ struct IterativeArgUpdateDispatch : BasicMutableCommandBufferTest
         args.arg_size = sizeof(new_out_mem);
         args.arg_value = &new_out_mem;
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueFillBuffer(queue, new_out_mem, &pattern_pri,
                                     sizeof(cl_int), 0, data_size(), 0, nullptr,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
@@ -89,6 +89,8 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -111,6 +113,31 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            0 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            nullptr /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            &update_global_size /* global_work_size */,
+            &update_local_size /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
@@ -89,31 +89,6 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed.");
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            0 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            nullptr /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            &update_global_size /* global_work_size */,
-            &update_local_size /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             0 /* num_args */,
@@ -133,11 +108,9 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                           nullptr, nullptr);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_multiple_dispatches.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_multiple_dispatches.cpp
@@ -162,6 +162,8 @@ struct MultipleCommandsDispatch : BasicMutableCommandBufferTest
                                              &new_out_mem };
         cl_mutable_dispatch_arg_khr args_sec[] = { arg_sec };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         // modify two mutable parameters, each one with separate handle
         cl_mutable_dispatch_config_khr dispatch_config[] = {
             { CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR, nullptr,
@@ -179,6 +181,26 @@ struct MultipleCommandsDispatch : BasicMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        // modify two mutable parameters, each one with separate handle
+        cl_mutable_dispatch_config_khr dispatch_config[] = {
+            { command_pri, 1, 0, 0, 0, args_pri, nullptr, nullptr, nullptr,
+              nullptr, nullptr },
+            { command_sec, 1, 0, 0, 0, args_sec, nullptr, nullptr, nullptr,
+              nullptr, nullptr },
+        };
+
+        cl_uint num_configs = 2;
+        cl_command_buffer_update_type_khr config_types[2] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[2] = { &dispatch_config[0], &dispatch_config[1] };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // repeat execution of modified command buffer
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_multiple_dispatches.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_multiple_dispatches.cpp
@@ -162,26 +162,6 @@ struct MultipleCommandsDispatch : BasicMutableCommandBufferTest
                                              &new_out_mem };
         cl_mutable_dispatch_arg_khr args_sec[] = { arg_sec };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        // modify two mutable parameters, each one with separate handle
-        cl_mutable_dispatch_config_khr dispatch_config[] = {
-            { CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR, nullptr,
-              command_pri, 1, 0, 0, 0, args_pri, nullptr, nullptr, nullptr,
-              nullptr, nullptr },
-            { CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR, nullptr,
-              command_sec, 1, 0, 0, 0, args_sec, nullptr, nullptr, nullptr,
-              nullptr, nullptr },
-        };
-
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2,
-            dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         // modify two mutable parameters, each one with separate handle
         cl_mutable_dispatch_config_khr dispatch_config[] = {
             { command_pri, 1, 0, 0, 0, args_pri, nullptr, nullptr, nullptr,
@@ -196,11 +176,9 @@ struct MultipleCommandsDispatch : BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[2] = { &dispatch_config[0], &dispatch_config[1] };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // repeat execution of modified command buffer
         error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_overwrite_update.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_overwrite_update.cpp
@@ -156,6 +156,8 @@ struct OverwriteUpdateDispatch : BasicMutableCommandBufferTest
                                                { 1, sizeof(unused_mem),
                                                  &unused_mem } };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -179,13 +181,46 @@ struct OverwriteUpdateDispatch : BasicMutableCommandBufferTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            2 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void *configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
+
 
         // overwrite previous update of mutable arguments
         args[0].arg_value = &pattern_sec;
         args[1].arg_value = &new_out_mem;
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueFillBuffer(queue, new_out_mem, &pattern_pri,
                                     sizeof(cl_int), 0, data_size(), 0, nullptr,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_overwrite_update.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_overwrite_update.cpp
@@ -156,32 +156,6 @@ struct OverwriteUpdateDispatch : BasicMutableCommandBufferTest
                                                { 1, sizeof(unused_mem),
                                                  &unused_mem } };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            2 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             2 /* num_args */,
@@ -201,26 +175,17 @@ struct OverwriteUpdateDispatch : BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void *configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
-
 
         // overwrite previous update of mutable arguments
         args[0].arg_value = &pattern_sec;
         args[1].arg_value = &new_out_mem;
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueFillBuffer(queue, new_out_mem, &pattern_pri,
                                     sizeof(cl_int), 0, data_size(), 0, nullptr,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
@@ -223,6 +223,8 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -246,6 +248,31 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         error =
             clUpdateMutableCommandsKHR(work_command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void* configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, work_command_buffer, 0,
                                           nullptr, &single_event);
@@ -342,6 +369,8 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -365,6 +394,31 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         error =
             clUpdateMutableCommandsKHR(work_command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            1 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void* configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // command buffer execution must wait for two wait-events
         error =
@@ -551,6 +605,8 @@ struct CrossQueueSimultaneousMutableDispatchTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_0, arg_1 };
 
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
+    < CL_MAKE_VERSION(0, 9, 2)
         cl_mutable_dispatch_config_khr dispatch_config{
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
             nullptr,
@@ -573,6 +629,32 @@ struct CrossQueueSimultaneousMutableDispatchTest
 
         error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
         test_error(error, "clUpdateMutableCommandsKHR failed");
+#else
+        cl_mutable_dispatch_config_khr dispatch_config{
+            command,
+            2 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */
+        };
+
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
+        };
+        const void* configs[1] = { &dispatch_config };
+
+        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                           config_types, configs);
+        test_error(error, "clUpdateMutableCommandsKHR failed");
+#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
+
 
         // enqueue command buffer to non-default queue
         error = clEnqueueCommandBufferKHR(1, &queue_sec, command_buffer, 0,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
@@ -223,32 +223,6 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error =
-            clUpdateMutableCommandsKHR(work_command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -268,11 +242,9 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void* configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         error = clEnqueueCommandBufferKHR(0, nullptr, work_command_buffer, 0,
                                           nullptr, &single_event);
@@ -369,32 +341,6 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            1 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error =
-            clUpdateMutableCommandsKHR(work_command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             1 /* num_args */,
@@ -414,11 +360,9 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void* configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
 
         // command buffer execution must wait for two wait-events
         error =
@@ -605,31 +549,6 @@ struct CrossQueueSimultaneousMutableDispatchTest
                                            &new_out_mem };
         cl_mutable_dispatch_arg_khr args[] = { arg_0, arg_1 };
 
-#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION                   \
-    < CL_MAKE_VERSION(0, 9, 2)
-        cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
-            command,
-            2 /* num_args */,
-            0 /* num_svm_arg */,
-            0 /* num_exec_infos */,
-            0 /* work_dim - 0 means no change to dimensions */,
-            args /* arg_list */,
-            nullptr /* arg_svm_list - nullptr means no change*/,
-            nullptr /* exec_info_list */,
-            nullptr /* global_work_offset */,
-            nullptr /* global_work_size */,
-            nullptr /* local_work_size */
-        };
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
-        };
-
-        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
-        test_error(error, "clUpdateMutableCommandsKHR failed");
-#else
         cl_mutable_dispatch_config_khr dispatch_config{
             command,
             2 /* num_args */,
@@ -649,12 +568,9 @@ struct CrossQueueSimultaneousMutableDispatchTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void* configs[1] = { &dispatch_config };
-
         error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
-#endif // CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION
-
 
         // enqueue command buffer to non-default queue
         error = clEnqueueCommandBufferKHR(1, &queue_sec, command_buffer, 0,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
@@ -199,8 +199,6 @@ struct MutableDispatchWorkGroups : public BasicMutableCommandBufferTest
     {
         cl_int error;
         cl_mutable_dispatch_config_khr dispatch_config{
-            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-            nullptr,
             command,
             0, // num_args
             0, // num_svm_arg
@@ -214,13 +212,14 @@ struct MutableDispatchWorkGroups : public BasicMutableCommandBufferTest
             nullptr // local_work_size
         };
 
-        cl_mutable_base_config_khr mutable_config{
-            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-            &dispatch_config
+        cl_uint num_configs = 1;
+        cl_command_buffer_update_type_khr config_types[1] = {
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
-
+        const void *configs[1] = { &dispatch_config };
         error =
-            clUpdateMutableCommandsKHR(single_command_buffer, &mutable_config);
+            clUpdateMutableCommandsKHR(single_command_buffer, num_configs,
+                                       config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
 
         clEventWrapper events[2];


### PR DESCRIPTION
CTS changes to reflect the spec changes merged in https://github.com/KhronosGroup/OpenCL-Docs/pull/1045 and requires header updates from https://github.com/KhronosGroup/OpenCL-Headers/pull/245

Tested using OCK implementation from https://github.com/codeplaysoftware/oneapi-construction-kit/pull/501

