### PR TITLE
Fix payload value query for external semaphores

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
+++ b/test_conformance/extensions/cl_khr_external_semaphore/test_external_semaphore.cpp
@@ -197,10 +197,15 @@ int test_external_semaphores_queries(cl_device_id deviceID, cl_context context,
         test_error(err, "Could not release semaphore");
         SEMAPHORE_PARAM_TEST(CL_SEMAPHORE_REFERENCE_COUNT_KHR, cl_uint, 1);
 
-        // Confirm that querying CL_SEMAPHORE_PAYLOAD_KHR returns the unsignaled
+        // Confirm that querying CL_SEMAPHORE_PAYLOAD_KHR returns the correct
         // state
+        cl_semaphore_payload_khr expected_payload_value =
+            (vkExternalSemaphoreHandleType
+             == VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD)
+            ? 1
+            : 0;
         SEMAPHORE_PARAM_TEST(CL_SEMAPHORE_PAYLOAD_KHR, cl_semaphore_payload_khr,
-                             0);
+                             expected_payload_value);
     }
 
     return TEST_PASS;


### PR DESCRIPTION
When creating a CL semaphore object from a Vulkan semaphore one, we explicitly pass `-1` as the file descriptor value in the case of `VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD`. According to the CL specification:

>     The special value -1 for fd is treated like a valid sync file
>     descriptor referring to an object that has already signaled. The
>     import operation will succeed and the semaphore will have a
>     temporarily imported payload as if a valid file descriptor had
>     been provided.

The test currently checks that the semaphore payload is unsignalled, unconditionally, which is incorrect.

Changed the test to check for the correct expected payload value.