### PR TITLE
cl_khr_mutable_dispatch: fix -Wformat warnings

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -325,8 +325,8 @@ struct MutableDispatchLocalArguments : public MutableDispatchArgumentsTest
         for (size_t i = 0; i < number_of_ints; i++)
             if (constant_data[i] != result_data[i])
             {
-                log_error("Data failed to verify: constant_data[%d]=%d != "
-                          "result_data[%d]=%d\n",
+                log_error("Data failed to verify: constant_data[%zu]=%d != "
+                          "result_data[%zu]=%d\n",
                           i, constant_data[i], i, result_data[i]);
                 return TEST_FAIL;
             }
@@ -458,8 +458,8 @@ struct MutableDispatchPODArguments : public MutableDispatchArgumentsTest
         for (size_t i = 0; i < number_of_ints; i++)
             if (constant_data[i] != result_data[i])
             {
-                log_error("Data failed to verify: constant_data[%d]=%d != "
-                          "result_data[%d]=%d\n",
+                log_error("Data failed to verify: constant_data[%zu]=%d != "
+                          "result_data[%zu]=%d\n",
                           i, constant_data[i], i, result_data[i]);
                 return TEST_FAIL;
             }

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_offset.cpp
@@ -137,7 +137,7 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
             if (i < update_global_offset && 0 != resultData[i])
             {
                 log_error("Data failed to verify: update_global_offset != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }
@@ -145,7 +145,7 @@ struct MutableDispatchGlobalOffset : InfoMutableCommandBufferTest
                      && update_global_offset != resultData[i])
             {
                 log_error("Data failed to verify: update_global_offset != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_global_size.cpp
@@ -136,7 +136,7 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
             if (i >= update_global_size && global_work_size != resultData[i])
             {
                 log_error("Data failed to verify: update_global_size != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }
@@ -144,7 +144,7 @@ struct MutableDispatchGlobalSize : public InfoMutableCommandBufferTest
                      && update_global_size != resultData[i])
             {
                 log_error("Data failed to verify: update_global_size != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_image_arguments.cpp
@@ -198,8 +198,8 @@ struct MutableDispatchImage1DArguments : public BasicMutableCommandBufferTest
         {
             if (imageValues_input[i] != outputData[i])
             {
-                log_error("Data failed to verify: imageValues[%d]=%d != "
-                          "outputData[%d]=%d\n",
+                log_error("Data failed to verify: imageValues[%zu]=%d != "
+                          "outputData[%zu]=%d\n",
                           i, imageValues_input[i], i, outputData[i]);
 
                 return TEST_FAIL;
@@ -397,8 +397,8 @@ struct MutableDispatchImage2DArguments : public BasicMutableCommandBufferTest
         {
             if (imageValues_input[i] != outputData[i])
             {
-                log_error("Data failed to verify: imageValues[%d]=%d != "
-                          "outputData[%d]=%d\n",
+                log_error("Data failed to verify: imageValues[%zu]=%d != "
+                          "outputData[%zu]=%d\n",
                           i, imageValues_input[i], i, outputData[i]);
                 return TEST_FAIL;
             }

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_local_size.cpp
@@ -139,7 +139,7 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
             if (i < update_global_size && update_local_size != resultData[i])
             {
                 log_error("Data failed to verify: update_local_size != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }
@@ -147,7 +147,7 @@ struct MutableDispatchLocalSize : public InfoMutableCommandBufferTest
                      && local_work_size != resultData[i])
             {
                 log_error("Data failed to verify: update_local_size != "
-                          "resultData[%d]=%d\n",
+                          "resultData[%zu]=%d\n",
                           i, resultData[i]);
                 return TEST_FAIL;
             }


### PR DESCRIPTION
Printing of a `size_t` requires the `%zu` specifier.