### PR TITLE
printf: add fflush(stdout) at the end

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -689,6 +689,7 @@ static void print_results(int failed, int count, const char *name)
             log_error("FAILED %s.\n", name);
         }
     }
+    fflush(stdout);
 }
 
 int parseAndCallCommandLineTests(int argc, const char *argv[],


### PR DESCRIPTION
Some platforms (Windows in our case) seem to need this.