### PR TITLE
math_brute_force: only test correctly rounded divide/sqrt for fp32

### DIFF
--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -65,6 +65,7 @@
 #define binaryOF NULL
 #define binaryF_nextafter NULL
 #define binaryOperatorF NULL
+#define binaryOperatorOF NULL
 #define binaryF_i NULL
 #define macro_binaryF NULL
 #define ternaryF NULL
@@ -169,6 +170,13 @@ static constexpr vtbl _binary_operator = {
     TestFunc_Half_Half_Half_Operator,
 };
 
+static constexpr vtbl _binary_operator_of = {
+    "binaryOperator_of",
+    TestFunc_Float_Float_Float_Operator,
+    nullptr,
+    nullptr,
+};
+
 static constexpr vtbl _binary_i = {
     "binary_i",
     TestFunc_Float_Float_Int,
@@ -227,6 +235,7 @@ static constexpr vtbl _mad_tbl = {
 #define binaryF_nextafter &_binary_nextafter
 #define binaryOF &_binaryof
 #define binaryOperatorF &_binary_operator
+#define binaryOperatorOF &_binary_operator_of
 #define binaryF_i &_binary_i
 #define macro_binaryF &_macro_binary
 #define ternaryF &_ternary
@@ -370,17 +379,17 @@ const Func functionList[] = {
     { "sqrt_cr",
       "sqrt",
       { (void*)reference_sqrt },
-      { (void*)reference_sqrtl },
+      { nullptr },
       { NULL },
       0.0f,
-      0.0f,
-      0.0f,
-      0.0f,
+      INFINITY,
+      INFINITY,
+      INFINITY,
       INFINITY,
       INFINITY,
       FTZ_OFF,
       RELAXED_OFF,
-      unaryF },
+      unaryOF /* only for single precision */ },
 
     // In derived mode it the ulp error is calculated as sin/cos.
     // In non-derived mode it is the same as half_tan.
@@ -426,17 +435,17 @@ const Func functionList[] = {
     { "divide_cr",
       "/",
       { (void*)reference_divide },
-      { (void*)reference_dividel },
-      { (void*)reference_relaxed_divide },
+      { nullptr },
+      { nullptr },
       0.0f,
-      0.0f,
-      0.0f,
-      0.0f,
-      0.f,
+      INFINITY,
+      INFINITY,
+      INFINITY,
+      INFINITY,
       INFINITY,
       FTZ_OFF,
       RELAXED_OFF,
-      binaryOperatorF },
+      binaryOperatorOF /* only for single precision */ },
     OPERATOR_ENTRY(multiply, "*", 0.0f, 0.0f, 0.0f, FTZ_OFF, binaryOperatorF),
     OPERATOR_ENTRY(assignment, "", 0.0f, 0.0f, 0.0f, FTZ_OFF,
                    unaryF), // A simple copy operation


### PR DESCRIPTION
Skip the correctly rounded divide (divide_cr) and sqrt (sqrt_cr) tests for fp16 and fp64.

The corresponding build option to enable correctly rounded divide and sqrt is named `-cl-fp32-correctly-rounded-divide-sqrt` and the description refers only to "single precision floating-point", so this option should not apply to fp16 or fp64.

The specification states that fp16 and fp64 divide and sqrt must be correctly rounded for the full profile, without needing any additional build options.  This is already tested by the regular divide and sqrt tests.  For the embedded profile the ULP requirement is non-zero, but there is no build option to request a correctly rounded implementation anyway.

Fixes https://github.com/KhronosGroup/OpenCL-CTS/issues/1901 .
Relates to https://github.com/KhronosGroup/OpenCL-CTS/issues/1996 .