### PR TITLE
remove using namespace std and use std namespace explicitly

### DIFF
--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -25,8 +25,6 @@
 #include <sys/stat.h>
 #include <string.h>
 
-using namespace std;
-
 #define DEFAULT_COMPILATION_PROGRAM "cl_offline_compiler"
 #define DEFAULT_SPIRV_VALIDATOR "spirv-val"
 

--- a/test_conformance/api/test_clone_kernel.cpp
+++ b/test_conformance/api/test_clone_kernel.cpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <cmath>
 
-using namespace std;
-
 const char *clone_kernel_test_img[] =
 {
     "__kernel void img_read_kernel(read_only image2d_t img, sampler_t sampler, __global int* outbuf)\n"

--- a/test_conformance/api/test_queue_hint.cpp
+++ b/test_conformance/api/test_queue_hint.cpp
@@ -19,11 +19,6 @@
 #include <sstream>
 #include <string>
 
-using namespace std;
-/*
-
-*/
-
 const char *queue_hint_test_kernel[] = {
 "__kernel void vec_cpy(__global int *src, __global int *dst)\n"
 "{\n"

--- a/test_conformance/api/test_queue_properties.cpp
+++ b/test_conformance/api/test_queue_properties.cpp
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 /*
 The test against cl_khr_create_command_queue extension. It validates if devices with Opencl 1.X can use clCreateCommandQueueWithPropertiesKHR function.
 Based on device capabilities test will create queue with NULL properties, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE property and

--- a/test_conformance/gl/test_image_methods.cpp
+++ b/test_conformance/gl/test_image_methods.cpp
@@ -17,8 +17,6 @@
 
 #include <algorithm>
 
-using namespace std;
-
 struct image_kernel_data
 {
     cl_int width;
@@ -383,17 +381,18 @@ int test_image_methods_depth(cl_device_id device, cl_context context,
     glGetIntegerv(GL_MAX_RECTANGLE_TEXTURE_SIZE_EXT, &maxTextureRectangleSize);
     glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, &maxTextureLayers);
 
-    size = min(maxTextureSize, maxTextureRectangleSize);
+    size = std::min(maxTextureSize, maxTextureRectangleSize);
 
     RandomSeed seed(gRandomSeed);
 
     // Generate some random sizes (within reasonable ranges)
     for (size_t i = 0; i < nsizes; i++)
     {
-        sizes[i].width = random_in_range(2, min(size, 1 << (i + 4)), seed);
-        sizes[i].height = random_in_range(2, min(size, 1 << (i + 4)), seed);
+        sizes[i].width = random_in_range(2, std::min(size, 1 << (i + 4)), seed);
+        sizes[i].height =
+            random_in_range(2, std::min(size, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
     }
 
     for (size_t i = 0; i < nsizes; i++)
@@ -440,11 +439,11 @@ int test_image_methods_multisample(cl_device_id device, cl_context context,
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
     }
 
     glEnable(GL_MULTISAMPLE);

--- a/test_conformance/gl/test_images_1D.cpp
+++ b/test_conformance/gl/test_images_1D.cpp
@@ -24,8 +24,6 @@
 #endif
 #include <algorithm>
 
-using namespace std;
-
 void calc_test_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit array size according to GL device properties
@@ -33,14 +31,14 @@ void calc_test_size_descriptors(sizevec_t* sizes, size_t nsizes)
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
     glGetIntegerv(GL_MAX_TEXTURE_BUFFER_SIZE, &maxTextureBufferSize);
 
-    size = min(maxTextureSize, maxTextureBufferSize);
+    size = std::min(maxTextureSize, maxTextureBufferSize);
 
     RandomSeed seed(gRandomSeed);
 
     // Generate some random sizes (within reasonable ranges)
     for (size_t i = 0; i < nsizes; i++)
     {
-        sizes[i].width = random_in_range(2, min(size, 1 << (i + 4)), seed);
+        sizes[i].width = random_in_range(2, std::min(size, 1 << (i + 4)), seed);
         sizes[i].height = 1;
         sizes[i].depth = 1;
     }

--- a/test_conformance/gl/test_images_1Darray.cpp
+++ b/test_conformance/gl/test_images_1Darray.cpp
@@ -24,7 +24,6 @@
 #endif
 #include <algorithm>
 
-using namespace std;
 void calc_1D_array_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit array size according to GL device properties
@@ -38,9 +37,9 @@ void calc_1D_array_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
         sizes[i].depth = 1;
     }
 }

--- a/test_conformance/gl/test_images_2D.cpp
+++ b/test_conformance/gl/test_images_2D.cpp
@@ -24,11 +24,6 @@
 #endif
 #include <algorithm>
 
-using namespace std;
-
-#pragma mark -
-#pragma mark _2D read tests
-
 void calc_2D_test_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit array size according to GL device properties
@@ -37,15 +32,16 @@ void calc_2D_test_size_descriptors(sizevec_t* sizes, size_t nsizes)
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
     glGetIntegerv(GL_MAX_RECTANGLE_TEXTURE_SIZE_EXT, &maxTextureRectangleSize);
 
-    size = min(maxTextureSize, maxTextureRectangleSize);
+    size = std::min(maxTextureSize, maxTextureRectangleSize);
 
     RandomSeed seed(gRandomSeed);
 
     // Generate some random sizes (within reasonable ranges)
     for (size_t i = 0; i < nsizes; i++)
     {
-        sizes[i].width = random_in_range(2, min(size, 1 << (i + 4)), seed);
-        sizes[i].height = random_in_range(2, min(size, 1 << (i + 4)), seed);
+        sizes[i].width = random_in_range(2, std::min(size, 1 << (i + 4)), seed);
+        sizes[i].height =
+            random_in_range(2, std::min(size, 1 << (i + 4)), seed);
         sizes[i].depth = 1;
     }
 }
@@ -63,7 +59,7 @@ void calc_cube_test_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width = sizes[i].height =
-            random_in_range(2, min(maxQubeMapSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxQubeMapSize, 1 << (i + 4)), seed);
         sizes[i].depth = 1;
     }
 }

--- a/test_conformance/gl/test_images_2Darray.cpp
+++ b/test_conformance/gl/test_images_2Darray.cpp
@@ -24,8 +24,6 @@
 #endif
 #include <algorithm>
 
-using namespace std;
-
 void calc_2D_array_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit array size according to GL device properties
@@ -39,11 +37,11 @@ void calc_2D_array_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
     }
 }
 

--- a/test_conformance/gl/test_images_3D.cpp
+++ b/test_conformance/gl/test_images_3D.cpp
@@ -24,11 +24,6 @@
 #endif
 #include <algorithm>
 
-using namespace std;
-
-#pragma mark -
-#pragma mark _3D read test
-
 void calc_3D_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit array size according to GL device properties
@@ -41,11 +36,11 @@ void calc_3D_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
     }
 }
 

--- a/test_conformance/gl/test_images_depth.cpp
+++ b/test_conformance/gl/test_images_depth.cpp
@@ -25,11 +25,6 @@
 
 #include <algorithm>
 
-using namespace std;
-
-#pragma mark -
-#pragma mark _2D depth read tests
-
 void calc_depth_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit texture size according to GL device properties
@@ -37,15 +32,16 @@ void calc_depth_size_descriptors(sizevec_t* sizes, size_t nsizes)
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
     glGetIntegerv(GL_MAX_RECTANGLE_TEXTURE_SIZE_EXT, &maxTextureRectangleSize);
 
-    size = min(maxTextureSize, maxTextureRectangleSize);
+    size = std::min(maxTextureSize, maxTextureRectangleSize);
 
     RandomSeed seed(gRandomSeed);
 
     // Generate some random sizes (within reasonable ranges)
     for (size_t i = 0; i < nsizes; i++)
     {
-        sizes[i].width = random_in_range(2, min(size, 1 << (i + 4)), seed);
-        sizes[i].height = random_in_range(2, min(size, 1 << (i + 4)), seed);
+        sizes[i].width = random_in_range(2, std::min(size, 1 << (i + 4)), seed);
+        sizes[i].height =
+            random_in_range(2, std::min(size, 1 << (i + 4)), seed);
         sizes[i].depth = 1;
     }
 }
@@ -59,17 +55,18 @@ void calc_depth_array_size_descriptors(sizevec_t* sizes, size_t nsizes)
     glGetIntegerv(GL_MAX_RECTANGLE_TEXTURE_SIZE_EXT, &maxTextureRectangleSize);
     glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, &maxTextureLayers);
 
-    size = min(maxTextureSize, maxTextureRectangleSize);
+    size = std::min(maxTextureSize, maxTextureRectangleSize);
 
     RandomSeed seed(gRandomSeed);
 
     // Generate some random sizes (within reasonable ranges)
     for (size_t i = 0; i < nsizes; i++)
     {
-        sizes[i].width = random_in_range(2, min(size, 1 << (i + 4)), seed);
-        sizes[i].height = random_in_range(2, min(size, 1 << (i + 4)), seed);
+        sizes[i].width = random_in_range(2, std::min(size, 1 << (i + 4)), seed);
+        sizes[i].height =
+            random_in_range(2, std::min(size, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
     }
 }
 

--- a/test_conformance/gl/test_images_multisample.cpp
+++ b/test_conformance/gl/test_images_multisample.cpp
@@ -25,8 +25,6 @@
 
 #include <algorithm>
 
-using namespace std;
-
 void calc_2D_multisample_size_descriptors(sizevec_t* sizes, size_t nsizes)
 {
     // Need to limit texture size according to GL device properties
@@ -39,9 +37,9 @@ void calc_2D_multisample_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].depth = 1;
     }
 }
@@ -59,11 +57,11 @@ void calc_2D_array_multisample_size_descriptors(sizevec_t* sizes, size_t nsizes)
     for (size_t i = 0; i < nsizes; i++)
     {
         sizes[i].width =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].height =
-            random_in_range(2, min(maxTextureSize, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureSize, 1 << (i + 4)), seed);
         sizes[i].depth =
-            random_in_range(2, min(maxTextureLayers, 1 << (i + 4)), seed);
+            random_in_range(2, std::min(maxTextureLayers, 1 << (i + 4)), seed);
     }
 }
 

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -42,16 +42,15 @@ const std::string spvVersionSkipArg = "--skip-spirv-version-check";
 
 std::vector<unsigned char> readBinary(const char *file_name)
 {
-    using namespace std;
-
-    ifstream file(file_name, ios::in | ios::binary | ios::ate);
+    std::ifstream file(file_name,
+                       std::ios::in | std::ios::binary | std::ios::ate);
 
     std::vector<char> tmpBuffer(0);
 
     if (file.is_open()) {
         size_t size = file.tellg();
         tmpBuffer.resize(size);
-        file.seekg(0, ios::beg);
+        file.seekg(0, std::ios::beg);
         file.read(&tmpBuffer[0], size);
         file.close();
     } else {


### PR DESCRIPTION
Removes `using namespace std` and adds `std::` explicitly instead, which is usually on calls to `min`.

This is generally best practice, and it also might be helpful when there are the same function names in the std namespace and in the global namespace (e.g. #1833).