### PR TITLE
Fix Windows build with MSVC 19.41

### DIFF
--- a/test_common/harness/compat.h
+++ b/test_common/harness/compat.h
@@ -112,6 +112,8 @@ int feclearexcept(int excepts);
 
 #if defined(__INTEL_COMPILER)
 #include <mathimf.h>
+#elif __cplusplus && defined(_MSC_VER)
+#include <cmath>
 #else
 #include <math.h>
 #endif


### PR DESCRIPTION
Include `cmath` instead of `math.h` in C++ mode under MSVC, to avoid
build errors inside the header.  Ideally we would not condition this
on `_MSC_VER`, but issue 1833 currently prevents doing so.