### PR TITLE
Command-buffer query for supported queue properties

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -52,6 +52,14 @@ bool BasicCommandBufferTest::Skip()
                "Unable to query "
                "CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR");
 
+    cl_command_queue_properties supported_properties;
+    error = clGetDeviceInfo(
+        device, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+        sizeof(supported_properties), &supported_properties, NULL);
+    test_error(error,
+               "Unable to query "
+               "CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR");
+
     cl_command_queue_properties queue_properties;
     error = clGetCommandQueueInfo(queue, CL_QUEUE_PROPERTIES,
                                   sizeof(queue_properties), &queue_properties,
@@ -70,7 +78,7 @@ bool BasicCommandBufferTest::Skip()
         && (capabilities & CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR)
             != 0;
     out_of_order_support =
-        capabilities & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR;
+        supported_properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
     device_side_enqueue_support =
         (capabilities & CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR)
         != 0;

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -104,10 +104,9 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
         cl_version extension_version =
             get_extension_version(device, "cl_khr_command_buffer");
 
-        if (extension_version != CL_MAKE_VERSION(0, 9, 5))
+        if (extension_version != CL_MAKE_VERSION(0, 9, 6))
         {
-
-            log_info("cl_khr_command_buffer version 0.9.5 is required to run "
+            log_info("cl_khr_command_buffer version 0.9.6 is required to run "
                      "the test, skipping.\n ");
             return TEST_SKIPPED_ITSELF;
         }

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_profiling.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_profiling.cpp
@@ -70,7 +70,22 @@ struct CommandBufferProfiling : public BasicCommandBufferTest
     //--------------------------------------------------------------------------
     cl_int SetUp(int elements) override
     {
-        cl_int error = CL_SUCCESS;
+
+        cl_command_queue_properties supported_properties;
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+            sizeof(supported_properties), &supported_properties, NULL);
+        test_error(error,
+                   "Unable to query "
+                   "CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR");
+
+        // CL_QUEUE_PROFILING_ENABLE is mandated minimum property returned by
+        // CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR
+        if (!(supported_properties & CL_QUEUE_PROFILING_ENABLE))
+        {
+            return TEST_FAIL;
+        }
+
         queue = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE,
                                      &error);
         test_error(error, "clCreateCommandQueue failed");

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -248,8 +248,8 @@ struct CreateCommandBufferQueueWithoutMinProperties
 
 // CL_INCOMPATIBLE_COMMAND_QUEUE_KHR if any command-queue in queues is an
 // out-of-order command-queue and the device associated with the command-queue
-// does not support the CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR
-// capability.
+// does not return CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE from
+// CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR
 struct CreateCommandBufferDeviceDoesNotSupportOutOfOderQueue
     : public BasicCommandBufferTest
 {


### PR DESCRIPTION
CTS test update to match OpenCL-Doc & OpenCL-Header PRs:
* https://github.com/KhronosGroup/OpenCL-Headers/pull/265
* https://github.com/KhronosGroup/OpenCL-Docs/pull/850

Tested with https://github.com/bashbaug/SimpleOpenCLSamples/pull/126 locally using a checkout of the linked OpenCL-Headers branch