### PR TITLE
Extend printf tests with more %% corner cases

### DIFF
--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -724,6 +724,12 @@ std::vector<printDataGenParameters> printStringGenParameters = {
 
     { {"%s"}, "\"%%\"" },
 
+    { {"%s"}, "\"foo%%bar%%bar%%foo\"" },
+
+    { {"%%%s%%"}, "\"foo\"" },
+
+    { {"%%s%s"}, "\"foo\"" },
+
     // special symbols
     // nested
 
@@ -763,6 +769,12 @@ std::vector<std::string> correctBufferString = {
     "f",
 
     "%%",
+
+    "foo%%bar%%bar%%foo",
+
+    "%foo%",
+
+    "%sfoo",
 
     "\"%%\"",
 
@@ -819,6 +831,8 @@ std::vector<printDataGenParameters> printFormatStringGenParameters = {
 
     { {"\'%%\'"} },
 
+    { {"\'foo%%bar%%bar%%foo\'"} },
+
     // tabs
 
     { {"foo\\t\\t\\tfoo"} },
@@ -848,6 +862,8 @@ std::vector<std::string> correctBufferFormatString = {
     "\"%\"",
 
     "\'%\'",
+
+    "\'foo%bar%bar%foo\'",
 
     "foo\t\t\tfoo",
 


### PR DESCRIPTION
We've had a couple of bugs inside mesa/rusticl processing %% correctly. I've added those cases locally to make sure all corner cases are properly handled.