### PR TITLE
Fix more 32-bit Wformat warnings

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -16,6 +16,7 @@
 #include "testBase.h"
 #include <limits.h>
 #include <ctype.h>
+#include <cinttypes>
 #ifndef _WIN32
 #include <unistd.h>
 #endif
@@ -216,7 +217,9 @@ int test_compiler_defines_for_extensions(cl_device_id device, cl_context context
         char *extension = (char *)malloc((extension_length + 1) * sizeof(char));
         if (extension == NULL)
         {
-            log_error( "Error: unable to allocate memory to hold extension name: %ld chars\n", extension_length );
+            log_error("Error: unable to allocate memory to hold extension "
+                      "name: %" PRIdPTR " chars\n",
+                      extension_length);
             return -1;
         }
         extensions_supported[num_of_supported_extensions] = extension;

--- a/test_conformance/computeinfo/main.cpp
+++ b/test_conformance/computeinfo/main.cpp
@@ -736,7 +736,7 @@ void dumpConfigInfo(config_info* info)
             }
             break;
         case type_cl_device_id:
-            log_info("\t%s == %ld\n", info->opcode_name,
+            log_info("\t%s == %" PRIdPTR "\n", info->opcode_name,
                      (intptr_t)info->config.device_id);
             break;
         case type_cl_device_affinity_domain:

--- a/test_conformance/device_timer/test_device_timer.cpp
+++ b/test_conformance/device_timer/test_device_timer.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include <stdio.h>
+#include <cinttypes>
 #include <CL/cl.h>
 #include "harness/errorHelpers.h"
 #include "harness/compat.h"
@@ -74,13 +75,16 @@ REGISTER_TEST(device_and_host_timers)
 
     if (deviceEndTime <= deviceStartTime) {
         log_error("Device timer is not monotonically increasing.\n");
-        log_error("    deviceStartTime: %lu, deviceEndTime: %lu\n", deviceStartTime, deviceEndTime);
+        log_error("    deviceStartTime: %" PRIu64 ", deviceEndTime: %" PRIu64
+                  "\n",
+                  deviceStartTime, deviceEndTime);
         errors++;
     }
 
     if (hostEndTime <= hostStartTime) {
         log_error("Error: Host timer is not monotonically increasing.\n");
-        log_error("    hostStartTime: %lu, hostEndTime: %lu\n", hostStartTime, hostEndTime);
+        log_error("    hostStartTime: %" PRIu64 ", hostEndTime: %" PRIu64 "\n",
+                  hostStartTime, hostEndTime);
         errors++;
     }
 
@@ -95,7 +99,9 @@ REGISTER_TEST(device_and_host_timers)
 
     if (observedDiff > allowedDiff) {
         log_error("Error: Device and host timers did not increase by same amount\n");
-        log_error("    Observed difference between timers %lu (max allowed %lu).\n", observedDiff, allowedDiff);
+        log_error("    Observed difference between timers %" PRIu64
+                  " (max allowed %" PRIu64 ").\n",
+                  observedDiff, allowedDiff);
         errors++;
     }
 
@@ -103,21 +109,26 @@ REGISTER_TEST(device_and_host_timers)
 
     if (hostOnlyEndTime <= hostOnlyStartTime) {
         log_error("Error: Host timer is not monotonically increasing.\n");
-        log_error("    hostStartTime: %lu, hostEndTime: %lu\n", hostOnlyStartTime, hostOnlyEndTime);
+        log_error("    hostStartTime: %" PRIu64 ", hostEndTime: %" PRIu64 "\n",
+                  hostOnlyStartTime, hostOnlyEndTime);
         errors++;
     }
 
     if (hostOnlyStartTime < hostStartTime) {
         log_error("Error: Host start times do not correlate.\n");
         log_error("clGetDeviceAndHostTimer was called before clGetHostTimer but timers are not in that order.\n");
-        log_error("    clGetDeviceAndHostTimer: %lu, clGetHostTimer: %lu\n", hostStartTime, hostOnlyStartTime);
+        log_error("    clGetDeviceAndHostTimer: %" PRIu64
+                  ", clGetHostTimer: %" PRIu64 "\n",
+                  hostStartTime, hostOnlyStartTime);
         errors++;
     }
 
     if (hostOnlyEndTime < hostEndTime) {
         log_error("Error: Host end times do not correlate.\n");
         log_error("clGetDeviceAndHostTimer was called before clGetHostTimer but timers are not in that order.\n");
-        log_error("    clGetDeviceAndHostTimer: %lu, clGetHostTimer: %lu\n", hostEndTime, hostOnlyEndTime);
+        log_error("    clGetDeviceAndHostTimer: %" PRIu64
+                  ", clGetHostTimer: %" PRIu64 "\n",
+                  hostEndTime, hostOnlyEndTime);
         errors++;
     }
 
@@ -145,7 +156,9 @@ REGISTER_TEST(timer_resolution_queries)
         errors++;
     }
     else {
-        log_info("CL_DEVICE_PROFILING_TIMER_RESOLUTION == %lu nanoseconds\n", deviceTimerResolution);
+        log_info("CL_DEVICE_PROFILING_TIMER_RESOLUTION == %" PRIu64
+                 " nanoseconds\n",
+                 deviceTimerResolution);
     }
    
     if (platform) {
@@ -155,7 +168,9 @@ REGISTER_TEST(timer_resolution_queries)
             errors++;
         }
         else {
-            log_info("CL_PLATFORM_HOST_TIMER_RESOLUTION == %lu nanoseconds\n", hostTimerResolution);
+            log_info("CL_PLATFORM_HOST_TIMER_RESOLUTION == %" PRIu64
+                     " nanoseconds\n",
+                     hostTimerResolution);
         }
     }
     else {

--- a/test_conformance/generic_address_space/advanced_tests.cpp
+++ b/test_conformance/generic_address_space/advanced_tests.cpp
@@ -264,8 +264,10 @@ public:
         size_t passCount = std::count(results.begin(), results.end(), 1);
         if (passCount != results.size()) {
             std::vector<cl_uint>::iterator iter = std::find(results.begin(), results.end(), 0);
-            log_error("Verification on device failed at index %ld\n", std::distance(results.begin(), iter));
-            log_error("%ld out of %ld failed\n", (results.size()-passCount), results.size());
+            log_error("Verification on device failed at index %td\n",
+                      std::distance(results.begin(), iter));
+            log_error("%zu out of %zu failed\n", (results.size() - passCount),
+                      results.size());
             return -1;
         }
 
@@ -276,7 +278,8 @@ public:
         cl_int result = CL_SUCCESS;
 
         for (std::vector<std::string>::const_iterator it = _kernels.begin(); it != _kernels.end(); ++it) {
-            log_info("Executing subcase #%ld out of %ld\n", (it - _kernels.begin() + 1), _kernels.size());
+            log_info("Executing subcase #%zu out of %zu\n",
+                     (it - _kernels.begin() + 1), _kernels.size());
 
             result |= ExecuteSubcase(deviceID, context, queue, num_elements, *it);
         }

--- a/test_conformance/generic_address_space/basic_tests.cpp
+++ b/test_conformance/generic_address_space/basic_tests.cpp
@@ -70,8 +70,10 @@ public:
         size_t passCount = std::count(results.begin(), results.end(), 1);
         if (passCount != results.size()) {
             std::vector<cl_uint>::iterator iter = std::find(results.begin(), results.end(), 0);
-            log_error("Verification on device failed at index %ld\n", std::distance(results.begin(), iter));
-            log_error("%ld out of %ld failed\n", (results.size()-passCount), results.size());
+            log_error("Verification on device failed at index %td\n",
+                      std::distance(results.begin(), iter));
+            log_error("%zu out of %zu failed\n", (results.size() - passCount),
+                      results.size());
             return -1;
         }
 
@@ -82,7 +84,8 @@ public:
         cl_int result = CL_SUCCESS;
 
         for (std::vector<std::string>::const_iterator it = _kernels.begin(); it != _kernels.end(); ++it) {
-            log_info("Executing subcase #%ld out of %ld\n", (it - _kernels.begin() + 1), _kernels.size());
+            log_info("Executing subcase #%zu out of %zu\n",
+                     (it - _kernels.begin() + 1), _kernels.size());
 
             result |= ExecuteSubcase(deviceID, context, queue, num_elements, *it);
         }

--- a/test_conformance/generic_address_space/stress_tests.cpp
+++ b/test_conformance/generic_address_space/stress_tests.cpp
@@ -72,8 +72,10 @@ public:
         size_t passCount = std::count(results.begin(), results.end(), 1);
         if (passCount != results.size()) {
             std::vector<cl_uint>::iterator iter = std::find(results.begin(), results.end(), 0);
-            log_error("Verification on device failed at index %ld\n", std::distance(results.begin(), iter));
-            log_error("%ld out of %ld failed\n", (results.size()-passCount), results.size());
+            log_error("Verification on device failed at index %td\n",
+                      std::distance(results.begin(), iter));
+            log_error("%zu out of %zu failed\n", (results.size() - passCount),
+                      results.size());
             return -1;
         }
 
@@ -84,7 +86,8 @@ public:
         cl_int result = CL_SUCCESS;
 
         for (std::vector<std::string>::const_iterator it = _kernels.begin(); it != _kernels.end(); ++it) {
-            log_info("Executing subcase #%ld out of %ld\n", (it - _kernels.begin() + 1), _kernels.size());
+            log_info("Executing subcase #%zu out of %zu\n",
+                     (it - _kernels.begin() + 1), _kernels.size());
 
             result |= ExecuteSubcase(deviceID, context, queue, num_elements, *it);
         }


### PR DESCRIPTION
This fixes occurrences where the previous wrong specifier appears to work in a typical 64-bit build, but causes a Wformat warning in 32-bit builds.