### PR TITLE
compile Vulkan SPIR-V shaders in CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
@@ -753,43 +753,9 @@ std::ostream &operator<<(std::ostream &os, VulkanFormat format)
     return os;
 }
 
-static char *findFilePath(const std::string filename)
-{
-    const char *searchPath[] = {
-        "./", // Same dir
-        "./shaders/", // In shaders folder in same dir
-        "../test_conformance/vulkan/shaders/" // In src folder
-    };
-    for (unsigned int i = 0; i < sizeof(searchPath) / sizeof(char *); ++i)
-    {
-        std::string path(searchPath[i]);
-
-        path.append(filename);
-        FILE *fp;
-        fp = fopen(path.c_str(), "rb");
-
-        if (fp != NULL)
-        {
-            fclose(fp);
-            // File found
-            char *file_path = (char *)(malloc(path.length() + 1));
-            strncpy(file_path, path.c_str(), path.length() + 1);
-            return file_path;
-        }
-        if (fp)
-        {
-            fclose(fp);
-        }
-    }
-    // File not found
-    return 0;
-}
-
 std::vector<char> readFile(const std::string &filename)
 {
-    char *file_path = findFilePath(filename);
-
-    std::ifstream file(file_path, std::ios::ate | std::ios::binary);
+    std::ifstream file(filename, std::ios::ate | std::ios::binary);
 
     if (!file.is_open())
     {
@@ -800,6 +766,6 @@ std::vector<char> readFile(const std::string &filename)
     file.seekg(0);
     file.read(buffer.data(), fileSize);
     file.close();
-    printf("filesize is %d", fileSize);
+    printf("filesize is %d\n", fileSize);
     return buffer;
 }

--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.cpp
@@ -752,10 +752,11 @@ std::ostream &operator<<(std::ostream &os, VulkanFormat format)
     return os;
 }
 
