### PR TITLE
fixes a narrowing warning (treated as an error) affecting some platforms

### DIFF
--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_queries.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_queries.cpp
@@ -186,7 +186,7 @@ struct SemaphoreMultiDeviceContextQueries : public SemaphoreTestBase
 
         cl_device_partition_property partitionProp[] = {
             CL_DEVICE_PARTITION_EQUALLY,
-            static_cast<cl_device_partition_property>(maxComputeUnits / 2), 0, 0
+            static_cast<cl_device_partition_property>(maxComputeUnits / 2), 0
         };
 
         cl_uint deviceCount = 0;

--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_queries.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_queries.cpp
@@ -185,7 +185,8 @@ struct SemaphoreMultiDeviceContextQueries : public SemaphoreTestBase
         test_error(err, "Unable to get maximal number of compute units");
 
         cl_device_partition_property partitionProp[] = {
-            CL_DEVICE_PARTITION_EQUALLY, maxComputeUnits / 2, 0
+            CL_DEVICE_PARTITION_EQUALLY,
+            static_cast<cl_device_partition_property>(maxComputeUnits / 2), 0, 0
         };
 
         cl_uint deviceCount = 0;


### PR DESCRIPTION
Looks like https://github.com/KhronosGroup/OpenCL-CTS/pull/2063 has a "narrowing" warning that is now treated as an error and is hence causing CI builds to fail.

Applies the same fix as https://github.com/KhronosGroup/OpenCL-CTS/pull/2107 to fix this warning.