### PR TITLE
vulkan: Use Vulkan 1.1

### DIFF
--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -137,7 +137,7 @@ VulkanInstance::VulkanInstance(): m_vkInstance(VK_NULL_HANDLE)
     vkApplicationInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
     vkApplicationInfo.pEngineName = "No engine";
     vkApplicationInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-    vkApplicationInfo.apiVersion = VK_API_VERSION_1_0;
+    vkApplicationInfo.apiVersion = VK_API_VERSION_1_1;
 
     std::vector<const char *> enabledExtensionNameList;
     enabledExtensionNameList.push_back(


### PR DESCRIPTION
Increase Vulkan version to 1.1, which is required to support vkGetBufferMemoryRequirements2.