### PR TITLE
Add properties parameter to all command-buffer commands

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -254,13 +254,8 @@ struct MixedCommandsTest : public BasicCommandBufferTest
         {
             const cl_int pattern = pattern_base + i;
             cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
                 command_buffer, nullptr, nullptr, in_mem, &pattern,
                 sizeof(cl_int), 0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-                command_buffer, nullptr, in_mem, &pattern, sizeof(cl_int), 0,
-                data_size(), 0, nullptr, nullptr, nullptr);
-#endif
             test_error(error, "clCommandFillBufferKHR failed");
 
             error = clCommandNDRangeKernelKHR(
@@ -270,13 +265,8 @@ struct MixedCommandsTest : public BasicCommandBufferTest
 
             const size_t result_offset = i * sizeof(cl_int);
             error = clCommandCopyBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
                 command_buffer, nullptr, nullptr, out_mem, result_mem, 0,
                 result_offset, sizeof(cl_int), 0, nullptr, nullptr, nullptr);
-#else
-                command_buffer, nullptr, out_mem, result_mem, 0, result_offset,
-                sizeof(cl_int), 0, nullptr, nullptr, nullptr);
-#endif
             test_error(error, "clCommandCopyBufferKHR failed");
         }
 

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -254,8 +254,13 @@ struct MixedCommandsTest : public BasicCommandBufferTest
         {
             const cl_int pattern = pattern_base + i;
             cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                command_buffer, nullptr, nullptr, in_mem, &pattern,
+                sizeof(cl_int), 0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
                 command_buffer, nullptr, in_mem, &pattern, sizeof(cl_int), 0,
                 data_size(), 0, nullptr, nullptr, nullptr);
+#endif
             test_error(error, "clCommandFillBufferKHR failed");
 
             error = clCommandNDRangeKernelKHR(
@@ -265,8 +270,13 @@ struct MixedCommandsTest : public BasicCommandBufferTest
 
             const size_t result_offset = i * sizeof(cl_int);
             error = clCommandCopyBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                command_buffer, nullptr, nullptr, out_mem, result_mem, 0,
+                result_offset, sizeof(cl_int), 0, nullptr, nullptr, nullptr);
+#else
                 command_buffer, nullptr, out_mem, result_mem, 0, result_offset,
                 sizeof(cl_int), 0, nullptr, nullptr, nullptr);
+#endif
             test_error(error, "clCommandCopyBufferKHR failed");
         }
 

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -87,8 +87,30 @@ template <class T>
 int MakeAndRunTest(cl_device_id device, cl_context context,
                    cl_command_queue queue, int num_elements)
 {
-    CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device);
+    if (!is_extension_available(device, "cl_khr_command_buffer"))
+    {
+        log_info("Device does not support 'cl_khr_command_buffer'. Skipping "
+                 "the test.\n");
+        return TEST_SKIPPED_ITSELF;
+    }
 
