### PR TITLE
Fix warning now treated as error

### DIFF
--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_negative_wait_signal.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_negative_wait_signal.cpp
@@ -88,7 +88,8 @@ template <RunMode mode> struct InvalidCommandQueue : public SemaphoreTestBase
         }
 
         cl_device_partition_property partitionProp[] = {
-            CL_DEVICE_PARTITION_EQUALLY, maxComputeUnits / 2, 0
+            CL_DEVICE_PARTITION_EQUALLY,
+            static_cast<cl_device_partition_property>(maxComputeUnits / 2), 0
         };
 
         cl_uint deviceCount = 0;


### PR DESCRIPTION
Following the re-enablement of narrowing warnings, this fixes a compilation error when running the `ubuntu 22.04 arm` GitHub action.