### PR TITLE
Fix CTS mutable_dispatch memory leak

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_work_groups.cpp
@@ -82,13 +82,41 @@ struct MutableDispatchWorkGroups : public BasicMutableCommandBufferTest
             || BasicMutableCommandBufferTest::Skip();
     }
 
+    cl_int SetUpKernel() override
+    {
+        // Create kernel
+        const char *num_groups_kernel =
+            R"(
+                __kernel void sample_test(__global int *dst)
+            {
+                size_t tid = get_global_id(0);
+                dst[tid] = get_num_groups(0);
+            })";
+
+        cl_int error = create_single_kernel_helper(
+            context, &program, &kernel, 1, &num_groups_kernel, "sample_test");
+        test_error(error, "Creating kernel failed");
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUpKernelArgs() override
+    {
+        cl_int error = CL_SUCCESS;
+        stream = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeToAllocate,
+                                nullptr, &error);
+        test_error(error, "Creating src buffer");
+
+        error = clSetKernelArg(kernel, 0, sizeof(cl_mem), &stream);
+        test_error(error, "Unable to set indexed kernel arguments");
+
+        return CL_SUCCESS;
+    }
+
     cl_int SetUp(int elements) override
     {
         cl_int error = BasicMutableCommandBufferTest::SetUp(elements);
         test_error(error, "BasicMutableCommandBufferTest::SetUp failed");
-
-        error = SetUpKernel();
-        test_error(error, "SetUpKernel failed");
 
         cl_command_buffer_properties_khr properties[5];
         int index = 0;
@@ -110,23 +138,7 @@ struct MutableDispatchWorkGroups : public BasicMutableCommandBufferTest
 
     cl_int Run() override
     {
-        const char *num_groups_kernel =
-            R"(
-                __kernel void sample_test(__global int *dst)
-            {
-                size_t tid = get_global_id(0);
-                dst[tid] = get_num_groups(0);
-            })";
-        cl_int error = create_single_kernel_helper(
-            context, &program, &kernel, 1, &num_groups_kernel, "sample_test");
-        test_error(error, "Creating kernel failed");
-
-        clMemWrapper stream = clCreateBuffer(context, CL_MEM_READ_WRITE,
-                                             sizeToAllocate, nullptr, &error);
-
-        error = clSetKernelArg(kernel, 0, sizeof(cl_mem), &stream);
-        test_error(error, "Unable to set indexed kernel arguments");
-
+        cl_int error = CL_SUCCESS;
         // Record an ND-range kernel of the kernel above in the command buffer
         // with a non-null local work size so that the resulting number of
         // workgroups will be greater than 1.
@@ -262,6 +274,7 @@ struct MutableDispatchWorkGroups : public BasicMutableCommandBufferTest
 
     clCommandBufferWrapper single_command_buffer;
     cl_mutable_command_khr command = nullptr;
+    clMemWrapper stream;
     Configuration config;
 
     size_t info_global_size = 0;


### PR DESCRIPTION
Current class wrapper of the CTS test framework allows getting the pointer of the private member object. This puts the object at risk of losing its original value if the pointer gets reassigned, causing a memory leak and potentially other problems.

This happens to the "clMemWrapper kernel" used by
mutable_command_work_groups tests, where the "clMemWrapper kernel" gets initialised by the default basic setup function and then it gets reassigned by the build_program_create_kernel_helper() helper  function through pointer.

This patch fixes this issue by updating mutable_command_work_groups tests: instead of calling basic setup function and then initialise the "clMemWrapper kernel" object again in the helper function, it now overrides the basic setup function to make sure the "clMemWrapper kernel" will be assigned only once.