### PR TITLE
Add Android to the CI build matrix

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -27,6 +27,14 @@ jobs:
             arch: aarch64
             debug: 1
             extra: " debug"
+          - os: ubuntu-22.04
+            mainmatrix: false
+            arch: android-arm
+            android_arch_abi: armeabi-v7a
+          - os: ubuntu-22.04
+            mainmatrix: false
+            arch: android-aarch64
+            android_arch_abi: arm64-v8a
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ninja
@@ -66,6 +74,15 @@ jobs:
         with:
           version: 1.3.275.0
           cache: true
+      - name: Install Android NDK
+        if: ${{ matrix.arch == 'android-arm' || matrix.arch == 'android-aarch64' }}
+        run: |
+          wget https://dl.google.com/android/repository/android-ndk-r27c-linux.zip -O android-ndk.zip
+          unzip android-ndk.zip -d $HOME
+          export ANDROID_NDK=$HOME/android-ndk-r27c
+          echo "ANDROID_NDK=$ANDROID_NDK" >> $GITHUB_ENV
+          export ANDROID_ARCH_ABI=${{ matrix.android_arch_abi }}
+          echo "ANDROID_ARCH_ABI=$ANDROID_ARCH_ABI" >> $GITHUB_ENV
       - name: Build
         shell: bash
         run: ./presubmit.sh

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -7,8 +7,14 @@ export TOP=$(pwd)
 TOOLCHAIN_PREFIX_arm=arm-linux-gnueabihf
 TOOLCHAIN_PREFIX_aarch64=aarch64-linux-gnu
 
-TOOLCHAIN_FILE=${TOP}/toolchain.cmake
-touch ${TOOLCHAIN_FILE}
+if [[ ${JOB_ARCHITECTURE} == android-* ]]; then
+    TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake
+    CMAKE_CONFIG_ARGS_ANDROID="-DCMAKE_ANDROID_ARCH_ABI=${ANDROID_ARCH_ABI}"
+else
+    TOOLCHAIN_FILE=${TOP}/toolchain.cmake
+    touch ${TOOLCHAIN_FILE}
+fi
+
 BUILD_OPENGL_TEST="OFF"
 BUILD_VULKAN_TEST="ON"
 
@@ -16,17 +22,19 @@ cmake --version
 echo
 
 # Prepare toolchain if needed
-if [[ ${JOB_ARCHITECTURE} != "" && ${RUNNER_OS} != "Windows" ]]; then
-    TOOLCHAIN_PREFIX_VAR=TOOLCHAIN_PREFIX_${JOB_ARCHITECTURE}
-    TOOLCHAIN_PREFIX=${!TOOLCHAIN_PREFIX_VAR}
+if [[ ${JOB_ARCHITECTURE} != android-* ]]; then
+    if [[ ${JOB_ARCHITECTURE} != "" && ${RUNNER_OS} != "Windows" ]]; then
+        TOOLCHAIN_PREFIX_VAR=TOOLCHAIN_PREFIX_${JOB_ARCHITECTURE}
+        TOOLCHAIN_PREFIX=${!TOOLCHAIN_PREFIX_VAR}
 
-    echo "SET(CMAKE_SYSTEM_NAME Linux)" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_SYSTEM_PROCESSOR ${JOB_ARCHITECTURE})" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> ${TOOLCHAIN_FILE}
-    echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_SYSTEM_NAME Linux)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_SYSTEM_PROCESSOR ${JOB_ARCHITECTURE})" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> ${TOOLCHAIN_FILE}
+        echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> ${TOOLCHAIN_FILE}
+    fi
 fi
 
 if [[ ( ${JOB_ARCHITECTURE} == "" && ${JOB_ENABLE_GL} == "1" ) ]]; then
@@ -50,24 +58,29 @@ cd build
 cmake .. -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
