### PR TITLE
Fix various Wformat warnings

### DIFF
--- a/test_conformance/SVM/test_enqueue_api.cpp
+++ b/test_conformance/SVM/test_enqueue_api.cpp
@@ -193,7 +193,8 @@ int test_svm_enqueue_api(cl_device_id deviceID, cl_context c, cl_command_queue q
       for (size_t j = 0; j < data_size; ++j)
       {
         if (dst_ptr[j] != src_ptr[j]) {
-            log_error("Invalid data at index %ld, dst_ptr %d, src_ptr %d\n", j, dst_ptr[j], src_ptr[j]);
+            log_error("Invalid data at index %zu, dst_ptr %d, src_ptr %d\n", j,
+                      dst_ptr[j], src_ptr[j]);
             return TEST_FAIL;
         }
       }
@@ -291,8 +292,10 @@ int test_svm_enqueue_api(cl_device_id deviceID, cl_context c, cl_command_queue q
   //check if number of SVM pointers returned in the callback matches with expected
   if (data.num_svm_pointers != buffers.size())
   {
-    log_error("Invalid number of SVM pointers returned in the callback, expected: %ld, got: %d\n", buffers.size(), data.num_svm_pointers);
-    return TEST_FAIL;
+      log_error("Invalid number of SVM pointers returned in the callback, "
+                "expected: %zu, got: %d\n",
+                buffers.size(), data.num_svm_pointers);
+      return TEST_FAIL;
   }
 
   //check if pointers returned in callback are correct
@@ -300,8 +303,9 @@ int test_svm_enqueue_api(cl_device_id deviceID, cl_context c, cl_command_queue q
   {
     if (data.svm_pointers[i] != buffers[i])
     {
-      log_error("Invalid SVM pointer returned in the callback, idx: %ld\n", i);
-      return TEST_FAIL;
+        log_error("Invalid SVM pointer returned in the callback, idx: %zu\n",
+                  i);
+        return TEST_FAIL;
     }
   }
 

--- a/test_conformance/allocations/allocation_execute.cpp
+++ b/test_conformance/allocations/allocation_execute.cpp
@@ -373,8 +373,8 @@ int execute_kernel(cl_context context, cl_command_queue *queue,
     if (result != SUCCEEDED)
     {
         if (result == FAILED_TOO_BIG)
-            log_info("\t\tExecute kernel failed: %s (global dim: %ld, local "
-                     "dim: %ld)\n",
+            log_info("\t\tExecute kernel failed: %s (global dim: %zu, local "
+                     "dim: %zu)\n",
                      IGetErrorString(error), global_dims[0], local_dims[0]);
         else
             print_error(error, "clEnqueueNDRangeKernel failed");

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -441,9 +441,12 @@ int test_partition_of_device(cl_device_id deviceID, cl_context context, cl_comma
                properties_returned[1] == CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE ||
                properties_returned[1] == CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE ||
                properties_returned[1] == CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE))) {
-            log_error("properties_returned[%d] 0x%x != 0x%x partition_type[%d].", i, properties_returned[i], partition_type[i], i);
-            return -1;
-              }
+              log_error(
+                  "properties_returned[%d] 0x%x != 0x%x partition_type[%d].", i,
+                  static_cast<unsigned int>(properties_returned[i]),
+                  static_cast<unsigned int>(partition_type[i]), i);
+              return -1;
+          }
         }
       } // for
     }
@@ -493,8 +496,10 @@ int test_partition_of_device(cl_device_id deviceID, cl_context context, cl_comma
       }
       else
       {
-        log_info("Testing on device %p partition type \"%s\" (%d,%d)\n", deviceID, printPartition(partitionProp[i][0]),
-                  partitionProp[i][1], partitionProp[i][2]);
+          log_info("Testing on device %p partition type \"%s\" (%d,%d)\n",
+                   deviceID, printPartition(partitionProp[i][0]),
+                   static_cast<unsigned int>(partitionProp[i][1]),
+                   static_cast<unsigned int>(partitionProp[i][2]));
       }
 
       cl_uint deviceCount;

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -213,7 +213,7 @@ int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_
       {
         log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
         if ( gTestMipmaps )
-          log_info( "   and %llu mip levels\n", (size_t) imageInfo.num_mip_levels );
+            log_info("   and %u mip levels\n", imageInfo.num_mip_levels);
       }
 
             int ret = test_copy_image_size_1D( context, queue, &imageInfo, seed );

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -160,7 +160,9 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     }
     if ( !allZeroes )
     {
-        log_error( " Sampler-less reads differ from reads with sampler at index %lu.\n", ic );
+        log_error(" Sampler-less reads differ from reads with sampler at index "
+                  "%zu.\n",
+                  ic);
         return -1;
     }
 

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -149,7 +149,9 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     }
     if ( !allZeroes )
     {
-        log_error( " Sampler-less reads differ from reads with sampler at index %lu.\n", ic );
+        log_error(" Sampler-less reads differ from reads with sampler at index "
+                  "%zu.\n",
+                  ic);
         return -1;
     }
 

