### PR TITLE
[NFC] math_brute_force: use getAllowedUlpError for half

### DIFF
--- a/test_conformance/math_brute_force/binary_half.cpp
+++ b/test_conformance/math_brute_force/binary_half.cpp
@@ -653,7 +653,7 @@ int TestFunc_Half_Half_Half_common(const Func *f, MTdata d, int isNextafter,
     }
 
     test_info.f = f;
-    test_info.ulps = f->half_ulps;
+    test_info.ulps = getAllowedUlpError(f, khalf, relaxedMode);
     test_info.ftz =
         f->ftz || gForceFTZ || 0 == (CL_FP_DENORM & gHalfCapabilities);
 

--- a/test_conformance/math_brute_force/binary_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_i_half.cpp
@@ -427,7 +427,7 @@ int TestFunc_Half_Half_Int(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->half_ulps;
+    test_info.ulps = getAllowedUlpError(f, khalf, relaxedMode);
     test_info.ftz =
         f->ftz || gForceFTZ || 0 == (CL_FP_DENORM & gHalfCapabilities);
 

--- a/test_conformance/math_brute_force/binary_operator_half.cpp
+++ b/test_conformance/math_brute_force/binary_operator_half.cpp
@@ -564,7 +564,7 @@ int TestFunc_Half_Half_Half_Operator(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->half_ulps;
+    test_info.ulps = getAllowedUlpError(f, khalf, relaxedMode);
     test_info.ftz =
         f->ftz || gForceFTZ || 0 == (CL_FP_DENORM & gHalfCapabilities);
 

--- a/test_conformance/math_brute_force/binary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_half.cpp
@@ -91,7 +91,7 @@ int TestFunc_HalfI_Half_Half(const Func *f, MTdata d, bool relaxedMode)
 
     cl_uint threadCount = GetThreadCount();
 
-    float half_ulps = f->half_ulps;
+    float half_ulps = getAllowedUlpError(f, khalf, relaxedMode);
 
     int testingRemquo = !strcmp(f->name, "remquo");
 

--- a/test_conformance/math_brute_force/ternary_half.cpp
+++ b/test_conformance/math_brute_force/ternary_half.cpp
@@ -80,7 +80,7 @@ int TestFunc_Half_Half_Half_Half(const Func *f, MTdata d, bool relaxedMode)
     constexpr size_t bufferElements = BUFFER_SIZE / sizeof(cl_half);
 
     std::vector<cl_uchar> overflow(bufferElements);
-    float half_ulps = f->half_ulps;
+    float half_ulps = getAllowedUlpError(f, khalf, relaxedMode);
     int skipNanInf = (0 == strcmp("fma", f->nameInCode));
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);

--- a/test_conformance/math_brute_force/unary_half.cpp
+++ b/test_conformance/math_brute_force/unary_half.cpp
@@ -362,7 +362,7 @@ int TestFunc_Half_Half(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->half_ulps;
+    test_info.ulps = getAllowedUlpError(f, khalf, relaxedMode);
     test_info.ftz =
         f->ftz || gForceFTZ || 0 == (CL_FP_DENORM & gHalfCapabilities);
 

--- a/test_conformance/math_brute_force/unary_two_results_half.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_half.cpp
@@ -61,7 +61,7 @@ int TestFunc_Half2_Half(const Func *f, MTdata d, bool relaxedMode)
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
 
-    float half_ulps = f->half_ulps;
+    float half_ulps = getAllowedUlpError(f, khalf, relaxedMode);
 
     // Init the kernels
     BuildKernelInfo build_info{ 1, kernels, programs, f->nameInCode };

--- a/test_conformance/math_brute_force/unary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_i_half.cpp
@@ -71,7 +71,7 @@ int TestFunc_HalfI_Half(const Func *f, MTdata d, bool relaxedMode)
 
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
 
-    float half_ulps = f->half_ulps;
+    float half_ulps = getAllowedUlpError(f, khalf, relaxedMode);
 
     maxiError = half_ulps == INFINITY ? CL_ULONG_MAX : 0;
 

--- a/test_conformance/math_brute_force/unary_u_half.cpp
+++ b/test_conformance/math_brute_force/unary_u_half.cpp
@@ -54,7 +54,7 @@ int TestFunc_Half_UShort(const Func *f, MTdata d, bool relaxedMode)
     size_t bufferSize = bufferElements * sizeof(cl_half);
     logFunctionInfo(f->name, sizeof(cl_half), relaxedMode);
     const char *name = f->name;
-    float half_ulps = f->half_ulps;
+    float half_ulps = getAllowedUlpError(f, khalf, relaxedMode);
 
     // Init the kernels
     BuildKernelInfo build_info = { 1, kernels, programs, f->nameInCode };


### PR DESCRIPTION
Call `getAllowedUlpError` to obtain the allowed ULP error for all of the half type (fp16) tests.  The aim is to standardise obtaining the desired ULP requirement and pave the way for adding the Embedded Profile ULP errors.

Contributes to https://github.com/KhronosGroup/OpenCL-CTS/issues/867
Contributes to https://github.com/KhronosGroup/OpenCL-CTS/issues/1685