+    Version device_version = get_device_cl_version(device);
+    if ((device_version >= Version(3, 0))
+        || is_extension_available(device, "cl_khr_extended_versioning"))
+    {
+
+        cl_version extension_version =
+            get_extension_version(device, "cl_khr_command_buffer");
+
+        if (extension_version < CL_MAKE_VERSION(0, 9, 5))
+        {
+
+            log_info("cl_khr_command_buffer version 0.9.5 or later is required "
+                     "to run "
+                     "the test, skipping.\n ");
+            return TEST_SKIPPED_ITSELF;
+        }
+    }
     try
     {
         auto test_fixture = T(device, context, queue);

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -140,14 +140,9 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -276,14 +271,9 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
         threads[0] = number_of_ints;
         local_threads[0] = 1;
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -414,14 +404,9 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
         threads[0] = number_of_ints;
         local_threads[0] = 1;
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -550,14 +535,9 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
     cl_int Run() override
     {
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -744,11 +724,7 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
                                     sizeof(init_buffer), &init_buffer);
         test_error(error, "clSetKernelExecInfo failed for init_buffer");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
             CL_MUTABLE_DISPATCH_ARGUMENTS_KHR
                 | CL_MUTABLE_DISPATCH_EXEC_INFO_KHR,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -140,9 +140,14 @@ struct MutableDispatchGlobalArguments : public MutableDispatchArgumentsTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -271,9 +276,14 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
         threads[0] = number_of_ints;
         local_threads[0] = 1;
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -404,9 +414,14 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
         threads[0] = number_of_ints;
         local_threads[0] = 1;
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -534,9 +549,15 @@ struct MutableDispatchNullArguments : public MutableDispatchArgumentsTest
 
     cl_int Run() override
     {
+
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -723,7 +744,11 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
                                     sizeof(init_buffer), &init_buffer);
         test_error(error, "clSetKernelExecInfo failed for init_buffer");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
             CL_MUTABLE_DISPATCH_ARGUMENTS_KHR
                 | CL_MUTABLE_DISPATCH_EXEC_INFO_KHR,

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -295,15 +295,8 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
     // run command buffer with full mutable dispatch test
     cl_int Run() override
     {
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
-            CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            available_caps,
-            0
+            CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR, available_caps, 0
         };
 
         size_t work_offset = 0;

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -295,8 +295,15 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
     // run command buffer with full mutable dispatch test
     cl_int Run() override
     {
+
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
-            CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR, available_caps, 0
+#endif
+            CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
+            available_caps,
+            0
         };
 
         size_t work_offset = 0;

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
@@ -131,9 +131,14 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         error = clSetKernelArg(kernel, 2, sizeof(cl_mem), &dst_image);
         test_error(error, "Unable to set indexed kernel arguments");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         size_t globalDim[3] = { 4, 1, 1 }, localDim[3] = { 1, 1, 1 };
@@ -330,9 +335,14 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
 
         size_t globalDim[3] = { 4, 4, 1 }, localDim[3] = { 1, 1, 1 };
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
@@ -131,14 +131,9 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         error = clSetKernelArg(kernel, 2, sizeof(cl_mem), &dst_image);
         test_error(error, "Unable to set indexed kernel arguments");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         size_t globalDim[3] = { 4, 1, 1 }, localDim[3] = { 1, 1, 1 };
@@ -335,14 +330,9 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
 
         size_t globalDim[3] = { 4, 4, 1 }, localDim[3] = { 1, 1, 1 };
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -34,7 +34,7 @@
 // CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR
 // CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR
 // CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR
-// CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR
+// CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR
 // CL_MUTABLE_DISPATCH_KERNEL_KHR
 // CL_MUTABLE_DISPATCH_DIMENSIONS_KHR
 // CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR
@@ -117,16 +117,26 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
         : InfoMutableCommandBufferTest(device, context, queue)
     {}
 
+    virtual bool Skip() override {
+        Version device_version = get_device_cl_version(device);
+        if ((device_version >= Version(3, 0))
+            || is_extension_available(device, "cl_khr_extended_versioning")) {
+
+           cl_version extension_version =
+            get_extension_version(device, "cl_khr_command_buffer_mutable_dispatch");
+
+          if (extension_version < CL_MAKE_VERSION(0, 9, 3)) {
+            return true;
+          }
+        }
+        return InfoMutableCommandBufferTest::Skip();
+    }
+
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -134,15 +144,11 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
             &global_work_size, nullptr, 0, nullptr, nullptr, &command);
         test_error(error, "clCommandNDRangeKernelKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr test_props[] = { 0, 0, 0 };
-#else
-        cl_ndrange_kernel_command_properties_khr test_props[] = { 0, 0, 0 };
-#endif
         size_t size;
 
         error = clGetMutableCommandInfoKHR(
-            command, CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR,
+            command, CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR,
             sizeof(test_props), test_props, &size);
         test_error(error, "clGetMutableCommandInfoKHR failed");
 

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -119,9 +119,14 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         cl_int error = clCommandNDRangeKernelKHR(
@@ -129,7 +134,11 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
             &global_work_size, nullptr, 0, nullptr, nullptr, &command);
         test_error(error, "clCommandNDRangeKernelKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr test_props[] = { 0, 0, 0 };
+#else
         cl_ndrange_kernel_command_properties_khr test_props[] = { 0, 0, 0 };
+#endif
         size_t size;
 
         error = clGetMutableCommandInfoKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
@@ -170,14 +170,27 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         cl_sync_point_khr sync_points[2];
         const cl_int pattern = pattern_pri;
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            work_command_buffer, nullptr, nullptr, in_mem, &pattern,
+            sizeof(cl_int), 0, data_size(), 0, nullptr, &sync_points[0],
+            nullptr);
+#else
             work_command_buffer, nullptr, in_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, &sync_points[0], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(work_command_buffer, nullptr, nullptr,
+                                       out_mem, &overwritten_pattern,
+                                       sizeof(cl_int), 0, data_size(), 0,
+                                       nullptr, &sync_points[1], nullptr);
+#else
         error = clCommandFillBufferKHR(work_command_buffer, nullptr, out_mem,
                                        &overwritten_pattern, sizeof(cl_int), 0,
                                        data_size(), 0, nullptr, &sync_points[1],
                                        nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandNDRangeKernelKHR(
@@ -269,9 +282,15 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         cl_sync_point_khr sync_points[2];
         // for both simultaneous passes this call will fill entire in_mem buffer
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            work_command_buffer, nullptr, nullptr, in_mem, &pattern_pri,
+            sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
+            &sync_points[0], nullptr);
+#else
             work_command_buffer, nullptr, in_mem, &pattern_pri, sizeof(cl_int),
             0, data_size() * buffer_size_multiplier, 0, nullptr,
             &sync_points[0], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         // to avoid overwriting the entire result buffer instead of filling
@@ -519,13 +538,24 @@ struct CrossQueueSimultaneousMutableDispatchTest
         // record command buffer
         cl_int pattern = 0;
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
+
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props[] = {
+#else
         cl_ndrange_kernel_command_properties_khr props[] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
+            0
         };
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
@@ -170,27 +170,15 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         cl_sync_point_khr sync_points[2];
         const cl_int pattern = pattern_pri;
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             work_command_buffer, nullptr, nullptr, in_mem, &pattern,
             sizeof(cl_int), 0, data_size(), 0, nullptr, &sync_points[0],
             nullptr);
-#else
-            work_command_buffer, nullptr, in_mem, &pattern, sizeof(cl_int), 0,
-            data_size(), 0, nullptr, &sync_points[0], nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(work_command_buffer, nullptr, nullptr,
                                        out_mem, &overwritten_pattern,
                                        sizeof(cl_int), 0, data_size(), 0,
                                        nullptr, &sync_points[1], nullptr);
-#else
-        error = clCommandFillBufferKHR(work_command_buffer, nullptr, out_mem,
-                                       &overwritten_pattern, sizeof(cl_int), 0,
-                                       data_size(), 0, nullptr, &sync_points[1],
-                                       nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandNDRangeKernelKHR(
@@ -282,15 +270,9 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
         cl_sync_point_khr sync_points[2];
         // for both simultaneous passes this call will fill entire in_mem buffer
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             work_command_buffer, nullptr, nullptr, in_mem, &pattern_pri,
             sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
             &sync_points[0], nullptr);
-#else
-            work_command_buffer, nullptr, in_mem, &pattern_pri, sizeof(cl_int),
-            0, data_size() * buffer_size_multiplier, 0, nullptr,
-            &sync_points[0], nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         // to avoid overwriting the entire result buffer instead of filling
@@ -538,24 +520,13 @@ struct CrossQueueSimultaneousMutableDispatchTest
         // record command buffer
         cl_int pattern = 0;
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props[] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props[] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR,
-            0
+            CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0
         };
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
@@ -34,12 +34,7 @@
 struct Configuration
 {
     const cl_command_buffer_properties_khr *command_buffer_properties;
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
     const cl_command_properties_khr *ndrange_properties;
-#else
-    const cl_ndrange_kernel_command_properties_khr *ndrange_properties;
-#endif
 };
 
 // Define the command buffer properties for each configuration
@@ -49,11 +44,7 @@ const cl_command_buffer_properties_khr command_buffer_properties[] = {
 };
 
 // Define the ndrange properties
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
 const cl_command_properties_khr ndrange_properties[] = {
-#else
-const cl_ndrange_kernel_command_properties_khr ndrange_properties[] = {
-#endif
     CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
     CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR, CL_MUTABLE_DISPATCH_ASSERTS_KHR,
     CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR, 0

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
@@ -34,7 +34,12 @@
 struct Configuration
 {
     const cl_command_buffer_properties_khr *command_buffer_properties;
+
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+    const cl_command_properties_khr *ndrange_properties;
+#else
     const cl_ndrange_kernel_command_properties_khr *ndrange_properties;
+#endif
 };
 
 // Define the command buffer properties for each configuration
@@ -44,7 +49,11 @@ const cl_command_buffer_properties_khr command_buffer_properties[] = {
 };
 
 // Define the ndrange properties
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+const cl_command_properties_khr ndrange_properties[] = {
+#else
 const cl_ndrange_kernel_command_properties_khr ndrange_properties[] = {
+#endif
     CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
     CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR, CL_MUTABLE_DISPATCH_ASSERTS_KHR,
     CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR, 0

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_out_of_order.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_out_of_order.cpp
@@ -162,15 +162,29 @@ struct OutOfOrderTest : public BasicCommandBufferTest
         cl_sync_point_khr sync_points[2];
         const cl_int pattern = pattern_pri;
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
+                                   nullptr, in_mem, &pattern, sizeof(cl_int), 0,
+                                   data_size(), 0, nullptr, &sync_points[0],
+                                   nullptr);
+#else
             clCommandFillBufferKHR(out_of_order_command_buffer, nullptr, in_mem,
                                    &pattern, sizeof(cl_int), 0, data_size(), 0,
                                    nullptr, &sync_points[0], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
+                                       nullptr, out_mem, &overwritten_pattern,
+                                       sizeof(cl_int), 0, data_size(), 0,
+                                       nullptr, &sync_points[1], nullptr);
+#else
         error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
                                        out_mem, &overwritten_pattern,
                                        sizeof(cl_int), 0, data_size(), 0,
                                        nullptr, &sync_points[1], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandNDRangeKernelKHR(
@@ -214,9 +228,15 @@ struct OutOfOrderTest : public BasicCommandBufferTest
         cl_sync_point_khr sync_points[2];
         // for both simultaneous passes this call will fill entire in_mem buffer
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            out_of_order_command_buffer, nullptr, nullptr, in_mem, &pattern_pri,
+            sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
+            &sync_points[0], nullptr);
+#else
             out_of_order_command_buffer, nullptr, in_mem, &pattern_pri,
             sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
             &sync_points[0], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         // to avoid overwriting the entire result buffer instead of filling only

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_out_of_order.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_out_of_order.cpp
@@ -161,30 +161,16 @@ struct OutOfOrderTest : public BasicCommandBufferTest
     {
         cl_sync_point_khr sync_points[2];
         const cl_int pattern = pattern_pri;
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
-                                   nullptr, in_mem, &pattern, sizeof(cl_int), 0,
-                                   data_size(), 0, nullptr, &sync_points[0],
-                                   nullptr);
-#else
-            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr, in_mem,
-                                   &pattern, sizeof(cl_int), 0, data_size(), 0,
-                                   nullptr, &sync_points[0], nullptr);
-#endif
+        cl_int error = clCommandFillBufferKHR(
+            out_of_order_command_buffer, nullptr, nullptr, in_mem, &pattern,
+            sizeof(cl_int), 0, data_size(), 0, nullptr, &sync_points[0],
+            nullptr);
         test_error(error, "clCommandFillBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
                                        nullptr, out_mem, &overwritten_pattern,
                                        sizeof(cl_int), 0, data_size(), 0,
                                        nullptr, &sync_points[1], nullptr);
-#else
-        error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
-                                       out_mem, &overwritten_pattern,
-                                       sizeof(cl_int), 0, data_size(), 0,
-                                       nullptr, &sync_points[1], nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandNDRangeKernelKHR(
@@ -228,15 +214,9 @@ struct OutOfOrderTest : public BasicCommandBufferTest
         cl_sync_point_khr sync_points[2];
         // for both simultaneous passes this call will fill entire in_mem buffer
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             out_of_order_command_buffer, nullptr, nullptr, in_mem, &pattern_pri,
             sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
             &sync_points[0], nullptr);
-#else
-            out_of_order_command_buffer, nullptr, in_mem, &pattern_pri,
-            sizeof(cl_int), 0, data_size() * buffer_size_multiplier, 0, nullptr,
-            &sync_points[0], nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         // to avoid overwriting the entire result buffer instead of filling only

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
@@ -40,42 +40,22 @@ struct BarrierWithWaitListKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
-                                   nullptr, in_mem, &pattern, sizeof(cl_int), 0,
-                                   data_size(), 0, nullptr, &sync_points[0],
-                                   nullptr);
-#else
-            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr, in_mem,
-                                   &pattern, sizeof(cl_int), 0, data_size(), 0,
-                                   nullptr, &sync_points[0], nullptr);
-#endif
+        cl_int error = clCommandFillBufferKHR(
+            out_of_order_command_buffer, nullptr, nullptr, in_mem, &pattern,
+            sizeof(cl_int), 0, data_size(), 0, nullptr, &sync_points[0],
+            nullptr);
         test_error(error, "clCommandFillBufferKHR failed");
 
         const cl_int overwritten_pattern = 0xACDC;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
                                        nullptr, out_mem, &overwritten_pattern,
                                        sizeof(cl_int), 0, data_size(), 0,
                                        nullptr, &sync_points[1], nullptr);
