### PR TITLE
Fix using incorrect free function in arrayimagecopy and imagearraycopy basic tests' unique_ptr

### DIFF
--- a/test_conformance/basic/test_arrayimagecopy.cpp
+++ b/test_conformance/basic/test_arrayimagecopy.cpp
@@ -37,7 +37,8 @@ int test_arrayimagecopy_single_format(cl_device_id device, cl_context context,
                                       cl_mem_object_type image_type,
                                       const cl_image_format *format)
 {
-    std::unique_ptr<cl_uchar> bufptr, imgptr;
+    std::unique_ptr<cl_uchar, decltype(&free)> bufptr{ nullptr, free },
+        imgptr{ nullptr, free };
     clMemWrapper buffer, image;
     int img_width = 512;
     int img_height = 512;

--- a/test_conformance/basic/test_imagearraycopy.cpp
+++ b/test_conformance/basic/test_imagearraycopy.cpp
@@ -37,7 +37,8 @@ int test_imagearraycopy_single_format(cl_device_id device, cl_context context,
                                       cl_mem_object_type image_type,
                                       const cl_image_format *format)
 {
-    std::unique_ptr<cl_uchar> bufptr, imgptr;
+    std::unique_ptr<cl_uchar, decltype(&free)> bufptr{ nullptr, free },
+        imgptr{ nullptr, free };
     clMemWrapper buffer, image;
     const int img_width = 512;
     const int img_height = 512;


### PR DESCRIPTION
This change addresses a free function mis-match issue where `delete` is used to free memory allocated via `malloc` within `create_random_data` and in the test function.

The change involves the following tests:
1. arrayimagecopy
2. arrayimagecopy3d
3. imagearraycopy
4. imagearraycopy3d

This should address #2173