### PR TITLE
bruteforce: Fix comparions of unsigned shorts with 0.0f

### DIFF
--- a/test_conformance/math_brute_force/binary_two_results_i_half.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_half.cpp
@@ -304,7 +304,7 @@ int TestFunc_HalfI_Half_Half(const Func *f, MTdata d, bool relaxedMode)
                     // retry per section 6.5.3.2
                     if (IsHalfResultSubnormal(correct, half_ulps))
                     {
-                        fail = fail && !(test == 0.0f && iErr == 0);
+                        fail = fail && !((HTF(test) == 0.0f) && iErr == 0);
                         if (!fail) err = 0.0f;
                     }
 


### PR DESCRIPTION
Comparing test (of type cl_half) with 0.0f is incorrect because cl_half is a typedef of uint16_t (or unsigned short in c)