### PR TITLE
conversions: fix condition for adding -cl-denorms-are-zero

### DIFF
--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -1540,7 +1540,11 @@ cl_program MakeProgram(Type outType, Type inType, SaturationMode sat,
     *outKernel = NULL;
 
     const char *flags = NULL;
-    if (gForceFTZ || gForceHalfFTZ) flags = "-cl-denorms-are-zero";
+    if ((gForceFTZ && (inType == kfloat || outType == kfloat))
+        || (gForceHalfFTZ && (inType == khalf || outType == khalf)))
+    {
+        flags = "-cl-denorms-are-zero";
+    }
 
     // build it
     std::string sourceString = source.str();


### PR DESCRIPTION
Commit b6941b6c ("Add fp16 testing to conversions and bruteforce (#1975)", 2024-06-18) introduced a behavioural change for non-half tests.  The `-cl-denorms-are-zero` option could be added for non-half tests such as `char_rtn_float` even when `gForceFTZ` was `false`.  Fix the condition by also taking the input and output types into account.