### PR TITLE
computeinfo: add CL_DEVICE_HALF_FP_CONFIG

### DIFF
--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -188,6 +188,7 @@ config_info config_infos[] = {
     CONFIG_INFO(2, 0, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, cl_uint),
 
     CONFIG_INFO(1, 1, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint),
+    CONFIG_INFO(1, 1, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config),
     CONFIG_INFO(1, 1, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config),
     CONFIG_INFO(1, 1, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config),
     CONFIG_INFO(1, 1, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE,


### PR DESCRIPTION
The computeinfo test already checks that the cl_khr_fp16 extension is available before querying `CL_DEVICE_HALF_FP_CONFIG`, but never actually made the `CL_DEVICE_HALF_FP_CONFIG` query.