### PR TITLE
update CI to use the cl_khr_unified_svm headers

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -97,4 +97,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check code format
-        run: ./check-format.sh
+        run: ./check-format.sh origin/cl_khr_unified_svm

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           git clone https://github.com/KhronosGroup/OpenCL-Headers.git
           cd OpenCL-Headers
+          git checkout cl_khr_unified_svm
           ln -s CL OpenCL # For OSX builds
           cd ..
       - name: Install Vulkan SDK


### PR DESCRIPTION
Updates CI to use headers with support for the cl_khr_unified_svm extension in the cl_khr_unified_svm branch.

Note that this PR targets the cl_khr_unified_svm branch, not the main branch.