### PR TITLE
Fix more Wformat warnings related to size_t

### DIFF
--- a/test_conformance/buffers/test_sub_buffers.cpp
+++ b/test_conformance/buffers/test_sub_buffers.cpp
@@ -344,16 +344,16 @@ int test_sub_buffers_read_write_core( cl_context context, cl_command_queue queue
                     size_t sbThatFailed = find_subbuffer_by_index( subBuffers, numSubBuffers, i + j );
                     if ( sbThatFailed == numSubBuffers )
                     {
-                        log_error( "ERROR: Validation failure outside of a sub-buffer! (Shouldn't be possible, but it happened at index %ld out of %ld...)\n", i + j, mainSize );
+                        log_error( "ERROR: Validation failure outside of a sub-buffer! (Shouldn't be possible, but it happened at index %zu out of %zu...)\n", i + j, mainSize );
                         // Since this is a nonsensical, don't bother continuing to check
                         // (we will, however, print our map of sub-buffers for comparison)
                         for ( size_t k = 0; k < numSubBuffers; k++ )
                         {
-                            log_error( "\tBuffer %ld: %ld to %ld (length %ld)\n", k, subBuffers[ k ].mOrigin, subBuffers[ k ].mOrigin + subBuffers[ k ].mSize, subBuffers[ k ].mSize );
+                            log_error( "\tBuffer %zu: %zu to %zu (length %zu)\n", k, subBuffers[ k ].mOrigin, subBuffers[ k ].mOrigin + subBuffers[ k ].mSize, subBuffers[ k ].mSize );
                         }
                         return -1;
                     }
-                    log_error( "ERROR: Validation failure on sub-buffer %ld (start: %ld, length: %ld)\n", sbThatFailed, subBuffers[ sbThatFailed ].mOrigin, subBuffers[ sbThatFailed ].mSize );
+                    log_error( "ERROR: Validation failure on sub-buffer %zu (start: %zu, length: %zu)\n", sbThatFailed, subBuffers[ sbThatFailed ].mOrigin, subBuffers[ sbThatFailed ].mSize );
                     size_t newPos = subBuffers[ sbThatFailed ].mOrigin + subBuffers[ sbThatFailed ].mSize - 1;
                     i = newPos & ~65535;
                     j = newPos - i;
@@ -589,7 +589,7 @@ int test_sub_buffers_overlapping( cl_device_id deviceID, cl_context context, cl_
         }
     }
 
