### PR TITLE
computeinfo: fix memory leak

### DIFF
--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -1452,5 +1452,9 @@ int main(int argc, const char** argv)
         }
     }
 
-    return runTestHarness(argCount, argList, test_num, test_list, true, 0);
+    int error = runTestHarness(argCount, argList, test_num, test_list, true, 0);
+
+    free(argList);
+
+    return error;
 }


### PR DESCRIPTION
Even on the common code path (i.e., no error paths taken), test_computeinfo failed to release its allocated memory, preventing a clean run with LeakSanitizer.