### PR TITLE
fix generic_address_space, command_buffer_event_sync, test_compiler and images/test_1D_buffer

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -92,6 +92,7 @@ const char *known_extensions[] = {
     "cl_khr_external_memory_dma_buf",
     "cl_khr_command_buffer",
     "cl_khr_command_buffer_mutable_dispatch",
+    "cl_khr_command_buffer_multi_device"
 };
 
 size_t num_known_extensions = ARRAY_SIZE(known_extensions);

--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #endif
 
+// clang-format off
 // List should follow order in the extension spec
 const char *known_extensions[] = {
     "cl_khr_byte_addressable_store",
@@ -94,6 +95,7 @@ const char *known_extensions[] = {
     "cl_khr_command_buffer_mutable_dispatch",
     "cl_khr_command_buffer_multi_device"
 };
+// clang-format on
 
 size_t num_known_extensions = ARRAY_SIZE(known_extensions);
 size_t first_API_extension = 32;

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_event_sync.cpp
@@ -18,6 +18,8 @@
 #include "procs.h"
 
 #include <vector>
+#include <thread>
+#include <chrono>
 
 //--------------------------------------------------------------------------
 enum class EventMode
@@ -416,6 +418,12 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
         error = clFinish(queue);
         test_error(error, "clFinish failed");
 
+        for (unsigned i = 0; i < 30; ++i)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (confirmation) break;
+        }
+
         // verify the result
         if (!confirmation)
         {
@@ -762,6 +770,12 @@ struct CommandBufferEventSync : public BasicCommandBufferTest
 
         error = clFinish(queue);
         test_error(error, "clFinish failed");
+
+        for (unsigned i = 0; i < 30; ++i)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (confirmation) break;
+        }
 
         // verify the result
         if (!confirmation)

--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -92,7 +92,8 @@ test_status InitCL(cl_device_id device) {
     if (version >= Version(3, 0))
     {
         cl_int error;
-        cl_bool support_generic;
+        cl_bool support_generic = CL_FALSE;
+        size_t max_gvar_size = 0;
 
         error = clGetDeviceInfo(device, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT,
                                 sizeof(support_generic), &support_generic, NULL);
@@ -103,6 +104,21 @@ test_status InitCL(cl_device_id device) {
         }
 
         if (!support_generic)
+        {
+            return TEST_SKIP;
+        }
+
+        error = clGetDeviceInfo(device, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE,
+                                sizeof(max_gvar_size), &max_gvar_size, NULL);
+        if (error != CL_SUCCESS)
+        {
+            print_error(error,
+                        "Unable to MAX_GLOBAL_VARIABLE_SIZE value. "
+                        "Program scope variable support is required");
+            return TEST_FAIL;
+        }
+
+        if (!max_gvar_size)
         {
             return TEST_SKIP;
         }

--- a/test_conformance/generic_address_space/main.cpp
+++ b/test_conformance/generic_address_space/main.cpp
@@ -113,8 +113,7 @@ test_status InitCL(cl_device_id device) {
         if (error != CL_SUCCESS)
         {
             print_error(error,
-                        "Unable to MAX_GLOBAL_VARIABLE_SIZE value. "
-                        "Program scope variable support is required");
+                        "Unable to query CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.");
             return TEST_FAIL;
         }
 


### PR DESCRIPTION
fixes several issues:

* `generic_address_space` test: add check for program scope variables. The test uses both generic AS and program-scope variables, however it only checked the generic-AS presence in `clGetDeviceInfo`.
* `compiler/test_compiler_defines_for_extensions.cpp`: add `cl_khr_command_buffer_multi_device` to the list of recognized extensions
* `command_buffer_event_sync.cpp`: add delays for testing `clSetEventCallback` - according to specification, these can be executed asynchronously (in a separate thread) by the OpenCL implementation, hence the event callback is not quaranteed to be called before `clFinish()` returns. Existing test `events/test_callbacks.cpp` also waits for callback with loops of usleep.
* `images/kernel_image_methods/test_1D_buffer.cpp`: fix allocation size being too small for the 1D buffer backing the image