-#else
-        error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
-                                       out_mem, &overwritten_pattern,
-                                       sizeof(cl_int), 0, data_size(), 0,
-                                       nullptr, &sync_points[1], nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(out_of_order_command_buffer,
                                                 nullptr, nullptr, 2,
                                                 sync_points, nullptr, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(out_of_order_command_buffer,
-                                                nullptr, 2, sync_points,
-                                                nullptr, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_barrier.cpp
@@ -41,21 +41,41 @@ struct BarrierWithWaitListKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
+                                   nullptr, in_mem, &pattern, sizeof(cl_int), 0,
+                                   data_size(), 0, nullptr, &sync_points[0],
+                                   nullptr);
+#else
             clCommandFillBufferKHR(out_of_order_command_buffer, nullptr, in_mem,
                                    &pattern, sizeof(cl_int), 0, data_size(), 0,
                                    nullptr, &sync_points[0], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         const cl_int overwritten_pattern = 0xACDC;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
+                                       nullptr, out_mem, &overwritten_pattern,
+                                       sizeof(cl_int), 0, data_size(), 0,
+                                       nullptr, &sync_points[1], nullptr);
+#else
         error = clCommandFillBufferKHR(out_of_order_command_buffer, nullptr,
                                        out_mem, &overwritten_pattern,
                                        sizeof(cl_int), 0, data_size(), 0,
                                        nullptr, &sync_points[1], nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(out_of_order_command_buffer,
+                                                nullptr, nullptr, 2,
+                                                sync_points, nullptr, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(out_of_order_command_buffer,
                                                 nullptr, 2, sync_points,
                                                 nullptr, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_base.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_base.h
@@ -161,17 +161,4 @@ public:
 
     operator cl_command_buffer_khr() const { return object; }
 };
-
-#define CHECK_COMMAND_BUFFER_EXTENSION_AVAILABLE(device)                       \
-    {                                                                          \
-        if (!is_extension_available(device, "cl_khr_command_buffer"))          \
-        {                                                                      \
-            log_info(                                                          \
-                "Device does not support 'cl_khr_command_buffer'. Skipping "   \
-                "the test.\n");                                                \
-            return TEST_SKIPPED_ITSELF;                                        \
-        }                                                                      \
-    }
-
-
 #endif // CL_KHR_COMMAND_BUFFER_TEST_BASE_H

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_copy.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_copy.cpp
@@ -38,15 +38,27 @@ struct CopyImageKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, src_image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandFillImageKHR(command_buffer, nullptr, src_image,
                                              fill_color_1, origin, region, 0,
                                              nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandFillImageKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 0, 0, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image, origin, origin, region, 0, 0,
                                       nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandCopyImageKHR failed");
 
@@ -141,13 +153,24 @@ struct CopyBufferKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, &pattern_1,
+            sizeof(cl_char), 0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem, 0, 0, data_size(), 0, nullptr,
+                                       nullptr, nullptr);
+#else
         error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem,
                                        0, 0, data_size(), 0, nullptr, nullptr,
                                        nullptr);
+#endif
         test_error(error, "clCommandCopyBufferKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -204,14 +227,26 @@ struct CopySVMBufferKHR : public BasicSVMCommandBufferTest
 
     cl_int Run() override
     {
+
         cl_int error = clCommandSVMMemFillKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, svm_in_mem(), &pattern_1, sizeof(cl_char),
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
         test_error(error, "clCommandSVMMemFillKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
+                                      svm_out_mem(), svm_in_mem(), data_size(),
+                                      0, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
                                       svm_in_mem(), data_size(), 0, nullptr,
                                       nullptr, nullptr);
+#endif
         test_error(error, "clCommandSVMMemcpyKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -273,14 +308,25 @@ struct CopyBufferToImageKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, buffer, &pattern_1,
+            sizeof(cl_char), 0, data_size, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, buffer, &pattern_1, sizeof(cl_char), 0,
             data_size, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandFillBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyBufferToImageKHR(command_buffer, nullptr, nullptr,
+                                              buffer, image, 0, origin, region,
+                                              0, 0, nullptr, nullptr);
+#else
         error = clCommandCopyBufferToImageKHR(command_buffer, nullptr, buffer,
                                               image, 0, origin, region, 0, 0,
                                               nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandCopyBufferToImageKHR failed");
 
@@ -380,14 +426,26 @@ struct CopyImageToBufferKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandFillImageKHR(command_buffer, nullptr, nullptr, image,
+                                  fill_color_1, origin, region, 0, nullptr,
+                                  nullptr, nullptr);
+#else
             clCommandFillImageKHR(command_buffer, nullptr, image, fill_color_1,
                                   origin, region, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandFillImageKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer, origin, region, 0,
+                                              0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
                                               buffer, origin, region, 0, 0,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandCopyImageToBufferKHR failed");
 
@@ -484,13 +542,23 @@ struct CopyBufferRectKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, &pattern_1,
+            sizeof(cl_char), 0, data_size, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
             data_size, 0, nullptr, nullptr, nullptr);
+#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandCopyBufferRectKHR failed");
 

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_copy.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_copy.cpp
@@ -38,27 +38,15 @@ struct CopyImageKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandFillImageKHR(
             command_buffer, nullptr, nullptr, src_image, fill_color_1, origin,
             region, 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandFillImageKHR(command_buffer, nullptr, src_image,
-                                             fill_color_1, origin, region, 0,
-                                             nullptr, nullptr, nullptr);
-#endif
 
         test_error(error, "clCommandFillImageKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image, origin, origin,
                                       region, 0, 0, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image, origin, origin, region, 0, 0,
-                                      nullptr, nullptr);
-#endif
 
         test_error(error, "clCommandCopyImageKHR failed");
 
@@ -153,24 +141,13 @@ struct CopyBufferKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, &pattern_1,
             sizeof(cl_char), 0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
                                        out_mem, 0, 0, data_size(), 0, nullptr,
                                        nullptr, nullptr);
-#else
-        error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem,
-                                       0, 0, data_size(), 0, nullptr, nullptr,
-                                       nullptr);
-#endif
         test_error(error, "clCommandCopyBufferKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -229,24 +206,13 @@ struct CopySVMBufferKHR : public BasicSVMCommandBufferTest
     {
 
         cl_int error = clCommandSVMMemFillKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, svm_in_mem(), &pattern_1, sizeof(cl_char),
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
         test_error(error, "clCommandSVMMemFillKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
                                       svm_out_mem(), svm_in_mem(), data_size(),
                                       0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
-                                      svm_in_mem(), data_size(), 0, nullptr,
-                                      nullptr, nullptr);
-#endif
         test_error(error, "clCommandSVMMemcpyKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -308,26 +274,13 @@ struct CopyBufferToImageKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, buffer, &pattern_1,
             sizeof(cl_char), 0, data_size, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, buffer, &pattern_1, sizeof(cl_char), 0,
-            data_size, 0, nullptr, nullptr, nullptr);
-#endif
-
         test_error(error, "clCommandFillBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyBufferToImageKHR(command_buffer, nullptr, nullptr,
                                               buffer, image, 0, origin, region,
                                               0, 0, nullptr, nullptr);
-#else
-        error = clCommandCopyBufferToImageKHR(command_buffer, nullptr, buffer,
-                                              image, 0, origin, region, 0, 0,
-                                              nullptr, nullptr);
-#endif
-
         test_error(error, "clCommandCopyBufferToImageKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -425,28 +378,14 @@ struct CopyImageToBufferKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandFillImageKHR(command_buffer, nullptr, nullptr, image,
-                                  fill_color_1, origin, region, 0, nullptr,
-                                  nullptr, nullptr);
-#else
-            clCommandFillImageKHR(command_buffer, nullptr, image, fill_color_1,
-                                  origin, region, 0, nullptr, nullptr, nullptr);
-#endif
-
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
         test_error(error, "clCommandFillImageKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
                                               image, buffer, origin, region, 0,
                                               0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
-                                              buffer, origin, region, 0, 0,
-                                              nullptr, nullptr, nullptr);
-#endif
-
         test_error(error, "clCommandCopyImageToBufferKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -542,24 +481,13 @@ struct CopyBufferRectKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, &pattern_1,
             sizeof(cl_char), 0, data_size, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
-            data_size, 0, nullptr, nullptr, nullptr);
-#endif
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 0, nullptr, nullptr, nullptr);
-#endif
-
         test_error(error, "clCommandCopyBufferRectKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_fill.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_fill.cpp
@@ -35,16 +35,9 @@ struct FillImageKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandFillImageKHR(command_buffer, nullptr, nullptr, image,
-                                  fill_color_1, origin, region, 0, nullptr,
-                                  nullptr, nullptr);
-#else
-            clCommandFillImageKHR(command_buffer, nullptr, image, fill_color_1,
-                                  origin, region, 0, nullptr, nullptr, nullptr);
-#endif
-
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
         test_error(error, "clCommandFillImageKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -129,16 +122,9 @@ struct FillBufferKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandFillBufferKHR(
             command_buffer, nullptr, nullptr, in_mem, &pattern_1,
             sizeof(cl_char), 0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandFillBufferKHR(
-            command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
-
         test_error(error, "clCommandFillBufferKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
@@ -190,15 +176,9 @@ struct FillSVMBufferKHR : public BasicSVMCommandBufferTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandSVMMemFillKHR(
-            command_buffer, nullptr, svm_in_mem(), &pattern_1, sizeof(cl_char),
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
         test_error(error, "clCommandSVMMemFillKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_fill.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_test_fill.cpp
@@ -36,8 +36,14 @@ struct FillImageKHR : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandFillImageKHR(command_buffer, nullptr, nullptr, image,
+                                  fill_color_1, origin, region, 0, nullptr,
+                                  nullptr, nullptr);
+#else
             clCommandFillImageKHR(command_buffer, nullptr, image, fill_color_1,
                                   origin, region, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandFillImageKHR failed");
 
@@ -123,9 +129,15 @@ struct FillBufferKHR : public BasicCommandBufferTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, in_mem, &pattern_1,
+            sizeof(cl_char), 0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandFillBufferKHR(
             command_buffer, nullptr, in_mem, &pattern_1, sizeof(cl_char), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
 
         test_error(error, "clCommandFillBufferKHR failed");
 
@@ -178,9 +190,15 @@ struct FillSVMBufferKHR : public BasicSVMCommandBufferTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, svm_in_mem(), &pattern_1, sizeof(cl_char),
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
         test_error(error, "clCommandSVMMemFillKHR failed");
 
         error = clFinalizeCommandBufferKHR(command_buffer);

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
@@ -28,7 +28,11 @@ struct CommandBufferBarrierNotNullQueue : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandBarrierWithWaitListKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, queue, nullptr, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, queue, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -55,7 +59,11 @@ struct CommandBufferBarrierInvalidCommandBuffer : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandBarrierWithWaitListKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            nullptr, queue, nullptr, 0, nullptr, nullptr, nullptr);
+#else
             nullptr, queue, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -76,8 +84,13 @@ struct CommandBufferBarrierBufferFinalized : public BasicCommandBufferTest
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -98,7 +111,12 @@ struct CommandBufferBarrierMutableHandleNotNull : public BasicCommandBufferTest
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandBarrierWithWaitListKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, 0, nullptr, nullptr,
+            &mutable_handle);
+#else
             command_buffer, nullptr, 0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -123,7 +141,12 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandBarrierWithWaitListKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, 1, &invalid_point, nullptr,
+            nullptr);
+#else
             command_buffer, nullptr, 1, &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -131,8 +154,13 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 1, nullptr, nullptr, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 1,
                                                 nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -142,12 +170,23 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
 
         cl_sync_point_khr point;
         error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                   out_mem, 0, 0, data_size(), 0, nullptr,
+                                   &point, nullptr);
+#else
             clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
                                    0, data_size(), 0, nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandCopyBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, &point, nullptr, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_barrier.cpp
@@ -28,11 +28,7 @@ struct CommandBufferBarrierNotNullQueue : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandBarrierWithWaitListKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, queue, nullptr, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, queue, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -59,11 +55,7 @@ struct CommandBufferBarrierInvalidCommandBuffer : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandBarrierWithWaitListKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             nullptr, queue, nullptr, 0, nullptr, nullptr, nullptr);
-#else
-            nullptr, queue, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -84,14 +76,8 @@ struct CommandBufferBarrierBufferFinalized : public BasicCommandBufferTest
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, nullptr, nullptr);
-#endif
-
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandBarrierWithWaitListKHR should return "
                                "CL_INVALID_OPERATION",
@@ -110,14 +96,9 @@ struct CommandBufferBarrierMutableHandleNotNull : public BasicCommandBufferTest
     {
         cl_mutable_command_khr mutable_handle;
 
-        cl_int error = clCommandBarrierWithWaitListKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            command_buffer, nullptr, nullptr, 0, nullptr, nullptr,
-            &mutable_handle);
-#else
-            command_buffer, nullptr, 0, nullptr, nullptr, &mutable_handle);
-#endif
-
+        cl_int error =
+            clCommandBarrierWithWaitListKHR(command_buffer, nullptr, nullptr, 0,
+                                            nullptr, nullptr, &mutable_handle);
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandBarrierWithWaitListKHR should return "
                                "CL_INVALID_VALUE",
@@ -140,13 +121,9 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
     {
         cl_sync_point_khr invalid_point = 0;
 
-        cl_int error = clCommandBarrierWithWaitListKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            command_buffer, nullptr, nullptr, 1, &invalid_point, nullptr,
-            nullptr);
-#else
-            command_buffer, nullptr, 1, &invalid_point, nullptr, nullptr);
-#endif
+        cl_int error =
+            clCommandBarrierWithWaitListKHR(command_buffer, nullptr, nullptr, 1,
+                                            &invalid_point, nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -154,13 +131,8 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 1,
-                                                nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "
@@ -169,24 +141,13 @@ struct CommandBufferBarrierSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
-        error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
-                                   out_mem, 0, 0, data_size(), 0, nullptr,
-                                   &point, nullptr);
-#else
-            clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
-                                   0, data_size(), 0, nullptr, &point, nullptr);
-#endif
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem, 0, 0, data_size(), 0, nullptr,
+                                       &point, nullptr);
         test_error(error, "clCommandCopyBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, &point, nullptr, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandBarrierWithWaitListKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
@@ -95,15 +95,9 @@ struct CommandBufferCopyBufferQueueNotNull
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(command_buffer, queue, nullptr, in_mem,
-                                   out_mem, 0, 0, data_size, 0, nullptr,
-                                   nullptr, nullptr);
-#else
-            clCommandCopyBufferKHR(command_buffer, queue, in_mem, out_mem, 0, 0,
-                                   data_size, 0, nullptr, nullptr, nullptr);
-#endif
+        cl_int error = clCommandCopyBufferKHR(command_buffer, queue, nullptr,
+                                              in_mem, out_mem, 0, 0, data_size,
+                                              0, nullptr, nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyBufferKHR should return "
@@ -111,13 +105,8 @@ struct CommandBufferCopyBufferQueueNotNull
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, queue, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, queue, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyBufferRectKHR should return "
@@ -137,13 +126,8 @@ struct CommandBufferCopyImageQueueNotNull
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, queue, nullptr, image, buffer, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
-#else
-            command_buffer, queue, image, buffer, origin, region, 0, 0, nullptr,
-            nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyImageToBufferKHR should return "
@@ -183,13 +167,8 @@ struct CommandBufferCopyBufferDifferentContexts
     cl_int Run() override
     {
         cl_int error = clCommandCopyBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem_ctx, out_mem, 0, 0,
             data_size, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem_ctx, out_mem, 0, 0, data_size, 0,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferKHR should return "
@@ -198,29 +177,17 @@ struct CommandBufferCopyBufferDifferentContexts
 
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem_ctx, out_mem, origin,
             origin, region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem_ctx, out_mem, origin, origin,
-            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferRectKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
                                        out_mem_ctx, 0, 0, data_size, 0, nullptr,
                                        nullptr, nullptr);
-#else
-        error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem,
-                                       out_mem_ctx, 0, 0, data_size, 0, nullptr,
-                                       nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferKHR should return "
@@ -228,13 +195,8 @@ struct CommandBufferCopyBufferDifferentContexts
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem_ctx, origin,
             origin, region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, out_mem_ctx, origin, origin,
-            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferRectKHR should return "
@@ -279,29 +241,17 @@ struct CommandBufferCopyImageDifferentContexts
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, image_ctx, buffer, origin, region,
             0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, image_ctx, buffer, origin, region, 0, 0,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
                                               image, buffer_ctx, origin, region,
                                               0, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
-                                              buffer_ctx, origin, region, 0, 0,
-                                              nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -330,15 +280,9 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
     {
         cl_sync_point_khr invalid_point = 0;
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandCopyBufferKHR(
             command_buffer, nullptr, nullptr, in_mem, out_mem, 0, 0, data_size,
             1, &invalid_point, nullptr, nullptr);
-#else
-        cl_int error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem,
-                                              out_mem, 0, 0, data_size, 1,
-                                              &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
@@ -346,13 +290,8 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 1, &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -360,15 +299,9 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
-        error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
-                                   out_mem, 0, 0, data_size, 1, nullptr,
-                                   nullptr, nullptr);
-#else
-            clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
-                                   0, data_size, 1, nullptr, nullptr, nullptr);
-#endif
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem, 0, 0, data_size, 1, nullptr,
+                                       nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
@@ -377,13 +310,8 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
 
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 1, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 1, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -392,39 +320,22 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
-        error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
-                                   out_mem, 0, 0, data_size, 0, &point, nullptr,
-                                   nullptr);
-#else
-            clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
-                                   0, data_size, 0, &point, nullptr, nullptr);
-#endif
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem, 0, 0, data_size, 0, &point,
+                                       nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyBufferRectKHR(
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, &point, nullptr, nullptr);
-#else
-        error = clCommandCopyBufferRectKHR(
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 0, &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -450,13 +361,8 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, image, buffer, origin, region, 0,
             1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, image, buffer, origin, region, 0, 1,
-            &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -464,15 +370,9 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
                                               image, buffer, origin, region, 0,
                                               1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
-                                              buffer, origin, region, 0, 1,
-                                              nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -481,24 +381,13 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
                                               image, buffer, origin, region, 0,
                                               0, &point, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
-                                              buffer, origin, region, 0, 0,
-                                              &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -518,30 +407,18 @@ struct CommandBufferCopyBufferInvalidCommandBuffer
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(nullptr, nullptr, nullptr, in_mem, out_mem,
-                                   0, 0, data_size, 0, nullptr, nullptr,
-                                   nullptr);
-#else
-            clCommandCopyBufferKHR(nullptr, nullptr, in_mem, out_mem, 0, 0,
-                                   data_size, 0, nullptr, nullptr, nullptr);
-#endif
+        cl_int error = clCommandCopyBufferKHR(nullptr, nullptr, nullptr, in_mem,
+                                              out_mem, 0, 0, data_size, 0,
+                                              nullptr, nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyBufferKHR should return "
                                "CL_INVALID_COMMAND_BUFFER_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyBufferRectKHR(
             nullptr, nullptr, nullptr, in_mem, out_mem, origin, origin, region,
             0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyBufferRectKHR(nullptr, nullptr, in_mem, out_mem,
-                                           origin, origin, region, 0, 0, 0, 0,
-                                           0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -562,13 +439,8 @@ struct CommandBufferCopyImageInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             nullptr, nullptr, nullptr, image, buffer, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
-#else
-            nullptr, nullptr, image, buffer, origin, region, 0, 0, nullptr,
-            nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -590,15 +462,9 @@ struct CommandBufferCopyBufferFinalizedCommandBuffer
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
-        error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
-                                   out_mem, 0, 0, data_size, 0, nullptr,
-                                   nullptr, nullptr);
-#else
-            clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
-                                   0, data_size, 0, nullptr, nullptr, nullptr);
-#endif
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem, 0, 0, data_size, 0, nullptr,
+                                       nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyBufferKHR should return "
@@ -607,13 +473,8 @@ struct CommandBufferCopyBufferFinalizedCommandBuffer
 
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyBufferRectKHR should return "
@@ -636,15 +497,9 @@ struct CommandBufferCopyImageFinalizedCommandBuffer
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
                                               image, buffer, origin, region, 0,
                                               0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
-                                              buffer, origin, region, 0, 0,
-                                              nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageToBufferKHR should return "
@@ -666,13 +521,8 @@ struct CommandBufferCopyBufferMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandCopyBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, 0, 0, data_size,
             0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, in_mem, out_mem, 0, 0, data_size, 0,
-            nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyBufferKHR should return "
@@ -681,13 +531,8 @@ struct CommandBufferCopyBufferMutableHandleNotNull
 
 
         error = clCommandCopyBufferRectKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
-            0, 0, 0, 0, nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyBufferRectKHR should return "
@@ -710,13 +555,8 @@ struct CommandBufferCopyImageMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, image, buffer, origin, region, 0,
             0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, image, buffer, origin, region, 0, 0,
-            nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageToBufferKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
@@ -96,8 +96,14 @@ struct CommandBufferCopyBufferQueueNotNull
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(command_buffer, queue, nullptr, in_mem,
+                                   out_mem, 0, 0, data_size, 0, nullptr,
+                                   nullptr, nullptr);
+#else
             clCommandCopyBufferKHR(command_buffer, queue, in_mem, out_mem, 0, 0,
                                    data_size, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyBufferKHR should return "
@@ -105,8 +111,13 @@ struct CommandBufferCopyBufferQueueNotNull
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, queue, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, queue, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyBufferRectKHR should return "
@@ -126,8 +137,13 @@ struct CommandBufferCopyImageQueueNotNull
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, queue, nullptr, image, buffer, origin, region, 0, 0,
+            nullptr, nullptr, nullptr);
+#else
             command_buffer, queue, image, buffer, origin, region, 0, 0, nullptr,
             nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyImageToBufferKHR should return "
@@ -167,8 +183,13 @@ struct CommandBufferCopyBufferDifferentContexts
     cl_int Run() override
     {
         cl_int error = clCommandCopyBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem_ctx, out_mem, 0, 0,
+            data_size, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem_ctx, out_mem, 0, 0, data_size, 0,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferKHR should return "
@@ -177,8 +198,13 @@ struct CommandBufferCopyBufferDifferentContexts
 
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem_ctx, out_mem, origin,
+            origin, region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem_ctx, out_mem, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferRectKHR should return "
@@ -186,9 +212,15 @@ struct CommandBufferCopyBufferDifferentContexts
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                       out_mem_ctx, 0, 0, data_size, 0, nullptr,
+                                       nullptr, nullptr);
+#else
         error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem,
                                        out_mem_ctx, 0, 0, data_size, 0, nullptr,
                                        nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferKHR should return "
@@ -196,8 +228,13 @@ struct CommandBufferCopyBufferDifferentContexts
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem_ctx, origin,
+            origin, region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, out_mem_ctx, origin, origin,
             region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyBufferRectKHR should return "
@@ -242,8 +279,13 @@ struct CommandBufferCopyImageDifferentContexts
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, image_ctx, buffer, origin, region,
+            0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, image_ctx, buffer, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -251,9 +293,15 @@ struct CommandBufferCopyImageDifferentContexts
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer_ctx, origin, region,
+                                              0, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
                                               buffer_ctx, origin, region, 0, 0,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -282,9 +330,15 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
     {
         cl_sync_point_khr invalid_point = 0;
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandCopyBufferKHR(
+            command_buffer, nullptr, nullptr, in_mem, out_mem, 0, 0, data_size,
+            1, &invalid_point, nullptr, nullptr);
+#else
         cl_int error = clCommandCopyBufferKHR(command_buffer, nullptr, in_mem,
                                               out_mem, 0, 0, data_size, 1,
                                               &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
@@ -292,8 +346,13 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
                                TEST_FAIL);
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 1, &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -302,8 +361,14 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
 
 
         error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                   out_mem, 0, 0, data_size, 1, nullptr,
+                                   nullptr, nullptr);
+#else
             clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
                                    0, data_size, 1, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
@@ -312,8 +377,13 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
 
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 1, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 1, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -322,22 +392,39 @@ struct CommandBufferCopyBufferSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
         error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                   out_mem, 0, 0, data_size, 0, &point, nullptr,
+                                   nullptr);
+#else
             clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
                                    0, data_size, 0, &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyBufferRectKHR(
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 0, &point, nullptr, nullptr);
+#else
         error = clCommandCopyBufferRectKHR(
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 0, &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -363,8 +450,13 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, image, buffer, origin, region, 0,
+            1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, image, buffer, origin, region, 0, 1,
             &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -372,9 +464,15 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer, origin, region, 0,
+                                              1, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
                                               buffer, origin, region, 0, 1,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -383,13 +481,24 @@ struct CommandBufferCopyImageSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer, origin, region, 0,
+                                              0, &point, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
                                               buffer, origin, region, 0, 0,
                                               &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -410,17 +519,29 @@ struct CommandBufferCopyBufferInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(nullptr, nullptr, nullptr, in_mem, out_mem,
+                                   0, 0, data_size, 0, nullptr, nullptr,
+                                   nullptr);
+#else
             clCommandCopyBufferKHR(nullptr, nullptr, in_mem, out_mem, 0, 0,
                                    data_size, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyBufferKHR should return "
                                "CL_INVALID_COMMAND_BUFFER_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyBufferRectKHR(
+            nullptr, nullptr, nullptr, in_mem, out_mem, origin, origin, region,
+            0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyBufferRectKHR(nullptr, nullptr, in_mem, out_mem,
                                            origin, origin, region, 0, 0, 0, 0,
                                            0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyBufferRectKHR should return "
@@ -441,8 +562,13 @@ struct CommandBufferCopyImageInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            nullptr, nullptr, nullptr, image, buffer, origin, region, 0, 0,
+            nullptr, nullptr, nullptr);
+#else
             nullptr, nullptr, image, buffer, origin, region, 0, 0, nullptr,
             nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -465,8 +591,14 @@ struct CommandBufferCopyBufferFinalizedCommandBuffer
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
         error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandCopyBufferKHR(command_buffer, nullptr, nullptr, in_mem,
+                                   out_mem, 0, 0, data_size, 0, nullptr,
+                                   nullptr, nullptr);
+#else
             clCommandCopyBufferKHR(command_buffer, nullptr, in_mem, out_mem, 0,
                                    0, data_size, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyBufferKHR should return "
@@ -475,8 +607,13 @@ struct CommandBufferCopyBufferFinalizedCommandBuffer
 
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyBufferRectKHR should return "
@@ -499,9 +636,15 @@ struct CommandBufferCopyImageFinalizedCommandBuffer
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer, origin, region, 0,
+                                              0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, image,
                                               buffer, origin, region, 0, 0,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageToBufferKHR should return "
@@ -523,8 +666,13 @@ struct CommandBufferCopyBufferMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandCopyBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, 0, 0, data_size,
+            0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, in_mem, out_mem, 0, 0, data_size, 0,
             nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyBufferKHR should return "
@@ -533,8 +681,13 @@ struct CommandBufferCopyBufferMutableHandleNotNull
 
 
         error = clCommandCopyBufferRectKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, in_mem, out_mem, origin, origin,
+            region, 0, 0, 0, 0, 0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, in_mem, out_mem, origin, origin, region, 0,
             0, 0, 0, 0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyBufferRectKHR should return "
@@ -557,8 +710,13 @@ struct CommandBufferCopyImageMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, image, buffer, origin, region, 0,
+            0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, image, buffer, origin, region, 0, 0,
             nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageToBufferKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy_image.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy_image.cpp
@@ -76,18 +76,31 @@ struct CommandBufferCopyImageQueueNotNull : public CommandCopyBaseTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandCopyImageKHR(
+            command_buffer, queue, nullptr, src_image, dst_image, origin,
+            origin, region, 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandCopyImageKHR(command_buffer, queue, src_image,
                                              dst_image, origin, origin, region,
                                              0, nullptr, nullptr, nullptr);
+#endif
+
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_COMMAND_QUEUE",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(
+            command_buffer, queue, nullptr, src_image, out_mem, origin, region,
+            0, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(command_buffer, queue, src_image,
                                               out_mem, origin, region, 0, 0,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyImageToBufferKHR should return "
@@ -115,8 +128,13 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image_ctx, dst_image, origin,
+            origin, region, 0, 0, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image_ctx, dst_image, origin, origin,
             region, 0, 0, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
@@ -124,26 +142,43 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image_ctx, out_mem, origin,
+            region, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image_ctx, out_mem, origin, region, 0,
             0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image_ctx, origin, origin,
+                                      region, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image_ctx, origin, origin, region, 0,
                                       nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(
+            command_buffer, nullptr, nullptr, src_image, dst_image_ctx, origin,
+            region, 0, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(
             command_buffer, nullptr, src_image, dst_image_ctx, origin, region,
             0, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -154,18 +189,30 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
         command_buffer = clCreateCommandBufferKHR(1, &queue1, 0, &error);
         test_error(error, "clCreateCommandBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image, origin, origin, region, 0,
                                       nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -216,8 +263,13 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandCopyImageKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, dst_image, origin,
+            origin, region, 1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image, dst_image, origin, origin,
             region, 1, &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -225,8 +277,13 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 1,
             &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -234,9 +291,15 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 1, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image, origin, origin, region, 1,
                                       nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -244,8 +307,13 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 1, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 1,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -254,13 +322,24 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 0, &point, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image, origin, origin, region, 0,
                                       &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -268,8 +347,13 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 0, &point, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
             &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -289,18 +373,30 @@ struct CommandBufferCopyImageInvalidCommandBuffer : public CommandCopyBaseTest
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandCopyImageKHR(
+            nullptr, nullptr, nullptr, src_image, dst_image, origin, origin,
+            region, 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandCopyImageKHR(nullptr, nullptr, src_image,
                                              dst_image, origin, origin, region,
                                              0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_COMMAND_BUFFER_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageToBufferKHR(
+            nullptr, nullptr, nullptr, src_image, out_mem, origin, region, 0, 0,
+            nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageToBufferKHR(nullptr, nullptr, src_image,
                                               out_mem, origin, region, 0, 0,
                                               nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -322,9 +418,15 @@ struct CommandBufferCopyImageFinalizedCommandBuffer : public CommandCopyBaseTest
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
                                       dst_image, origin, origin, region, 0,
                                       nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageKHR should return "
@@ -332,8 +434,13 @@ struct CommandBufferCopyImageFinalizedCommandBuffer : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageToBufferKHR should return "
@@ -354,8 +461,13 @@ struct CommandBufferCopyImageMutableHandleNotNull : public CommandCopyBaseTest
     {
         cl_mutable_command_khr mutable_handle;
         cl_int error = clCommandCopyImageKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, dst_image, origin,
+            origin, region, 0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, src_image, dst_image, origin, origin,
             region, 0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageKHR should return "
@@ -363,8 +475,13 @@ struct CommandBufferCopyImageMutableHandleNotNull : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, src_image, out_mem, origin,
+            region, 0, 0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
             nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageToBufferKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy_image.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy_image.cpp
@@ -76,15 +76,9 @@ struct CommandBufferCopyImageQueueNotNull : public CommandCopyBaseTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandCopyImageKHR(
             command_buffer, queue, nullptr, src_image, dst_image, origin,
             origin, region, 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandCopyImageKHR(command_buffer, queue, src_image,
-                                             dst_image, origin, origin, region,
-                                             0, nullptr, nullptr, nullptr);
-#endif
 
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
@@ -92,15 +86,9 @@ struct CommandBufferCopyImageQueueNotNull : public CommandCopyBaseTest
                                "CL_INVALID_COMMAND_QUEUE",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(
             command_buffer, queue, nullptr, src_image, out_mem, origin, region,
             0, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(command_buffer, queue, src_image,
-                                              out_mem, origin, region, 0, 0,
-                                              nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandCopyImageToBufferKHR should return "
@@ -128,13 +116,8 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
     cl_int Run() override
     {
         cl_int error = clCommandCopyImageKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image_ctx, dst_image, origin,
             origin, region, 0, 0, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image_ctx, dst_image, origin, origin,
-            region, 0, 0, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
@@ -142,43 +125,26 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image_ctx, out_mem, origin,
             region, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image_ctx, out_mem, origin, region, 0,
-            0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image_ctx, origin, origin,
                                       region, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image_ctx, origin, origin, region, 0,
-                                      nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(
             command_buffer, nullptr, nullptr, src_image, dst_image_ctx, origin,
             region, 0, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(
-            command_buffer, nullptr, src_image, dst_image_ctx, origin, region,
-            0, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -189,30 +155,18 @@ struct CommandBufferCopyImageContextNotSame : public CommandCopyBaseTest
         command_buffer = clCreateCommandBufferKHR(1, &queue1, 0, &error);
         test_error(error, "clCreateCommandBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image, origin, origin,
                                       region, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image, origin, origin, region, 0,
-                                      nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_CONTEXT",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandCopyImageToBufferKHR should return "
@@ -263,13 +217,8 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandCopyImageKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, dst_image, origin,
             origin, region, 1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image, dst_image, origin, origin,
-            region, 1, &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -277,29 +226,17 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 1,
-            &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image, origin, origin,
                                       region, 1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image, origin, origin, region, 1,
-                                      nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -307,13 +244,8 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 1, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 1,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -322,24 +254,13 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
 
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image, origin, origin,
                                       region, 0, &point, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image, origin, origin, region, 0,
-                                      &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageKHR should return "
@@ -347,13 +268,8 @@ struct CommandBufferCopySyncPointsNullOrNumZero : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 0, &point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
-            &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -373,30 +289,18 @@ struct CommandBufferCopyImageInvalidCommandBuffer : public CommandCopyBaseTest
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandCopyImageKHR(
             nullptr, nullptr, nullptr, src_image, dst_image, origin, origin,
             region, 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandCopyImageKHR(nullptr, nullptr, src_image,
-                                             dst_image, origin, origin, region,
-                                             0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageKHR should return "
                                "CL_INVALID_COMMAND_BUFFER_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageToBufferKHR(
             nullptr, nullptr, nullptr, src_image, out_mem, origin, region, 0, 0,
             nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageToBufferKHR(nullptr, nullptr, src_image,
-                                              out_mem, origin, region, 0, 0,
-                                              nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandCopyImageToBufferKHR should return "
@@ -418,15 +322,9 @@ struct CommandBufferCopyImageFinalizedCommandBuffer : public CommandCopyBaseTest
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
                                       src_image, dst_image, origin, origin,
                                       region, 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandCopyImageKHR(command_buffer, nullptr, src_image,
-                                      dst_image, origin, origin, region, 0,
-                                      nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageKHR should return "
@@ -434,13 +332,8 @@ struct CommandBufferCopyImageFinalizedCommandBuffer : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandCopyImageToBufferKHR should return "
@@ -461,13 +354,8 @@ struct CommandBufferCopyImageMutableHandleNotNull : public CommandCopyBaseTest
     {
         cl_mutable_command_khr mutable_handle;
         cl_int error = clCommandCopyImageKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, dst_image, origin,
             origin, region, 0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, src_image, dst_image, origin, origin,
-            region, 0, nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageKHR should return "
@@ -475,13 +363,8 @@ struct CommandBufferCopyImageMutableHandleNotNull : public CommandCopyBaseTest
                                TEST_FAIL);
 
         error = clCommandCopyImageToBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, src_image, out_mem, origin,
             region, 0, 0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, src_image, out_mem, origin, region, 0, 0,
-            nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandCopyImageToBufferKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
@@ -82,13 +82,8 @@ struct CommandBufferCommandFillBufferQueueNotNull
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, queue, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, queue, out_mem, &pattern, sizeof(cl_int), 0,
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandFillBufferKHR should return "
@@ -114,15 +109,9 @@ struct CommandBufferCommandFillImageQueueNotNull
 
     cl_int Run() override
     {
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandFillImageKHR(
             command_buffer, queue, nullptr, src_image, fill_color_1, origin,
             region, 0, nullptr, nullptr, nullptr);
-#else
-        cl_int error = clCommandFillImageKHR(command_buffer, queue, src_image,
-                                             fill_color_1, origin, region, 0,
-                                             nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandFillImageKHR should return "
@@ -150,13 +139,8 @@ struct CommandBufferCommandFillBufferContextNotSame
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, out_mem_ctx, &pattern,
             sizeof(cl_int), 0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, out_mem_ctx, &pattern, sizeof(cl_int), 0,
-            data_size(), 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandFillBufferKHR should return "
@@ -197,13 +181,8 @@ struct CommandBufferCommandFillImageContextNotSame
     cl_int Run() override
     {
         cl_int error = clCommandFillImageKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, dst_image_ctx, fill_color_1,
             origin, region, 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, nullptr, dst_image_ctx, fill_color_1, origin,
-            region, 0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandFillImageKHR should return "
@@ -246,13 +225,8 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
-            data_size(), 1, &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -260,15 +234,9 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
-                                       &pattern, sizeof(cl_int), 0, data_size(),
-                                       1, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -277,24 +245,13 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 0, &point, nullptr, nullptr);
-#else
-        error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
-                                       &pattern, sizeof(cl_int), 0, data_size(),
-                                       0, &point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -319,15 +276,9 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
     {
         cl_sync_point_khr invalid_point = 0;
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandFillImageKHR(
             command_buffer, nullptr, nullptr, dst_image, fill_color_1, origin,
             region, 1, &invalid_point, nullptr, nullptr);
-#else
-        cl_int error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
-                                             fill_color_1, origin, region, 1,
-                                             &invalid_point, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -335,15 +286,9 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
                                       dst_image, fill_color_1, origin, region,
                                       1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
-                                      fill_color_1, origin, region, 1, nullptr,
-                                      nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -351,25 +296,14 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
                                       dst_image, fill_color_1, origin, region,
                                       0, &point, nullptr, nullptr);
-#else
-        error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
-                                      fill_color_1, origin, region, 0, &point,
-                                      nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -392,13 +326,8 @@ struct CommandBufferCommandFillBufferInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             nullptr, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            nullptr, nullptr, out_mem, &pattern, sizeof(cl_int), 0, data_size(),
-            0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandFillBufferKHR should return "
@@ -418,15 +347,9 @@ struct CommandBufferCommandFillImageInvalidCommandBuffer
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandFillImageKHR(nullptr, nullptr, nullptr, dst_image,
-                                  fill_color_1, origin, region, 0, nullptr,
-                                  nullptr, nullptr);
-#else
-            clCommandFillImageKHR(nullptr, nullptr, dst_image, fill_color_1,
-                                  origin, region, 0, nullptr, nullptr, nullptr);
-#endif
+        cl_int error = clCommandFillImageKHR(
+            nullptr, nullptr, nullptr, dst_image, fill_color_1, origin, region,
+            0, nullptr, nullptr, nullptr);
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandFillImageKHR should return "
@@ -448,15 +371,9 @@ struct CommandBufferCommandFillBufferFinalizedCommandBuffer
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillBufferKHR(
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
-                                       &pattern, sizeof(cl_int), 0, data_size(),
-                                       0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandFillBufferKHR should return "
@@ -480,15 +397,9 @@ struct CommandBufferCommandFillImageFinalizedCommandBuffer
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
                                       dst_image, fill_color_1, origin, region,
                                       0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
-                                      fill_color_1, origin, region, 0, nullptr,
-                                      nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandFillImageKHR should return "
@@ -510,13 +421,8 @@ struct CommandBufferCommandFillBufferMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandFillBufferKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
             0, data_size(), 0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
-            data_size(), 0, nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandFillBufferKHR should return "
@@ -538,15 +444,9 @@ struct CommandBufferCommandFillImageMutableHandleNotNull
     {
         cl_mutable_command_khr mutable_handle;
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_int error = clCommandFillImageKHR(
             command_buffer, nullptr, nullptr, dst_image, fill_color_1, origin,
             region, 0, nullptr, nullptr, &mutable_handle);
-#else
-        cl_int error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
-                                             fill_color_1, origin, region, 0,
-                                             nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandFillImageKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
@@ -82,8 +82,13 @@ struct CommandBufferCommandFillBufferQueueNotNull
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, queue, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, queue, out_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandFillBufferKHR should return "
@@ -109,9 +114,15 @@ struct CommandBufferCommandFillImageQueueNotNull
 
     cl_int Run() override
     {
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, queue, nullptr, src_image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
+#else
         cl_int error = clCommandFillImageKHR(command_buffer, queue, src_image,
                                              fill_color_1, origin, region, 0,
                                              nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_QUEUE,
                                "clCommandFillImageKHR should return "
@@ -139,8 +150,13 @@ struct CommandBufferCommandFillBufferContextNotSame
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, out_mem_ctx, &pattern,
+            sizeof(cl_int), 0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, out_mem_ctx, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandFillBufferKHR should return "
@@ -181,8 +197,13 @@ struct CommandBufferCommandFillImageContextNotSame
     cl_int Run() override
     {
         cl_int error = clCommandFillImageKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, dst_image_ctx, fill_color_1,
+            origin, region, 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, nullptr, dst_image_ctx, fill_color_1, origin,
             region, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_CONTEXT,
                                "clCommandFillImageKHR should return "
@@ -225,8 +246,13 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 1, &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -234,9 +260,15 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 1, nullptr, nullptr, nullptr);
+#else
         error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
                                        &pattern, sizeof(cl_int), 0, data_size(),
                                        1, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -245,13 +277,24 @@ struct CommandBufferCommandFillBufferSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, &point, nullptr, nullptr);
+#else
         error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
                                        &pattern, sizeof(cl_int), 0, data_size(),
                                        0, &point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillBufferKHR should return "
@@ -276,9 +319,15 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
     {
         cl_sync_point_khr invalid_point = 0;
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, dst_image, fill_color_1, origin,
+            region, 1, &invalid_point, nullptr, nullptr);
+#else
         cl_int error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
                                              fill_color_1, origin, region, 1,
                                              &invalid_point, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -286,9 +335,15 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
+                                      dst_image, fill_color_1, origin, region,
+                                      1, nullptr, nullptr, nullptr);
+#else
         error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
                                       fill_color_1, origin, region, 1, nullptr,
                                       nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -296,14 +351,25 @@ struct CommandBufferCommandFillImageSyncPointsNullOrNumZero
                                TEST_FAIL);
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
+                                      dst_image, fill_color_1, origin, region,
+                                      0, &point, nullptr, nullptr);
+#else
         error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
                                       fill_color_1, origin, region, 0, &point,
                                       nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandFillImageKHR should return "
@@ -326,8 +392,13 @@ struct CommandBufferCommandFillBufferInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            nullptr, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
+            data_size(), 0, nullptr, nullptr, nullptr);
+#else
             nullptr, nullptr, out_mem, &pattern, sizeof(cl_int), 0, data_size(),
             0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandFillBufferKHR should return "
@@ -348,8 +419,14 @@ struct CommandBufferCommandFillImageInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandFillImageKHR(nullptr, nullptr, nullptr, dst_image,
+                                  fill_color_1, origin, region, 0, nullptr,
+                                  nullptr, nullptr);
+#else
             clCommandFillImageKHR(nullptr, nullptr, dst_image, fill_color_1,
                                   origin, region, 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandFillImageKHR should return "
@@ -371,9 +448,15 @@ struct CommandBufferCommandFillBufferFinalizedCommandBuffer
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandFillBufferKHR(command_buffer, nullptr, out_mem,
                                        &pattern, sizeof(cl_int), 0, data_size(),
                                        0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandFillBufferKHR should return "
@@ -397,9 +480,15 @@ struct CommandBufferCommandFillImageFinalizedCommandBuffer
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandFillImageKHR(command_buffer, nullptr, nullptr,
+                                      dst_image, fill_color_1, origin, region,
+                                      0, nullptr, nullptr, nullptr);
+#else
         error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
                                       fill_color_1, origin, region, 0, nullptr,
                                       nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_OPERATION,
                                "clCommandFillImageKHR should return "
@@ -421,8 +510,13 @@ struct CommandBufferCommandFillBufferMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandFillBufferKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, out_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, out_mem, &pattern, sizeof(cl_int), 0,
             data_size(), 0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandFillBufferKHR should return "
@@ -444,9 +538,15 @@ struct CommandBufferCommandFillImageMutableHandleNotNull
     {
         cl_mutable_command_khr mutable_handle;
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, dst_image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, &mutable_handle);
+#else
         cl_int error = clCommandFillImageKHR(command_buffer, nullptr, dst_image,
                                              fill_color_1, origin, region, 0,
                                              nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_VALUE,
                                "clCommandFillImageKHR should return "

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
@@ -29,17 +29,28 @@ struct CommandBufferCommandSVMQueueNotNull : public BasicSVMCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandSVMMemcpyKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, queue, nullptr, svm_out_mem(), svm_in_mem(),
+            data_size(), 0, nullptr, nullptr, nullptr);
+#else
             command_buffer, queue, svm_out_mem(), svm_in_mem(), data_size(), 0,
             nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_QUEUE,
             "clCommandSVMMemcpyKHR should return CL_INVALID_COMMAND_QUEUE",
             TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, queue, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, queue, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_QUEUE,
@@ -73,37 +84,57 @@ struct CommandBufferCommandSVMSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandSVMMemcpyKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, svm_out_mem(), svm_in_mem(),
+            data_size(), 1, &invalid_point, nullptr, nullptr);
+#else
             command_buffer, nullptr, svm_out_mem(), svm_in_mem(), data_size(),
             1, &invalid_point, nullptr, nullptr);
-
+#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 1, &invalid_point, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        1, &invalid_point, nullptr, nullptr);
-
+#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
+                                      svm_out_mem(), svm_in_mem(), data_size(),
+                                      1, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
                                       svm_in_mem(), data_size(), 1, nullptr,
                                       nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 1, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        1, nullptr, nullptr, nullptr);
-
+#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
@@ -111,23 +142,39 @@ struct CommandBufferCommandSVMSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
+                                      svm_out_mem(), svm_in_mem(), data_size(),
+                                      0, &point, nullptr, nullptr);
+#else
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
                                       svm_in_mem(), data_size(), 0, &point,
                                       nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, &point, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, &point, nullptr, nullptr);
-
+#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
@@ -150,17 +197,29 @@ struct CommandBufferCommandSVMInvalidCommandBuffer
     cl_int Run() override
     {
         cl_int error =
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            clCommandSVMMemcpyKHR(nullptr, nullptr, nullptr, svm_out_mem(),
+                                  svm_in_mem(), data_size(), 0, nullptr,
+                                  nullptr, nullptr);
+#else
             clCommandSVMMemcpyKHR(nullptr, nullptr, svm_out_mem(), svm_in_mem(),
                                   data_size(), 0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_BUFFER_KHR,
             "clCommandSVMMemcpyKHR should return CL_INVALID_COMMAND_BUFFER_KHR",
             TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(nullptr, nullptr, nullptr, svm_in_mem(),
+                                       &pattern_1, sizeof(cl_char), data_size(),
+                                       0, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(nullptr, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, nullptr, nullptr, nullptr);
+#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandSVMMemFillKHR should return "
@@ -184,19 +243,29 @@ struct CommandBufferCommandSVMFinalizedCommandBuffer
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
+                                      svm_out_mem(), svm_in_mem(), data_size(),
+                                      0, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
                                       svm_in_mem(), data_size(), 0, nullptr,
                                       nullptr, nullptr);
-
+#endif
         test_failure_error_ret(
             error, CL_INVALID_OPERATION,
             "clCommandSVMMemcpyKHR should return CL_INVALID_OPERATION",
             TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, nullptr, nullptr, nullptr);
-
+#endif
         test_failure_error_ret(
             error, CL_INVALID_OPERATION,
             "clCommandSVMMemFillKHR should return CL_INVALID_OPERATION",
@@ -219,16 +288,27 @@ struct CommandBufferCommandSVMMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandSVMMemcpyKHR(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            command_buffer, nullptr, nullptr, svm_out_mem(), svm_in_mem(),
+            data_size(), 0, nullptr, nullptr, &mutable_handle);
+#else
             command_buffer, nullptr, svm_out_mem(), svm_in_mem(), data_size(),
             0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(
             error, CL_INVALID_VALUE,
             "clCommandSVMMemcpyKHR should return CL_INVALID_VALUE", TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandSVMMemFillKHR(
+            command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
+            sizeof(cl_char), data_size(), 0, nullptr, nullptr, &mutable_handle);
+#else
         error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, nullptr, nullptr, &mutable_handle);
+#endif
 
         test_failure_error_ret(
             error, CL_INVALID_VALUE,

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_svm_mem.cpp
@@ -29,28 +29,17 @@ struct CommandBufferCommandSVMQueueNotNull : public BasicSVMCommandBufferTest
     cl_int Run() override
     {
         cl_int error = clCommandSVMMemcpyKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, queue, nullptr, svm_out_mem(), svm_in_mem(),
             data_size(), 0, nullptr, nullptr, nullptr);
-#else
-            command_buffer, queue, svm_out_mem(), svm_in_mem(), data_size(), 0,
-            nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_QUEUE,
             "clCommandSVMMemcpyKHR should return CL_INVALID_COMMAND_QUEUE",
             TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, queue, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, queue, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_QUEUE,
@@ -84,57 +73,33 @@ struct CommandBufferCommandSVMSyncPointsNullOrNumZero
         cl_sync_point_khr invalid_point = 0;
 
         cl_int error = clCommandSVMMemcpyKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, svm_out_mem(), svm_in_mem(),
             data_size(), 1, &invalid_point, nullptr, nullptr);
-#else
-            command_buffer, nullptr, svm_out_mem(), svm_in_mem(), data_size(),
-            1, &invalid_point, nullptr, nullptr);
-#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 1, &invalid_point, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       1, &invalid_point, nullptr, nullptr);
-#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
                                       svm_out_mem(), svm_in_mem(), data_size(),
                                       1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
-                                      svm_in_mem(), data_size(), 1, nullptr,
-                                      nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 1, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       1, nullptr, nullptr, nullptr);
-#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
@@ -142,39 +107,22 @@ struct CommandBufferCommandSVMSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
                                       svm_out_mem(), svm_in_mem(), data_size(),
                                       0, &point, nullptr, nullptr);
-#else
-        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
-                                      svm_in_mem(), data_size(), 0, &point,
-                                      nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemcpyKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, &point, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       0, &point, nullptr, nullptr);
-#endif
         test_failure_error_ret(error, CL_INVALID_SYNC_POINT_WAIT_LIST_KHR,
                                "clCommandSVMMemFillKHR should return "
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
@@ -196,30 +144,18 @@ struct CommandBufferCommandSVMInvalidCommandBuffer
 
     cl_int Run() override
     {
-        cl_int error =
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
-            clCommandSVMMemcpyKHR(nullptr, nullptr, nullptr, svm_out_mem(),
-                                  svm_in_mem(), data_size(), 0, nullptr,
-                                  nullptr, nullptr);
-#else
-            clCommandSVMMemcpyKHR(nullptr, nullptr, svm_out_mem(), svm_in_mem(),
-                                  data_size(), 0, nullptr, nullptr, nullptr);
-#endif
+        cl_int error = clCommandSVMMemcpyKHR(
+            nullptr, nullptr, nullptr, svm_out_mem(), svm_in_mem(), data_size(),
+            0, nullptr, nullptr, nullptr);
 
         test_failure_error_ret(
             error, CL_INVALID_COMMAND_BUFFER_KHR,
             "clCommandSVMMemcpyKHR should return CL_INVALID_COMMAND_BUFFER_KHR",
             TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(nullptr, nullptr, nullptr, svm_in_mem(),
                                        &pattern_1, sizeof(cl_char), data_size(),
                                        0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(nullptr, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       0, nullptr, nullptr, nullptr);
-#endif
 
         test_failure_error_ret(error, CL_INVALID_COMMAND_BUFFER_KHR,
                                "clCommandSVMMemFillKHR should return "
@@ -243,29 +179,17 @@ struct CommandBufferCommandSVMFinalizedCommandBuffer
         cl_int error = clFinalizeCommandBufferKHR(command_buffer);
         test_error(error, "clFinalizeCommandBufferKHR failed");
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemcpyKHR(command_buffer, nullptr, nullptr,
                                       svm_out_mem(), svm_in_mem(), data_size(),
                                       0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemcpyKHR(command_buffer, nullptr, svm_out_mem(),
-                                      svm_in_mem(), data_size(), 0, nullptr,
-                                      nullptr, nullptr);
-#endif
         test_failure_error_ret(
             error, CL_INVALID_OPERATION,
             "clCommandSVMMemcpyKHR should return CL_INVALID_OPERATION",
             TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, nullptr, nullptr, nullptr);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       0, nullptr, nullptr, nullptr);
-#endif
         test_failure_error_ret(
             error, CL_INVALID_OPERATION,
             "clCommandSVMMemFillKHR should return CL_INVALID_OPERATION",
@@ -288,27 +212,16 @@ struct CommandBufferCommandSVMMutableHandleNotNull
         cl_mutable_command_khr mutable_handle;
 
         cl_int error = clCommandSVMMemcpyKHR(
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
             command_buffer, nullptr, nullptr, svm_out_mem(), svm_in_mem(),
             data_size(), 0, nullptr, nullptr, &mutable_handle);
-#else
-            command_buffer, nullptr, svm_out_mem(), svm_in_mem(), data_size(),
-            0, nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(
             error, CL_INVALID_VALUE,
             "clCommandSVMMemcpyKHR should return CL_INVALID_VALUE", TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandSVMMemFillKHR(
             command_buffer, nullptr, nullptr, svm_in_mem(), &pattern_1,
             sizeof(cl_char), data_size(), 0, nullptr, nullptr, &mutable_handle);
-#else
-        error = clCommandSVMMemFillKHR(command_buffer, nullptr, svm_in_mem(),
-                                       &pattern_1, sizeof(cl_char), data_size(),
-                                       0, nullptr, nullptr, &mutable_handle);
-#endif
 
         test_failure_error_ret(
             error, CL_INVALID_VALUE,

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
@@ -135,8 +135,13 @@ struct CommandNDRangeKerneSyncPointsNullOrNumZero
 
 
         cl_sync_point_khr point;
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        error = clCommandBarrierWithWaitListKHR(
+            command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
+#else
         error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
                                                 nullptr, &point, nullptr);
+#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
         cl_sync_point_khr* sync_points[] = { &point };
@@ -182,8 +187,14 @@ struct CommandNDRangeKernelInvalidProperties : public BasicCommandBufferTest
 
     cl_int Run() override
     {
+
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr empty_properties =
+            ~cl_command_properties_khr(0);
+#else
         cl_ndrange_kernel_command_properties_khr empty_properties =
             ~cl_ndrange_kernel_command_properties_khr(0);
+#endif
 
         cl_int error = clCommandNDRangeKernelKHR(
             command_buffer, nullptr, &empty_properties, kernel, 1, nullptr,
@@ -194,9 +205,14 @@ struct CommandNDRangeKernelInvalidProperties : public BasicCommandBufferTest
                                "CL_INVALID_VALUE",
                                TEST_FAIL);
 
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+        cl_command_properties_khr props_invalid[3] = {
+#else
         cl_ndrange_kernel_command_properties_khr props_invalid[3] = {
+#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MEM_USE_CACHED_CPU_MEMORY_IMG, 1
+            CL_MEM_USE_CACHED_CPU_MEMORY_IMG,
+            1
         };
 
         error = clCommandNDRangeKernelKHR(

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
@@ -133,15 +133,9 @@ struct CommandNDRangeKerneSyncPointsNullOrNumZero
                                "CL_INVALID_SYNC_POINT_WAIT_LIST_KHR",
                                TEST_FAIL);
 
-
         cl_sync_point_khr point;
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         error = clCommandBarrierWithWaitListKHR(
             command_buffer, nullptr, nullptr, 0, nullptr, &point, nullptr);
-#else
-        error = clCommandBarrierWithWaitListKHR(command_buffer, nullptr, 0,
-                                                nullptr, &point, nullptr);
-#endif
         test_error(error, "clCommandBarrierWithWaitListKHR failed");
 
         cl_sync_point_khr* sync_points[] = { &point };
@@ -187,14 +181,8 @@ struct CommandNDRangeKernelInvalidProperties : public BasicCommandBufferTest
 
     cl_int Run() override
     {
-
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr empty_properties =
             ~cl_command_properties_khr(0);
-#else
-        cl_ndrange_kernel_command_properties_khr empty_properties =
-            ~cl_ndrange_kernel_command_properties_khr(0);
-#endif
 
         cl_int error = clCommandNDRangeKernelKHR(
             command_buffer, nullptr, &empty_properties, kernel, 1, nullptr,
@@ -205,14 +193,9 @@ struct CommandNDRangeKernelInvalidProperties : public BasicCommandBufferTest
                                "CL_INVALID_VALUE",
                                TEST_FAIL);
 
-#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
         cl_command_properties_khr props_invalid[3] = {
-#else
-        cl_ndrange_kernel_command_properties_khr props_invalid[3] = {
-#endif
             CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
-            CL_MEM_USE_CACHED_CPU_MEMORY_IMG,
-            1
+            CL_MEM_USE_CACHED_CPU_MEMORY_IMG, 1
         };
 
         error = clCommandNDRangeKernelKHR(


### PR DESCRIPTION
Make changes to reflect OpenCL-Docs change https://github.com/KhronosGroup/OpenCL-Docs/pull/1215 and requires header change https://github.com/KhronosGroup/OpenCL-Headers/pull/260 to use preprocessor path with extra parameters

Used [CL_DEVICE_EXTENSIONS_WITH_VERSION](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_DEVICE_EXTENSIONS_WITH_VERSION) runtime check and skipped testing when a device doesn't support required versions.

Tested using OCK updated with this API change https://github.com/codeplaysoftware/oneapi-construction-kit/pull/519