### PR TITLE
Drop linking Vulkan directly

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_external_semaphore/CMakeLists.txt
@@ -15,12 +15,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories (${CLConform_INCLUDE_DIR})
 
-# needed by Vulkan wrapper to link
-if(WIN32)
-    list(APPEND CLConform_LIBRARIES vulkan-1 vulkan_wrapper)
-else(WIN32)
-    list(APPEND CLConform_LIBRARIES vulkan dl vulkan_wrapper)
-endif(WIN32)
+list(APPEND CLConform_LIBRARIES vulkan_wrapper)
 set(CMAKE_CXX_FLAGS "-fpermissive")
 
 include_directories("../../common/vulkan_wrapper")

--- a/test_conformance/vulkan/CMakeLists.txt
+++ b/test_conformance/vulkan/CMakeLists.txt
@@ -1,10 +1,6 @@
 set (MODULE_NAME VULKAN)
 
-if(WIN32)
-    list(APPEND CLConform_LIBRARIES vulkan-1 vulkan_wrapper)
-else(WIN32)
-    list(APPEND CLConform_LIBRARIES vulkan dl vulkan_wrapper)
-endif(WIN32)
+list(APPEND CLConform_LIBRARIES vulkan_wrapper)
 set(CMAKE_CXX_FLAGS "-fpermissive")
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_USE_PLATFORM_WIN32_KHR")


### PR DESCRIPTION
The `vulkan-wrapper` helper library's purpose is to eliminate the need to link targets directly to Vulkan, and load it dynamically instead at runtime, using `dlopen` and `LoadLibrary`.

Remove the direct linking of the Vulkan library from targets that link to `vulkan-wrapper`.

Fixes #1999