### PR TITLE
Fix bug in `mutable_command_full_dispatch`

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -100,21 +100,17 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
 
         if ((available_caps & CL_MUTABLE_DISPATCH_EXEC_INFO_KHR) == 0)
         {
-            error = create_single_kernel_helper_create_program(
-                context, &program, 1, &kernel_str_no_svm);
+            error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                                &kernel_str_no_svm,
+                                                "full_dispatch");
         }
         else
         {
-            error = create_single_kernel_helper_create_program(
-                context, &program, 1, &kernel_str_svm);
+            error =
+                create_single_kernel_helper(context, &program, &kernel, 1,
+                                            &kernel_str_svm, "full_dispatch");
         }
         test_error(error, "Failed to create program with source");
-
-        error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
-        test_error(error, "Failed to build program");
-
-        kernel = clCreateKernel(program, "full_dispatch", &error);
-        test_error(error, "Failed to create copy kernel");
 
         return CL_SUCCESS;
     }


### PR DESCRIPTION
This test did not pass the `-cl-std=` flag when building the program. As a result, for an OpenCL 3.0 device, the program will be "compiled using the highest OpenCL C 1.x language version supported" by the device. However this will force uniform work-group sizes which leads to a `CL_INVALID_WORK_GROUP_SIZE` error.

To fix this, use the `create_single_kernel_helper()` helper function which will automatically get the device version and pass that to `-cl-std=` when building the program.