### PR TITLE
Use `cl_uint` in some SPIR-V tests to avoid UB

### DIFF
--- a/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm32
@@ -39,7 +39,7 @@
          %21 = OpLoad %uint %20 Aligned 4
          %22 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %19
          %23 = OpLoad %uint %22 Aligned 4
-         %24 = OpSLessThan %bool %21 %23
+         %24 = OpULessThan %bool %21 %23
                OpBranchConditional %24 %25 %26
          %25 = OpLabel
          %27 = OpISub %uint %23 %21

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm64
@@ -45,7 +45,7 @@
          %26 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %23
          %27 = OpLoad %uint %26 Aligned 4
                OpStore %19 %uint_0
-         %28 = OpSLessThan %bool %25 %27
+         %28 = OpULessThan %bool %25 %27
                OpBranchConditional %28 %29 %30
          %29 = OpLabel
          %31 = OpISub %uint %27 %25

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm32
@@ -39,7 +39,7 @@
          %21 = OpLoad %uint %20 Aligned 4
          %22 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %19
          %23 = OpLoad %uint %22 Aligned 4
-         %24 = OpSLessThan %bool %21 %23
+         %24 = OpULessThan %bool %21 %23
                OpBranchConditional %24 %25 %26 4 6
          %25 = OpLabel
          %27 = OpISub %uint %23 %21

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm64
@@ -45,7 +45,7 @@
          %26 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %23
          %27 = OpLoad %uint %26 Aligned 4
                OpStore %19 %uint_0
-         %28 = OpSLessThan %bool %25 %27
+         %28 = OpULessThan %bool %25 %27
                OpBranchConditional %28 %29 %30 4 6
          %29 = OpLabel
          %31 = OpISub %uint %27 %25

--- a/test_conformance/spirv_new/spirv_asm/phi_2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_2.spvasm32
@@ -36,7 +36,7 @@
          %18 = OpLoad %uint %17 Aligned 4
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %16
          %20 = OpLoad %uint %19 Aligned 4
-         %21 = OpSLessThan %bool %18 %20
+         %21 = OpULessThan %bool %18 %20
                OpBranchConditional %21 %22 %23
          %22 = OpLabel
          %24 = OpISub %uint %20 %18

--- a/test_conformance/spirv_new/spirv_asm/phi_2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_2.spvasm64
@@ -41,7 +41,7 @@
          %22 = OpLoad %uint %21 Aligned 4
          %23 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %20
          %24 = OpLoad %uint %23 Aligned 4
-         %25 = OpSLessThan %bool %22 %24
+         %25 = OpULessThan %bool %22 %24
                OpBranchConditional %25 %26 %27
          %26 = OpLabel
          %28 = OpISub %uint %24 %22

--- a/test_conformance/spirv_new/spirv_asm/phi_3.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_3.spvasm32
@@ -23,6 +23,7 @@
        %bool = OpTypeBool
        %void = OpTypeVoid
      %uint_0 = OpConstant %uint 0
+ %uint_65535 = OpConstant %uint 65535
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
          %14 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
 %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
@@ -37,10 +38,10 @@
          %19 = OpLoad %uint %18 Aligned 4
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %17
          %21 = OpLoad %uint %20 Aligned 4
-         %22 = OpSLessThan %bool %19 %21
+         %22 = OpULessThan %bool %19 %21
                OpBranchConditional %22 %23 %24
          %23 = OpLabel
-         %25 = OpSLessThan %bool %19 %uint_0
+         %25 = OpULessThan %bool %19 %uint_65535
                OpBranchConditional %25 %26 %27
          %26 = OpLabel
          %28 = OpISub %uint %uint_0 %19

--- a/test_conformance/spirv_new/spirv_asm/phi_3.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_3.spvasm64
@@ -26,6 +26,7 @@
        %void = OpTypeVoid
        %uint = OpTypeInt 32 0
      %uint_0 = OpConstant %uint 0
+ %uint_65535 = OpConstant %uint 65535
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
          %16 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
 %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3ulong Input
@@ -42,10 +43,10 @@
          %23 = OpLoad %uint %22 Aligned 4
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %21
          %25 = OpLoad %uint %24 Aligned 4
-         %26 = OpSLessThan %bool %23 %25
+         %26 = OpULessThan %bool %23 %25
                OpBranchConditional %26 %27 %28
          %27 = OpLabel
-         %29 = OpSLessThan %bool %23 %uint_0
+         %29 = OpULessThan %bool %23 %uint_65535
                OpBranchConditional %29 %30 %31
          %30 = OpLabel
          %32 = OpISub %uint %uint_0 %23

