### PR TITLE
[NFC] relationals: fix -Wformat-security warnings

### DIFF
--- a/test_conformance/relationals/test_comparisons_fp.cpp
+++ b/test_conformance/relationals/test_comparisons_fp.cpp
@@ -309,7 +309,7 @@ int RelationalsFPTest::test_equiv_kernel(unsigned int vecSize,
         sstr << "ERROR: Data sample " << i << ":" << j << " at size " << vs
              << " does not validate! Expected " << e << ", got " << o
              << ", source " << iA << ":" << iB << std::endl;
-        log_error(sstr.str().c_str());
+        log_error("%s", sstr.str().c_str());
     };
 
     /* And verify! */


### PR DESCRIPTION
Fix a "format string is not a string literal (potentially insecure)" warning.

There is no security issue here as the format string argument is constructed using a stringstream right before.  Fix this occurrence anyway to allow enabling the warning globally.