### PR TITLE
fix a few array-based mutable command buffer issues

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_arguments.cpp
@@ -772,6 +772,7 @@ struct MutableDispatchSVMArguments : public MutableDispatchArgumentsTest
         exec_info.param_value = &new_buffer;
 
         cl_mutable_dispatch_config_khr dispatch_config{};
+        dispatch_config.command = command;
         dispatch_config.num_svm_args = 1;
         dispatch_config.arg_svm_list = &arg_svm;
         dispatch_config.num_exec_infos = 1;

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_simultaneous.cpp
@@ -243,7 +243,7 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void* configs[1] = { &dispatch_config };
-        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+        error = clUpdateMutableCommandsKHR(work_command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
 
@@ -361,7 +361,7 @@ struct SimultaneousMutableDispatchTest : public BasicMutableCommandBufferTest
             CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR
         };
         const void* configs[1] = { &dispatch_config };
-        error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+        error = clUpdateMutableCommandsKHR(work_command_buffer, num_configs,
                                            config_types, configs);
         test_error(error, "clUpdateMutableCommandsKHR failed");
 


### PR DESCRIPTION
fixes a few minor issues introduced by #1984.

edit: Tested with the updated command buffer emulation layer on a device that supports out-of-order queues and SVM and all of the `test_cl_khr_mutable_dispatch` tests pass.