### PR TITLE
math_brute_force: remove spurious tan skip check

### DIFF
--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -489,7 +489,6 @@ int TestFunc_Float_Float(const Func *f, MTdata d, bool relaxedMode)
     cl_int error;
     float maxError = 0.0f;
     double maxErrorVal = 0.0;
-    int skipTestingRelaxed = (relaxedMode && strcmp(f->name, "tan") == 0);
 
     logFunctionInfo(f->name, sizeof(cl_float), relaxedMode);
 
@@ -583,7 +582,7 @@ int TestFunc_Float_Float(const Func *f, MTdata d, bool relaxedMode)
         return error;
 
     // Run the kernels
-    if (!gSkipCorrectnessTesting || skipTestingRelaxed)
+    if (!gSkipCorrectnessTesting)
     {
         error = ThreadPool_Do(Test, test_info.jobCount, &test_info);
         if (error) return error;
@@ -602,12 +601,6 @@ int TestFunc_Float_Float(const Func *f, MTdata d, bool relaxedMode)
             vlog("Wimp pass");
         else
             vlog("passed");
-
-        if (skipTestingRelaxed)
-        {
-            vlog(" (rlx skip correctness testing)\n");
-            return error;
-        }
 
         vlog("\t%8.2f @ %a", maxError, maxErrorVal);
     }


### PR DESCRIPTION
The `skipTestingRelaxed` check suffers the following problems:

 - The use of `skipTestingRelaxed` in the `if` seems reversed: when skipping correctness testing using the `-l` command line option, this variable causes correctness testing to be run for relaxed-mode `tan` regardless.

 - Accuracy testing should only be skipped for derived `tan` implementations.  Non-derived `tan` implementations must still be tested for accuracy, so the condition for setting the `skipTestingRelaxed` variable is incomplete.

 - It is unclear why only `tan` is conditionalized here.  There are other functions such as `tanpi` for which one would expect identical behaviour.

The actual skipping of accuracy checks for derived implementations happens in `Test()`, so just remove `skipTestingRelaxed` as it does not seem to add any value.