### PR TITLE
vulkan: Use image row pitch

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -477,7 +477,8 @@ getCLImageInfoFromVkImageInfo(const VkImageCreateInfo *VulkanImageCreateInfo,
         throw std::runtime_error("get2DImageDimensions failed!!!");
     }
 
-    img_desc->image_depth = 0; // VulkanImageCreateInfo->extent.depth;
+    img_desc->image_depth =
+        static_cast<size_t>(VulkanImageCreateInfo->extent.depth);
     img_desc->image_array_size = 0;
     img_desc->image_row_pitch = 0; // Row pitch set to zero as host_ptr is NULL
     img_desc->image_slice_pitch =
@@ -761,6 +762,7 @@ clExternalMemoryImage::clExternalMemoryImage(
     {
         VkSubresourceLayout subresourceLayout = image2D.getSubresourceLayout();
         image_desc.image_row_pitch = subresourceLayout.rowPitch;
+        image_desc.image_slice_pitch = subresourceLayout.depthPitch;
     }
 
     extMemProperties1.push_back(

--- a/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_api_list.hpp
@@ -100,7 +100,8 @@
     VK_FUNC_DECL(vkEnumerateDeviceExtensionProperties)                         \
     VK_FUNC_DECL(vkGetPhysicalDeviceSurfaceSupportKHR)                         \
     VK_FUNC_DECL(vkImportSemaphoreFdKHR)                                       \
-    VK_FUNC_DECL(vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)
+    VK_FUNC_DECL(vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)            \
+    VK_FUNC_DECL(vkGetImageSubresourceLayout)
 #define VK_WINDOWS_FUNC_LIST                                                   \
     VK_FUNC_DECL(vkGetMemoryWin32HandleKHR)                                    \
     VK_FUNC_DECL(vkGetSemaphoreWin32HandleKHR)                                 \
@@ -200,5 +201,6 @@
 #define vkGetMemoryWin32HandleKHR _vkGetMemoryWin32HandleKHR
 #define vkGetSemaphoreWin32HandleKHR _vkGetSemaphoreWin32HandleKHR
 #define vkImportSemaphoreWin32HandleKHR _vkImportSemaphoreWin32HandleKHR
+#define vkGetImageSubresourceLayout _vkGetImageSubresourceLayout
 
 #endif //_vulkan_api_list_hpp_

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -1870,6 +1870,16 @@ VulkanExtent3D VulkanImage2D::getExtent3D(uint32_t mipLevel) const
     return VulkanExtent3D(width, height, depth);
 }
 
+VkSubresourceLayout VulkanImage2D::getSubresourceLayout() const
+{
+    VkImageSubresource subresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
+
+    VkSubresourceLayout subresourceLayout = { 0 };
+    vkGetImageSubresourceLayout(m_device, m_vkImage, &subresource,
+                                &subresourceLayout);
+    return subresourceLayout;
+}
+
 //////////////////////////////////
 // VulkanImage3D implementation //
 //////////////////////////////////

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -552,6 +552,7 @@ public:
         VulkanSharingMode sharingMode = VULKAN_SHARING_MODE_EXCLUSIVE);
     virtual ~VulkanImage2D();
     virtual VulkanExtent3D getExtent3D(uint32_t mipLevel = 0) const;
+    virtual VkSubresourceLayout getSubresourceLayout() const;
 
     VulkanImage2D(const VulkanImage2D &image2D);
 };


### PR DESCRIPTION
When importing a Vulkan external image, query and
pass OpenCL a row pitch if OpenCL is assuming linear for the imported external handle type.  Additionally fix a bug where OpenCL is being told to create mipmapped images at all times.