### PR TITLE
Fix for out of bounds access

### DIFF
--- a/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
+++ b/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
@@ -103,7 +103,7 @@ template <typename Ty, ArithmeticOp operation> struct RED_CLU
                 int ii = j * ns;
                 int n = ii + ns > nw ? nw - ii : ns;
                 std::vector<Ty> clusters_results;
-                int clusters_counter = ns / test_params.cluster_size;
+                int clusters_counter = (ns + test_params.cluster_size - 1) / test_params.cluster_size;
                 clusters_results.resize(clusters_counter);
 
                 // Compute target

--- a/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
+++ b/test_conformance/subgroups/test_subgroup_clustered_reduce.cpp
@@ -103,7 +103,8 @@ template <typename Ty, ArithmeticOp operation> struct RED_CLU
                 int ii = j * ns;
                 int n = ii + ns > nw ? nw - ii : ns;
                 std::vector<Ty> clusters_results;
-                int clusters_counter = (ns + test_params.cluster_size - 1) / test_params.cluster_size;
+                int clusters_counter = (ns + test_params.cluster_size - 1)
+                    / test_params.cluster_size;
                 clusters_results.resize(clusters_counter);
 
                 // Compute target


### PR DESCRIPTION
Rounding up the clusters_results size to avoid out of bounds access when subgroup_size is not a multiple of cluster_size.