### PR TITLE
[NFC] Use std::vector to store large size array.

### DIFF
--- a/test_conformance/math_brute_force/ternary_float.cpp
+++ b/test_conformance/math_brute_force/ternary_float.cpp
@@ -139,7 +139,7 @@ int TestFunc_Float_Float_Float_Float(const Func *f, MTdata d, bool relaxedMode)
     float maxErrorVal3 = 0.0f;
     uint64_t step = getTestStep(sizeof(float), BUFFER_SIZE);
 
-    cl_uchar overflow[BUFFER_SIZE / sizeof(float)];
+    std::vector<cl_uchar> overflow(BUFFER_SIZE / sizeof(float));
 
     float float_ulps;
     if (gIsEmbedded)

--- a/test_conformance/math_brute_force/ternary_half.cpp
+++ b/test_conformance/math_brute_force/ternary_half.cpp
@@ -79,7 +79,7 @@ int TestFunc_Half_Half_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 
     constexpr size_t bufferElements = BUFFER_SIZE / sizeof(cl_half);
 
-    cl_uchar overflow[bufferElements];
+    std::vector<cl_uchar> overflow(bufferElements);
     float half_ulps = f->half_ulps;
     int skipNanInf = (0 == strcmp("fma", f->nameInCode));
 

--- a/test_conformance/math_brute_force/unary_two_results_float.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_float.cpp
@@ -51,7 +51,7 @@ int TestFunc_Float2_Float(const Func *f, MTdata d, bool relaxedMode)
     float maxErrorVal1 = 0.0f;
     uint64_t step = getTestStep(sizeof(float), BUFFER_SIZE);
     int scale = (int)((1ULL << 32) / (16 * BUFFER_SIZE / sizeof(float)) + 1);
-    cl_uchar overflow[BUFFER_SIZE / sizeof(float)];
+    std::vector<cl_uchar> overflow(BUFFER_SIZE / sizeof(float));
     int isFract = 0 == strcmp("fract", f->nameInCode);
     int skipNanInf = isFract && !gInfNanSupport;
 


### PR DESCRIPTION
windows default stack size is 1M, BUFFER_SIZE is 2 * 1024 * 1024, use array with BUFFER_SIZE elemets on stack can exceed available stack size limits.