### PR TITLE
Fix 1D buffer image tests

### DIFF
--- a/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
@@ -67,9 +67,7 @@ static int test_get_1Dimage_buffer_info_single(cl_context context,
     if (gDebugTrace)
         log_info(" - Creating 1D image %d ...\n", (int)imageInfo->width);
 
-    buffer = clCreateBuffer(
-        context, flags, imageInfo->width * get_pixel_size(imageInfo->format),
-        NULL, &error);
+    buffer = clCreateBuffer(context, flags, imageInfo->rowPitch, NULL, &error);
     if (error != CL_SUCCESS)
     {
         log_error("ERROR: Unable to create buffer for 1D image buffer of size "


### PR DESCRIPTION
Buffer size needs to be greater than or equal the image row pitch which was not the case.