-      -DOPENCL_ICD_LOADER_HEADERS_DIR=${TOP}/OpenCL-Headers/
+      -DOPENCL_ICD_LOADER_HEADERS_DIR=${TOP}/OpenCL-Headers/ \
+      "${CMAKE_CONFIG_ARGS_ANDROID}"
 cmake --build . --parallel
 
 #Vulkan Loader
-cd ${TOP}
-git clone https://github.com/KhronosGroup/Vulkan-Loader.git
-cd Vulkan-Loader
-mkdir build
-cd build
-python3 ../scripts/update_deps.py
-cmake .. -G Ninja \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
-      -DBUILD_WSI_XLIB_SUPPORT=OFF \
-      -DBUILD_WSI_XCB_SUPPORT=OFF \
-      -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
-      -C helper.cmake ..
-cmake --build . --parallel
+if [[ ${JOB_ARCHITECTURE} != android-* ]]; then
+    # Building the Vulkan loader is not supported on Android,
+    # instead, the loader is shipped as part of the operating system
+    cd ${TOP}
+    git clone https://github.com/KhronosGroup/Vulkan-Loader.git
+    cd Vulkan-Loader
+    mkdir build
+    cd build
+    python3 ../scripts/update_deps.py
+    cmake .. -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
+          -DBUILD_WSI_XLIB_SUPPORT=OFF \
+          -DBUILD_WSI_XCB_SUPPORT=OFF \
+          -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
+          -C helper.cmake ..
+    cmake --build . --parallel
+fi
 
 # Build CTS
 cd ${TOP}
@@ -75,9 +88,12 @@ ls -l
 mkdir build
 cd build
 if [[ ${RUNNER_OS} == "Windows" ]]; then
-  CMAKE_OPENCL_LIBRARIES_OPTION="OpenCL"
+    CMAKE_OPENCL_LIBRARIES_OPTION="OpenCL"
 else
-  CMAKE_OPENCL_LIBRARIES_OPTION="-lOpenCL -lpthread"
+    CMAKE_OPENCL_LIBRARIES_OPTION="-lOpenCL"
+    if [[ ${JOB_ARCHITECTURE} != android-* ]]; then
+        CMAKE_OPENCL_LIBRARIES_OPTION="${CMAKE_OPENCL_LIBRARIES_OPTION} -lpthread"
+    fi
 fi
 cmake .. -G Ninja \
       -DCMAKE_BUILD_TYPE="${BUILD_CONFIG}" \
@@ -91,5 +107,6 @@ cmake .. -G Ninja \
       -DGL_IS_SUPPORTED=${BUILD_OPENGL_TEST} \
       -DVULKAN_IS_SUPPORTED=${BUILD_VULKAN_TEST} \
       -DVULKAN_INCLUDE_DIR=${TOP}/Vulkan-Headers/include/ \
-      -DVULKAN_LIB_DIR=${TOP}/Vulkan-Loader/build/loader/
+      -DVULKAN_LIB_DIR=${TOP}/Vulkan-Loader/build/loader/ \
+      "${CMAKE_CONFIG_ARGS_ANDROID}"
 cmake --build . --parallel


### PR DESCRIPTION
Support building for Android on Arm and AArch64 platforms.

Modify the build matrix to add to new variations. Both variants download, extract and setup the Android Native Development Kit (NDK) on a Linux runner. Each variant specifies a `android_arch_abi`, which is passed to CMake during configuration as its `CMAKE_ANDROID_ARCH_ABI` option.

The CMake toolchain file provided by the NDK is used when building for Android. The NDK version used is r27c, which is the latest Long-Term Support (LTS) version. `ANDROID_PLATFORM` is intentionally not set, so the NDK can default to the minimum supported version, which is 21. The compiler (Clang) version used by this NDK is 18.0.3.

The NDK ships with its own sysroot, which has the Linux kernel headers of version 6.8.0, or `LINUX_VERSION_CODE 395264`.

CMake
https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#id23 https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARCH_ABI.html

NDK
https://developer.android.com/ndk/downloads