-    log_info( "\tTesting %d sub-buffers with %lld overlapping Kbytes (%d%%; as many as %ld buffers overlapping at once)\n",
+    log_info( "\tTesting %d sub-buffers with %lld overlapping Kbytes (%d%%; as many as %zu buffers overlapping at once)\n",
               16, ( delta / 1024LL ), (int)( delta * 100LL / (long long)mainSize ), maxOverlap );
 
     // Write some random contents to the main buffer
@@ -615,7 +615,7 @@ int test_sub_buffers_overlapping( cl_device_id deviceID, cl_context context, cl_
 
         if ( memcmp( tempBuffer, contents + subBuffers[ i ].mOrigin, subBuffers[ i ].mSize ) != 0 )
         {
-            log_error( "ERROR: Validation for sub-buffer %ld failed!\n", i );
+            log_error( "ERROR: Validation for sub-buffer %zu failed!\n", i );
             numErrors++;
         }
     }

--- a/test_conformance/buffers/test_sub_buffers.cpp
+++ b/test_conformance/buffers/test_sub_buffers.cpp
@@ -344,16 +344,26 @@ int test_sub_buffers_read_write_core( cl_context context, cl_command_queue queue
                     size_t sbThatFailed = find_subbuffer_by_index( subBuffers, numSubBuffers, i + j );
                     if ( sbThatFailed == numSubBuffers )
                     {
-                        log_error( "ERROR: Validation failure outside of a sub-buffer! (Shouldn't be possible, but it happened at index %zu out of %zu...)\n", i + j, mainSize );
+                        log_error("ERROR: Validation failure outside of a "
+                                  "sub-buffer! (Shouldn't be possible, but it "
+                                  "happened at index %zu out of %zu...)\n",
+                                  i + j, mainSize);
                         // Since this is a nonsensical, don't bother continuing to check
                         // (we will, however, print our map of sub-buffers for comparison)
                         for ( size_t k = 0; k < numSubBuffers; k++ )
                         {
-                            log_error( "\tBuffer %zu: %zu to %zu (length %zu)\n", k, subBuffers[ k ].mOrigin, subBuffers[ k ].mOrigin + subBuffers[ k ].mSize, subBuffers[ k ].mSize );
+                            log_error("\tBuffer %zu: %zu to %zu (length %zu)\n",
+                                      k, subBuffers[k].mOrigin,
+                                      subBuffers[k].mOrigin
+                                          + subBuffers[k].mSize,
+                                      subBuffers[k].mSize);
                         }
                         return -1;
                     }
-                    log_error( "ERROR: Validation failure on sub-buffer %zu (start: %zu, length: %zu)\n", sbThatFailed, subBuffers[ sbThatFailed ].mOrigin, subBuffers[ sbThatFailed ].mSize );
+                    log_error("ERROR: Validation failure on sub-buffer %zu "
+                              "(start: %zu, length: %zu)\n",
+                              sbThatFailed, subBuffers[sbThatFailed].mOrigin,
+                              subBuffers[sbThatFailed].mSize);
                     size_t newPos = subBuffers[ sbThatFailed ].mOrigin + subBuffers[ sbThatFailed ].mSize - 1;
                     i = newPos & ~65535;
                     j = newPos - i;
@@ -589,8 +599,10 @@ int test_sub_buffers_overlapping( cl_device_id deviceID, cl_context context, cl_
         }
     }
 
-    log_info( "\tTesting %d sub-buffers with %lld overlapping Kbytes (%d%%; as many as %zu buffers overlapping at once)\n",
-              16, ( delta / 1024LL ), (int)( delta * 100LL / (long long)mainSize ), maxOverlap );
+    log_info("\tTesting %d sub-buffers with %lld overlapping Kbytes (%d%%; as "
+             "many as %zu buffers overlapping at once)\n",
+             16, (delta / 1024LL), (int)(delta * 100LL / (long long)mainSize),
+             maxOverlap);
 
     // Write some random contents to the main buffer
     cl_char * contents = new cl_char[ mainSize ];
@@ -615,7 +627,7 @@ int test_sub_buffers_overlapping( cl_device_id deviceID, cl_context context, cl_
 
         if ( memcmp( tempBuffer, contents + subBuffers[ i ].mOrigin, subBuffers[ i ].mSize ) != 0 )
         {
-            log_error( "ERROR: Validation for sub-buffer %zu failed!\n", i );
+            log_error("ERROR: Validation for sub-buffer %zu failed!\n", i);
             numErrors++;
         }
     }

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -84,8 +84,8 @@ int test_load_program_source(cl_device_id deviceID, cl_context context, cl_comma
     // Note: according to spec section 5.4.5, the length returned should include the null terminator
     if (length != line_length + 1)
     {
-        log_error("ERROR: Length of program (%ld) does not match reference "
-                  "length (%ld)!\n",
+        log_error("ERROR: Length of program (%zu) does not match reference "
+                  "length (%zu)!\n",
                   length, line_length + 1);
         return -1;
     }
@@ -520,7 +520,7 @@ int test_get_program_build_info(cl_device_id deviceID, cl_context context, cl_co
     error = clGetProgramBuildInfo( program, deviceID, CL_PROGRAM_BUILD_LOG, 0, NULL, &length );
     test_error( error, "Unable to get program build log length" );
 
-    log_info("Build log is %ld long.\n", length);
+    log_info("Build log is %zu long.\n", length);
 
     buffer = (char*)malloc(length);
 

--- a/test_conformance/compiler/test_compile.cpp
+++ b/test_conformance/compiler/test_compile.cpp
@@ -1999,14 +1999,14 @@ static int verifyCopyBuffer(cl_context context, cl_command_queue queue,
 
     if (srcBuffer == NULL)
     {
-        log_error("ERROR: Unable to allocate srcBuffer float array with %lu "
+        log_error("ERROR: Unable to allocate srcBuffer float array with %zu "
                   "floats! (in %s:%d)\n",
                   cnDimension, __FILE__, __LINE__);
         return -1;
     }
     if (dstBuffer == NULL)
     {
-        log_error("ERROR: Unable to allocate dstBuffer float array with %lu "
+        log_error("ERROR: Unable to allocate dstBuffer float array with %zu "
                   "floats! (in %s:%d)\n",
                   cnDimension, __FILE__, __LINE__);
         return -1;
@@ -2067,7 +2067,7 @@ static int verifyCopyBuffer(cl_context context, cl_command_queue queue,
             {
                 if (mismatch < 4)
                 {
-                    log_info("Offset %08lX:  Expected %08X, Got %08X\n", i * 4,
+                    log_info("Offset %08zX:  Expected %08X, Got %08X\n", i * 4,
                              pSrc[i], pDst[i]);
                 }
                 else
@@ -2292,7 +2292,7 @@ int test_execute_after_serialize_reload_object(cl_device_id deviceID,
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binarySize);
     if (binary == NULL)
     {
-        log_error("ERROR: Unable to allocate binary character array with %lu "
+        log_error("ERROR: Unable to allocate binary character array with %zu "
                   "characters! (in %s:%d)\n",
                   binarySize, __FILE__, __LINE__);
         return -1;
@@ -2404,7 +2404,7 @@ int test_execute_after_serialize_reload_library(cl_device_id deviceID,
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binarySize);
     if (binary == NULL)
     {
-        log_error("ERROR: Unable to allocate binary character array with %lu "
+        log_error("ERROR: Unable to allocate binary character array with %zu "
                   "characters (in %s:%d)!",
                   binarySize, __FILE__, __LINE__);
         return -1;
@@ -3308,7 +3308,7 @@ int test_program_binary_type(cl_device_id deviceID, cl_context context,
         if (binary == NULL)
         {
             log_error("ERROR: Unable to allocate binary character array with "
-                      "%lu characters! (in %s:%d)\n",
+                      "%zu characters! (in %s:%d)\n",
                       binarySize, __FILE__, __LINE__);
             return -1;
         }
@@ -3389,7 +3389,7 @@ int test_program_binary_type(cl_device_id deviceID, cl_context context,
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binarySize);
     if (binary == NULL)
     {
-        log_error("ERROR: Unable to allocate binary character array with %lu "
+        log_error("ERROR: Unable to allocate binary character array with %zu "
                   "characters! (in %s:%d)\n",
                   binarySize, __FILE__, __LINE__);
         return -1;
@@ -3487,7 +3487,7 @@ int test_program_binary_type(cl_device_id deviceID, cl_context context,
         if (binary == NULL)
         {
             log_error("ERROR: Unable to allocate binary character array with "
-                      "%lu characters! (in %s:%d)\n",
+                      "%zu characters! (in %s:%d)\n",
                       binarySize, __FILE__, __LINE__);
             return -1;
         }

--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -976,7 +976,7 @@ static int RunTest( int testNumber )
         for( i = 0; i < sizeof(args ) / sizeof( args[0]); i++ )
             if( (error = clSetKernelArg(k, i, sizeof( cl_mem ), args + i) ))
             {
-                vlog_error( "Error %d setting kernel arg # %zu\n", error, i );
+                vlog_error("Error %d setting kernel arg # %zu\n", error, i);
                 return error;
             }
 
@@ -1021,24 +1021,72 @@ static int RunTest( int testNumber )
                 switch( testNumber )
                 {
                         // Zeros for these should be positive
-                    case 0:     vlog_error( "%zu) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 1:     vlog_error( "%zu) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 2:     vlog_error( "%zu) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 3:     vlog_error( "%zu) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
+                    case 0:
+                        vlog_error("%zu) Error for %s %s: %a * %a + %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 1:
+                        vlog_error("%zu) Error for %s %s: %a * %a - %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 2:
+                        vlog_error("%zu) Error for %s %s: %a + %a * %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 3:
+                        vlog_error("%zu) Error for %s %s: %a - %a * %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
 
                         // Zeros for these shouzu be negative
-                    case 4:     vlog_error( "%zu) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 5:     vlog_error( "%zu) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 6:     vlog_error( "%zu) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 7:     vlog_error( "%zu) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
+                    case 4:
+                        vlog_error("%zu) Error for %s %s: -(%a * %a + %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 5:
+                        vlog_error("%zu) Error for %s %s: -(%a * %a - %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 6:
+                        vlog_error("%zu) Error for %s %s: -(%a + %a * %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
+                    case 7:
+                        vlog_error("%zu) Error for %s %s: -(%a - %a * %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        clReleaseKernel(k);
+                        return -1;
                     default:
                         vlog_error( "error: Unknown test number!\n" );
                         clReleaseKernel(k);
@@ -1097,7 +1145,7 @@ static int RunTest_Double( int testNumber )
         for( i = 0; i < sizeof(args ) / sizeof( args[0]); i++ )
             if( (error = clSetKernelArg(k, i, sizeof( cl_mem ), args + i) ))
             {
-                vlog_error( "Error %d setting kernel arg # %zu\n", error, i );
+                vlog_error("Error %d setting kernel arg # %zu\n", error, i);
                 return error;
             }
 
@@ -1138,24 +1186,64 @@ static int RunTest_Double( int testNumber )
                 switch( testNumber )
                 {
                         // Zeros for these should be positive
-                    case 0:     vlog_error( "%zu) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 1:     vlog_error( "%zu) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 2:     vlog_error( "%zu) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
-                    case 3:     vlog_error( "%zu) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
+                    case 0:
+                        vlog_error("%zu) Error for %s %s: %a * %a + %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 1:
+                        vlog_error("%zu) Error for %s %s: %a * %a - %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 2:
+                        vlog_error("%zu) Error for %s %s: %a + %a * %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 3:
+                        vlog_error("%zu) Error for %s %s: %a - %a * %a =  *%a "
+                                   "vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
 
                         // Zeros for these shouzu be negative
-                    case 4:     vlog_error( "%zu) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 5:     vlog_error( "%zu) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 6:     vlog_error( "%zu) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
-                    case 7:     vlog_error( "%zu) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
-                                           c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
+                    case 4:
+                        vlog_error("%zu) Error for %s %s: -(%a * %a + %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 5:
+                        vlog_error("%zu) Error for %s %s: -(%a * %a - %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], a[i], b[i], c[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 6:
+                        vlog_error("%zu) Error for %s %s: -(%a + %a * %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
+                    case 7:
+                        vlog_error("%zu) Error for %s %s: -(%a - %a * %a) =  "
+                                   "*%a vs. %a\n",
+                                   i, sizeNames_double[vectorSize],
+                                   kernelName[testNumber], c[i], a[i], b[i],
+                                   correct[testNumber][i], test[i]);
+                        return -1;
                     default:
                         vlog_error( "error: Unknown test number!\n" );
                         return -2;

--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -976,7 +976,7 @@ static int RunTest( int testNumber )
         for( i = 0; i < sizeof(args ) / sizeof( args[0]); i++ )
             if( (error = clSetKernelArg(k, i, sizeof( cl_mem ), args + i) ))
             {
-                vlog_error( "Error %d setting kernel arg # %ld\n", error, i );
+                vlog_error( "Error %d setting kernel arg # %zu\n", error, i );
                 return error;
             }
 
@@ -1021,23 +1021,23 @@ static int RunTest( int testNumber )
                 switch( testNumber )
                 {
                         // Zeros for these should be positive
-                    case 0:     vlog_error( "%ld) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 0:     vlog_error( "%zu) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 1:     vlog_error( "%ld) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 1:     vlog_error( "%zu) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 2:     vlog_error( "%ld) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 2:     vlog_error( "%zu) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 3:     vlog_error( "%ld) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 3:     vlog_error( "%zu) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
 
-                        // Zeros for these should be negative
-                    case 4:     vlog_error( "%ld) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                        // Zeros for these shouzu be negative
+                    case 4:     vlog_error( "%zu) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 5:     vlog_error( "%ld) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 5:     vlog_error( "%zu) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 6:     vlog_error( "%ld) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 6:     vlog_error( "%zu) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
-                    case 7:     vlog_error( "%ld) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
+                    case 7:     vlog_error( "%zu) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       clReleaseKernel(k); return -1;
                     default:
                         vlog_error( "error: Unknown test number!\n" );
@@ -1097,7 +1097,7 @@ static int RunTest_Double( int testNumber )
         for( i = 0; i < sizeof(args ) / sizeof( args[0]); i++ )
             if( (error = clSetKernelArg(k, i, sizeof( cl_mem ), args + i) ))
             {
-                vlog_error( "Error %d setting kernel arg # %ld\n", error, i );
+                vlog_error( "Error %d setting kernel arg # %zu\n", error, i );
                 return error;
             }
 
@@ -1138,23 +1138,23 @@ static int RunTest_Double( int testNumber )
                 switch( testNumber )
                 {
                         // Zeros for these should be positive
-                    case 0:     vlog_error( "%ld) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 0:     vlog_error( "%zu) Error for %s %s: %a * %a + %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 1:     vlog_error( "%ld) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 1:     vlog_error( "%zu) Error for %s %s: %a * %a - %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 2:     vlog_error( "%ld) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 2:     vlog_error( "%zu) Error for %s %s: %a + %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
-                    case 3:     vlog_error( "%ld) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 3:     vlog_error( "%zu) Error for %s %s: %a - %a * %a =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
 
-                        // Zeros for these should be negative
-                    case 4:     vlog_error( "%ld) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                        // Zeros for these shouzu be negative
+                    case 4:     vlog_error( "%zu) Error for %s %s: -(%a * %a + %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 5:     vlog_error( "%ld) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 5:     vlog_error( "%zu) Error for %s %s: -(%a * %a - %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            a[i], b[i], c[i], correct[testNumber][i], test[i] );       return -1;
-                    case 6:     vlog_error( "%ld) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 6:     vlog_error( "%zu) Error for %s %s: -(%a + %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
-                    case 7:     vlog_error( "%ld) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
+                    case 7:     vlog_error( "%zu) Error for %s %s: -(%a - %a * %a) =  *%a vs. %a\n", i, sizeNames_double[ vectorSize], kernelName[ testNumber ],
                                            c[i], a[i], b[i], correct[testNumber][i], test[i] );       return -1;
                     default:
                         vlog_error( "error: Unknown test number!\n" );

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -534,7 +534,7 @@ test_status InitCL(cl_device_id device)
     vlog("\tCL C Version: %s\n", c);
     clGetDeviceInfo(device, CL_DRIVER_VERSION, sizeof(c), c, NULL);
     vlog("\tDriver Version: %s\n", c);
-    vlog("\tProcessing with %ld devices\n", gComputeDevices);
+    vlog("\tProcessing with %zu devices\n", gComputeDevices);
     vlog("\tDevice Frequency: %d MHz\n", gDeviceFrequency);
     vlog("\tSubnormal values supported for floats? %s\n",
          no_yes[0 != (CL_FP_DENORM & floatCapabilities)]);

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -336,8 +336,8 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
             if( expectedResults[ i ] != outputData[ i ] )
             {
                 log_error("ERROR: Sample data did not verify for queue %d on "
-                          "device %zu (sample %d, expected %d, got %d)\n",
-                          q, q % deviceCount, (int)i, expectedResults[i],
+                          "device %zu (sample %zu, expected %d, got %d)\n",
+                          q, q % deviceCount, i, expectedResults[i],
                           outputData[i]);
                 for (size_t j=0; j<deviceCount; j++) {
                     if (expectedResultsOneDevice[j][i] == outputData[i])

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -229,11 +229,14 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     RandomSeed seed( gRandomSeed );
 
     if (queueCount > MAX_QUEUES) {
-        log_error("Number of queues (%zu) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
+        log_error("Number of queues (%zu) is greater than the number for which "
+                  "the test was written (%d).",
+                  queueCount, MAX_QUEUES);
         return -1;
     }
 
-    log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
+    log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n",
+             queueCount, deviceCount, queueCount * num_elements / TEST_SIZE);
 
     for (i=0; i<deviceCount; i++) {
         size_t deviceNameSize;
@@ -332,11 +335,15 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
         {
             if( expectedResults[ i ] != outputData[ i ] )
             {
-                log_error( "ERROR: Sample data did not verify for queue %d on device %zu (sample %d, expected %d, got %d)\n",
-                    q, q % deviceCount, (int)i, expectedResults[ i ], outputData[ i ] );
+                log_error("ERROR: Sample data did not verify for queue %d on "
+                          "device %zu (sample %d, expected %d, got %d)\n",
+                          q, q % deviceCount, (int)i, expectedResults[i],
+                          outputData[i]);
                 for (size_t j=0; j<deviceCount; j++) {
                     if (expectedResultsOneDevice[j][i] == outputData[i])
-                        log_info("Sample consistent with only device %zu having modified the data.\n", j);
+                        log_info("Sample consistent with only device %zu "
+                                 "having modified the data.\n",
+                                 j);
                 }
                 errorsThisTime++;
                 break;

--- a/test_conformance/device_partition/test_device_partition.cpp
+++ b/test_conformance/device_partition/test_device_partition.cpp
@@ -229,11 +229,11 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     RandomSeed seed( gRandomSeed );
 
     if (queueCount > MAX_QUEUES) {
-        log_error("Number of queues (%ld) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
+        log_error("Number of queues (%zu) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
         return -1;
     }
 
-    log_info("Testing with %ld queues on %ld devices, %ld kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
+    log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
 
     for (i=0; i<deviceCount; i++) {
         size_t deviceNameSize;
@@ -242,7 +242,7 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
         char *deviceName = (char *)alloca(deviceNameSize * (sizeof(char)));
         error = clGetDeviceInfo(devices[i], CL_DEVICE_NAME, deviceNameSize, deviceName, NULL);
         test_error(error, "clGetDeviceInfo CL_DEVICE_NAME failed");
-        log_info("Device %ld is \"%s\".\n", i, deviceName);
+        log_info("Device %zu is \"%s\".\n", i, deviceName);
     }
 
     /* Create a context */
@@ -332,11 +332,11 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
         {
             if( expectedResults[ i ] != outputData[ i ] )
             {
-                log_error( "ERROR: Sample data did not verify for queue %d on device %ld (sample %d, expected %d, got %d)\n",
+                log_error( "ERROR: Sample data did not verify for queue %d on device %zu (sample %d, expected %d, got %d)\n",
                     q, q % deviceCount, (int)i, expectedResults[ i ], outputData[ i ] );
                 for (size_t j=0; j<deviceCount; j++) {
                     if (expectedResultsOneDevice[j][i] == outputData[i])
-                        log_info("Sample consistent with only device %ld having modified the data.\n", j);
+                        log_info("Sample consistent with only device %zu having modified the data.\n", j);
                 }
                 errorsThisTime++;
                 break;

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -149,7 +149,9 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
     {
         if ( NULL == host_ptr )
         {
-            log_error( "ERROR: Unable to create backing store for pitched 3D image. %zu bytes\n",  imageInfo->depth * imageInfo->slicePitch );
+            log_error("ERROR: Unable to create backing store for pitched 3D "
+                      "image. %zu bytes\n",
+                      imageInfo->depth * imageInfo->slicePitch);
             return NULL;
         }
         if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
@@ -424,7 +426,8 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         // Update the host verification copy of the data.
         srcHost.reset(malloc(srcBytes),NULL,0,srcBytes);
         if (srcHost == NULL) {
-            log_error( "ERROR: Unable to malloc %zu bytes for srcHost\n", srcBytes );
+            log_error("ERROR: Unable to malloc %zu bytes for srcHost\n",
+                      srcBytes);
             return -1;
         }
         memcpy(srcHost,srcData,srcBytes);
@@ -456,7 +459,8 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
             log_info( " - Resizing destination buffer...\n" );
         dstData.reset(malloc(destImageSize),NULL,0,destImageSize);
         if (dstData == NULL) {
-            log_error( "ERROR: Unable to malloc %zu bytes for dstData\n", destImageSize );
+            log_error("ERROR: Unable to malloc %zu bytes for dstData\n",
+                      destImageSize);
             return -1;
         }
     }
@@ -467,7 +471,8 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         dstHost.reset(malloc(destImageSize),NULL,0,destImageSize);
         if (dstHost == NULL) {
             dstData.reset(NULL);
-            log_error( "ERROR: Unable to malloc %zu bytes for dstHost\n", destImageSize );
+            log_error("ERROR: Unable to malloc %zu bytes for dstHost\n",
+                      destImageSize);
             return -1;
         }
     }

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -133,7 +133,7 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
                 if (err != CL_SUCCESS)
                 {
                     log_error("ERROR: Could not create buffer for 1D buffer "
-                              "image. %ld bytes\n",
+                              "image. %zu bytes\n",
                               imageInfo->width);
                     return NULL;
                 }
@@ -149,7 +149,7 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
     {
         if ( NULL == host_ptr )
         {
-            log_error( "ERROR: Unable to create backing store for pitched 3D image. %ld bytes\n",  imageInfo->depth * imageInfo->slicePitch );
+            log_error( "ERROR: Unable to create backing store for pitched 3D image. %zu bytes\n",  imageInfo->depth * imageInfo->slicePitch );
             return NULL;
         }
         if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
@@ -424,7 +424,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         // Update the host verification copy of the data.
         srcHost.reset(malloc(srcBytes),NULL,0,srcBytes);
         if (srcHost == NULL) {
-            log_error( "ERROR: Unable to malloc %lu bytes for srcHost\n", srcBytes );
+            log_error( "ERROR: Unable to malloc %zu bytes for srcHost\n", srcBytes );
             return -1;
         }
         memcpy(srcHost,srcData,srcBytes);
@@ -456,7 +456,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
             log_info( " - Resizing destination buffer...\n" );
         dstData.reset(malloc(destImageSize),NULL,0,destImageSize);
         if (dstData == NULL) {
-            log_error( "ERROR: Unable to malloc %lu bytes for dstData\n", destImageSize );
+            log_error( "ERROR: Unable to malloc %zu bytes for dstData\n", destImageSize );
             return -1;
         }
     }
@@ -467,7 +467,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         dstHost.reset(malloc(destImageSize),NULL,0,destImageSize);
         if (dstHost == NULL) {
             dstData.reset(NULL);
-            log_error( "ERROR: Unable to malloc %lu bytes for dstHost\n", destImageSize );
+            log_error( "ERROR: Unable to malloc %zu bytes for dstHost\n", destImageSize );
             return -1;
         }
     }

--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -145,7 +145,7 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
                 if (err != CL_SUCCESS)
                 {
                     log_error("ERROR: Could not create buffer for 1D buffer "
-                              "image. %ld bytes\n",
+                              "image. %zu bytes\n",
                               imageInfo->rowPitch);
                     return NULL;
                 }
@@ -158,7 +158,7 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
     {
         if ( NULL == host_ptr )
         {
-            log_error( "ERROR: Unable to create backing store for pitched 3D image. %ld bytes\n",  imageInfo->depth * imageInfo->slicePitch );
+            log_error( "ERROR: Unable to create backing store for pitched 3D image. %zu bytes\n",  imageInfo->depth * imageInfo->slicePitch );
             return NULL;
         }
         if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
@@ -427,7 +427,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
         imgHost.reset(malloc(dataBytes),NULL,0,dataBytes);
         if (imgHost == NULL)
         {
-            log_error( "ERROR: Unable to malloc %lu bytes for imgHost\n", dataBytes );
+            log_error( "ERROR: Unable to malloc %zu bytes for imgHost\n", dataBytes );
             return -1;
         }
     }

--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -158,7 +158,9 @@ cl_mem create_image( cl_context context, cl_command_queue queue, BufferOwningPtr
     {
         if ( NULL == host_ptr )
         {
-            log_error( "ERROR: Unable to create backing store for pitched 3D image. %zu bytes\n",  imageInfo->depth * imageInfo->slicePitch );
+            log_error("ERROR: Unable to create backing store for pitched 3D "
+                      "image. %zu bytes\n",
+                      imageInfo->depth * imageInfo->slicePitch);
             return NULL;
         }
         if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
@@ -427,7 +429,8 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
         imgHost.reset(malloc(dataBytes),NULL,0,dataBytes);
         if (imgHost == NULL)
         {
-            log_error( "ERROR: Unable to malloc %zu bytes for imgHost\n", dataBytes );
+            log_error("ERROR: Unable to malloc %zu bytes for imgHost\n",
+                      dataBytes);
             return -1;
         }
     }

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -86,7 +86,7 @@ int determine_validation_error_offset(
             {
                 if (printAsFloat)
                 {
-                    log_error("Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did "
+                    log_error("Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did "
                               "not validate! Expected (%g,%g,%g,%g), got "
                               "(%g,%g,%g,%g), error of %g\n",
                               j, x, x, y, y, z, z, (float)expected[0],
@@ -98,7 +98,7 @@ int determine_validation_error_offset(
                 else
                 {
                     log_error(
-                        "Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did not "
+                        "Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did not "
                         "validate! Expected (%x,%x,%x,%x), got (%x,%x,%x,%x)\n",
                         j, x, x, y, y, z, z, (int)expected[0], (int)expected[1],
                         (int)expected[2], (int)expected[3], (int)resultPtr[0],
@@ -134,7 +134,7 @@ int determine_validation_error_offset(
             {
                 if (printAsFloat)
                 {
-                    log_error("Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did "
+                    log_error("Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did "
                               "not validate! Expected (%g,%g,%g,%g), got "
                               "(%g,%g,%g,%g), error of %g\n",
                               j, x, x, y, y, z, z, (float)expected[0],
@@ -146,7 +146,7 @@ int determine_validation_error_offset(
                 else
                 {
                     log_error(
-                        "Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did not "
+                        "Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did not "
                         "validate! Expected (%x,%x,%x,%x), got (%x,%x,%x,%x)\n",
                         j, x, x, y, y, z, z, (int)expected[0], (int)expected[1],
                         (int)expected[2], (int)expected[3], (int)resultPtr[0],
@@ -164,7 +164,7 @@ int determine_validation_error_offset(
     {
         if (printAsFloat)
         {
-            log_error("Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did not "
+            log_error("Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did not "
                       "validate!\n\tExpected (%g,%g,%g,%g),\n\t     got "
                       "(%g,%g,%g,%g), error of %g\n",
                       j, x, x, y, y, z, z, (float)expected[0],
@@ -175,7 +175,7 @@ int determine_validation_error_offset(
         }
         else
         {
-            log_error("Sample %ld: coord {%f(%a),%f(%a),%f(%a)} did not "
+            log_error("Sample %zu: coord {%f(%a),%f(%a),%f(%a)} did not "
                       "validate!\n\tExpected (%x,%x,%x,%x),\n\t     got "
                       "(%x,%x,%x,%x)\n",
                       j, x, x, y, y, z, z, (int)expected[0], (int)expected[1],

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -97,7 +97,7 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
         {
             if( (--numClamped) == 0 )
             {
-                log_error( "ERROR: TEST FAILED: Read is erroneously clamping coordinates for image size %ld x %ld!\n", imageInfo->width, imageInfo->height );
+                log_error( "ERROR: TEST FAILED: Read is erroneously clamping coordinates for image size %zu x %zu!\n", imageInfo->width, imageInfo->height );
                 if (imageInfo->format->image_channel_order == CL_DEPTH)
                 {
                     if( printAsFloat )
@@ -139,7 +139,7 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
         {
             if( (--numClamped) == 0 )
             {
-                log_error( "ERROR: TEST FAILED: Clamping is erroneously returning border color for image size %ld x %ld!\n", imageInfo->width, imageInfo->height );
+                log_error( "ERROR: TEST FAILED: Clamping is erroneously returning border color for image size %zu x %zu!\n", imageInfo->width, imageInfo->height );
                 if (imageInfo->format->image_channel_order == CL_DEPTH)
                 {
                     if( printAsFloat )
@@ -203,7 +203,7 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
                                     (int)resultPtr[ 0 ], (int)resultPtr[ 1 ], (int)resultPtr[ 2 ], (int)resultPtr[ 3 ] );
             }
         }
-        log_error( "img size %ld,%ld (pitch %ld)", imageInfo->width, imageInfo->height, imageInfo->rowPitch );
+        log_error( "img size %zu,%zu (pitch %zu)", imageInfo->width, imageInfo->height, imageInfo->rowPitch );
         if( clamped )
         {
             log_error( " which would clamp to %d,%d\n", clampedX, clampedY );

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -97,7 +97,9 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
         {
             if( (--numClamped) == 0 )
             {
-                log_error( "ERROR: TEST FAILED: Read is erroneously clamping coordinates for image size %zu x %zu!\n", imageInfo->width, imageInfo->height );
+                log_error("ERROR: TEST FAILED: Read is erroneously clamping "
+                          "coordinates for image size %zu x %zu!\n",
+                          imageInfo->width, imageInfo->height);
                 if (imageInfo->format->image_channel_order == CL_DEPTH)
                 {
                     if( printAsFloat )
@@ -139,7 +141,9 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
         {
             if( (--numClamped) == 0 )
             {
-                log_error( "ERROR: TEST FAILED: Clamping is erroneously returning border color for image size %zu x %zu!\n", imageInfo->width, imageInfo->height );
+                log_error("ERROR: TEST FAILED: Clamping is erroneously "
+                          "returning border color for image size %zu x %zu!\n",
+                          imageInfo->width, imageInfo->height);
                 if (imageInfo->format->image_channel_order == CL_DEPTH)
                 {
                     if( printAsFloat )
@@ -203,7 +207,8 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
                                     (int)resultPtr[ 0 ], (int)resultPtr[ 1 ], (int)resultPtr[ 2 ], (int)resultPtr[ 3 ] );
             }
         }
-        log_error( "img size %zu,%zu (pitch %zu)", imageInfo->width, imageInfo->height, imageInfo->rowPitch );
+        log_error("img size %zu,%zu (pitch %zu)", imageInfo->width,
+                  imageInfo->height, imageInfo->rowPitch);
         if( clamped )
         {
             log_error( " which would clamp to %d,%d\n", clampedX, clampedY );

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -207,8 +207,11 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             }
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 1D image of size %zu pitch %zu (%s, %s)\n", imageInfo->width,
-                          imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                log_error("ERROR: Unable to create 1D image of size %zu pitch "
+                          "%zu (%s, %s)\n",
+                          imageInfo->width, imageInfo->rowPitch,
+                          IGetErrorString(error),
+                          mem_flag_names[mem_flag_index]);
                 return error;
             }
 
@@ -234,8 +237,11 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 1D image of size %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width,
-                               IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create %d level 1D image of "
+                              "size %zu (%s, %s)\n",
+                              imageInfo->num_mip_levels, imageInfo->width,
+                              IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -246,8 +252,11 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                               imageValues, NULL, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 1D image of size %zu pitch %zu (%s, %s)\n", imageInfo->width,
-                              imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create 1D image of size %zu "
+                              "pitch %zu (%s, %s)\n",
+                              imageInfo->width, imageInfo->rowPitch,
+                              IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -368,7 +377,9 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %zu did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
+                            log_error(
+                                "ERROR: Sample %zu did not validate! (%s)\n", i,
+                                mem_flag_names[mem_flag_index]);
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -385,7 +396,9 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %zu did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
+                            log_error(
+                                "ERROR: Sample %zu did not validate! (%s)\n", i,
+                                mem_flag_names[mem_flag_index]);
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -435,7 +448,12 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error(
+                                        "ERROR: Rounding mode sample (%zu) did "
+                                        "not validate, probably due to the "
+                                        "device's rounding mode being wrong "
+                                        "(%s)\n",
+                                        i, mem_flag_names[mem_flag_index]);
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -207,7 +207,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             }
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 1D image of size %ld pitch %ld (%s, %s)\n", imageInfo->width,
+                log_error( "ERROR: Unable to create 1D image of size %zu pitch %zu (%s, %s)\n", imageInfo->width,
                           imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                 return error;
             }
@@ -234,7 +234,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 1D image of size %ld (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width,
+                    log_error( "ERROR: Unable to create %d level 1D image of size %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width,
                                IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -246,7 +246,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                               imageValues, NULL, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 1D image of size %ld pitch %ld (%s, %s)\n", imageInfo->width,
+                    log_error( "ERROR: Unable to create 1D image of size %zu pitch %zu (%s, %s)\n", imageInfo->width,
                               imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -368,7 +368,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %ld did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -385,7 +385,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %ld did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu did not validate! (%s)\n", i, mem_flag_names[ mem_flag_index ] );
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -435,7 +435,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%ld) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -218,7 +218,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             }
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 1D image array of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
+                log_error( "ERROR: Unable to create 1D image array of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
                           imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                 return error;
             }
@@ -245,7 +245,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 1D image array of size %ld x %ld (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->arraySize,
+                    log_error( "ERROR: Unable to create %d level 1D image array of size %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->arraySize,
                                IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -257,7 +257,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                               imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 1D image array of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
+                    log_error( "ERROR: Unable to create 1D image array of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
                               imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -388,7 +388,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %ld (%ld,%ld) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -405,7 +405,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %ld (%ld,%ld) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -456,7 +456,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%ld) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -218,8 +218,11 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             }
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 1D image array of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
-                          imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                log_error("ERROR: Unable to create 1D image array of size %zu "
+                          "x %zu pitch %zu (%s, %s)\n",
+                          imageInfo->width, imageInfo->arraySize,
+                          imageInfo->rowPitch, IGetErrorString(error),
+                          mem_flag_names[mem_flag_index]);
                 return error;
             }
 
@@ -245,8 +248,11 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 1D image array of size %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->arraySize,
-                               IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create %d level 1D image array "
+                              "of size %zu x %zu (%s, %s)\n",
+                              imageInfo->num_mip_levels, imageInfo->width,
+                              imageInfo->arraySize, IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -257,8 +263,11 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                               imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 1D image array of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->arraySize,
-                              imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create 1D image array of size "
+                              "%zu x %zu pitch %zu (%s, %s)\n",
+                              imageInfo->width, imageInfo->arraySize,
+                              imageInfo->rowPitch, IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -388,7 +397,9 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error("ERROR: Sample %zu (%zu,%zu) did not "
+                                      "validate! (%s)\n",
+                                      i, x, y, mem_flag_names[mem_flag_index]);
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -405,7 +416,9 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error("ERROR: Sample %zu (%zu,%zu) did not "
+                                      "validate! (%s)\n",
+                                      i, x, y, mem_flag_names[mem_flag_index]);
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -456,7 +469,12 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error(
+                                        "ERROR: Rounding mode sample (%zu) did "
+                                        "not validate, probably due to the "
+                                        "device's rounding mode being wrong "
+                                        "(%s)\n",
+                                        i, mem_flag_names[mem_flag_index]);
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -245,7 +245,11 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 2D image array of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
+                log_error("ERROR: Unable to create 2D image array of size %zu "
+                          "x %zu x %zu pitch %zu (%s)\n",
+                          imageInfo->width, imageInfo->height,
+                          imageInfo->arraySize, imageInfo->rowPitch,
+                          IGetErrorString(error));
                 return error;
             }
 
@@ -269,8 +273,12 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 2D image array of size %zu x %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->arraySize,
-                               IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create %d level 2D image array "
+                              "of size %zu x %zu x %zu (%s, %s)\n",
+                              imageInfo->num_mip_levels, imageInfo->width,
+                              imageInfo->height, imageInfo->arraySize,
+                              IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -280,7 +288,11 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                               imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 2D image array of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
+                    log_error("ERROR: Unable to create 2D image array of size "
+                              "%zu x %zu x %zu pitch %zu (%s)\n",
+                              imageInfo->width, imageInfo->height,
+                              imageInfo->arraySize, imageInfo->rowPitch,
+                              IGetErrorString(error));
                     return error;
                 }
             }
@@ -413,7 +425,10 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                             {
                                 unsigned int *e = (unsigned int *)resultBuffer;
                                 unsigned int *a = (unsigned int *)resultPtr;
-                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error("ERROR: Sample %zu (%zu,%zu,%zu) did "
+                                          "not validate! (%s)\n",
+                                          i, x, y, z,
+                                          mem_flag_names[mem_flag_index]);
                                 log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                                 log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                                 log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -430,7 +445,10 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                             if( !validate_half_write_results( e, a, imageInfo ) )
                             {
                                 totalErrors++;
-                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error("ERROR: Sample %zu (%zu,%zu,%zu) did "
+                                          "not validate! (%s)\n",
+                                          i, x, y, z,
+                                          mem_flag_names[mem_flag_index]);
                                 unsigned short *e = (unsigned short *)resultBuffer;
                                 unsigned short *a = (unsigned short *)resultPtr;
                                 log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
@@ -484,7 +502,12 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                                 deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                             deviceRounding = "round to even";
 
-                                        log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                        log_error(
+                                            "ERROR: Rounding mode sample (%zu) "
+                                            "did not validate, probably due to "
+                                            "the device's rounding mode being "
+                                            "wrong (%s)\n",
+                                            i, mem_flag_names[mem_flag_index]);
                                         log_error( "       Actual values rounded by device: %d %d %d %d %d %d %d %d\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                                   deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                         log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );
@@ -804,8 +827,11 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
             } while(  size > maxAllocSize || buffSize > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
-                log_info( "   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of %zu,%zu,%zu\n", imageInfo.width, imageInfo.height, imageInfo.arraySize,
-                         imageInfo.rowPitch, imageInfo.slicePitch, maxWidth, maxHeight, maxArraySize );
+                log_info("   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of "
+                         "%zu,%zu,%zu\n",
+                         imageInfo.width, imageInfo.height, imageInfo.arraySize,
+                         imageInfo.rowPitch, imageInfo.slicePitch, maxWidth,
+                         maxHeight, maxArraySize);
 
             int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );
             if( retCode )

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -245,7 +245,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 2D image array of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
+                log_error( "ERROR: Unable to create 2D image array of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
                 return error;
             }
 
@@ -269,7 +269,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 2D image array of size %ld x %ld x %ld (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->arraySize,
+                    log_error( "ERROR: Unable to create %d level 2D image array of size %zu x %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->arraySize,
                                IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -280,7 +280,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                               imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 2D image array of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
+                    log_error( "ERROR: Unable to create 2D image array of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );
                     return error;
                 }
             }
@@ -413,7 +413,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                             {
                                 unsigned int *e = (unsigned int *)resultBuffer;
                                 unsigned int *a = (unsigned int *)resultPtr;
-                                log_error( "ERROR: Sample %ld (%ld,%ld,%ld) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
                                 log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                                 log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                                 log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -430,7 +430,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                             if( !validate_half_write_results( e, a, imageInfo ) )
                             {
                                 totalErrors++;
-                                log_error( "ERROR: Sample %ld (%ld,%ld,%ld) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
                                 unsigned short *e = (unsigned short *)resultBuffer;
                                 unsigned short *a = (unsigned short *)resultPtr;
                                 log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
@@ -484,7 +484,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                                                 deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                             deviceRounding = "round to even";
 
-                                        log_error( "ERROR: Rounding mode sample (%ld) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                        log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
                                         log_error( "       Actual values rounded by device: %d %d %d %d %d %d %d %d\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                                   deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                         log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );
@@ -804,7 +804,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
             } while(  size > maxAllocSize || buffSize > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
-                log_info( "   at size %ld,%ld,%ld (pitch %ld, slice %ld) out of %ld,%ld,%ld\n", imageInfo.width, imageInfo.height, imageInfo.arraySize,
+                log_info( "   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of %zu,%zu,%zu\n", imageInfo.width, imageInfo.height, imageInfo.arraySize,
                          imageInfo.rowPitch, imageInfo.slicePitch, maxWidth, maxHeight, maxArraySize );
 
             int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -249,7 +249,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 3D image of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
+                log_error( "ERROR: Unable to create 3D image of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
                 return error;
             }
 
@@ -273,7 +273,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level mipmapped 3D image of size %ld x %ld *%ld (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->depth,
+                    log_error( "ERROR: Unable to create %d level mipmapped 3D image of size %zu x %zu *%zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->depth,
                                IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -284,7 +284,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                               imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 3D image of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
+                    log_error( "ERROR: Unable to create 3D image of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
                     return error;
                 }
             }
@@ -420,7 +420,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                             {
                                 unsigned int *e = (unsigned int *)resultBuffer;
                                 unsigned int *a = (unsigned int *)resultPtr;
-                                log_error( "ERROR: Sample %ld (%ld,%ld,%ld) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
                                 log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                                 log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                                 log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -437,7 +437,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                             if( !validate_half_write_results( e, a, imageInfo ) )
                             {
                                 totalErrors++;
-                                log_error( "ERROR: Sample %ld (%ld,%ld,%ld) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
                                 unsigned short *e = (unsigned short *)resultBuffer;
                                 unsigned short *a = (unsigned short *)resultPtr;
                                 log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
@@ -491,7 +491,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                                 deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                             deviceRounding = "round to even";
 
-                                        log_error( "ERROR: Rounding mode sample (%ld) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                        log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
                                         log_error( "       Actual values rounded by device: %d %d %d %d %d %d %d %d\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                                   deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                         log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );
@@ -798,7 +798,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
-                log_info( "   at size %ld,%ld,%ld (pitch %ld, slice %ld) out of %ld,%ld,%ld\n", imageInfo.width, imageInfo.height, imageInfo.depth,
+                log_info( "   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of %zu,%zu,%zu\n", imageInfo.width, imageInfo.height, imageInfo.depth,
                          imageInfo.rowPitch, imageInfo.slicePitch, maxWidth, maxHeight, maxDepth );
 
             int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -249,7 +249,10 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 
             if( error != CL_SUCCESS )
             {
-                log_error( "ERROR: Unable to create 3D image of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
+                log_error("ERROR: Unable to create 3D image of size %zu x %zu "
+                          "x %zu pitch %zu (%s)\n",
+                          imageInfo->width, imageInfo->height, imageInfo->depth,
+                          imageInfo->rowPitch, IGetErrorString(error));
                 return error;
             }
 
@@ -273,8 +276,12 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level mipmapped 3D image of size %zu x %zu *%zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height, imageInfo->depth,
-                               IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create %d level mipmapped 3D "
+                              "image of size %zu x %zu *%zu (%s, %s)\n",
+                              imageInfo->num_mip_levels, imageInfo->width,
+                              imageInfo->height, imageInfo->depth,
+                              IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -284,7 +291,11 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                               imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create 3D image of size %zu x %zu x %zu pitch %zu (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );
+                    log_error("ERROR: Unable to create 3D image of size %zu x "
+                              "%zu x %zu pitch %zu (%s)\n",
+                              imageInfo->width, imageInfo->height,
+                              imageInfo->depth, imageInfo->rowPitch,
+                              IGetErrorString(error));
                     return error;
                 }
             }
@@ -420,7 +431,10 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                             {
                                 unsigned int *e = (unsigned int *)resultBuffer;
                                 unsigned int *a = (unsigned int *)resultPtr;
-                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error("ERROR: Sample %zu (%zu,%zu,%zu) did "
+                                          "not validate! (%s)\n",
+                                          i, x, y, z,
+                                          mem_flag_names[mem_flag_index]);
                                 log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                                 log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                                 log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -437,7 +451,10 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                             if( !validate_half_write_results( e, a, imageInfo ) )
                             {
                                 totalErrors++;
-                                log_error( "ERROR: Sample %zu (%zu,%zu,%zu) did not validate! (%s)\n", i, x, y, z, mem_flag_names[ mem_flag_index ] );
+                                log_error("ERROR: Sample %zu (%zu,%zu,%zu) did "
+                                          "not validate! (%s)\n",
+                                          i, x, y, z,
+                                          mem_flag_names[mem_flag_index]);
                                 unsigned short *e = (unsigned short *)resultBuffer;
                                 unsigned short *a = (unsigned short *)resultPtr;
                                 log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
@@ -491,7 +508,12 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                                                 deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                             deviceRounding = "round to even";
 
-                                        log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                        log_error(
+                                            "ERROR: Rounding mode sample (%zu) "
+                                            "did not validate, probably due to "
+                                            "the device's rounding mode being "
+                                            "wrong (%s)\n",
+                                            i, mem_flag_names[mem_flag_index]);
                                         log_error( "       Actual values rounded by device: %d %d %d %d %d %d %d %d\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                                   deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                         log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );
@@ -798,8 +820,11 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
-                log_info( "   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of %zu,%zu,%zu\n", imageInfo.width, imageInfo.height, imageInfo.depth,
-                         imageInfo.rowPitch, imageInfo.slicePitch, maxWidth, maxHeight, maxDepth );
+                log_info("   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of "
+                         "%zu,%zu,%zu\n",
+                         imageInfo.width, imageInfo.height, imageInfo.depth,
+                         imageInfo.rowPitch, imageInfo.slicePitch, maxWidth,
+                         maxHeight, maxDepth);
 
             int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );
             if( retCode )

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -261,8 +261,11 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     }
                 }
 
-                log_error( "ERROR: Unable to create 2D image of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->height,
-                          imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                log_error("ERROR: Unable to create 2D image of size %zu x %zu "
+                          "pitch %zu (%s, %s)\n",
+                          imageInfo->width, imageInfo->height,
+                          imageInfo->rowPitch, IGetErrorString(error),
+                          mem_flag_names[mem_flag_index]);
                 return error;
             }
 
@@ -285,8 +288,11 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 2D image of size %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height,
-                               IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                    log_error("ERROR: Unable to create %d level 2D image of "
+                              "size %zu x %zu (%s, %s)\n",
+                              imageInfo->num_mip_levels, imageInfo->width,
+                              imageInfo->height, IGetErrorString(error),
+                              mem_flag_names[mem_flag_index]);
                     return error;
                 }
             }
@@ -320,8 +326,11 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     }
                 }
 
-                log_error( "ERROR: Unable to create 2D image of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->height,
-                          imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
+                log_error("ERROR: Unable to create 2D image of size %zu x %zu "
+                          "pitch %zu (%s, %s)\n",
+                          imageInfo->width, imageInfo->height,
+                          imageInfo->rowPitch, IGetErrorString(error),
+                          mem_flag_names[mem_flag_index]);
                 return error;
             }
             image = unprotImage;
@@ -450,7 +459,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error("ERROR: Sample %zu (%zu,%zu) did not "
+                                      "validate! (%s)\n",
+                                      i, x, y, mem_flag_names[mem_flag_index]);
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -467,7 +478,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error("ERROR: Sample %zu (%zu,%zu) did not "
+                                      "validate! (%s)\n",
+                                      i, x, y, mem_flag_names[mem_flag_index]);
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -518,7 +531,12 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error(
+                                        "ERROR: Rounding mode sample (%zu) did "
+                                        "not validate, probably due to the "
+                                        "device's rounding mode being wrong "
+                                        "(%s)\n",
+                                        i, mem_flag_names[mem_flag_index]);
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -261,7 +261,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     }
                 }
 
-                log_error( "ERROR: Unable to create 2D image of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->height,
+                log_error( "ERROR: Unable to create 2D image of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->height,
                           imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                 return error;
             }
@@ -285,7 +285,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                              imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
-                    log_error( "ERROR: Unable to create %d level 2D image of size %ld x %ld (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height,
+                    log_error( "ERROR: Unable to create %d level 2D image of size %zu x %zu (%s, %s)\n", imageInfo->num_mip_levels, imageInfo->width, imageInfo->height,
                                IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                     return error;
                 }
@@ -320,7 +320,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     }
                 }
 
-                log_error( "ERROR: Unable to create 2D image of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->height,
+                log_error( "ERROR: Unable to create 2D image of size %zu x %zu pitch %zu (%s, %s)\n", imageInfo->width, imageInfo->height,
                           imageInfo->rowPitch, IGetErrorString( error ), mem_flag_names[mem_flag_index] );
                 return error;
             }
@@ -450,7 +450,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                         {
                             unsigned int *e = (unsigned int *)resultBuffer;
                             unsigned int *a = (unsigned int *)resultPtr;
-                            log_error( "ERROR: Sample %ld (%ld,%ld) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
                             log_error( "       Expected: %a %a %a %a\n", expected[ 0 ], expected[ 1 ], expected[ 2 ], expected[ 3 ] );
                             log_error( "       Expected: %08x %08x %08x %08x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "       Actual:   %a %a %a %a\n", actual[ 0 ], actual[ 1 ], actual[ 2 ], actual[ 3 ] );
@@ -467,7 +467,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                         if( !validate_half_write_results( e, a, imageInfo ) )
                         {
                             totalErrors++;
-                            log_error( "ERROR: Sample %ld (%ld,%ld) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
+                            log_error( "ERROR: Sample %zu (%zu,%zu) did not validate! (%s)\n", i, x, y, mem_flag_names[ mem_flag_index ] );
                             log_error( "    Expected: 0x%04x 0x%04x 0x%04x 0x%04x\n", e[ 0 ], e[ 1 ], e[ 2 ], e[ 3 ] );
                             log_error( "    Actual:   0x%04x 0x%04x 0x%04x 0x%04x\n", a[ 0 ], a[ 1 ], a[ 2 ], a[ 3 ] );
                             if( inputType == kFloat )
@@ -518,7 +518,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                                             deviceResults[ 4 ] == 5 && deviceResults[ 5 ] == 5 && deviceResults[ 6 ] == 6 && deviceResults[ 7 ] == 6 )
                                         deviceRounding = "round to even";
 
-                                    log_error( "ERROR: Rounding mode sample (%ld) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
+                                    log_error( "ERROR: Rounding mode sample (%zu) did not validate, probably due to the device's rounding mode being wrong (%s)\n", i, mem_flag_names[mem_flag_index] );
                                     log_error( "       Actual values rounded by device: %x %x %x %x %x %x %x %x\n", deviceResults[ 0 ], deviceResults[ 1 ], deviceResults[ 2 ], deviceResults[ 3 ],
                                               deviceResults[ 4 ], deviceResults[ 5 ], deviceResults[ 6 ], deviceResults[ 7 ] );
                                     log_error( "       Rounding mode of device appears to be %s\n", deviceRounding );

--- a/test_conformance/multiple_device_context/test_multiple_contexts.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_contexts.cpp
@@ -180,7 +180,7 @@ TestItem *CreateTestItem( cl_device_id deviceID, cl_int *err )
         {
             if( err )
             {
-                log_error("FAILURE: clCreateBuffer( %ld bytes ) failed in "
+                log_error("FAILURE: clCreateBuffer( %zu bytes ) failed in "
                           "CreateTestItem: %d\n",
                           TEST_SIZE * sizeof(cl_uint), error);
                 *err = error;
@@ -294,7 +294,7 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE to set arg 0 for kernel # %ld :  %d\n", j, error );
+                log_error( "FAILURE to set arg 0 for kernel # %zu :  %d\n", j, error );
                 *err = error;
             }
             return error;
@@ -305,7 +305,7 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE: Unable to set arg 1 for kernel # %ld :  %d\n", j, error );
+                log_error( "FAILURE: Unable to set arg 1 for kernel # %zu :  %d\n", j, error );
                 *err = error;
             }
             return error;
@@ -318,7 +318,7 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE: Unable to enqueue kernel %ld: %d\n", j, error );
+                log_error( "FAILURE: Unable to enqueue kernel %zu: %d\n", j, error );
                 *err = error;
             }
             return error;
@@ -360,7 +360,7 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
             cl_uint result = mapped[i];
             if( expected != result )
             {
-                log_error( "FAILURE:  Sample data at position %ld does not match expected result: *0x%8.8x vs. 0x%8.8x\n", i, expected, result );
+                log_error( "FAILURE:  Sample data at position %zu does not match expected result: *0x%8.8x vs. 0x%8.8x\n", i, expected, result );
                 if( err )
                     *err = -1;
                 return -1;
@@ -441,16 +441,16 @@ int test_context_multiple_contexts_same_device(cl_device_id deviceID, size_t max
     // Check to make sure we made the minimum amount
     if( i < minCount )
     {
-        log_error( "FAILURE: only could make %ld of %ld contexts!\n", i, minCount );
+        log_error( "FAILURE: only could make %zu of %zu contexts!\n", i, minCount );
         err = -1;
         goto exit;
     }
 
     // Report how many contexts we made
     if( i == maxCount )
-        log_info( "Successfully created all %lu contexts.\n", i );
+        log_info( "Successfully created all %zu contexts.\n", i );
     else
-        log_info( "Successfully created %lu contexts out of %lu\n", i, maxCount );
+        log_info( "Successfully created %zu contexts out of %zu\n", i, maxCount );
 
     // Set the count to be the number we succesfully made
     maxCount = i;

--- a/test_conformance/multiple_device_context/test_multiple_contexts.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_contexts.cpp
@@ -294,7 +294,8 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE to set arg 0 for kernel # %zu :  %d\n", j, error );
+                log_error("FAILURE to set arg 0 for kernel # %zu :  %d\n", j,
+                          error);
                 *err = error;
             }
             return error;
@@ -305,7 +306,9 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE: Unable to set arg 1 for kernel # %zu :  %d\n", j, error );
+                log_error(
+                    "FAILURE: Unable to set arg 1 for kernel # %zu :  %d\n", j,
+                    error);
                 *err = error;
             }
             return error;
@@ -318,7 +321,8 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
         {
             if( err )
             {
-                log_error( "FAILURE: Unable to enqueue kernel %zu: %d\n", j, error );
+                log_error("FAILURE: Unable to enqueue kernel %zu: %d\n", j,
+                          error);
                 *err = error;
             }
             return error;
@@ -360,7 +364,9 @@ cl_int UseTestItem( const TestItem *item, cl_int *err )
             cl_uint result = mapped[i];
             if( expected != result )
             {
-                log_error( "FAILURE:  Sample data at position %zu does not match expected result: *0x%8.8x vs. 0x%8.8x\n", i, expected, result );
+                log_error("FAILURE:  Sample data at position %zu does not "
+                          "match expected result: *0x%8.8x vs. 0x%8.8x\n",
+                          i, expected, result);
                 if( err )
                     *err = -1;
                 return -1;
@@ -441,16 +447,17 @@ int test_context_multiple_contexts_same_device(cl_device_id deviceID, size_t max
     // Check to make sure we made the minimum amount
     if( i < minCount )
     {
-        log_error( "FAILURE: only could make %zu of %zu contexts!\n", i, minCount );
+        log_error("FAILURE: only could make %zu of %zu contexts!\n", i,
+                  minCount);
         err = -1;
         goto exit;
     }
 
     // Report how many contexts we made
     if( i == maxCount )
-        log_info( "Successfully created all %zu contexts.\n", i );
+        log_info("Successfully created all %zu contexts.\n", i);
     else
-        log_info( "Successfully created %zu contexts out of %zu\n", i, maxCount );
+        log_info("Successfully created %zu contexts out of %zu\n", i, maxCount);
 
     // Set the count to be the number we succesfully made
     maxCount = i;

--- a/test_conformance/multiple_device_context/test_multiple_devices.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_devices.cpp
@@ -53,16 +53,21 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     RandomSeed seed( gRandomSeed );
 
     if (deviceCount > MAX_DEVICES) {
-       log_error("Number of devices in set (%zu) is greater than the number for which the test was written (%d).", deviceCount, MAX_DEVICES);
-    return -1;
+        log_error("Number of devices in set (%zu) is greater than the number "
+                  "for which the test was written (%d).",
+                  deviceCount, MAX_DEVICES);
+        return -1;
   }
 
   if (queueCount > MAX_QUEUES) {
-       log_error("Number of queues (%zu) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
-    return -1;
+      log_error("Number of queues (%zu) is greater than the number for which "
+                "the test was written (%d).",
+                queueCount, MAX_QUEUES);
+      return -1;
   }
 
-  log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
+  log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n",
+           queueCount, deviceCount, queueCount * num_elements / TEST_SIZE);
 
   for (i=0; i<deviceCount; i++) {
     char deviceName[4096] = "";
@@ -158,14 +163,19 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     {
       if( expectedResults[ i ] != outputData[ i ] )
       {
-        log_error( "ERROR: Sample data did not verify for queue %d on device %zu (sample %d, expected %d, got %d)\n",
-                  q, q % deviceCount, (int)i, expectedResults[ i ], outputData[ i ] );
-        for (size_t j=0; j<deviceCount; j++) {
-          if (expectedResultsOneDevice[j][i] == outputData[i])
-            log_info("Sample consistent with only device %zu having modified the data.\n", j);
-        }
-        errorsThisTime++;
-        break;
+          log_error("ERROR: Sample data did not verify for queue %d on device "
+                    "%zu (sample %d, expected %d, got %d)\n",
+                    q, q % deviceCount, (int)i, expectedResults[i],
+                    outputData[i]);
+          for (size_t j = 0; j < deviceCount; j++)
+          {
+              if (expectedResultsOneDevice[j][i] == outputData[i])
+                  log_info("Sample consistent with only device %zu having "
+                           "modified the data.\n",
+                           j);
+          }
+          errorsThisTime++;
+          break;
       }
     }
     if (errorsThisTime)

--- a/test_conformance/multiple_device_context/test_multiple_devices.cpp
+++ b/test_conformance/multiple_device_context/test_multiple_devices.cpp
@@ -53,22 +53,22 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     RandomSeed seed( gRandomSeed );
 
     if (deviceCount > MAX_DEVICES) {
-       log_error("Number of devices in set (%ld) is greater than the number for which the test was written (%d).", deviceCount, MAX_DEVICES);
+       log_error("Number of devices in set (%zu) is greater than the number for which the test was written (%d).", deviceCount, MAX_DEVICES);
     return -1;
   }
 
   if (queueCount > MAX_QUEUES) {
-       log_error("Number of queues (%ld) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
+       log_error("Number of queues (%zu) is greater than the number for which the test was written (%d).", queueCount, MAX_QUEUES);
     return -1;
   }
 
-  log_info("Testing with %ld queues on %ld devices, %ld kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
+  log_info("Testing with %zu queues on %zu devices, %zu kernel executions.\n", queueCount, deviceCount, queueCount*num_elements/TEST_SIZE);
 
   for (i=0; i<deviceCount; i++) {
     char deviceName[4096] = "";
     error = clGetDeviceInfo(devices[i], CL_DEVICE_NAME, sizeof(deviceName), deviceName, NULL);
     test_error(error, "clGetDeviceInfo CL_DEVICE_NAME failed");
-    log_info("Device %ld is \"%s\".\n", i, deviceName);
+    log_info("Device %zu is \"%s\".\n", i, deviceName);
   }
 
     /* Create a context */
@@ -158,11 +158,11 @@ int test_device_set(size_t deviceCount, size_t queueCount, cl_device_id *devices
     {
       if( expectedResults[ i ] != outputData[ i ] )
       {
-        log_error( "ERROR: Sample data did not verify for queue %d on device %ld (sample %d, expected %d, got %d)\n",
+        log_error( "ERROR: Sample data did not verify for queue %d on device %zu (sample %d, expected %d, got %d)\n",
                   q, q % deviceCount, (int)i, expectedResults[ i ], outputData[ i ] );
         for (size_t j=0; j<deviceCount; j++) {
           if (expectedResultsOneDevice[j][i] == outputData[i])
-            log_info("Sample consistent with only device %ld having modified the data.\n", j);
+            log_info("Sample consistent with only device %zu having modified the data.\n", j);
         }
         errorsThisTime++;
         break;


### PR DESCRIPTION
Printing of a `size_t` requires the `%zu` specifier.

This fixes occurrences where the previous wrong specifier appears to work in a typical 64-bit build, but causes a Wformat warning in 32-bit builds.