### PR TITLE
Fix snorm

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -488,7 +488,9 @@ size_t compare_scanlines(const image_descriptor *imageInfo, const char *aPtr,
                 cl_uchar aPixel = *(cl_uchar *)aPtr;
                 cl_uchar bPixel = *(cl_uchar *)bPtr;
                 // -1.0 is defined as 0x80 and 0x81
-                if ((aPixel != bPixel) && ((aPixel | bPixel) != 0x81))
+                aPixel = (aPixel == 0x80) ? 0x81 : aPixel;
+                bPixel = (bPixel == 0x80) ? 0x81 : bPixel;
+                if (aPixel != bPixel)
                 {
                     return column;
                 }

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -501,9 +501,9 @@ size_t compare_scanlines(const image_descriptor *imageInfo, const char *aPtr,
                 cl_ushort aPixel = *(cl_ushort *)aPtr;
                 cl_ushort bPixel = *(cl_ushort *)bPtr;
                 // -1.0 is defined as 0x8000 and 0x8001
-                aPixel = aPixel == 0x8000 ? 0x8001 : aPixel;
-                bPixel = bPixel == 0x8000 ? 0x8001 : bPixel;
-                if ((aPixel != bPixel))
+                aPixel = (aPixel == 0x8000) ? 0x8001 : aPixel;
+                bPixel = (bPixel == 0x8000) ? 0x8001 : bPixel;
+                if (aPixel != bPixel)
                 {
                     return column;
                 }

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -496,8 +496,8 @@ size_t compare_scanlines(const image_descriptor *imageInfo, const char *aPtr,
             break;
 
             case CL_SNORM_INT16: {
-                cl_short aPixel = *(cl_short *)aPtr;
-                cl_short bPixel = *(cl_short *)bPtr;
+                cl_ushort aPixel = *(cl_ushort *)aPtr;
+                cl_ushort bPixel = *(cl_ushort *)bPtr;
                 // -1.0 is defined as 0x8000 and 0x8001
                 if ((aPixel != bPixel) && ((aPixel | bPixel) != 0x8001))
                 {

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -499,7 +499,9 @@ size_t compare_scanlines(const image_descriptor *imageInfo, const char *aPtr,
                 cl_ushort aPixel = *(cl_ushort *)aPtr;
                 cl_ushort bPixel = *(cl_ushort *)bPtr;
                 // -1.0 is defined as 0x8000 and 0x8001
-                if ((aPixel != bPixel) && ((aPixel | bPixel) != 0x8001))
+                aPixel = aPixel == 0x8000 ? 0x8001 : aPixel;
+                bPixel = bPixel == 0x8000 ? 0x8001 : bPixel;
+                if ((aPixel != bPixel))
                 {
                     return column;
                 }

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -484,6 +484,28 @@ size_t compare_scanlines(const image_descriptor *imageInfo, const char *aPtr,
             }
             break;
 
+            case CL_SNORM_INT8: {
+                cl_uchar aPixel = *(cl_uchar *)aPtr;
+                cl_uchar bPixel = *(cl_uchar *)bPtr;
+                // -1.0 is defined as 0x80 and 0x81
+                if ((aPixel != bPixel) && ((aPixel | bPixel) != 0x81))
+                {
+                    return column;
+                }
+            }
+            break;
+
+            case CL_SNORM_INT16: {
+                cl_short aPixel = *(cl_short *)aPtr;
+                cl_short bPixel = *(cl_short *)bPtr;
+                // -1.0 is defined as 0x8000 and 0x8001
+                if ((aPixel != bPixel) && ((aPixel | bPixel) != 0x8001))
+                {
+                    return column;
+                }
+            }
+            break;
+
             default:
                 if (memcmp(aPtr, bPtr, pixel_size) != 0) return column;
                 break;


### PR DESCRIPTION
When comparing scanlines for SNORM images, take into account that -1.0 can be exactly represented in two different ways.