### PR TITLE
[NFC] math_brute_force: move TestInfoBase to common.h

### DIFF
--- a/test_conformance/math_brute_force/binary_half.cpp
+++ b/test_conformance/math_brute_force/binary_half.cpp
@@ -56,27 +56,8 @@ struct ThreadInfo
         tQueue; // per thread command queue to improve performance
 };
 
-struct TestInfoBase
-{
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isFDim;
-    int skipNanInf;
-    int isNextafter;
-};
-
 struct TestInfo : public TestInfoBase
 {
-    TestInfo(const TestInfoBase &base): TestInfoBase(base) {}
-
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
@@ -646,7 +627,6 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
 int TestFunc_Half_Half_Half_common(const Func *f, MTdata d, int isNextafter,
                                    bool relaxedMode)
 {
-    TestInfoBase test_info_base;
     cl_int error;
     float maxError = 0.0f;
     double maxErrorVal = 0.0;
@@ -654,8 +634,7 @@ int TestFunc_Half_Half_Half_common(const Func *f, MTdata d, int isNextafter,
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
     // Init test_info
-    memset(&test_info_base, 0, sizeof(test_info_base));
-    TestInfo test_info(test_info_base);
+    TestInfo test_info;
 
     test_info.threadCount = GetThreadCount();
     test_info.subBufferSize = BUFFER_SIZE

--- a/test_conformance/math_brute_force/binary_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_i_half.cpp
@@ -52,23 +52,8 @@ typedef struct ThreadInfo
         tQueue; // per thread command queue to improve performance
 } ThreadInfo;
 
-struct TestInfoBase
-{
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-};
-
 struct TestInfo : public TestInfoBase
 {
-    TestInfo(const TestInfoBase &base): TestInfoBase(base) {}
-
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
@@ -415,7 +400,6 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
 
 int TestFunc_Half_Half_Int(const Func *f, MTdata d, bool relaxedMode)
 {
-    TestInfoBase test_info_base;
     cl_int error;
     size_t i, j;
     float maxError = 0.0f;
@@ -425,8 +409,7 @@ int TestFunc_Half_Half_Int(const Func *f, MTdata d, bool relaxedMode)
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
 
     // Init test_info
-    memset(&test_info_base, 0, sizeof(test_info_base));
-    TestInfo test_info(test_info_base);
+    TestInfo test_info;
 
     test_info.threadCount = GetThreadCount();
     test_info.subBufferSize = BUFFER_SIZE

--- a/test_conformance/math_brute_force/common.h
+++ b/test_conformance/math_brute_force/common.h
@@ -86,6 +86,53 @@ struct BuildKernelInfo
     bool relaxedMode;
 };
 
+// Data common to all math tests.
+struct TestInfoBase
+{
+    TestInfoBase() = default;
+    ~TestInfoBase() = default;
+
+    // Prevent accidental copy/move.
+    TestInfoBase(const TestInfoBase &) = delete;
+    TestInfoBase &operator=(const TestInfoBase &) = delete;
+    TestInfoBase(TestInfoBase &&h) = delete;
+    TestInfoBase &operator=(TestInfoBase &&h) = delete;
+
+    // Size of the sub-buffer in elements.
+    size_t subBufferSize = 0;
+    // Function info.
+    const Func *f = nullptr;
+
+    // Number of worker threads.
+    cl_uint threadCount = 0;
+    // Number of jobs.
+    cl_uint jobCount = 0;
+    // step between each chunk and the next.
+    cl_uint step = 0;
+    // stride between individual test values.
+    cl_uint scale = 0;
+    // max_allowed ulps.
+    float ulps = -1.f;
+    // non-zero if running in flush to zero mode.
+    int ftz = 0;
+
+    // 1 if running the fdim test.
+    int isFDim = 0;
+    // 1 if input/output NaNs and INFs are skipped.
+    int skipNanInf = 0;
+    // 1 if running the nextafter test.
+    int isNextafter = 0;
+
+    // 1 if the function is only to be evaluated over a range.
+    int isRangeLimited = 0;
+
+    // Result limit for half_sin/half_cos/half_tan.
+    float half_sin_cos_tan_limit = -1.f;
+
+    // Whether the test is being run in relaxed mode.
+    bool relaxedMode = false;
+};
+
 using SourceGenerator = std::string (*)(const std::string &kernel_name,
                                         const char *builtin,
                                         cl_uint vector_size_index);

--- a/test_conformance/math_brute_force/macro_binary_half.cpp
+++ b/test_conformance/math_brute_force/macro_binary_half.cpp
@@ -45,22 +45,8 @@ struct ThreadInfo
         tQueue; // per thread command queue to improve performance
 };
 
-struct TestInfoBase
-{
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-};
-
 struct TestInfo : public TestInfoBase
 {
-    TestInfo(const TestInfoBase &base): TestInfoBase(base) {}
-
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
@@ -430,15 +416,13 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
 
 int TestMacro_Int_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 {
-    TestInfoBase test_info_base;
     cl_int error;
     size_t i, j;
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
 
     // Init test_info
-    memset(&test_info_base, 0, sizeof(test_info_base));
-    TestInfo test_info(test_info_base);
+    TestInfo test_info;
 
     test_info.threadCount = GetThreadCount();
     test_info.subBufferSize = BUFFER_SIZE

--- a/test_conformance/math_brute_force/macro_unary_half.cpp
+++ b/test_conformance/math_brute_force/macro_unary_half.cpp
@@ -43,21 +43,8 @@ struct ThreadInfo
         tQueue; // per thread command queue to improve performance
 };
 
-struct TestInfoBase
-{
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-};
-
 struct TestInfo : public TestInfoBase
 {
-    TestInfo(const TestInfoBase &base): TestInfoBase(base) {}
-
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
@@ -328,14 +315,12 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
 
 int TestMacro_Int_Half(const Func *f, MTdata d, bool relaxedMode)
 {
-    TestInfoBase test_info_base;
     cl_int error;
     size_t i, j;
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
     // Init test_info
-    memset(&test_info_base, 0, sizeof(test_info_base));
-    TestInfo test_info(test_info_base);
+    TestInfo test_info;
 
     test_info.threadCount = GetThreadCount();
     test_info.subBufferSize = BUFFER_SIZE

--- a/test_conformance/math_brute_force/unary_half.cpp
+++ b/test_conformance/math_brute_force/unary_half.cpp
@@ -45,26 +45,8 @@ typedef struct ThreadInfo
         tQueue; // per thread command queue to improve performance
 } ThreadInfo;
 
-struct TestInfoBase
-{
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isRangeLimited; // 1 if the function is only to be evaluated over a
-                        // range
-    float half_sin_cos_tan_limit;
-};
-
 struct TestInfo : public TestInfoBase
 {
-    TestInfo(const TestInfoBase &base): TestInfoBase(base) {}
-
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
@@ -351,7 +333,6 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
 
 int TestFunc_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 {
-    TestInfoBase test_info_base;
     cl_int error;
     size_t i, j;
     float maxError = 0.0f;
@@ -360,8 +341,7 @@ int TestFunc_Half_Half(const Func *f, MTdata d, bool relaxedMode)
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
 
     // Init test_info
-    memset(&test_info_base, 0, sizeof(test_info_base));
-    TestInfo test_info(test_info_base);
+    TestInfo test_info;
 
     test_info.threadCount = GetThreadCount();
 


### PR DESCRIPTION
The various forms of `TestInfoBase` have many members in common, so avoid duplicating the struct definition and move it to `common.h`.

Provide a description and initializer for every struct member, and drop initializations done with `memset`.