-static std::string findFilePath(const std::string& filename, const std::string& startdir)
+static std::string findFilePath(const std::string &filename,
+                                const std::string &startdir)
 {
     const char *searchPath[] = {
-        "/shaders/",    // shaders directory, for most builds
+        "/shaders/", // shaders directory, for most builds
         "/../shaders/", // one directory up, for multi-config builds
     };
     for (unsigned int i = 0; i < sizeof(searchPath) / sizeof(char *); ++i)
@@ -777,7 +778,8 @@ static std::string findFilePath(const std::string& filename, const std::string& 
     return "";
 }
 
-std::vector<char> readFile(const std::string &filename, const std::string& startdir = "")
+std::vector<char> readFile(const std::string &filename,
+                           const std::string &startdir = "")
 {
     std::string filepath = findFilePath(filename, startdir);
     std::ifstream file(filepath, std::ios::ate | std::ios::binary);

--- a/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_utility.hpp
@@ -72,5 +72,6 @@ operator<<(std::ostream& os,
            VulkanExternalSemaphoreHandleType externalSemaphoreHandleType);
 std::ostream& operator<<(std::ostream& os, VulkanFormat format);
 
-std::vector<char> readFile(const std::string& filename);
+std::vector<char> readFile(const std::string& filename,
+                           const std::string& startdir);
 #endif // _vulkan_utility_hpp_

--- a/test_conformance/vulkan/CMakeLists.txt
+++ b/test_conformance/vulkan/CMakeLists.txt
@@ -25,20 +25,8 @@ set (${MODULE_NAME}_SOURCES
         test_vulkan_api_consistency_for_1dimages.cpp
         test_vulkan_platform_device_info.cpp
         vulkan_interop_common.cpp
-        ../../test_common/harness/genericThread.cpp
-        ../../test_common/harness/errorHelpers.cpp
-        ../../test_common/harness/testHarness.cpp
-        ../../test_common/harness/kernelHelpers.cpp
-        ../../test_common/harness/mt19937.cpp
-        ../../test_common/harness/msvc9.c
-        ../../test_common/harness/parseParameters.cpp
-        ../../test_common/harness/deviceInfo.cpp
-        ../../test_common/harness/crc32.cpp
     )
 
-set_source_files_properties(
-    ${${MODULE_NAME}_SOURCES}
-    PROPERTIES LANGUAGE CXX)
 include_directories("../common/vulkan_wrapper")
 
 add_subdirectory(shaders)

--- a/test_conformance/vulkan/shaders/CMakeLists.txt
+++ b/test_conformance/vulkan/shaders/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
         string(REPLACE "GLSL_TYPE_PREFIX" "${GLSL_TYPE_PREFIX}" IMAGE2D_SHADER_CONTENT "${IMAGE2D_SHADER_CONTENT}")
         file(WRITE ${IMAGE2D_SHADER_TMP_OUT_FILE} "${IMAGE2D_SHADER_CONTENT}")
         execute_process(
-            COMMAND ${Vulkan_glslang_binary} --target-env vulkan1.0 -o image2D_${GLSL_FORMAT}.spv ${IMAGE2D_SHADER_TMP_OUT_FILE}
+            COMMAND ${Vulkan_glslang_binary} --target-env vulkan1.0 -o ${CMAKE_CURRENT_BINARY_DIR}/image2D_${GLSL_FORMAT}.spv ${IMAGE2D_SHADER_TMP_OUT_FILE}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             RESULT_VARIABLE commandStatus
             OUTPUT_QUIET)
@@ -34,7 +34,7 @@ else()
         endif()
     endforeach(IMAGE2D_FORMAT)
     execute_process(
-        COMMAND ${Vulkan_glslang_binary} --target-env vulkan1.0 -o ${BUFFER_SHADER_IN_FILE}.spv ${BUFFER_SHADER_IN_FILE}.comp
+        COMMAND ${Vulkan_glslang_binary} --target-env vulkan1.0 -o ${CMAKE_CURRENT_BINARY_DIR}/${BUFFER_SHADER_IN_FILE}.spv ${BUFFER_SHADER_IN_FILE}.comp
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         RESULT_VARIABLE commandStatus
         OUTPUT_QUIET)

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string.h>
 #include "harness/errorHelpers.h"
+#include "harness/os_helpers.h"
 #include "deviceInfo.h"
 
 #define MAX_BUFFERS 5
@@ -115,7 +116,8 @@ int run_test_with_two_queue(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::vector<char> vkBufferShader = readFile("buffer.spv");
+    std::string filepath = exe_dir() + "/shaders/buffer.spv";
+    std::vector<char> vkBufferShader = readFile(filepath);
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
@@ -447,7 +449,9 @@ int run_test_with_one_queue(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::vector<char> vkBufferShader = readFile("buffer.spv");
+    std::string filepath = exe_dir() + "/shaders/buffer.spv";
+    std::vector<char> vkBufferShader = readFile(filepath);
+
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
     vkDescriptorSetLayoutBindingList.addBinding(
@@ -749,7 +753,8 @@ int run_test_with_multi_import_same_ctx(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::vector<char> vkBufferShader = readFile("buffer.spv");
+    std::string filepath = exe_dir() + "/shaders/buffer.spv";
+    std::vector<char> vkBufferShader = readFile(filepath);
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
@@ -1097,7 +1102,8 @@ int run_test_with_multi_import_diff_ctx(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::vector<char> vkBufferShader = readFile("buffer.spv");
+    std::string filepath = exe_dir() + "/shaders/buffer.spv";
+    std::vector<char> vkBufferShader = readFile(filepath);
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -116,8 +116,7 @@ int run_test_with_two_queue(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::string filepath = exe_dir() + "/shaders/buffer.spv";
-    std::vector<char> vkBufferShader = readFile(filepath);
+    std::vector<char> vkBufferShader = readFile("buffer.spv", exe_dir());
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
@@ -449,8 +448,7 @@ int run_test_with_one_queue(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::string filepath = exe_dir() + "/shaders/buffer.spv";
-    std::vector<char> vkBufferShader = readFile(filepath);
+    std::vector<char> vkBufferShader = readFile("buffer.spv", exe_dir());
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
@@ -753,8 +751,7 @@ int run_test_with_multi_import_same_ctx(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::string filepath = exe_dir() + "/shaders/buffer.spv";
-    std::vector<char> vkBufferShader = readFile(filepath);
+    std::vector<char> vkBufferShader = readFile("buffer.spv", exe_dir());
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
@@ -1102,8 +1099,7 @@ int run_test_with_multi_import_diff_ctx(
 
     VulkanQueue &vkQueue = vkDevice.getQueue();
 
-    std::string filepath = exe_dir() + "/shaders/buffer.spv";
-    std::vector<char> vkBufferShader = readFile(filepath);
+    std::vector<char> vkBufferShader = readFile("buffer.spv", exe_dir());
 
     VulkanShaderModule vkBufferShaderModule(vkDevice, vkBufferShader);
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList(

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -17,6 +17,7 @@
 #include <vulkan_interop_common.hpp>
 #include <string>
 #include "harness/errorHelpers.h"
+#include "harness/os_helpers.h"
 #include <algorithm>
 #include "deviceInfo.h"
 
@@ -270,10 +271,10 @@ int run_test_with_two_queue(
         ASSERT_LEQ(elementSize, (uint32_t)MAX_2D_IMAGE_ELEMENT_SIZE);
         log_info("elementSize= %d\n", elementSize);
 
-        std::string fileName = "image2D_"
+        std::string filepath = exe_dir() + "/shaders/image2D_"
             + std::string(getVulkanFormatGLSLFormat(vkFormat)) + ".spv";
-        log_info("Load %s file", fileName.c_str());
-        vkImage2DShader = readFile(fileName);
+        log_info("Load file: %s\n", filepath.c_str());
+        vkImage2DShader = readFile(filepath);
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         VulkanComputePipeline vkComputePipeline(vkDevice, vkPipelineLayout,
@@ -882,10 +883,10 @@ int run_test_with_one_queue(
         ASSERT_LEQ(elementSize, (uint32_t)MAX_2D_IMAGE_ELEMENT_SIZE);
         log_info("elementSize= %d\n", elementSize);
 
-        std::string fileName = "image2D_"
+        std::string filepath = exe_dir() + "/shaders/image2D_"
             + std::string(getVulkanFormatGLSLFormat(vkFormat)) + ".spv";
-        log_info("Load %s file", fileName.c_str());
-        vkImage2DShader = readFile(fileName);
+        log_info("Load file: %s\n", filepath.c_str());
+        vkImage2DShader = readFile(filepath);
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         VulkanComputePipeline vkComputePipeline(vkDevice, vkPipelineLayout,

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -271,10 +271,10 @@ int run_test_with_two_queue(
         ASSERT_LEQ(elementSize, (uint32_t)MAX_2D_IMAGE_ELEMENT_SIZE);
         log_info("elementSize= %d\n", elementSize);
 
-        std::string filepath = exe_dir() + "/shaders/image2D_"
+        std::string fileName = "image2D_"
             + std::string(getVulkanFormatGLSLFormat(vkFormat)) + ".spv";
-        log_info("Load file: %s\n", filepath.c_str());
-        vkImage2DShader = readFile(filepath);
+        log_info("Load file: %s\n", fileName.c_str());
+        vkImage2DShader = readFile(fileName, exe_dir());
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         VulkanComputePipeline vkComputePipeline(vkDevice, vkPipelineLayout,
@@ -883,10 +883,10 @@ int run_test_with_one_queue(
         ASSERT_LEQ(elementSize, (uint32_t)MAX_2D_IMAGE_ELEMENT_SIZE);
         log_info("elementSize= %d\n", elementSize);
 
-        std::string filepath = exe_dir() + "/shaders/image2D_"
+        std::string fileName = "image2D_"
             + std::string(getVulkanFormatGLSLFormat(vkFormat)) + ".spv";
-        log_info("Load file: %s\n", filepath.c_str());
-        vkImage2DShader = readFile(filepath);
+        log_info("Load file: %s\n", fileName.c_str());
+        vkImage2DShader = readFile(fileName, exe_dir());
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         VulkanComputePipeline vkComputePipeline(vkDevice, vkPipelineLayout,
@@ -1475,7 +1475,7 @@ int test_image_common(cl_device_id device_, cl_context context_,
     err = setMaxImageDimensions(deviceId, max_width, max_height);
     test_error_and_cleanup(err, CLEANUP, "error setting max image dimensions");
 
-    log_info("Set max_width to %lu and max_height to %lu\n", max_width,
+    log_info("Set max_width to %zu and max_height to %zu\n", max_width,
              max_height);
     context = clCreateContextFromType(contextProperties, CL_DEVICE_TYPE_GPU,
                                       NULL, NULL, &err);


### PR DESCRIPTION
fixes #2040 

* Compiles the Vulkan SPIR-V files in a directory based off of CMAKE_CURRENT_BINARY_DIR.
* Changes the search path for the Vulkan SPIR-V files to this directory rather than a semi-arbitrary set of directories.