### PR TITLE
math_brute_force: skip all enqueues in -l mode

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_double.cpp
@@ -104,6 +104,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         double *p2 = (double *)gIn2;
@@ -263,8 +265,6 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/binary_two_results_i_float.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_float.cpp
@@ -106,6 +106,8 @@ int TestFunc_FloatI_Float_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_uint *p = (cl_uint *)gIn;
         cl_uint *p2 = (cl_uint *)gIn2;
@@ -265,8 +267,6 @@ int TestFunc_FloatI_Float_Float(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/binary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_half.cpp
@@ -104,6 +104,8 @@ int TestFunc_HalfI_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_half *p = (cl_half *)gIn;
         cl_half *p2 = (cl_half *)gIn2;
@@ -256,8 +258,6 @@ int TestFunc_HalfI_Half_Half(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         cl_half *t = (cl_half *)gOut_Ref;

--- a/test_conformance/math_brute_force/i_unary_double.cpp
+++ b/test_conformance/math_brute_force/i_unary_double.cpp
@@ -64,6 +64,8 @@ int TestFunc_Int_Double(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         if (gWimpyMode)
@@ -162,8 +164,6 @@ int TestFunc_Int_Double(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/i_unary_float.cpp
+++ b/test_conformance/math_brute_force/i_unary_float.cpp
@@ -63,6 +63,8 @@ int TestFunc_Int_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_uint *p = (cl_uint *)gIn;
         if (gWimpyMode)
@@ -161,8 +163,6 @@ int TestFunc_Int_Float(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/i_unary_half.cpp
+++ b/test_conformance/math_brute_force/i_unary_half.cpp
@@ -73,6 +73,8 @@ int TestFunc_Int_Half(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 16); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_ushort *p = (cl_ushort *)gIn;
 
@@ -159,8 +161,6 @@ int TestFunc_Int_Half(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/mad_double.cpp
+++ b/test_conformance/math_brute_force/mad_double.cpp
@@ -61,6 +61,8 @@ int TestFunc_mad_Double(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         double *p2 = (double *)gIn2;
@@ -185,8 +187,6 @@ int TestFunc_mad_Double(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data -- No verification possible.
         // MAD is a random number generator.

--- a/test_conformance/math_brute_force/mad_float.cpp
+++ b/test_conformance/math_brute_force/mad_float.cpp
@@ -62,6 +62,8 @@ int TestFunc_mad_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_uint *p = (cl_uint *)gIn;
         cl_uint *p2 = (cl_uint *)gIn2;
@@ -186,8 +188,6 @@ int TestFunc_mad_Float(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data -- No verification possible.
         // MAD is a random number generator.

--- a/test_conformance/math_brute_force/mad_half.cpp
+++ b/test_conformance/math_brute_force/mad_half.cpp
@@ -63,6 +63,8 @@ int TestFunc_mad_Half(const Func *f, MTdata d, bool relaxedMode)
     }
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_ushort *p = (cl_ushort *)gIn;
         cl_ushort *p2 = (cl_ushort *)gIn2;
@@ -172,8 +174,6 @@ int TestFunc_mad_Half(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data - no verification possible. MAD is a random number
         // generator.

--- a/test_conformance/math_brute_force/ternary_double.cpp
+++ b/test_conformance/math_brute_force/ternary_double.cpp
@@ -141,6 +141,8 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         double *p2 = (double *)gIn2;
@@ -290,8 +292,6 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/ternary_float.cpp
+++ b/test_conformance/math_brute_force/ternary_float.cpp
@@ -159,6 +159,8 @@ int TestFunc_Float_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_uint *p = (cl_uint *)gIn;
         cl_uint *p2 = (cl_uint *)gIn2;
@@ -327,8 +329,6 @@ int TestFunc_Float_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/ternary_half.cpp
+++ b/test_conformance/math_brute_force/ternary_half.cpp
@@ -94,6 +94,8 @@ int TestFunc_Half_Half_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_half *hp0 = (cl_half *)gIn;
         cl_half *hp1 = (cl_half *)gIn2;
@@ -261,8 +263,6 @@ int TestFunc_Half_Half_Half_Half(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint16_t *t = (uint16_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_two_results_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_double.cpp
@@ -67,6 +67,8 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         if (gWimpyMode)
@@ -202,8 +204,6 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_two_results_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_float.cpp
@@ -68,6 +68,8 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         uint32_t *p = (uint32_t *)gIn;
         if (gWimpyMode)
@@ -256,12 +258,6 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
                 vlog_error("ReadArray2 failed %d\n", error);
                 return error;
             }
-        }
-
-        if (gSkipCorrectnessTesting)
-        {
-            if (isFract && gIsInRTZMode) (void)set_round(oldRoundMode, kfloat);
-            break;
         }
 
         // Verify data

--- a/test_conformance/math_brute_force/unary_two_results_half.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_half.cpp
@@ -72,6 +72,8 @@ int TestFunc_Half2_Half(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 16); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_half *pIn = (cl_half *)gIn;
         for (size_t j = 0; j < bufferElements; j++) pIn[j] = (cl_ushort)i + j;
@@ -229,12 +231,6 @@ int TestFunc_Half2_Half(const Func *f, MTdata d, bool relaxedMode)
                 vlog_error("ReadArray2 failed %d\n", error);
                 return error;
             }
-        }
-
-        if (gSkipCorrectnessTesting)
-        {
-            if (isFract && gIsInRTZMode) (void)set_round(oldRoundMode, kfloat);
-            break;
         }
 
         // Verify data

--- a/test_conformance/math_brute_force/unary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_double.cpp
@@ -75,6 +75,8 @@ int TestFunc_DoubleI_Double(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         double *p = (double *)gIn;
         if (gWimpyMode)
@@ -206,8 +208,6 @@ int TestFunc_DoubleI_Double(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_two_results_i_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_float.cpp
@@ -80,6 +80,8 @@ int TestFunc_FloatI_Float(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         uint32_t *p = (uint32_t *)gIn;
         if (gWimpyMode)
@@ -211,8 +213,6 @@ int TestFunc_FloatI_Float(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_half.cpp
@@ -84,6 +84,8 @@ int TestFunc_HalfI_Half(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 16); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_half *pIn = (cl_half *)gIn;
         for (size_t j = 0; j < bufferElements; j++) pIn[j] = (cl_ushort)i + j;
@@ -205,8 +207,6 @@ int TestFunc_HalfI_Half(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         for (size_t j = 0; j < bufferElements; j++)

--- a/test_conformance/math_brute_force/unary_u_double.cpp
+++ b/test_conformance/math_brute_force/unary_u_double.cpp
@@ -67,6 +67,8 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_ulong *p = (cl_ulong *)gIn;
         for (size_t j = 0; j < BUFFER_SIZE / sizeof(cl_ulong); j++)
@@ -156,8 +158,6 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_u_float.cpp
+++ b/test_conformance/math_brute_force/unary_u_float.cpp
@@ -67,6 +67,8 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         uint32_t *p = (uint32_t *)gIn;
         if (gWimpyMode)
@@ -163,8 +165,6 @@ int TestFunc_Float_UInt(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         uint32_t *t = (uint32_t *)gOut_Ref;

--- a/test_conformance/math_brute_force/unary_u_half.cpp
+++ b/test_conformance/math_brute_force/unary_u_half.cpp
@@ -67,6 +67,8 @@ int TestFunc_Half_UShort(const Func *f, MTdata d, bool relaxedMode)
 
     for (uint64_t i = 0; i < (1ULL << 32); i += step)
     {
+        if (gSkipCorrectnessTesting) break;
+
         // Init input array
         cl_ushort *p = (cl_ushort *)gIn;
         for (size_t j = 0; j < bufferElements; j++) p[j] = (uint16_t)i + j;
@@ -154,8 +156,6 @@ int TestFunc_Half_UShort(const Func *f, MTdata d, bool relaxedMode)
                 return error;
             }
         }
-
-        if (gSkipCorrectnessTesting) break;
 
         // Verify data
         cl_ushort *t = (cl_ushort *)gOut_Ref;


### PR DESCRIPTION
The math_brute_force test has a link-check-only mode to quickly test if all math functions are present.

In link-check-only mode, most tests return immediately after kernel compilation, but some tests also run the kernel and read back the result data before returning.  Running the kernels takes a lot more time, defeating the purpose of the `-l` mode.

Break out at the start of the main `for` loops in link-check-only mode instead of returning directly, so that each test can still log its trailing message (in most cases just a `\n`).