### PR TITLE
printf: add missing cstdint include

### DIFF
--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdarg>
+#include <cstdint>
 #include <errno.h>
 #include <memory>
 #include <string.h>


### PR DESCRIPTION
Since GCC 13 some headers are no longer included transitively through C++ Standard Library headers.