--- a/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
+++ b/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
@@ -299,7 +299,7 @@ TestNonUniformWorkGroup::TestNonUniformWorkGroup(
                 auto global_size_rounded = global_size_before
                     + (localSize[dim] - global_size_before % localSize[dim]);
                 globalSize[dim] = global_size_rounded;
-                log_info("Rounding globalSize[%d] = %d -> %d\n", dim,
+                log_info("Rounding globalSize[%d] = %zu -> %zu\n", dim,
                          global_size_before, global_size_rounded);
             }
         }
@@ -665,8 +665,8 @@ void TestNonUniformWorkGroup::showTestInfo () {
     if (!_localSize_IsNull) {
       log_info ("\tATTENTION: strict mode applies only NULL local work group size\n");
     } else {
-      log_info ("\t\tExpected value of local work group size is %ld.\n",
-        TestNonUniformWorkGroup::getMaxLocalWorkgroupSize(_device));
+        log_info("\t\tExpected value of local work group size is %zu.\n",
+                 TestNonUniformWorkGroup::getMaxLocalWorkgroupSize(_device));
     }
 
   }
@@ -687,7 +687,8 @@ size_t TestNonUniformWorkGroup::adjustLocalArraySize (size_t localArraySize) {
 
   if (kernelLocalMemSize + localArraySize > deviceLocalMemSize) {
     size_t adjustedLocalArraySize = deviceLocalMemSize - kernelLocalMemSize;
-    log_info("localArraySize was adjusted from %lu to %lu\n", localArraySize, adjustedLocalArraySize);
+    log_info("localArraySize was adjusted from %zu to %zu\n", localArraySize,
+             adjustedLocalArraySize);
     localArraySize = adjustedLocalArraySize;
   }
 
@@ -706,7 +707,8 @@ size_t TestNonUniformWorkGroup::adjustGlobalBufferSize(size_t globalBufferSize) 
   size_t adjustedGlobalBufferSize = globalBufferSize;
   if (deviceMaxAllocObjSize < globalBufferSize) {
     adjustedGlobalBufferSize = deviceMaxAllocObjSize;
-    log_info("globalBufferSize was adjusted from %lu to %lu\n", globalBufferSize, adjustedGlobalBufferSize);
+    log_info("globalBufferSize was adjusted from %zu to %zu\n",
+             globalBufferSize, adjustedGlobalBufferSize);
   }
 
   return adjustedGlobalBufferSize;

--- a/test_conformance/pipes/test_pipe_info.cpp
+++ b/test_conformance/pipes/test_pipe_info.cpp
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#include <cinttypes>
+
 #include "procs.h"
 #include "harness/parseParameters.h"
 
@@ -73,7 +76,7 @@ int test_pipe_info( cl_device_id deviceID, cl_context context, cl_command_queue 
         test_error_fail(err, "clGetKernelArgInfo failed");
         if (arg_type_qualifier != CL_KERNEL_ARG_TYPE_PIPE)
         {
-            test_fail("ERROR: Incorrect type qualifier: %i\n",
+            test_fail("ERROR: Incorrect type qualifier: 0x%" PRIx64 "\n",
                       arg_type_qualifier);
         }
     }

--- a/test_conformance/relationals/test_shuffles.cpp
+++ b/test_conformance/relationals/test_shuffles.cpp
@@ -324,7 +324,7 @@ void generate_shuffle_mask( char *outMaskString, size_t maskSize, const ShuffleO
         for( size_t jj = 0; jj < maskSize; jj++ )
         {
             char thisMask[ 16 ];
-            sprintf( thisMask, "%s%ld", ( jj == 0 ) ? "" : ", ", jj );
+            sprintf(thisMask, "%s%zu", (jj == 0) ? "" : ", ", jj);
             strcat( outMaskString, thisMask );
         }
     }
@@ -347,7 +347,7 @@ static int create_shuffle_kernel( cl_context context, cl_program *outProgram, cl
     if( inVecSize == 1 ) //|| (inVecSize == 3)) // just have arrays if we go with size 3
         inSizeName[ 0 ] = 0;
     else
-        sprintf( inSizeName, "%ld", inVecSize );
+        sprintf(inSizeName, "%zu", inVecSize);
     if( inVecSize == 3 )
         inSizeArgName[ 0 ] = 0;
     else

--- a/test_conformance/spirv_new/test_get_program_il.cpp
+++ b/test_conformance/spirv_new/test_get_program_il.cpp
@@ -68,8 +68,8 @@ TEST_SPIRV_FUNC(get_program_il)
         if (il_size != file_bytes)
         {
             test_fail("ERROR: Returned IL size is not the same as source IL "
-                      "size (%lu "
-                      "!= %lu)!\n",
+                      "size (%zu "
+                      "!= %zu)!\n",
                       il_size, file_bytes);
         }
 

--- a/test_conformance/thread_dimensions/test_thread_dimensions.cpp
+++ b/test_conformance/thread_dimensions/test_thread_dimensions.cpp
@@ -20,6 +20,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "procs.h"
 
 #define ITERATIONS 4
@@ -386,7 +388,8 @@ int run_test(cl_context context, cl_command_queue queue, cl_kernel kernel,
                                          global_size, NULL, 0, NULL, NULL);
             if (DEBUG)
                 log_info("\t\t\tExecuting kernel with global %s, NULL local, "
-                         "%d dim, start address %llu, end address %llu.\n",
+                         "%d dim, start address %" PRIu64
+                         ", end address %" PRIu64 ".\n",
                          print_dimensions(dim_str, global_size[0],
                                           global_size[1], global_size[2],
                                           dimensions),
@@ -401,7 +404,8 @@ int run_test(cl_context context, cl_command_queue queue, cl_kernel kernel,
             if (DEBUG)
                 log_info(
                     "\t\t\tExecuting kernel with global %s, local %s, %d "
-                    "dim, start address %llu, end address %llu.\n",
+                    "dim, start address %" PRIu64 ", end address %" PRIu64
+                    ".\n",
                     print_dimensions(dim_str, global_size[0], global_size[1],
                                      global_size[2], dimensions),
                     print_dimensions2(dim_str2, local_size[0], local_size[1],

--- a/test_conformance/vectors/structs.cpp
+++ b/test_conformance/vectors/structs.cpp
@@ -369,7 +369,7 @@ int checkCorrectnessStep(bufferStruct *pBufferStruct, clState *pClState,
     {
         if (targetArr[i] != targetSize)
         {
-            vlog_error("Error %ld (of %ld).  Expected %d, got %d\n", i,
+            vlog_error("Error %zu (of %zu).  Expected %d, got %d\n", i,
                        pClState->m_numThreads, targetSize, targetArr[i]);
             return -1;
         }

--- a/test_conformance/vectors/test_step.cpp
+++ b/test_conformance/vectors/test_step.cpp
@@ -128,7 +128,7 @@ int test_step_internal(cl_device_id deviceID, cl_context context,
             err = runKernel(pClState, 1024);
             if (err != 0)
             {
-                vlog_error("%s: runKernel fail (%ld threads) %s%s\n", testName,
+                vlog_error("%s: runKernel fail (%zu threads) %s%s\n", testName,
                            pClState->m_numThreads, g_arrTypeNames[typeIdx],
                            g_arrVecSizeNames[vecSizeIdx]);
                 destroyBufferStruct(pBuffers, pClState);

--- a/test_conformance/vectors/test_vec_align.cpp
+++ b/test_conformance/vectors/test_vec_align.cpp
@@ -183,7 +183,7 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
                     / (g_arrVecSizes[vecSizeIdx] * g_arrTypeSizes[typeIdx]));
             if (err != 0)
             {
-                vlog_error("%s: runKernel fail (%ld threads) %s%s\n", testName,
+                vlog_error("%s: runKernel fail (%zu threads) %s%s\n", testName,
                            pClState->m_numThreads, g_arrTypeNames[typeIdx],
                            g_arrVecSizeNames[vecSizeIdx]);
                 destroyBufferStruct(pBuffers, pClState);

--- a/test_conformance/workgroups/test_wg_all.cpp
+++ b/test_conformance/workgroups/test_wg_all.cpp
@@ -54,7 +54,9 @@ verify_wg_all(float *inptr, int *outptr, size_t n, size_t wg_size)
             if ( (predicate_all && (outptr[i+j] == 0)) ||
                  ((predicate_all == 0) && outptr[i+j]) )
             {
-                log_info("work_group_all: Error at %lu: expected = %d, got = %d\n", i+j, predicate_all, outptr[i+j]);
+                log_info(
+                    "work_group_all: Error at %zu: expected = %d, got = %d\n",
+                    i + j, predicate_all, outptr[i + j]);
                 return -1;
             }
         }

--- a/test_conformance/workgroups/test_wg_any.cpp
+++ b/test_conformance/workgroups/test_wg_any.cpp
@@ -54,7 +54,9 @@ verify_wg_any(float *inptr, int *outptr, size_t n, size_t wg_size)
             if ( (predicate_any && (outptr[i+j] == 0)) ||
                  ((predicate_any == 0) && outptr[i+j]) )
             {
-                log_info("work_group_any: Error at %lu: expected = %d, got = %d\n", i+j, predicate_any, outptr[i+j]);
+                log_info(
+                    "work_group_any: Error at %zu: expected = %d, got = %d\n",
+                    i + j, predicate_any, outptr[i + j]);
                 return -1;
             }
         }


### PR DESCRIPTION
test_copy_1D.cpp: num_mip_levels is a cl_uint, so don't cast and just print using `%u`.

test_pipe_info.cpp: arg_type_qualifier is a 64-bit wide bitfield, so print in hexadecimal format using the correct length modifier.

test_device_partition.cpp: it is not clear what the bit width of `cl_device_partition_property` should be, so cast the operands to align with the format specifiers.