### PR TITLE
Re-enable simple_semaphore_2

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/main.cpp
@@ -19,17 +19,13 @@ test_definition test_list[] = {
     ADD_TEST(external_semaphores_queries),
     ADD_TEST(external_semaphores_cross_context),
     ADD_TEST(external_semaphores_simple_1),
-    // ADD_TEST(external_semaphores_simple_2),
+    ADD_TEST(external_semaphores_simple_2),
     ADD_TEST(external_semaphores_reuse),
     ADD_TEST(external_semaphores_cross_queues_ooo),
     ADD_TEST(external_semaphores_cross_queues_io),
     ADD_TEST(external_semaphores_cross_queues_io2),
     ADD_TEST(external_semaphores_multi_signal),
     ADD_TEST(external_semaphores_multi_wait),
-    // ADD_TEST(external_semaphores_order_1),
-    // ADD_TEST(external_semaphores_order_2),
-    // ADD_TEST(external_semaphores_order_3),
-    // ADD_TEST(external_semaphores_invalid_command)
 };
 
 

--- a/test_conformance/extensions/cl_khr_external_semaphore/procs.h
+++ b/test_conformance/extensions/cl_khr_external_semaphore/procs.h
@@ -59,24 +59,8 @@ extern int test_external_semaphores_multi_wait(cl_device_id deviceID,
                                                cl_context context,
                                                cl_command_queue queue,
                                                int num_elements);
-extern int test_external_semaphores_order_1(cl_device_id deviceID,
-                                            cl_context context,
-                                            cl_command_queue queue,
-                                            int num_elements);
-extern int test_external_semaphores_order_2(cl_device_id deviceID,
-                                            cl_context context,
-                                            cl_command_queue queue,
-                                            int num_elements);
-extern int test_external_semaphores_order_3(cl_device_id deviceID,
-                                            cl_context context,
-                                            cl_command_queue queue,
-                                            int num_elements);
 extern int test_external_semaphores_import_export_fd(cl_device_id deviceID,
                                                      cl_context context,
                                                      cl_command_queue queue,
                                                      int num_elements);
-extern int test_external_semaphores_invalid_command(cl_device_id deviceID,
-                                                    cl_context context,
-                                                    cl_command_queue queue,
-                                                    int num_elements);
 #endif // CL_KHR_EXTERNAL_SEMAPHORE_PROCS_H

--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -6,8 +6,6 @@
 #include <chrono>
 #include <algorithm>
 
-#define FLUSH_DELAY_S 5
-
 #define SEMAPHORE_PARAM_TEST(param_name, param_type, expected)                 \
     do                                                                         \
     {                                                                          \
@@ -502,7 +500,10 @@ int test_external_semaphores_simple_2(cl_device_id deviceID, cl_context context,
         // Flush and delay
         err = clFlush(queue);
         test_error(err, "Could not flush queue");
-        std::this_thread::sleep_for(std::chrono::seconds(FLUSH_DELAY_S));
+
+        cl_event event_list[] = { signal_event, wait_event };
+        err = clWaitForEvents(2, event_list);
+        test_error(err, "Could not wait on events");
 
         // Ensure all events are completed except for task_1
         test_assert_event_inprogress(task_1_event);


### PR DESCRIPTION
Re-enable a disabled external semaphore test.
Delete obsolete subtests that remain in comments.