### PR TITLE
Fix external semaphore test when exportability is not supported

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -376,8 +376,10 @@ int test_external_semaphores_simple_1(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalSemaphore *raw_sema_ext = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext, vkVk2CLSemaphore, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext(raw_sema_ext);
 
         cl_int err = CL_SUCCESS;
 
@@ -388,13 +390,13 @@ int test_external_semaphores_simple_1(cl_device_id deviceID, cl_context context,
 
         // Signal semaphore
         clEventWrapper signal_event;
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                            nullptr, 0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore
         clEventWrapper wait_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                          nullptr, 0, nullptr, &wait_event);
         test_error(err, "Could not wait semaphore");
 
@@ -452,8 +454,10 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalSemaphore *raw_sema_ext = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext, vkVk2CLSemaphore, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext(raw_sema_ext);
 
         cl_int err = CL_SUCCESS;
 
@@ -480,13 +484,13 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
 
         // Signal semaphore
         clEventWrapper signal_event;
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                            nullptr, 0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore
         clEventWrapper wait_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                          nullptr, 0, nullptr, &wait_event);
         test_error(err, "Could not wait semaphore");
 
@@ -558,8 +562,10 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalSemaphore *raw_sema_ext = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext, vkVk2CLSemaphore, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext(raw_sema_ext);
 
         cl_int err = CL_SUCCESS;
 
@@ -585,7 +591,7 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         test_error(err, "Unable to enqueue task_1");
 
         // Signal semaphore (dependency on task_1)
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                            nullptr, 1, &task_events[0],
                                            &signal_events[0]);
         test_error(err, "Could not signal semaphore");
@@ -596,7 +602,7 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         {
             // Wait semaphore
             err = clEnqueueWaitSemaphoresKHR(
-                queue, 1, &sema_ext.getCLSemaphore(), nullptr, 0, nullptr,
+                queue, 1, &sema_ext->getCLSemaphore(), nullptr, 0, nullptr,
                 &wait_events[loop - 1]);
             test_error(err, "Could not wait semaphore");
 
@@ -611,13 +617,13 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
 
             // Signal semaphore (dependency on task_loop)
             err = clEnqueueSignalSemaphoresKHR(
-                queue, 1, &sema_ext.getCLSemaphore(), nullptr, 1,
+                queue, 1, &sema_ext->getCLSemaphore(), nullptr, 1,
                 &task_events[loop], &signal_events[loop]);
             test_error(err, "Could not signal semaphore");
         }
 
         // Wait semaphore
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
                                          nullptr, 0, nullptr,
                                          &wait_events[loop - 1]);
         test_error(err, "Could not wait semaphore");
