### PR TITLE
[NFC] math_brute_force: add type argument to getAllowedUlpError

### DIFF
--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -201,7 +201,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     fptr func = job->f->func;
     int ftz = job->ftz;
     bool relaxedMode = job->relaxedMode;
-    float ulps = getAllowedUlpError(job->f, relaxedMode);
+    float ulps = getAllowedUlpError(job->f, kfloat, relaxedMode);
     MTdata d = tinfo->d;
     cl_int error;
     std::vector<bool> overflow(buffer_elements, false);

--- a/test_conformance/math_brute_force/binary_operator_float.cpp
+++ b/test_conformance/math_brute_force/binary_operator_float.cpp
@@ -197,7 +197,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     fptr func = job->f->func;
     int ftz = job->ftz;
     bool relaxedMode = job->relaxedMode;
-    float ulps = getAllowedUlpError(job->f, relaxedMode);
+    float ulps = getAllowedUlpError(job->f, kfloat, relaxedMode);
     MTdata d = tinfo->d;
     cl_int error;
     std::vector<bool> overflow(buffer_elements, false);

--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -88,7 +88,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     fptr func = job->f->func;
     const char *fname = job->f->name;
     bool relaxedMode = job->relaxedMode;
-    float ulps = getAllowedUlpError(job->f, relaxedMode);
+    float ulps = getAllowedUlpError(job->f, kfloat, relaxedMode);
     if (relaxedMode)
     {
         func = job->f->rfunc;

--- a/test_conformance/math_brute_force/unary_two_results_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_float.cpp
@@ -57,7 +57,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
 
     logFunctionInfo(f->name, sizeof(cl_float), relaxedMode);
 
-    float float_ulps = getAllowedUlpError(f, relaxedMode);
+    float float_ulps = getAllowedUlpError(f, kfloat, relaxedMode);
     // Init the kernels
     BuildKernelInfo build_info{ 1, kernels, programs, f->nameInCode,
                                 relaxedMode };

--- a/test_conformance/math_brute_force/utility.cpp
+++ b/test_conformance/math_brute_force/utility.cpp
@@ -15,6 +15,9 @@
 //
 
 #include "utility.h"
+
+#include <cassert>
+
 #include "function_list.h"
 
 #if defined(__PPC__)
@@ -161,32 +164,42 @@ void logFunctionInfo(const char *fname, unsigned int float_size,
     vlog("%15s %4s %4s", fname, fpSizeStr, fpFastRelaxedStr);
 }
 
-float getAllowedUlpError(const Func *f, const bool relaxed)
+float getAllowedUlpError(const Func *f, Type t, const bool relaxed)
 {
-    float ulp;
-
-    if (relaxed)
+    switch (t)
     {
-        if (gIsEmbedded)
-        {
-            ulp = f->relaxed_embedded_error;
-        }
-        else
-        {
-            ulp = f->relaxed_error;
-        }
+        case kfloat:
+            if (relaxed)
+            {
+                if (gIsEmbedded)
+                {
+                    return f->relaxed_embedded_error;
+                }
+                else
+                {
+                    return f->relaxed_error;
+                }
+            }
+            else
+            {
+                if (gIsEmbedded)
+                {
+                    return f->float_embedded_ulps;
+                }
+                else
+                {
+                    return f->float_ulps;
+                }
+            }
+        case kdouble:
+            // TODO: distinguish between embedded and full profile.
+            return f->double_ulps;
+        case khalf:
+            // TODO: distinguish between embedded and full profile.
+            return f->half_ulps;
+        default:
+            assert(false && "unsupported type in getAllowedUlpError");
+            // Return a negative value which will make any test fail.
+            return -1.f;
     }
-    else
-    {
-        if (gIsEmbedded)
-        {
-            ulp = f->float_embedded_ulps;
-        }
-        else
-        {
-            ulp = f->float_ulps;
-        }
-    }
-
-    return ulp;
 }

--- a/test_conformance/math_brute_force/utility.h
+++ b/test_conformance/math_brute_force/utility.h
@@ -257,7 +257,7 @@ int compareDoubles(double x, double y);
 void logFunctionInfo(const char *fname, unsigned int float_size,
                      unsigned int isFastRelaxed);
 
-float getAllowedUlpError(const Func *f, const bool relaxed);
+float getAllowedUlpError(const Func *f, Type t, const bool relaxed);
 
 inline cl_uint getTestScale(size_t typeSize)
 {


### PR DESCRIPTION
Add a type argument so that in the future we can request the ULP requirement for fp16 and fp64 types through `getAllowedUlpError` too.

Contributes to https://github.com/KhronosGroup/OpenCL-CTS/issues/867