### PR TITLE
Add flag to track wether glut has been initialized

### DIFF
--- a/test_common/gl/setup_osx.cpp
+++ b/test_common/gl/setup_osx.cpp
@@ -19,21 +19,28 @@
 
 class OSXGLEnvironment : public GLEnvironment
 {
-    public:
-        OSXGLEnvironment()
-        {
-      mCGLContext = NULL;
-        }
+private:
+    bool mIsGlutInit;
+
+public:
+    OSXGLEnvironment()
+    {
+        mCGLContext = NULL;
+        mIsGlutInit = false;
+    }
 
   virtual int Init( int *argc, char **argv, int use_opengl_32 )
         {
       if (!use_opengl_32) {
-
-        // Create a GLUT window to render into
-        glutInit( argc, argv );
-        glutInitWindowSize( 512, 512 );
-        glutInitDisplayMode( GLUT_RGB | GLUT_DOUBLE );
-        glutCreateWindow( "OpenCL <-> OpenGL Test" );
+          if (!mIsGlutInit)
+          {
+              // Create a GLUT window to render into
+              glutInit(argc, argv);
+              glutInitWindowSize(512, 512);
+              glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE);
+              glutCreateWindow("OpenCL <-> OpenGL Test");
+              mIsGlutInit = true;
+          }
       }
 
       else {


### PR DESCRIPTION
I found an issue about CTS running gl / CL-GL interop case issue, I found glutInit double called in CTS CLGL test case code, which will lead to an error:

            freeglut (./test_gl): illegal glutInit() reinitialization attempt
root cause is in: test_conformance/gl/main.cpp:343

            if (glEnv->Init(&argc, (char **)argv, CL_TRUE))
the glEnv->Init has already called in same file line:260, the function glutInit in glEnv->Init can not be called twice, then a error will occur although all the gl / CLGL cases are passed. Then in the full quick CTS running it will appear:

            (12-Jul 03:54:01)     BEGIN  OpenCL-GL Sharing                       : 
           PASSED sub-test.
           PASSED 23 of 23 tests.
           (12-Jul 04:01:48)     FAILED OpenCL-GL Sharing                       : (467s, test  34/53)
Although all the gl/CLGL cases are passed, but this group test is judged to failed.

This issue already been found in https://github.com/KhronosGroup/OpenCL-CTS/pull/1885
And fixed partly by: https://github.com/KhronosGroup/OpenCL-CTS/commit/02471c8f56d75ef8e46c20a3dd00503faddf7a4e

But I found  in setup_osx.cpp, the glutInit still has double init issue, I add the same fix like previous fix,
can you please help to review?


