### PR TITLE
Fix vulkan subtest for diffCtx and platform/device info

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -1380,7 +1380,7 @@ int run_test_with_multi_import_diff_ctx(
                                                    "Failed to set kernel arg");
 
                             err = clEnqueueAcquireExternalMemObjectsKHRptr(
-                                cmd_queue1, 1, &buffers2[i][launchIter], 0,
+                                cmd_queue2, 1, &buffers2[i][launchIter], 0,
                                 nullptr, nullptr);
                             test_error_and_cleanup(err, CLEANUP,
                                                    "Failed to acquire buffers");
@@ -1400,7 +1400,7 @@ int run_test_with_multi_import_diff_ctx(
                         for (int i = 0; i < numBuffers; i++)
                         {
                             err = clEnqueueReleaseExternalMemObjectsKHRptr(
-                                cmd_queue1, 1, &buffers2[i][launchIter], 0,
+                                cmd_queue2, 1, &buffers2[i][launchIter], 0,
                                 nullptr, nullptr);
                             test_error_and_cleanup(err, CLEANUP,
                                                    "Failed to release buffers");


### PR DESCRIPTION
Fixes:
1. Multi import diff ctx subtest which acquires/releases external memory via queue not associated with the context in which memory was imported.
2. Platform/Device info subtests to handle different platforms and availability of the query.