### PR TITLE
change reference_relaxed_exp to use float type to calculate reference

### DIFF
--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -5084,7 +5084,10 @@ static long double reference_scalblnl(long double x, long n)
 #endif
 }
 
-double reference_relaxed_exp(double x) { return reference_exp(x); }
+double reference_relaxed_exp(double x) 
+{ 
+    return reference_exp2(((float)x) * HEX_FLT(+, 1, 715476, +, 0));
+}
 
 double reference_exp(double x)
 {


### PR DESCRIPTION
use lower precision for reference values used for the relaxed implementation of exp math built-in.