### PR TITLE
Fix failures in  clCopyImage and clFillImage

### DIFF
--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -94,17 +94,10 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
                             "Error: Could not get CL_QUEUE_DEVICE from queue");
                         return NULL;
                     }
-                    char major_version;
-                    err = clGetDeviceInfo(device, CL_DEVICE_VERSION,
-                                          sizeof(major_version), &major_version,
-                                          nullptr);
-                    if (err != CL_SUCCESS)
-                    {
-                        log_error("Error: Could not get CL_DEVICE_VERSION from "
-                                  "device");
-                        return NULL;
-                    }
-                    if (major_version == '1')
+
+                    auto ocl_version = get_device_cl_version(device);
+
+                    if (ocl_version < Version(2, 0))
                     {
                         host_ptr = malloc(imageInfo->rowPitch);
                     }


### PR DESCRIPTION
Fix failures in  clCopyImage and clFillImage:

Log:
$ ./test_clFillImage 1Dbuffer
Initializing random seed to 0.
Supports single precision denormals: YES
sizeof( void*) = 8  (host)
sizeof( void*) = 8  (device)
1Dbuffer...
Running 1D Image Buffer Fill tests...
[CL_R    CL_SIGNED_INT8           1]
Error: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from device[CL_R    CL_SIGNED_INT16          1]
Error: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from deviceError: Could not get CL_DEVICE_NUMERIC_VERSION from device[CL_R    CL_SIGNED_INT32          1]
^C
