### PR TITLE
kernel_image_methods: Fix size checks in 1Dbuffer case

### DIFF
--- a/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
@@ -262,8 +262,7 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                     imageInfo.rowPitch += extraWidth;
                 } while ((imageInfo.rowPitch % pixelSize) != 0);
 
-                size = (cl_ulong)imageInfo.rowPitch * (cl_ulong)imageInfo.height
-                    * 4;
+                size = (cl_ulong)imageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
             if (gDebugTrace)


### PR DESCRIPTION
Image height is initialized to 0.  But the size calculation should assume a height of 1.