### PR TITLE
bruteforce: Fixes comparisons with zero and reference math

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_half.cpp
@@ -304,7 +304,7 @@ int TestFunc_HalfI_Half_Half(const Func *f, MTdata d, bool relaxedMode)
                     // retry per section 6.5.3.2
                     if (IsHalfResultSubnormal(correct, half_ulps))
                     {
-                        fail = fail && !(test == 0.0f && iErr == 0);
+                        fail = fail && !((HTF(test) == 0.0f)  && iErr == 0);
                         if (!fail) err = 0.0f;
                     }
 


### PR DESCRIPTION
- test is an unsigned short, convert using HTF before comparison with 0.0f
- OpenCL s7.5.3 sign of zero is undefined when FTZ happens so modify to cover +0 and -0
- use f_fma for reference math