@@ -681,21 +687,23 @@ static int external_semaphore_cross_queue_helper(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
+        clExternalSemaphore *raw_sema_ext = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext, vkVk2CLSemaphore, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext(raw_sema_ext);
 
         cl_int err = CL_SUCCESS;
 
         // Signal semaphore on queue_1
         clEventWrapper signal_event;
         err =
-            clEnqueueSignalSemaphoresKHR(queue_1, 1, &sema_ext.getCLSemaphore(),
+            clEnqueueSignalSemaphoresKHR(queue_1, 1, &sema_ext->getCLSemaphore(),
                                          nullptr, 0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore on queue_2
         clEventWrapper wait_event;
-        err = clEnqueueWaitSemaphoresKHR(queue_2, 1, &sema_ext.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue_2, 1, &sema_ext->getCLSemaphore(),
                                          nullptr, 0, nullptr, &wait_event);
         test_error(err, "Could not wait semaphore");
 
@@ -807,11 +815,15 @@ int test_external_semaphores_cross_queues_io2(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore(vkDevice,
                                          vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext_1(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceID);
-        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore, context2,
-                                                 vkExternalSemaphoreHandleType,
-                                                 deviceID);
+        clExternalSemaphore *raw_sema_ext_1 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_1, vkVk2CLSemaphore, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_1(raw_sema_ext_1);
+
+        clExternalSemaphore *raw_sema_ext_2 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_2, vkVk2CLSemaphore, context2,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_2(raw_sema_ext_2);
 
         clCommandQueueWrapper queue1 =
             clCreateCommandQueue(context, deviceID, 0, &err);
@@ -824,28 +836,28 @@ int test_external_semaphores_cross_queues_io2(cl_device_id deviceID,
         // Signal semaphore 1
         clEventWrapper signal_1_event;
         err = clEnqueueSignalSemaphoresKHR(
-            queue1, 1, &sema_ext_1.getCLSemaphore(), nullptr, 0, nullptr,
+            queue1, 1, &sema_ext_1->getCLSemaphore(), nullptr, 0, nullptr,
             &signal_1_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore 1
         clEventWrapper wait_1_event;
         err =
-            clEnqueueWaitSemaphoresKHR(queue1, 1, &sema_ext_1.getCLSemaphore(),
+            clEnqueueWaitSemaphoresKHR(queue1, 1, &sema_ext_1->getCLSemaphore(),
                                        nullptr, 0, nullptr, &wait_1_event);
         test_error(err, "Could not wait semaphore");
 
         // Signal semaphore 2
         clEventWrapper signal_2_event;
         err = clEnqueueSignalSemaphoresKHR(
-            queue2, 1, &sema_ext_2.getCLSemaphore(), nullptr, 0, nullptr,
+            queue2, 1, &sema_ext_2->getCLSemaphore(), nullptr, 0, nullptr,
             &signal_2_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore 2
         clEventWrapper wait_2_event;
         err =
-            clEnqueueWaitSemaphoresKHR(queue2, 1, &sema_ext_2.getCLSemaphore(),
+            clEnqueueWaitSemaphoresKHR(queue2, 1, &sema_ext_2->getCLSemaphore(),
                                        nullptr, 0, nullptr, &wait_2_event);
         test_error(err, "Could not wait semaphore");
 
@@ -910,12 +922,15 @@ int test_external_semaphores_multi_signal(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore2(vkDevice,
                                           vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
-                                                 vkExternalSemaphoreHandleType,
-                                                 deviceID);
-        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
-                                                 vkExternalSemaphoreHandleType,
-                                                 deviceID);
+        clExternalSemaphore *raw_sema_ext_1 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_1, vkVk2CLSemaphore1, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_1(raw_sema_ext_1);
+
+        clExternalSemaphore *raw_sema_ext_2 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_2, vkVk2CLSemaphore2, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_2(raw_sema_ext_2);
 
         cl_int err = CL_SUCCESS;
 
@@ -926,21 +941,21 @@ int test_external_semaphores_multi_signal(cl_device_id deviceID,
 
         // Signal semaphore 1 and 2
         clEventWrapper signal_event;
-        cl_semaphore_khr sema_list[] = { sema_ext_1.getCLSemaphore(),
-                                         sema_ext_2.getCLSemaphore() };
+        cl_semaphore_khr sema_list[] = { sema_ext_1->getCLSemaphore(),
+                                         sema_ext_2->getCLSemaphore() };
         err = clEnqueueSignalSemaphoresKHR(queue, 2, sema_list, nullptr, 0,
                                            nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore 1
         clEventWrapper wait_1_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_1.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_1->getCLSemaphore(),
                                          nullptr, 0, nullptr, &wait_1_event);
         test_error(err, "Could not wait semaphore");
 
         // Wait semaphore 2
         clEventWrapper wait_2_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_2.getCLSemaphore(),
+        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_2->getCLSemaphore(),
                                          nullptr, 0, nullptr, &wait_2_event);
         test_error(err, "Could not wait semaphore");
 
@@ -1001,12 +1016,15 @@ int test_external_semaphores_multi_wait(cl_device_id deviceID,
         VulkanSemaphore vkVk2CLSemaphore2(vkDevice,
                                           vkExternalSemaphoreHandleType);
 
-        clExternalExportableSemaphore sema_ext_1(vkVk2CLSemaphore1, context,
-                                                 vkExternalSemaphoreHandleType,
-                                                 deviceID);
-        clExternalExportableSemaphore sema_ext_2(vkVk2CLSemaphore2, context,
-                                                 vkExternalSemaphoreHandleType,
-                                                 deviceID);
+        clExternalSemaphore *raw_sema_ext_1 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_1, vkVk2CLSemaphore1, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_1(raw_sema_ext_1);
+
+        clExternalSemaphore *raw_sema_ext_2 = NULL;
+        CREATE_OPENCL_SEMAPHORE(raw_sema_ext_2, vkVk2CLSemaphore2, context,
+                                vkExternalSemaphoreHandleType, deviceID, true);
+        std::unique_ptr<clExternalSemaphore> sema_ext_2(raw_sema_ext_2);
 
         cl_int err = CL_SUCCESS;
 
@@ -1018,21 +1036,21 @@ int test_external_semaphores_multi_wait(cl_device_id deviceID,
         // Signal semaphore 1
         clEventWrapper signal_1_event;
         err =
-            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_1.getCLSemaphore(),
+            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_1->getCLSemaphore(),
                                          nullptr, 0, nullptr, &signal_1_event);
         test_error(err, "Could not signal semaphore");
 
         // Signal semaphore 2
         clEventWrapper signal_2_event;
         err =
-            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_2.getCLSemaphore(),
+            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_2->getCLSemaphore(),
                                          nullptr, 0, nullptr, &signal_2_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore 1 and 2
         clEventWrapper wait_event;
-        cl_semaphore_khr sema_list[] = { sema_ext_1.getCLSemaphore(),
-                                         sema_ext_2.getCLSemaphore() };
+        cl_semaphore_khr sema_list[] = { sema_ext_1->getCLSemaphore(),
+                                         sema_ext_2->getCLSemaphore() };
         err = clEnqueueWaitSemaphoresKHR(queue, 2, sema_list, nullptr, 0,
                                          nullptr, &wait_event);
         test_error(err, "Could not wait semaphore");

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -99,13 +99,15 @@ static cl_int get_device_semaphore_handle_types(
 
     // Empty list (size_handle_types:0) is a valid value denoting that
     // implementation is incapable to import/export semaphore
-    if (num_handle_types > 0) {
+    if (num_handle_types > 0)
+    {
         std::vector<cl_external_semaphore_handle_type_khr>
             handle_types_query_result(num_handle_types);
-        err = clGetDeviceInfo(deviceID, param,
-                              handle_types_query_result.size()
-                                  * sizeof(cl_external_semaphore_handle_type_khr),
-                              handle_types_query_result.data(), nullptr);
+        err =
+            clGetDeviceInfo(deviceID, param,
+                            handle_types_query_result.size()
+                                * sizeof(cl_external_semaphore_handle_type_khr),
+                            handle_types_query_result.data(), nullptr);
         test_error(err, "Failed to get exportable handle types");
 
         for (auto handle_type : handle_types_query_result)
@@ -239,7 +241,8 @@ int test_external_semaphores_cross_context(cl_device_id deviceID,
 
     // If cl_khr_external_semaphore is reported, implementation must
     // support any of import, export or maybe both.
-    if (import_handle_types.empty() && export_handle_types.empty()) {
+    if (import_handle_types.empty() && export_handle_types.empty())
+    {
         test_fail("No support for import/export semaphore.\n");
     }
 
@@ -390,8 +393,9 @@ int test_external_semaphores_simple_1(cl_device_id deviceID, cl_context context,
 
         // Signal semaphore
         clEventWrapper signal_event;
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
-                                           nullptr, 0, nullptr, &signal_event);
+        err =
+            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
+                                         nullptr, 0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore
@@ -484,8 +488,9 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
 
         // Signal semaphore
         clEventWrapper signal_event;
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
-                                           nullptr, 0, nullptr, &signal_event);
+        err =
+            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
+                                         nullptr, 0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore
@@ -591,9 +596,9 @@ int test_external_semaphores_reuse(cl_device_id deviceID, cl_context context,
         test_error(err, "Unable to enqueue task_1");
 
         // Signal semaphore (dependency on task_1)
-        err = clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext->getCLSemaphore(),
-                                           nullptr, 1, &task_events[0],
-                                           &signal_events[0]);
+        err = clEnqueueSignalSemaphoresKHR(
+            queue, 1, &sema_ext->getCLSemaphore(), nullptr, 1, &task_events[0],
+            &signal_events[0]);
         test_error(err, "Could not signal semaphore");
 
         // In a loop
@@ -696,15 +701,16 @@ static int external_semaphore_cross_queue_helper(cl_device_id deviceID,
 
         // Signal semaphore on queue_1
         clEventWrapper signal_event;
-        err =
-            clEnqueueSignalSemaphoresKHR(queue_1, 1, &sema_ext->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &signal_event);
+        err = clEnqueueSignalSemaphoresKHR(queue_1, 1,
+                                           &sema_ext->getCLSemaphore(), nullptr,
+                                           0, nullptr, &signal_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore on queue_2
         clEventWrapper wait_event;
-        err = clEnqueueWaitSemaphoresKHR(queue_2, 1, &sema_ext->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &wait_event);
+        err =
+            clEnqueueWaitSemaphoresKHR(queue_2, 1, &sema_ext->getCLSemaphore(),
+                                       nullptr, 0, nullptr, &wait_event);
         test_error(err, "Could not wait semaphore");
 
         // Finish queue_1 and queue_2
@@ -949,14 +955,16 @@ int test_external_semaphores_multi_signal(cl_device_id deviceID,
 
         // Wait semaphore 1
         clEventWrapper wait_1_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_1->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &wait_1_event);
+        err =
+            clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_1->getCLSemaphore(),
+                                       nullptr, 0, nullptr, &wait_1_event);
         test_error(err, "Could not wait semaphore");
 
         // Wait semaphore 2
         clEventWrapper wait_2_event;
-        err = clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_2->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &wait_2_event);
+        err =
+            clEnqueueWaitSemaphoresKHR(queue, 1, &sema_ext_2->getCLSemaphore(),
+                                       nullptr, 0, nullptr, &wait_2_event);
         test_error(err, "Could not wait semaphore");
 
         // Finish
@@ -1035,16 +1043,16 @@ int test_external_semaphores_multi_wait(cl_device_id deviceID,
 
         // Signal semaphore 1
         clEventWrapper signal_1_event;
-        err =
-            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_1->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &signal_1_event);
+        err = clEnqueueSignalSemaphoresKHR(
+            queue, 1, &sema_ext_1->getCLSemaphore(), nullptr, 0, nullptr,
+            &signal_1_event);
         test_error(err, "Could not signal semaphore");
 
         // Signal semaphore 2
         clEventWrapper signal_2_event;
-        err =
-            clEnqueueSignalSemaphoresKHR(queue, 1, &sema_ext_2->getCLSemaphore(),
-                                         nullptr, 0, nullptr, &signal_2_event);
+        err = clEnqueueSignalSemaphoresKHR(
+            queue, 1, &sema_ext_2->getCLSemaphore(), nullptr, 0, nullptr,
+            &signal_2_event);
         test_error(err, "Could not signal semaphore");
 
         // Wait semaphore 1 and 2


### PR DESCRIPTION
An implementation may not support exportable semaphore, subtests available in cl_khr_external_semaphore assumes support for exportable semaphore, resulting in failure on such implementation. Allow implementations to use importable semaphore in such cases.