### PR TITLE
Fix bug in `mutable_command_full_dispatch`

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -241,6 +241,9 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
         error = clEnqueueSVMUnmap(queue, buf, 0, nullptr, nullptr);
         test_error(error, "clEnqueueSVMUnmap failed for svm buffer");
 
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
+
         return res;
     }
 


### PR DESCRIPTION
The test is missing clFinish after clEnqueueSVMUnmap. Add clFinish after clEnqueueSVMUnmap.