--- a/test_conformance/spirv_new/spirv_asm/phi_4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_4.spvasm32
@@ -23,6 +23,7 @@
        %bool = OpTypeBool
        %void = OpTypeVoid
      %uint_0 = OpConstant %uint 0
+ %uint_65535 = OpConstant %uint 65535
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
          %14 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
 %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
@@ -37,10 +38,10 @@
          %19 = OpLoad %uint %18 Aligned 4
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %17
          %21 = OpLoad %uint %20 Aligned 4
-         %22 = OpSLessThan %bool %19 %21
+         %22 = OpULessThan %bool %19 %21
                OpBranchConditional %22 %23 %24
          %23 = OpLabel
-         %25 = OpSLessThan %bool %19 %uint_0
+         %25 = OpULessThan %bool %19 %uint_65535
                OpBranchConditional %25 %26 %27
          %26 = OpLabel
          %28 = OpISub %uint %uint_0 %19
@@ -49,7 +50,7 @@
          %30 = OpISub %uint %19 %uint_0
                OpBranch %29
          %24 = OpLabel
-         %31 = OpSLessThan %bool %21 %uint_0
+         %31 = OpULessThan %bool %21 %uint_65535
                OpBranchConditional %31 %32 %33
          %32 = OpLabel
          %34 = OpISub %uint %uint_0 %21

--- a/test_conformance/spirv_new/spirv_asm/phi_4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_4.spvasm64
@@ -26,6 +26,7 @@
        %void = OpTypeVoid
        %uint = OpTypeInt 32 0
      %uint_0 = OpConstant %uint 0
+ %uint_65535 = OpConstant %uint 65535
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
          %16 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
 %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3ulong Input
@@ -42,10 +43,10 @@
          %23 = OpLoad %uint %22 Aligned 4
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %21
          %25 = OpLoad %uint %24 Aligned 4
-         %26 = OpSLessThan %bool %23 %25
+         %26 = OpULessThan %bool %23 %25
                OpBranchConditional %26 %27 %28
          %27 = OpLabel
-         %29 = OpSLessThan %bool %23 %uint_0
+         %29 = OpULessThan %bool %23 %uint_65535
                OpBranchConditional %29 %30 %31
          %30 = OpLabel
          %32 = OpISub %uint %uint_0 %23
@@ -54,7 +55,7 @@
          %34 = OpISub %uint %23 %uint_0
                OpBranch %33
          %28 = OpLabel
-         %35 = OpSLessThan %bool %25 %uint_0
+         %35 = OpULessThan %bool %25 %uint_65535
                OpBranchConditional %35 %36 %37
          %36 = OpLabel
          %38 = OpISub %uint %uint_0 %25

--- a/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm32
@@ -39,7 +39,7 @@
          %21 = OpLoad %uint %20 Aligned 4
          %22 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %19
          %23 = OpLoad %uint %22 Aligned 4
-         %24 = OpSLessThan %bool %21 %23
+         %24 = OpULessThan %bool %21 %23
                OpSelectionMerge %25 DontFlatten
                OpBranchConditional %24 %26 %27
          %26 = OpLabel

--- a/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm64
@@ -45,7 +45,7 @@
          %26 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %23
          %27 = OpLoad %uint %26 Aligned 4
                OpStore %19 %uint_0
-         %28 = OpSLessThan %bool %25 %27
+         %28 = OpULessThan %bool %25 %27
                OpSelectionMerge %29 DontFlatten
                OpBranchConditional %28 %30 %31
          %30 = OpLabel

--- a/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm32
@@ -39,7 +39,7 @@
          %21 = OpLoad %uint %20 Aligned 4
          %22 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %19
          %23 = OpLoad %uint %22 Aligned 4
-         %24 = OpSLessThan %bool %21 %23
+         %24 = OpULessThan %bool %21 %23
                OpSelectionMerge %25 Flatten
                OpBranchConditional %24 %26 %27
          %26 = OpLabel

--- a/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm64
@@ -45,7 +45,7 @@
          %26 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %23
          %27 = OpLoad %uint %26 Aligned 4
                OpStore %19 %uint_0
-         %28 = OpSLessThan %bool %25 %27
+         %28 = OpULessThan %bool %25 %27
                OpSelectionMerge %29 Flatten
                OpBranchConditional %28 %30 %31
          %30 = OpLabel

