### PR TITLE
printf: add missing vector length modifiers

### DIFF
--- a/test_conformance/printf/util_printf.cpp
+++ b/test_conformance/printf/util_printf.cpp
@@ -951,18 +951,18 @@ std::vector<printDataGenParameters> printVectorGenParameters = {
 
     // Three component vector in scientific notation
 
-    { { "" }, "(1234.25f,987654.5f,0.0005f)", "%.2", "e", "float", "3" },
+    { { "" }, "(1234.25f,987654.5f,0.0005f)", "%.2", "hle", "float", "3" },
 
     // Four component vector in hexadecimal floating point, lowercase format
 
-    { { "" }, "(0.25f,0.5f,1.f,1.5f)", "%", "a", "float", "4" },
+    { { "" }, "(0.25f,0.5f,1.f,1.5f)", "%", "hla", "float", "4" },
 
     // Eight component vector in the shortest float representation
 
     { { "" },
       "(1.f,2.f,3.f,4.f,1.5f,3.14f,2.5f,3.5f)",
       "%",
-      "g",
+      "hlg",
       "float",
       "8" },
 
@@ -971,17 +971,17 @@ std::vector<printDataGenParameters> printVectorGenParameters = {
     { { "" },
       "(1,2,3,4,5,6,7,8,9,0,32,64,128,256,512,1024)",
       "%",
-      "o",
+      "hlo",
       "uint",
       "16" },
 
     // Eight component vector in signed decimal integer format
 
-    { { "" }, "(1,-2,3,-4,5,-6,7,-8)", "%+", "i", "int", "8" },
+    { { "" }, "(1,-2,3,-4,5,-6,7,-8)", "%+", "hli", "int", "8" },
 
     // Four component vector in unsigned decimal integer format
 
-    { { "" }, "(512,1024,262144,1048576)", "%05", "u", "uint", "4" },
+    { { "" }, "(512,1024,262144,1048576)", "%05", "hlu", "uint", "4" },
 
 };
 


### PR DESCRIPTION
The length modifier is required with a vector specifier.

Fixes https://github.com/KhronosGroup/OpenCL-CTS/issues/2039