### PR TITLE
api: fix -Wformat warnings

### DIFF
--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#include <cinttypes>
+
 #include "testBase.h"
 #include "harness/testHarness.h"
 #include "harness/deviceInfo.h"
@@ -158,8 +160,9 @@ static int check_atomic_capabilities(cl_device_atomic_capabilities atomicCaps,
 {
     if ((atomicCaps & requiredCaps) != requiredCaps)
     {
-        log_error("Atomic capabilities %llx is missing support for at least "
-                  "one required capability %llx!\n",
+        log_error("Atomic capabilities %" PRIx64
+                  " is missing support for at least "
+                  "one required capability %" PRIx64 "!\n",
                   atomicCaps, requiredCaps);
         return TEST_FAIL;
     }

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -18,6 +18,7 @@
 #include "harness/testHarness.h"
 #include <ctype.h>
 #include <string.h>
+#include <cinttypes>
 
 const char *sample_single_param_kernel[] = {
     "__kernel void sample_test(__global int *src)\n"
@@ -227,13 +228,13 @@ int test_min_max_work_items_sizes(cl_device_id deviceID, cl_context context,
     {
         if (deviceMaxWorkItemSize[i] < 1)
         {
-            log_error("MAX_WORK_ITEM_SIZE in dimension %d is invalid: %lu\n", i,
+            log_error("MAX_WORK_ITEM_SIZE in dimension %d is invalid: %zu\n", i,
                       deviceMaxWorkItemSize[i]);
             errors++;
         }
         else
         {
-            log_info("Dimension %d has max work item size %lu\n", i,
+            log_info("Dimension %d has max work item size %zu\n", i,
                      deviceMaxWorkItemSize[i]);
         }
     }
@@ -257,7 +258,7 @@ int test_min_max_work_group_size(cl_device_id deviceID, cl_context context,
                             NULL);
     test_error(error, "Unable to get max work group size from device");
 
-    log_info("Reported %ld max device work group size.\n", deviceMaxThreadSize);
+    log_info("Reported %zu max device work group size.\n", deviceMaxThreadSize);
 
     if (deviceMaxThreadSize == 0)
     {
@@ -601,8 +602,9 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max allocation size of %lld bytes (%gMB) and global mem "
-             "size of %lld bytes (%gMB).\n",
+    log_info("Reported max allocation size of %" PRId64
+             " bytes (%gMB) and global mem "
+             "size of %" PRId64 " bytes (%gMB).\n",
              maxAllocSize, maxAllocSize / (1024.0 * 1024.0), memSize,
              memSize / (1024.0 * 1024.0));
 
@@ -611,14 +613,16 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
     while (currentSize >= maxAllocSize / MAX_REDUCTION_FACTOR)
     {
 
-        log_info("Trying to create a buffer of size of %lld bytes (%gMB).\n",
+        log_info("Trying to create a buffer of size of %" PRId64
+                 " bytes (%gMB).\n",
                  currentSize, (double)currentSize / (1024.0 * 1024.0));
         memHdl = clCreateBuffer(context, CL_MEM_READ_ONLY, (size_t)currentSize,
                                 NULL, &error);
         if (error == CL_MEM_OBJECT_ALLOCATION_FAILURE
             || error == CL_OUT_OF_RESOURCES || error == CL_OUT_OF_HOST_MEMORY)
         {
-            log_info("\tAllocation failed at size of %lld bytes (%gMB).\n",
+            log_info("\tAllocation failed at size of %" PRId64
+                     " bytes (%gMB).\n",
                      currentSize, (double)currentSize / (1024.0 * 1024.0));
             currentSize -= minSizeToTry;
             continue;
@@ -626,8 +630,8 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
         test_error(error, "clCreateBuffer failed for maximum sized buffer.");
         return 0;
     }
-    log_error("Failed to allocate even %lld bytes (%gMB).\n", currentSize,
-              (double)currentSize / (1024.0 * 1024.0));
+    log_error("Failed to allocate even %" PRId64 " bytes (%gMB).\n",
+              currentSize, (double)currentSize / (1024.0 * 1024.0));
     return -1;
 }
 
@@ -671,7 +675,7 @@ int test_min_max_image_2d_width(cl_device_id deviceID, cl_context context,
             (int)maxDimension);
         return -1;
     }
-    log_info("Max reported width is %ld.\n", maxDimension);
+    log_info("Max reported width is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -688,8 +692,8 @@ int test_min_max_image_2d_width(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -748,7 +752,7 @@ int test_min_max_image_2d_height(cl_device_id deviceID, cl_context context,
             (int)maxDimension);
         return -1;
     }
-    log_info("Max reported height is %ld.\n", maxDimension);
+    log_info("Max reported height is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -765,8 +769,8 @@ int test_min_max_image_2d_height(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -815,7 +819,7 @@ int test_min_max_image_3d_width(cl_device_id deviceID, cl_context context,
             (int)maxDimension);
         return -1;
     }
-    log_info("Max reported width is %ld.\n", maxDimension);
+    log_info("Max reported width is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -832,8 +836,8 @@ int test_min_max_image_3d_width(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 2 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 2 * 4, maxAllocSize);
         return -1;
     }
@@ -883,7 +887,7 @@ int test_min_max_image_3d_height(cl_device_id deviceID, cl_context context,
             (int)maxDimension);
         return -1;
     }
-    log_info("Max reported height is %ld.\n", maxDimension);
+    log_info("Max reported height is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -900,8 +904,8 @@ int test_min_max_image_3d_height(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 2 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 2 * 4, maxAllocSize);
         return -1;
     }
@@ -952,7 +956,7 @@ int test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context,
             (int)maxDimension);
         return -1;
     }
-    log_info("Max reported depth is %ld.\n", maxDimension);
+    log_info("Max reported depth is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -969,8 +973,8 @@ int test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -1019,7 +1023,7 @@ int test_min_max_image_array_size(cl_device_id deviceID, cl_context context,
                   (int)maxDimension);
         return -1;
     }
-    log_info("Max reported image array size is %ld.\n", maxDimension);
+    log_info("Max reported image array size is %zu.\n", maxDimension);
 
     /* Verify we can use the format */
     image_format_desc.image_channel_data_type = CL_UNORM_INT8;
@@ -1037,8 +1041,8 @@ int test_min_max_image_array_size(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %lld "
-                  "bytes, max allowed: %lld bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRId64
+                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -1091,7 +1095,7 @@ int test_min_max_image_buffer_size(cl_device_id deviceID, cl_context context,
                   (int)maxDimensionPixels);
         return -1;
     }
-    log_info("Max reported image buffer size is %ld pixels.\n",
+    log_info("Max reported image buffer size is %zu pixels.\n",
              maxDimensionPixels);
 
     pixelBytes = maxAllocSize / maxDimensionPixels;
@@ -1209,7 +1213,7 @@ int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
         {
             log_info(
                 "Trying a kernel with %ld int arguments (%ld bytes) and one "
-                "cl_mem (%ld bytes) for %ld bytes total.\n",
+                "cl_mem (%zu bytes) for %ld bytes total.\n",
                 numberOfIntParametersToTry,
                 sizeof(cl_int) * numberOfIntParametersToTry, sizeof(cl_mem),
                 sizeof(cl_mem) + numberOfIntParametersToTry * sizeof(cl_int));
@@ -1218,7 +1222,7 @@ int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
         {
             log_info(
                 "Trying a kernel with %ld long arguments (%ld bytes) and one "
-                "cl_mem (%ld bytes) for %ld bytes total.\n",
+                "cl_mem (%zu bytes) for %ld bytes total.\n",
                 numberOfIntParametersToTry,
                 sizeof(cl_long) * numberOfIntParametersToTry, sizeof(cl_mem),
                 sizeof(cl_mem) + numberOfIntParametersToTry * sizeof(cl_long));
@@ -1365,8 +1369,8 @@ int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
         {
             if (long_result != expectedResult)
             {
-                log_error("Expected result (%lld) does not equal actual result "
-                          "(%lld).\n",
+                log_error("Expected result (%" PRId64
+                          ") does not equal actual result (%" PRId64 ").\n",
                           expectedResult, long_result);
                 numberOfIntParametersToTry -= decrement;
                 continue;
@@ -1383,8 +1387,8 @@ int test_min_max_parameter_size(cl_device_id deviceID, cl_context context,
         {
             if (int_result != expectedResult)
             {
-                log_error("Expected result (%lld) does not equal actual result "
-                          "(%d).\n",
+                log_error("Expected result (%" PRId64
+                          ") does not equal actual result (%d).\n",
                           expectedResult, int_result);
                 numberOfIntParametersToTry -= decrement;
                 continue;
@@ -1555,7 +1559,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max constant buffer size of %lld bytes.\n", maxSize);
+    log_info("Reported max constant buffer size of %" PRId64 " bytes.\n",
+             maxSize);
 
     /* We have four buffers allocations */
     maxGlobalSize = get_device_info_global_mem_size(
@@ -1583,7 +1588,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
     d = init_genrand(gRandomSeed);
     while (!allocPassed && currentSize >= maxSize / MAX_REDUCTION_FACTOR)
     {
-        log_info("Attempting to allocate constant buffer of size %lld bytes\n",
+        log_info("Attempting to allocate constant buffer of size %" PRId64
+                 " bytes\n",
                  maxSize);
 
         /* Create some I/O streams */
@@ -1631,8 +1637,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
             || (error == CL_MEM_OBJECT_ALLOCATION_FAILURE)
             || (error == CL_OUT_OF_HOST_MEMORY))
         {
-            log_info("Kernel enqueue failed at size %lld, trying at a reduced "
-                     "size.\n",
+            log_info("Kernel enqueue failed at size %" PRId64
+                     ", trying at a reduced size.\n",
                      currentSize);
             currentSize -= stepSize;
             free(constantData);
@@ -1657,8 +1663,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
                 || (event_status == CL_MEM_OBJECT_ALLOCATION_FAILURE)
                 || (event_status == CL_OUT_OF_HOST_MEMORY))
             {
-                log_info("Kernel event indicates failure at size %lld, trying "
-                         "at a reduced size.\n",
+                log_info("Kernel event indicates failure at size %" PRId64
+                         ", trying at a reduced size.\n",
                          currentSize);
                 currentSize -= stepSize;
                 free(constantData);
@@ -1715,7 +1721,8 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         }
         else if (currentSize != maxSize)
         {
-            log_info("Passed at reduced size. (%lld of %lld bytes)\n",
+            log_info("Passed at reduced size. (%" PRId64 " of %" PRId64
+                     " bytes)\n",
                      currentSize, maxSize);
             return 0;
         }
@@ -1778,11 +1785,11 @@ int test_min_max_constant_args(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     individualBufferSize = ((int)maxSize / 2) / maxArgs;
 
-    log_info(
-        "Reported max constant arg count of %u and max constant buffer "
-        "size of %llu. Test will attempt to allocate half of that, or %llu "
-        "buffers of size %zu.\n",
-        maxArgs, maxSize, maxArgs, individualBufferSize);
+    log_info("Reported max constant arg count of %u and max constant buffer "
+             "size of %" PRIu64
+             ". Test will attempt to allocate half of that, or %u "
+             "buffers of size %zu.\n",
+             maxArgs, maxSize, maxArgs, individualBufferSize);
 
     str2 = (char *)malloc(sizeof(char) * 32 * (maxArgs + 2));
     constArgs = (char *)malloc(sizeof(char) * 32 * (maxArgs + 2));
@@ -2034,7 +2041,7 @@ int test_min_max_local_mem_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max local buffer size for device: %lld bytes.\n",
+    log_info("Reported max local buffer size for device: %" PRId64 " bytes.\n",
              maxSize);
 
     /* Create a kernel to test with */
@@ -2052,7 +2059,7 @@ int test_min_max_local_mem_size(cl_device_id deviceID, cl_context context,
                "clGetKernelWorkGroupInfo for CL_KERNEL_LOCAL_MEM_SIZE failed");
 
     log_info("Reported local buffer usage for kernel "
-             "(CL_KERNEL_LOCAL_MEM_SIZE): %lld bytes.\n",
+             "(CL_KERNEL_LOCAL_MEM_SIZE): %" PRId64 " bytes.\n",
              kernelLocalUsage);
 
     /* Create some I/O streams */
@@ -2167,13 +2174,13 @@ int test_min_max_kernel_preferred_work_group_size_multiple(
 
     // Since the preferred size is only a performance hint, we can only really
     // check that we get a sane value back
-    log_info("size: %ld     preferred: %ld      max: %ld\n", max_workgroup_size,
+    log_info("size: %zu     preferred: %zu      max: %zu\n", max_workgroup_size,
              preferred_workgroup_size, max_local_workgroup_size[0]);
 
     if (preferred_workgroup_size > max_workgroup_size)
     {
         log_error("ERROR: Reported preferred workgroup multiple larger than "
-                  "max workgroup size (preferred %ld, max %ld)\n",
+                  "max workgroup size (preferred %zu, max %zu)\n",
                   preferred_workgroup_size, max_workgroup_size);
         return -1;
     }

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -602,9 +602,9 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max allocation size of %" PRId64
+    log_info("Reported max allocation size of %" PRIu64
              " bytes (%gMB) and global mem "
-             "size of %" PRId64 " bytes (%gMB).\n",
+             "size of %" PRIu64 " bytes (%gMB).\n",
              maxAllocSize, maxAllocSize / (1024.0 * 1024.0), memSize,
              memSize / (1024.0 * 1024.0));
 
@@ -613,7 +613,7 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
     while (currentSize >= maxAllocSize / MAX_REDUCTION_FACTOR)
     {
 
-        log_info("Trying to create a buffer of size of %" PRId64
+        log_info("Trying to create a buffer of size of %" PRIu64
                  " bytes (%gMB).\n",
                  currentSize, (double)currentSize / (1024.0 * 1024.0));
         memHdl = clCreateBuffer(context, CL_MEM_READ_ONLY, (size_t)currentSize,
@@ -621,7 +621,7 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
         if (error == CL_MEM_OBJECT_ALLOCATION_FAILURE
             || error == CL_OUT_OF_RESOURCES || error == CL_OUT_OF_HOST_MEMORY)
         {
-            log_info("\tAllocation failed at size of %" PRId64
+            log_info("\tAllocation failed at size of %" PRIu64
                      " bytes (%gMB).\n",
                      currentSize, (double)currentSize / (1024.0 * 1024.0));
             currentSize -= minSizeToTry;
@@ -630,7 +630,7 @@ int test_min_max_mem_alloc_size(cl_device_id deviceID, cl_context context,
         test_error(error, "clCreateBuffer failed for maximum sized buffer.");
         return 0;
     }
-    log_error("Failed to allocate even %" PRId64 " bytes (%gMB).\n",
+    log_error("Failed to allocate even %" PRIu64 " bytes (%gMB).\n",
               currentSize, (double)currentSize / (1024.0 * 1024.0));
     return -1;
 }
@@ -692,8 +692,8 @@ int test_min_max_image_2d_width(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -769,8 +769,8 @@ int test_min_max_image_2d_height(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -836,8 +836,8 @@ int test_min_max_image_3d_width(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 2 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 2 * 4, maxAllocSize);
         return -1;
     }
@@ -904,8 +904,8 @@ int test_min_max_image_3d_height(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 2 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 2 * 4, maxAllocSize);
         return -1;
     }
@@ -973,8 +973,8 @@ int test_min_max_image_3d_depth(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -1041,8 +1041,8 @@ int test_min_max_image_array_size(cl_device_id deviceID, cl_context context,
         deviceID, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
     if ((cl_ulong)maxDimension * 1 * 4 > maxAllocSize)
     {
-        log_error("Can not allocate a large enough image (min size: %" PRId64
-                  " bytes, max allowed: %" PRId64 " bytes) to test.\n",
+        log_error("Can not allocate a large enough image (min size: %" PRIu64
+                  " bytes, max allowed: %" PRIu64 " bytes) to test.\n",
                   (cl_ulong)maxDimension * 1 * 4, maxAllocSize);
         return -1;
     }
@@ -1559,7 +1559,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max constant buffer size of %" PRId64 " bytes.\n",
+    log_info("Reported max constant buffer size of %" PRIu64 " bytes.\n",
              maxSize);
 
     /* We have four buffers allocations */
@@ -1588,7 +1588,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
     d = init_genrand(gRandomSeed);
     while (!allocPassed && currentSize >= maxSize / MAX_REDUCTION_FACTOR)
     {
-        log_info("Attempting to allocate constant buffer of size %" PRId64
+        log_info("Attempting to allocate constant buffer of size %" PRIu64
                  " bytes\n",
                  maxSize);
 
@@ -1637,7 +1637,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
             || (error == CL_MEM_OBJECT_ALLOCATION_FAILURE)
             || (error == CL_OUT_OF_HOST_MEMORY))
         {
-            log_info("Kernel enqueue failed at size %" PRId64
+            log_info("Kernel enqueue failed at size %" PRIu64
                      ", trying at a reduced size.\n",
                      currentSize);
             currentSize -= stepSize;
@@ -1663,7 +1663,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
                 || (event_status == CL_MEM_OBJECT_ALLOCATION_FAILURE)
                 || (event_status == CL_OUT_OF_HOST_MEMORY))
             {
-                log_info("Kernel event indicates failure at size %" PRId64
+                log_info("Kernel event indicates failure at size %" PRIu64
                          ", trying at a reduced size.\n",
                          currentSize);
                 currentSize -= stepSize;
@@ -1721,7 +1721,7 @@ int test_min_max_constant_buffer_size(cl_device_id deviceID, cl_context context,
         }
         else if (currentSize != maxSize)
         {
-            log_info("Passed at reduced size. (%" PRId64 " of %" PRId64
+            log_info("Passed at reduced size. (%" PRIu64 " of %" PRIu64
                      " bytes)\n",
                      currentSize, maxSize);
             return 0;
@@ -2041,7 +2041,7 @@ int test_min_max_local_mem_size(cl_device_id deviceID, cl_context context,
         return -1;
     }
 
-    log_info("Reported max local buffer size for device: %" PRId64 " bytes.\n",
+    log_info("Reported max local buffer size for device: %" PRIu64 " bytes.\n",
              maxSize);
 
     /* Create a kernel to test with */
@@ -2059,7 +2059,7 @@ int test_min_max_local_mem_size(cl_device_id deviceID, cl_context context,
                "clGetKernelWorkGroupInfo for CL_KERNEL_LOCAL_MEM_SIZE failed");
 
     log_info("Reported local buffer usage for kernel "
-             "(CL_KERNEL_LOCAL_MEM_SIZE): %" PRId64 " bytes.\n",
+             "(CL_KERNEL_LOCAL_MEM_SIZE): %" PRIu64 " bytes.\n",
              kernelLocalUsage);
 
     /* Create some I/O streams */

--- a/test_conformance/api/test_mem_object_info.cpp
+++ b/test_conformance/api/test_mem_object_info.cpp
@@ -18,21 +18,24 @@
 #include "harness/testHarness.h"
 
 
-#define TEST_MEM_OBJECT_PARAM( mem, paramName, val, expected, name, type, cast )    \
-error = clGetMemObjectInfo( mem, paramName, sizeof( val ), &val, &size );   \
-test_error( error, "Unable to get mem object " name );  \
-if( val != expected )   \
-{   \
-log_error( "ERROR: Mem object " name " did not validate! (expected " type ", got " type " from %s:%d)\n",   \
-expected, (cast)val, __FILE__, __LINE__ );   \
-return -1;  \
-}   \
-if( size != sizeof( val ) ) \
-{   \
-log_error( "ERROR: Returned size of mem object " name " does not validate! (expected %d, got %d from %s:%d)\n", \
-(int)sizeof( val ), (int)size , __FILE__, __LINE__ );   \
-return -1;  \
-}
+#define TEST_MEM_OBJECT_PARAM(mem, paramName, val, expected, name, type, cast) \
+    error = clGetMemObjectInfo(mem, paramName, sizeof(val), &val, &size);      \
+    test_error(error, "Unable to get mem object " name);                       \
+    if (val != expected)                                                       \
+    {                                                                          \
+        log_error("ERROR: Mem object " name                                    \
+                  " did not validate! (expected " type ", got " type           \
+                  " from %s:%d)\n",                                            \
+                  (cast)expected, (cast)val, __FILE__, __LINE__);              \
+        return -1;                                                             \
+    }                                                                          \
+    if (size != sizeof(val))                                                   \
+    {                                                                          \
+        log_error("ERROR: Returned size of mem object " name                   \
+                  " does not validate! (expected %d, got %d from %s:%d)\n",    \
+                  (int)sizeof(val), (int)size, __FILE__, __LINE__);            \
+        return -1;                                                             \
+    }
 
 static void CL_CALLBACK mem_obj_destructor_callback( cl_mem, void * data )
 {
@@ -236,7 +239,8 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
         TEST_MEM_OBJECT_PARAM( bufferObject, CL_MEM_FLAGS, flags, (unsigned int)bufferFlags[ i ], "flags", "%d", unsigned int )
 
         size_t sz;
-        TEST_MEM_OBJECT_PARAM( bufferObject, CL_MEM_SIZE, sz, (size_t)( addressAlign * 4 ), "size", "%ld", size_t )
+        TEST_MEM_OBJECT_PARAM(bufferObject, CL_MEM_SIZE, sz,
+                              (size_t)(addressAlign * 4), "size", "%zu", size_t)
 
         cl_uint mapCount;
         error = clGetMemObjectInfo( bufferObject, CL_MEM_MAP_COUNT, sizeof( mapCount ), &mapCount, &size );
@@ -265,7 +269,8 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
         TEST_MEM_OBJECT_PARAM( bufferObject, CL_MEM_ASSOCIATED_MEMOBJECT, origObj, (void *)NULL, "associated mem object", "%p", void * )
 
         size_t offset;
-        TEST_MEM_OBJECT_PARAM( bufferObject, CL_MEM_OFFSET, offset, 0L, "offset", "%ld", size_t )
+        TEST_MEM_OBJECT_PARAM(bufferObject, CL_MEM_OFFSET, offset, size_t(0),
+                              "offset", "%zu", size_t)
 
         cl_buffer_region region;
         region.origin = addressAlign;
@@ -321,7 +326,8 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
             }
             TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_FLAGS, flags, (unsigned int)inheritedFlags, "flags", "%d", unsigned int )
 
-            TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_SIZE, sz, (size_t)( addressAlign ), "size", "%ld", size_t )
+            TEST_MEM_OBJECT_PARAM(subBufferObject, CL_MEM_SIZE, sz,
+                                  (size_t)(addressAlign), "size", "%zu", size_t)
 
             if ( bufferFlags[ i ] & CL_MEM_USE_HOST_PTR )
             {
@@ -356,7 +362,9 @@ int test_get_buffer_info( cl_device_id deviceID, cl_context context, cl_command_
 
             TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_ASSOCIATED_MEMOBJECT, origObj, (cl_mem)bufferObject, "associated mem object", "%p", void * )
 
-            TEST_MEM_OBJECT_PARAM( subBufferObject, CL_MEM_OFFSET, offset, (size_t)( addressAlign ), "offset", "%ld", size_t )
+            TEST_MEM_OBJECT_PARAM(subBufferObject, CL_MEM_OFFSET, offset,
+                                  (size_t)(addressAlign), "offset", "%zu",
+                                  size_t)
         }
     }
 
@@ -405,7 +413,8 @@ int test_get_imageObject_info( cl_mem * image, cl_mem_flags objectFlags, cl_imag
 
     TEST_MEM_OBJECT_PARAM( *image, CL_MEM_CONTEXT, otherCtx, context, "context", "%p", cl_context )
 
-    TEST_MEM_OBJECT_PARAM( *image, CL_MEM_OFFSET, offset, 0L, "offset", "%ld", size_t )
+    TEST_MEM_OBJECT_PARAM(*image, CL_MEM_OFFSET, offset, size_t(0), "offset",
+                          "%zu", size_t)
 
     return CL_SUCCESS;
 }

--- a/test_conformance/api/test_mem_object_properties_queries.cpp
+++ b/test_conformance/api/test_mem_object_properties_queries.cpp
@@ -165,7 +165,7 @@ static int create_object_and_check_properties(cl_context context,
     }
     if (set_size != test_case.properties.size() * sizeof(cl_mem_properties))
     {
-        log_error("ERROR: CL_MEM_PROPERTIES size is %d, expected %d.\n",
+        log_error("ERROR: CL_MEM_PROPERTIES size is %zu, expected %zu.\n",
                   set_size,
                   test_case.properties.size() * sizeof(cl_queue_properties));
         return TEST_FAIL;

--- a/test_conformance/api/test_pipe_properties_queries.cpp
+++ b/test_conformance/api/test_pipe_properties_queries.cpp
@@ -60,7 +60,7 @@ static int create_pipe_and_check_array_properties(
     }
     if (set_size != test_case.properties.size() * sizeof(cl_pipe_properties))
     {
-        log_error("ERROR: CL_PIPE_PROPERTIES size is %d, expected %d.\n",
+        log_error("ERROR: CL_PIPE_PROPERTIES size is %zu, expected %zu.\n",
                   set_size,
                   test_case.properties.size() * sizeof(cl_pipe_properties));
         return TEST_FAIL;

--- a/test_conformance/api/test_platform.cpp
+++ b/test_conformance/api/test_platform.cpp
@@ -189,8 +189,10 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
     test_error(err, "clGetPlatformInfo for CL_PLATFORM_PROFILE failed");
     log_info("\tCL_PLATFORM_PROFILE: %s\n", string_returned);
     if (strlen(string_returned)+1 != size) {
-      log_error("Returned string length %ld does not equal reported one %ld.\n", strlen(string_returned)+1, size);
-      total_errors++;
+        log_error(
+            "Returned string length %zu does not equal reported one %zu.\n",
+            strlen(string_returned) + 1, size);
+        total_errors++;
     }
 
     memset(string_returned, 0, 8192);
@@ -198,8 +200,10 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
     test_error(err, "clGetPlatformInfo for CL_PLATFORM_VERSION failed");
     log_info("\tCL_PLATFORM_VERSION: %s\n", string_returned);
     if (strlen(string_returned)+1 != size) {
-      log_error("Returned string length %ld does not equal reported one %ld.\n", strlen(string_returned)+1, size);
-      total_errors++;
+        log_error(
+            "Returned string length %zu does not equal reported one %zu.\n",
+            strlen(string_returned) + 1, size);
+        total_errors++;
     }
 
     memset(string_returned, 0, 8192);
@@ -207,8 +211,10 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
     test_error(err, "clGetPlatformInfo for CL_PLATFORM_NAME failed");
     log_info("\tCL_PLATFORM_NAME: %s\n", string_returned);
     if (strlen(string_returned)+1 != size) {
-      log_error("Returned string length %ld does not equal reported one %ld.\n", strlen(string_returned)+1, size);
-      total_errors++;
+        log_error(
+            "Returned string length %zu does not equal reported one %zu.\n",
+            strlen(string_returned) + 1, size);
+        total_errors++;
     }
 
     memset(string_returned, 0, 8192);
@@ -216,8 +222,10 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
     test_error(err, "clGetPlatformInfo for CL_PLATFORM_VENDOR failed");
     log_info("\tCL_PLATFORM_VENDOR: %s\n", string_returned);
     if (strlen(string_returned)+1 != size) {
-      log_error("Returned string length %ld does not equal reported one %ld.\n", strlen(string_returned)+1, size);
-      total_errors++;
+        log_error(
+            "Returned string length %zu does not equal reported one %zu.\n",
+            strlen(string_returned) + 1, size);
+        total_errors++;
     }
 
     memset(string_returned, 0, 8192);
@@ -225,8 +233,10 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
     test_error(err, "clGetPlatformInfo for CL_PLATFORM_EXTENSIONS failed");
     log_info("\tCL_PLATFORM_EXTENSIONS: %s\n", string_returned);
     if (strlen(string_returned)+1 != size) {
-      log_error("Returned string length %ld does not equal reported one %ld.\n", strlen(string_returned)+1, size);
-      total_errors++;
+        log_error(
+            "Returned string length %zu does not equal reported one %zu.\n",
+            strlen(string_returned) + 1, size);
+        total_errors++;
     }
 
     err = clGetDeviceIDs(platforms[p], CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
@@ -258,8 +268,8 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
         test_error(err, "clGetDeviceInfo failed for CL_DEVICE_PLATFORM\n");
         if (returned_size != sizeof(cl_platform_id))
         {
-            log_error("Reported return size (%ld) does not match expected size "
-                      "(%ld).\n",
+            log_error("Reported return size (%zu) does not match expected size "
+                      "(%zu).\n",
                       returned_size, sizeof(cl_platform_id));
             total_errors++;
         }
@@ -288,7 +298,7 @@ int test_get_platform_ids(cl_device_id deviceID, cl_context context, cl_command_
         if (returned_size != sizeof(cl_context_properties) * 3)
         {
             log_error("Invalid size returned from clGetContextInfo for "
-                      "CL_CONTEXT_PROPERTIES. Got %ld, expected %ld.\n",
+                      "CL_CONTEXT_PROPERTIES. Got %zu, expected %zu.\n",
                       returned_size, sizeof(cl_context_properties) * 3);
             total_errors++;
         }

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <algorithm>
+#include <cinttypes>
 #include <vector>
 
 int test_get_platform_info(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements)
@@ -237,7 +238,7 @@ int test_sampler_params(cl_device_id deviceID, cl_context context,
             if (set_size != 0)
             {
                 log_error(
-                    "ERROR: CL_SAMPLER_PROPERTIES size is %d, expected 0\n",
+                    "ERROR: CL_SAMPLER_PROPERTIES size is %zu, expected 0\n",
                     set_size);
                 return TEST_FAIL;
             }
@@ -248,7 +249,7 @@ int test_sampler_params(cl_device_id deviceID, cl_context context,
                 != test_properties.size() * sizeof(cl_sampler_properties))
             {
                 log_error(
-                    "ERROR: CL_SAMPLER_PROPERTIES size is %d, expected %d.\n",
+                    "ERROR: CL_SAMPLER_PROPERTIES size is %zu, expected %zu.\n",
                     set_size,
                     test_properties.size() * sizeof(cl_sampler_properties));
                 return TEST_FAIL;
@@ -380,7 +381,8 @@ int check_get_command_queue_info_params(cl_device_id deviceID,
         clGetDeviceInfo(deviceID, host_queue_query, sizeof(host_queue_props),
                         &host_queue_props, NULL);
     test_error(error, "clGetDeviceInfo failed");
-    log_info("CL_DEVICE_QUEUE_ON_HOST_PROPERTIES is %d\n", host_queue_props);
+    log_info("CL_DEVICE_QUEUE_ON_HOST_PROPERTIES is %" PRId64 "\n",
+             host_queue_props);
 
     cl_queue_properties device_queue_props = 0;
     if (version >= Version(2, 0))
@@ -389,7 +391,7 @@ int check_get_command_queue_info_params(cl_device_id deviceID,
                                 sizeof(device_queue_props), &device_queue_props,
                                 NULL);
         test_error(error, "clGetDeviceInfo failed");
-        log_info("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES is %d\n",
+        log_info("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES is %" PRId64 "\n",
                  device_queue_props);
     }
 

--- a/test_conformance/api/test_queries.cpp
+++ b/test_conformance/api/test_queries.cpp
@@ -381,7 +381,7 @@ int check_get_command_queue_info_params(cl_device_id deviceID,
         clGetDeviceInfo(deviceID, host_queue_query, sizeof(host_queue_props),
                         &host_queue_props, NULL);
     test_error(error, "clGetDeviceInfo failed");
-    log_info("CL_DEVICE_QUEUE_ON_HOST_PROPERTIES is %" PRId64 "\n",
+    log_info("CL_DEVICE_QUEUE_ON_HOST_PROPERTIES is %" PRIu64 "\n",
              host_queue_props);
 
     cl_queue_properties device_queue_props = 0;
@@ -391,7 +391,7 @@ int check_get_command_queue_info_params(cl_device_id deviceID,
                                 sizeof(device_queue_props), &device_queue_props,
                                 NULL);
         test_error(error, "clGetDeviceInfo failed");
-        log_info("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES is %" PRId64 "\n",
+        log_info("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES is %" PRIu64 "\n",
                  device_queue_props);
     }
 

--- a/test_conformance/api/test_queue_properties_queries.cpp
+++ b/test_conformance/api/test_queue_properties_queries.cpp
@@ -142,9 +142,10 @@ static int create_queue_and_check_array_properties(
     }
     if (set_size != test_case.properties.size() * sizeof(cl_queue_properties))
     {
-        log_error("ERROR: CL_QUEUE_PROPERTIES_ARRAY size is %d, expected %d.\n",
-                  set_size,
-                  test_case.properties.size() * sizeof(cl_queue_properties));
+        log_error(
+            "ERROR: CL_QUEUE_PROPERTIES_ARRAY size is %zu, expected %zu.\n",
+            set_size,
+            test_case.properties.size() * sizeof(cl_queue_properties));
         return TEST_FAIL;
     }
 


### PR DESCRIPTION
The main sources of warnings were:

 * Printing of a `size_t` which requires the `%zu` specifier.

 * Printing of `cl_long`/`cl_ulong` which is now done using the `PRI*64` macros to ensure portability across 32 and 64-bit builds.