--- a/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm32
@@ -39,7 +39,7 @@
          %21 = OpLoad %uint %20 Aligned 4
          %22 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %19
          %23 = OpLoad %uint %22 Aligned 4
-         %24 = OpSLessThan %bool %21 %23
+         %24 = OpULessThan %bool %21 %23
                OpSelectionMerge %25 None
                OpBranchConditional %24 %26 %27
          %26 = OpLabel

--- a/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm64
@@ -45,7 +45,7 @@
          %26 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %rhs %23
          %27 = OpLoad %uint %26 Aligned 4
                OpStore %19 %uint_0
-         %28 = OpSLessThan %bool %25 %27
+         %28 = OpULessThan %bool %25 %27
                OpSelectionMerge %29 None
                OpBranchConditional %28 %30 %31
          %30 = OpLabel

--- a/test_conformance/spirv_new/test_op_branch_conditional.cpp
+++ b/test_conformance/spirv_new/test_op_branch_conditional.cpp
@@ -83,27 +83,26 @@ int test_branch_conditional(cl_device_id deviceID,
     return 0;
 }
 
-#define TEST_BRANCH_CONDITIONAL(name)                                   \
-    TEST_SPIRV_FUNC(op_##name)                                          \
-    {                                                                   \
-        const int num = 1 << 10;                                        \
-        RandomSeed seed(gRandomSeed);                                   \
-                                                                        \
-        std::vector<cl_int> lhs(num);                                   \
-        std::vector<cl_int> rhs(num);                                   \
-        std::vector<cl_int> out(num);                                   \
-                                                                        \
-        for (int i = 0; i < num; i++) {                                 \
-            lhs[i] = genrand<cl_int>(seed);                             \
-            rhs[i] = genrand<cl_int>(seed);                             \
-            out[i] = lhs[i] < rhs[i] ?                                  \
-                              (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);    \
-        }                                                               \
-                                                                        \
-        return test_branch_conditional(deviceID, context, queue,        \
-                                       #name,                           \
-                                       lhs, rhs, out);                  \
-    }                                                                   \
+#define TEST_BRANCH_CONDITIONAL(name)                                          \
+    TEST_SPIRV_FUNC(op_##name)                                                 \
+    {                                                                          \
+        const int num = 1 << 10;                                               \
+        RandomSeed seed(gRandomSeed);                                          \
+                                                                               \
+        std::vector<cl_uint> lhs(num);                                         \
+        std::vector<cl_uint> rhs(num);                                         \
+        std::vector<cl_uint> out(num);                                         \
+                                                                               \
+        for (int i = 0; i < num; i++)                                          \
+        {                                                                      \
+            lhs[i] = genrand<cl_uint>(seed);                                   \
+            rhs[i] = genrand<cl_uint>(seed);                                   \
+            out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);  \
+        }                                                                      \
+                                                                               \
+        return test_branch_conditional(deviceID, context, queue, #name, lhs,   \
+                                       rhs, out);                              \
+    }
 
 TEST_BRANCH_CONDITIONAL(branch_conditional)
 TEST_BRANCH_CONDITIONAL(branch_conditional_weighted)

--- a/test_conformance/spirv_new/test_op_phi.cpp
+++ b/test_conformance/spirv_new/test_op_phi.cpp
@@ -88,13 +88,13 @@ TEST_SPIRV_FUNC(op_phi_2_blocks)
     const int num = 1 << 10;
     RandomSeed seed(gRandomSeed);
 
-    std::vector<cl_int> lhs(num);
-    std::vector<cl_int> rhs(num);
-    std::vector<cl_int> out(num);
+    std::vector<cl_uint> lhs(num);
+    std::vector<cl_uint> rhs(num);
+    std::vector<cl_uint> out(num);
 
     for (int i = 0; i < num; i++) {
-        lhs[i] = genrand<cl_int>(seed);
-        rhs[i] = genrand<cl_int>(seed);
+        lhs[i] = genrand<cl_uint>(seed);
+        rhs[i] = genrand<cl_uint>(seed);
         out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);
     }
 
@@ -106,15 +106,15 @@ TEST_SPIRV_FUNC(op_phi_3_blocks)
     const int num = 1 << 10;
     RandomSeed seed(gRandomSeed);
 
