### PR TITLE
Use the system package manager to install cross-compilers

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -31,6 +31,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Install Arm and AArch64 compilers
+        if: ${{ matrix.arch == 'arm' || matrix.arch == 'aarch64' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-12-arm-linux-gnueabihf g++-12-arm-linux-gnueabihf \
+            gcc-12-aarch64-linux-gnu g++-12-aarch64-linux-gnu
+          sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-12 12
+          sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-12 12
+          sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-12 12
+          sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-12 12
       - name: Setup OpenGL build dependencies
         if: ${{ matrix.gl }}
         run: |

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -4,9 +4,6 @@ set -e
 
 export TOP=$(pwd)
 
-TOOLCHAIN_URL_arm="https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/arm-linux-gnueabihf/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz"
-TOOLCHAIN_URL_aarch64="https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz"
-
 TOOLCHAIN_PREFIX_arm=arm-linux-gnueabihf
 TOOLCHAIN_PREFIX_aarch64=aarch64-linux-gnu
 
@@ -20,14 +17,6 @@ echo
 
 # Prepare toolchain if needed
 if [[ ${JOB_ARCHITECTURE} != "" && ${RUNNER_OS} != "Windows" ]]; then
-    TOOLCHAIN_URL_VAR=TOOLCHAIN_URL_${JOB_ARCHITECTURE}
-    TOOLCHAIN_URL=${!TOOLCHAIN_URL_VAR}
-    wget ${TOOLCHAIN_URL}
-    TOOLCHAIN_ARCHIVE=${TOOLCHAIN_URL##*/}
-    tar xf ${TOOLCHAIN_ARCHIVE}
-    TOOLCHAIN_DIR=${TOP}/${TOOLCHAIN_ARCHIVE%.tar.xz}
-    export PATH=${TOOLCHAIN_DIR}/bin:${PATH}
-
     TOOLCHAIN_PREFIX_VAR=TOOLCHAIN_PREFIX_${JOB_ARCHITECTURE}
     TOOLCHAIN_PREFIX=${!TOOLCHAIN_PREFIX_VAR}
 


### PR DESCRIPTION
On Ubuntu, use the system's package manager, `apt`, to download and install the cross-compilers for Arm and AArch64. This replaces downloading the compilers as tarballs.

To ensure that the correct version of the compiler is used when calling one without the version suffix, e.g. `aarch64-linux-gnu-gcc`, use `update-alternatives`.

On Linux, the compilers for `x86_64`, `arm`, and `aarch64` will now correctly use the filesystem root as their sysroots, i.e. `/usr/include` will be used when searching for headers, instead of each compiler providing its own.