-    std::vector<cl_int> lhs(num);
-    std::vector<cl_int> rhs(num);
-    std::vector<cl_int> out(num);
+    std::vector<cl_uint> lhs(num);
+    std::vector<cl_uint> rhs(num);
+    std::vector<cl_uint> out(num);
 
     for (int i = 0; i < num; i++) {
-        lhs[i] = genrand<cl_int>(seed);
-        rhs[i] = genrand<cl_int>(seed);
+        lhs[i] = genrand<cl_uint>(seed);
+        rhs[i] = genrand<cl_uint>(seed);
         if (lhs[i] < rhs[i]) {
-            out[i] = lhs[i] < 0 ? -lhs[i] : lhs[i];
+            out[i] = lhs[i] < 65535 ? -lhs[i] : lhs[i];
         } else {
             out[i] = lhs[i] - rhs[i];
         }
@@ -128,17 +128,17 @@ TEST_SPIRV_FUNC(op_phi_4_blocks)
     const int num = 1 << 10;
     RandomSeed seed(gRandomSeed);
 
-    std::vector<cl_int> lhs(num);
-    std::vector<cl_int> rhs(num);
-    std::vector<cl_int> out(num);
+    std::vector<cl_uint> lhs(num);
+    std::vector<cl_uint> rhs(num);
+    std::vector<cl_uint> out(num);
 
     for (int i = 0; i < num; i++) {
-        lhs[i] = genrand<cl_int>(seed);
-        rhs[i] = genrand<cl_int>(seed);
+        lhs[i] = genrand<cl_uint>(seed);
+        rhs[i] = genrand<cl_uint>(seed);
         if (lhs[i] < rhs[i]) {
-            out[i] = lhs[i] < 0 ? -lhs[i] : lhs[i];
+            out[i] = lhs[i] < 65535 ? -lhs[i] : lhs[i];
         } else {
-            out[i] = rhs[i] < 0 ? -rhs[i] : rhs[i];
+            out[i] = rhs[i] < 65535 ? -rhs[i] : rhs[i];
         }
     }
 

--- a/test_conformance/spirv_new/test_op_selection_merge.cpp
+++ b/test_conformance/spirv_new/test_op_selection_merge.cpp
@@ -83,27 +83,26 @@ int test_selection_merge(cl_device_id deviceID,
     return 0;
 }
 
-#define TEST_SELECT_IF(control)                                         \
-    TEST_SPIRV_FUNC(op_selection_merge_if_##control)                    \
-    {                                                                   \
-        const int num = 1 << 10;                                        \
-        RandomSeed seed(gRandomSeed);                                   \
-                                                                        \
-        std::vector<cl_int> lhs(num);                                   \
-        std::vector<cl_int> rhs(num);                                   \
-        std::vector<cl_int> out(num);                                   \
-                                                                        \
-        for (int i = 0; i < num; i++) {                                 \
-            lhs[i] = genrand<cl_int>(seed);                             \
-            rhs[i] = genrand<cl_int>(seed);                             \
-            out[i] = lhs[i] < rhs[i] ?                                  \
-                              (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);    \
-        }                                                               \
-                                                                        \
-        return test_selection_merge(deviceID, context, queue,           \
-                                    "select_if_" #control,              \
-                                    lhs, rhs, out);                     \
-    }                                                                   \
+#define TEST_SELECT_IF(control)                                                \
+    TEST_SPIRV_FUNC(op_selection_merge_if_##control)                           \
+    {                                                                          \
+        const int num = 1 << 10;                                               \
+        RandomSeed seed(gRandomSeed);                                          \
+                                                                               \
+        std::vector<cl_uint> lhs(num);                                         \
+        std::vector<cl_uint> rhs(num);                                         \
+        std::vector<cl_uint> out(num);                                         \
+                                                                               \
+        for (int i = 0; i < num; i++)                                          \
+        {                                                                      \
+            lhs[i] = genrand<cl_uint>(seed);                                   \
+            rhs[i] = genrand<cl_uint>(seed);                                   \
+            out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);  \
+        }                                                                      \
+                                                                               \
+        return test_selection_merge(deviceID, context, queue,                  \
+                                    "select_if_" #control, lhs, rhs, out);     \
+    }
 
 TEST_SELECT_IF(none)
 TEST_SELECT_IF(flatten)


### PR DESCRIPTION
The following tests under `spirv_new`:
* `op_branch_conditional`
* `op_phi`
* `op_selection_merge`

were using randomly generated `cl_int` values, and storing the difference between them as a `cl_int`. If one of the generated values is negative and large enough, while the other is positive and large enough, the difference then becomes a larger value that cannot be represented using `cl_int`.

Switch the tests to use `cl_uint` instead, and update the relevant spvasm{32,64} files to use `OpULessThan` instead of `OpSLessThan`.