### PR TITLE
[NFC] Change the name of the default device provided by the new registration framework

### DIFF
--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -133,7 +133,7 @@ template <typename T> T *register_test(const char *name, Version version)
 }
 
 #define REGISTER_TEST_VERSION(name, version)                                   \
-    extern int test_##name(cl_device_id deviceID, cl_context context,          \
+    extern int test_##name(cl_device_id device, cl_context context,            \
                            cl_command_queue queue, int num_elements);          \
     class test_##name##_class : public test {                                  \
     private:                                                                   \
@@ -145,7 +145,7 @@ template <typename T> T *register_test(const char *name, Version version)
     };                                                                         \
     test_##name##_class *var_##name =                                          \
         register_test<test_##name##_class>(#name, version);                    \
-    int test_##name(cl_device_id deviceID, cl_context context,                 \
+    int test_##name(cl_device_id device, cl_context context,                   \
                     cl_command_queue queue, int num_elements)
 
 #define REGISTER_TEST(name) REGISTER_TEST_VERSION(name, Version(1, 2))

--- a/test_conformance/SVM/test_allocate_shared_buffer.cpp
+++ b/test_conformance/SVM/test_allocate_shared_buffer.cpp
@@ -50,14 +50,13 @@ REGISTER_TEST(svm_allocate_shared_buffer)
     clCommandQueueWrapper queues[MAXQ];
 
     cl_device_svm_capabilities caps;
-    err = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES,
+    err = clGetDeviceInfo(device, CL_DEVICE_SVM_CAPABILITIES,
                           sizeof(cl_device_svm_capabilities), &caps, NULL);
     test_error(err, "clGetDeviceInfo failed for CL_DEVICE_SVM_CAPABILITIES");
 
     // under construction...
-    err =
-        create_cl_objects(deviceID, NULL, &contextWrapper, &program, &queues[0],
-                          &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
+    err = create_cl_objects(device, NULL, &contextWrapper, &program, &queues[0],
+                            &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;
     if (err) return -1;
 

--- a/test_conformance/SVM/test_allocate_shared_buffer_negative.cpp
+++ b/test_conformance/SVM/test_allocate_shared_buffer_negative.cpp
@@ -50,14 +50,13 @@ REGISTER_TEST(svm_allocate_shared_buffer_negative)
     clCommandQueueWrapper queues[MAXQ];
 
     cl_device_svm_capabilities caps;
-    err = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES,
+    err = clGetDeviceInfo(device, CL_DEVICE_SVM_CAPABILITIES,
                           sizeof(cl_device_svm_capabilities), &caps, NULL);
     test_error(err, "clGetDeviceInfo failed for CL_DEVICE_SVM_CAPABILITIES");
 
     // under construction...
-    err =
-        create_cl_objects(deviceID, NULL, &contextWrapper, &program, &queues[0],
-                          &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
+    err = create_cl_objects(device, NULL, &contextWrapper, &program, &queues[0],
+                            &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;
     if (err) return err;
 

--- a/test_conformance/SVM/test_byte_granularity.cpp
+++ b/test_conformance/SVM/test_byte_granularity.cpp
@@ -58,7 +58,7 @@ REGISTER_TEST(svm_byte_granularity)
     cl_uint num_devices = 0;
     cl_int err = CL_SUCCESS;
 
-    err = create_cl_objects(deviceID, &byte_manipulation_kernels[0],
+    err = create_cl_objects(device, &byte_manipulation_kernels[0],
                             &contextWrapper, &program, &queues[0], &num_devices,
                             CL_DEVICE_SVM_FINE_GRAIN_BUFFER);
     context = contextWrapper;

--- a/test_conformance/SVM/test_cross_buffer_pointers.cpp
+++ b/test_conformance/SVM/test_cross_buffer_pointers.cpp
@@ -136,7 +136,7 @@ REGISTER_TEST(svm_cross_buffer_pointers_coarse_grain)
     cl_int error = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    error = create_cl_objects(deviceID, &SVMCrossBufferPointers_test_kernel[0],
+    error = create_cl_objects(device, &SVMCrossBufferPointers_test_kernel[0],
                               &contextWrapper, &program, &queues[0],
                               &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;

--- a/test_conformance/SVM/test_enqueue_api.cpp
+++ b/test_conformance/SVM/test_enqueue_api.cpp
@@ -80,7 +80,7 @@ REGISTER_TEST(svm_enqueue_api)
     cl_int error = CL_SUCCESS;
     RandomSeed seed(0);
 
-    error = create_cl_objects(deviceID, NULL, &contextWrapper, NULL, &queues[0],
+    error = create_cl_objects(device, NULL, &contextWrapper, NULL, &queues[0],
                               &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;
     if (error) return TEST_FAIL;

--- a/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
+++ b/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
@@ -158,7 +158,7 @@ REGISTER_TEST(svm_fine_grain_memory_consistency)
     char *source[] = { hash_table_kernel };
 
     err = create_cl_objects(
-        deviceID, (const char **)source, &contextWrapper, &program, &queues[0],
+        device, (const char **)source, &contextWrapper, &program, &queues[0],
         &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER | CL_DEVICE_SVM_ATOMICS,
         required_extensions);
     context = contextWrapper;

--- a/test_conformance/SVM/test_fine_grain_sync_buffers.cpp
+++ b/test_conformance/SVM/test_fine_grain_sync_buffers.cpp
@@ -52,10 +52,9 @@ REGISTER_TEST(svm_fine_grain_sync_buffers)
     cl_int err = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    err = create_cl_objects(deviceID, &find_targets_kernel[0], &contextWrapper,
-                            &program, &queues[0], &num_devices,
-                            CL_DEVICE_SVM_FINE_GRAIN_BUFFER
-                                | CL_DEVICE_SVM_ATOMICS);
+    err = create_cl_objects(
+        device, &find_targets_kernel[0], &contextWrapper, &program, &queues[0],
+        &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER | CL_DEVICE_SVM_ATOMICS);
     context = contextWrapper;
     if (err == 1)
         return 0; // no devices capable of requested SVM level, so don't execute

--- a/test_conformance/SVM/test_migrate.cpp
+++ b/test_conformance/SVM/test_migrate.cpp
@@ -92,7 +92,7 @@ REGISTER_TEST(svm_migrate)
     clProgramWrapper program;
     cl_int error;
 
-    error = create_cl_objects(deviceID, &sources[0], &contextWrapper, &program,
+    error = create_cl_objects(device, &sources[0], &contextWrapper, &program,
                               &queues[0], &num_devices,
                               CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;
@@ -202,7 +202,7 @@ REGISTER_TEST(svm_migrate)
 
     // Check the event command type for clEnqueueSVMMigrateMem (OpenCL 3.0 and
     // newer)
-    Version version = get_device_cl_version(deviceID);
+    Version version = get_device_cl_version(device);
     if (version >= Version(3, 0))
     {
         cl_command_type commandType;

--- a/test_conformance/SVM/test_pointer_passing.cpp
+++ b/test_conformance/SVM/test_pointer_passing.cpp
@@ -43,7 +43,7 @@ REGISTER_TEST(svm_pointer_passing)
     cl_int error = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    error = create_cl_objects(deviceID, &SVMPointerPassing_test_kernel[0],
+    error = create_cl_objects(device, &SVMPointerPassing_test_kernel[0],
                               &contextWrapper, &program, &queues[0],
                               &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;

--- a/test_conformance/SVM/test_set_kernel_exec_info_svm_ptrs.cpp
+++ b/test_conformance/SVM/test_set_kernel_exec_info_svm_ptrs.cpp
@@ -50,8 +50,11 @@ REGISTER_TEST(svm_set_kernel_exec_info_svm_ptrs)
   cl_int      error = CL_SUCCESS;
   clCommandQueueWrapper queues[MAXQ];
 
-  //error = create_cl_objects(deviceID, &set_kernel_exec_info_svm_ptrs_kernel[0], &context, &program, &q, &num_devices, CL_DEVICE_SVM_FINE_GRAIN);
-  error = create_cl_objects(deviceID, &set_kernel_exec_info_svm_ptrs_kernel[0], &c, &program, &queues[0], &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
+  // error = create_cl_objects(device, &set_kernel_exec_info_svm_ptrs_kernel[0],
+  // &context, &program, &q, &num_devices, CL_DEVICE_SVM_FINE_GRAIN);
+  error = create_cl_objects(device, &set_kernel_exec_info_svm_ptrs_kernel[0],
+                            &c, &program, &queues[0], &num_devices,
+                            CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
   if(error == 1) return 0; // no devices capable of requested SVM level, so don't execute but count test as passing.
   if(error < 0) return -1; // fail test.
 

--- a/test_conformance/SVM/test_shared_address_space_coarse_grain.cpp
+++ b/test_conformance/SVM/test_shared_address_space_coarse_grain.cpp
@@ -274,12 +274,12 @@ int shared_address_space_coarse_grain(cl_device_id deviceID, cl_context context2
 
 REGISTER_TEST(svm_shared_address_space_coarse_grain_old_api)
 {
-    return shared_address_space_coarse_grain(deviceID, context, queue,
+    return shared_address_space_coarse_grain(device, context, queue,
                                              num_elements, CL_FALSE);
 }
 
 REGISTER_TEST(svm_shared_address_space_coarse_grain_new_api)
 {
-    return shared_address_space_coarse_grain(deviceID, context, queue,
+    return shared_address_space_coarse_grain(device, context, queue,
                                              num_elements, CL_TRUE);
 }

--- a/test_conformance/SVM/test_shared_address_space_fine_grain.cpp
+++ b/test_conformance/SVM/test_shared_address_space_fine_grain.cpp
@@ -28,9 +28,9 @@ REGISTER_TEST(svm_shared_address_space_fine_grain)
     cl_int error = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    error = create_cl_objects(
-        deviceID, &linked_list_create_and_verify_kernels[0], &contextWrapper,
-        &program, &queues[0], &num_devices, CL_DEVICE_SVM_FINE_GRAIN_SYSTEM);
+    error = create_cl_objects(device, &linked_list_create_and_verify_kernels[0],
+                              &contextWrapper, &program, &queues[0],
+                              &num_devices, CL_DEVICE_SVM_FINE_GRAIN_SYSTEM);
     context = contextWrapper;
     if (error == 1)
         return 0; // no devices capable of requested SVM level, so don't execute

--- a/test_conformance/SVM/test_shared_address_space_fine_grain_buffers.cpp
+++ b/test_conformance/SVM/test_shared_address_space_fine_grain_buffers.cpp
@@ -69,9 +69,9 @@ REGISTER_TEST(svm_shared_address_space_fine_grain_buffers)
     cl_int error = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    error = create_cl_objects(
-        deviceID, &linked_list_create_and_verify_kernels[0], &contextWrapper,
-        &program, &queues[0], &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER);
+    error = create_cl_objects(device, &linked_list_create_and_verify_kernels[0],
+                              &contextWrapper, &program, &queues[0],
+                              &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER);
     context = contextWrapper;
     if (error == 1)
         return 0; // no devices capable of requested SVM level, so don't execute

--- a/test_conformance/SVM/test_shared_sub_buffers.cpp
+++ b/test_conformance/SVM/test_shared_sub_buffers.cpp
@@ -133,7 +133,7 @@ REGISTER_TEST(svm_shared_sub_buffers)
     cl_int error = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
-    error = create_cl_objects(deviceID, &shared_sub_buffers_test_kernel[0],
+    error = create_cl_objects(device, &shared_sub_buffers_test_kernel[0],
                               &contextWrapper, &program, &queues[0],
                               &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
     context = contextWrapper;

--- a/test_conformance/device_timer/test_device_timer.cpp
+++ b/test_conformance/device_timer/test_device_timer.cpp
@@ -35,14 +35,14 @@ REGISTER_TEST(device_and_host_timers)
     cl_ulong observedDiff;
     cl_ulong allowedDiff;
 
-    result = clGetDeviceAndHostTimer(deviceID, &deviceStartTime, &hostStartTime);
+    result = clGetDeviceAndHostTimer(device, &deviceStartTime, &hostStartTime);
     if (result != CL_SUCCESS) {
         log_error("clGetDeviceAndHostTimer failed with error %s\n", IGetErrorString(result));
         errors++;
         goto End;
     }
 
-    result = clGetHostTimer(deviceID, &hostOnlyStartTime);
+    result = clGetHostTimer(device, &hostOnlyStartTime);
     if (result != CL_SUCCESS) {
         log_error("clGetHostTimer failed with error %s\n", IGetErrorString(result));
         errors++;
@@ -52,14 +52,14 @@ REGISTER_TEST(device_and_host_timers)
     // Wait for a while to allow the timers to increment substantially.
     sleep(5);
 
-    result = clGetDeviceAndHostTimer(deviceID, &deviceEndTime, &hostEndTime);
+    result = clGetDeviceAndHostTimer(device, &deviceEndTime, &hostEndTime);
     if (result != CL_SUCCESS) {
         log_error("clGetDeviceAndHostTimer failed with error %s\n", IGetErrorString(result));
         errors++;
         goto End;
     }
 
-    result = clGetHostTimer(deviceID, &hostOnlyEndTime);
+    result = clGetHostTimer(device, &hostOnlyEndTime);
     if (result != CL_SUCCESS) {
         log_error("clGetHostTimer failed with error %s\n", IGetErrorString(result));
         errors++;
@@ -133,13 +133,16 @@ REGISTER_TEST(timer_resolution_queries)
     cl_ulong deviceTimerResolution = 0;
     cl_ulong hostTimerResolution = 0;
 
-    result = clGetDeviceInfo(deviceID, CL_DEVICE_PLATFORM, sizeof(platform), &platform, NULL);
+    result = clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform),
+                             &platform, NULL);
     if (result != CL_SUCCESS) {
         log_error("clGetDeviceInfo(CL_DEVICE_PLATFORM) failed with error %s.\n", IGetErrorString(result));
         errors++;
     }
-    
-    result = clGetDeviceInfo(deviceID, CL_DEVICE_PROFILING_TIMER_RESOLUTION, sizeof(deviceTimerResolution), &deviceTimerResolution, NULL);
+
+    result = clGetDeviceInfo(device, CL_DEVICE_PROFILING_TIMER_RESOLUTION,
+                             sizeof(deviceTimerResolution),
+                             &deviceTimerResolution, NULL);
     if (result != CL_SUCCESS) {
         log_error("clGetDeviceInfo(CL_DEVICE_PROFILING_TIMER_RESOLUTION) failed with error %s.\n", IGetErrorString(result));
         errors++;

--- a/test_conformance/spirv_new/test_basic_versions.cpp
+++ b/test_conformance/spirv_new/test_basic_versions.cpp
@@ -52,13 +52,13 @@ REGISTER_TEST(basic_versions)
     });
 
     size_t sz = 0;
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_IL_VERSION, 0, NULL, &sz);
+    error = clGetDeviceInfo(device, CL_DEVICE_IL_VERSION, 0, NULL, &sz);
     test_error(error, "Unable to query device IL versions size");
 
     std::string ilVersions;
     ilVersions.resize(sz);
-    error = clGetDeviceInfo(deviceID, CL_DEVICE_IL_VERSION, sz, &ilVersions[0],
-                            NULL);
+    error =
+        clGetDeviceInfo(device, CL_DEVICE_IL_VERSION, sz, &ilVersions[0], NULL);
     test_error(error, "Unable to query device IL versions string");
 
     for (auto& testCase : mapILtoSubdir)
@@ -88,7 +88,7 @@ REGISTER_TEST(basic_versions)
         std::string filename = testCase.second + "/basic";
 
         clProgramWrapper prog;
-        error = get_program_with_il(prog, deviceID, context, filename.c_str());
+        error = get_program_with_il(prog, device, context, filename.c_str());
         test_error(error, "Unable to build SPIR-V program");
 
         clKernelWrapper kernel = clCreateKernel(prog, "test_basic", &error);

--- a/test_conformance/spirv_new/test_cl_khr_expect_assume.cpp
+++ b/test_conformance/spirv_new/test_cl_khr_expect_assume.cpp
@@ -119,7 +119,7 @@ static int test_expect_type(cl_device_id device, cl_context context,
 
 REGISTER_TEST(op_expect)
 {
-    if (!is_extension_available(deviceID, "cl_khr_expect_assume"))
+    if (!is_extension_available(device, "cl_khr_expect_assume"))
     {
         log_info("cl_khr_expect_assume is not supported; skipping test.\n");
         return TEST_SKIPPED_ITSELF;
@@ -127,21 +127,21 @@ REGISTER_TEST(op_expect)
 
     int result = TEST_PASS;
 
-    result |= test_expect_type<cl_char>(deviceID, context, queue);
-    result |= test_expect_type<cl_short>(deviceID, context, queue);
-    result |= test_expect_type<cl_int>(deviceID, context, queue);
+    result |= test_expect_type<cl_char>(device, context, queue);
+    result |= test_expect_type<cl_short>(device, context, queue);
+    result |= test_expect_type<cl_int>(device, context, queue);
     if (gHasLong)
     {
-        result |= test_expect_type<cl_long>(deviceID, context, queue);
+        result |= test_expect_type<cl_long>(device, context, queue);
     }
-    result |= test_expect_type<cl_bool>(deviceID, context, queue);
+    result |= test_expect_type<cl_bool>(device, context, queue);
 
     return result;
 }
 
 REGISTER_TEST(op_assume)
 {
-    if (!is_extension_available(deviceID, "cl_khr_expect_assume"))
+    if (!is_extension_available(device, "cl_khr_expect_assume"))
     {
         log_info("cl_khr_expect_assume is not supported; skipping test.\n");
         return TEST_SKIPPED_ITSELF;
@@ -154,7 +154,7 @@ REGISTER_TEST(op_assume)
     test_error(error, "Unable to create destination buffer");
 
     clProgramWrapper prog;
-    error = get_program_with_il(prog, deviceID, context, "assume");
+    error = get_program_with_il(prog, device, context, "assume");
     test_error(error, "Unable to build SPIR-V program");
 
     clKernelWrapper kernel = clCreateKernel(prog, "test_assume", &error);

--- a/test_conformance/spirv_new/test_decorate.cpp
+++ b/test_conformance/spirv_new/test_decorate.cpp
@@ -112,24 +112,24 @@ int test_decorate_full(cl_device_id deviceID,
 
 REGISTER_TEST(decorate_restrict)
 {
-    return test_decorate_full(deviceID, context, queue, "decorate_restrict");
+    return test_decorate_full(device, context, queue, "decorate_restrict");
 }
 
 REGISTER_TEST(decorate_aliased)
 {
-    return test_decorate_full(deviceID, context, queue, "decorate_aliased");
+    return test_decorate_full(device, context, queue, "decorate_aliased");
 }
 
 REGISTER_TEST(decorate_alignment)
 {
     //TODO: Check for results ? How to ensure buffers are aligned
     clProgramWrapper prog;
-    return get_program_with_il(prog, deviceID, context, "decorate_alignment");
+    return get_program_with_il(prog, device, context, "decorate_alignment");
 }
 
 REGISTER_TEST(decorate_constant)
 {
-    return test_decorate_full(deviceID, context, queue, "decorate_constant");
+    return test_decorate_full(device, context, queue, "decorate_constant");
 }
 
 REGISTER_TEST(decorate_cpacked)
@@ -145,7 +145,7 @@ REGISTER_TEST(decorate_cpacked)
 
     std::vector<packed_t> packed(num);
     clProgramWrapper prog;
-    cl_int err = get_program_with_il(prog, deviceID, context, "decorate_cpacked");
+    cl_int err = get_program_with_il(prog, device, context, "decorate_cpacked");
 
     clKernelWrapper kernel = clCreateKernel(prog, "decorate_cpacked", &err);
     SPIRV_CHECK_ERROR(err, "Failed to create spv kernel");
@@ -388,8 +388,8 @@ int test_saturate_full(cl_device_id deviceID,
         typedef cl_##Tl cl_Tl;                                                 \
         typedef cl_##To cl_To;                                                 \
         const char *name = "decorate_saturated_conversion_" #Ti "_to_" #To;    \
-        return test_saturate_full<cl_Ti, cl_Tl, cl_To>(                        \
-            deviceID, context, queue, name, #Ti #Tl #To);                      \
+        return test_saturate_full<cl_Ti, cl_Tl, cl_To>(device, context, queue, \
+                                                       name, #Ti #Tl #To);     \
     }
 
 TEST_SATURATED_CONVERSION(half, short, char)
@@ -547,7 +547,7 @@ static inline Ti generate_fprounding_input(RandomSeed &seed)
             out[i] = func<clTi, clTo>(in[i]);                                  \
         }                                                                      \
         const char *name = "decorate_rounding_" #name "_" #Ti "_" #To;         \
-        return test_fp_rounding(deviceID, context, queue, name, in, out);      \
+        return test_fp_rounding(device, context, queue, name, in, out);        \
     }
 
 TEST_SPIRV_FP_ROUNDING_DECORATE(rte, round_to_even, half, short);

--- a/test_conformance/spirv_new/test_get_program_il.cpp
+++ b/test_conformance/spirv_new/test_get_program_il.cpp
@@ -34,7 +34,7 @@ REGISTER_TEST(get_program_il)
 
     /* If a program has been created with clCreateProgramWithIL, CL_PROGRAM_IL
      * should return the program IL it was created with and it's size */
-    if (gCoreILProgram || is_extension_available(deviceID, "cl_khr_il_program"))
+    if (gCoreILProgram || is_extension_available(device, "cl_khr_il_program"))
     {
         clProgramWrapper il_program;
         std::string spvStr = "op_function_none";
@@ -51,7 +51,7 @@ REGISTER_TEST(get_program_il)
         /* Create program with IL */
         unsigned char *spirv_buffer = &spirv_binary[0];
 
-        error = get_program_with_il(il_program, deviceID, context, spvName);
+        error = get_program_with_il(il_program, device, context, spvName);
 
         SPIRV_CHECK_ERROR(error, "Unable to create program with IL.");
         if (il_program == NULL)

--- a/test_conformance/spirv_new/test_linkage.cpp
+++ b/test_conformance/spirv_new/test_linkage.cpp
@@ -80,13 +80,13 @@ static int test_linkage_compile(cl_device_id deviceID,
 REGISTER_TEST(linkage_export_function_compile)
 {
     clProgramWrapper prog;
-    return test_linkage_compile(deviceID, context, queue, "linkage_export", prog);
+    return test_linkage_compile(device, context, queue, "linkage_export", prog);
 }
 
 REGISTER_TEST(linkage_import_function_compile)
 {
     clProgramWrapper prog;
-    return test_linkage_compile(deviceID, context, queue, "linkage_import", prog);
+    return test_linkage_compile(device, context, queue, "linkage_import", prog);
 }
 
 REGISTER_TEST(linkage_import_function_link)
@@ -94,16 +94,19 @@ REGISTER_TEST(linkage_import_function_link)
     int err = 0;
 
     clProgramWrapper prog_export;
-    err = test_linkage_compile(deviceID, context, queue, "linkage_export", prog_export);
+    err = test_linkage_compile(device, context, queue, "linkage_export",
+                               prog_export);
     SPIRV_CHECK_ERROR(err, "Failed to compile export program");
 
     clProgramWrapper prog_import;
-    err = test_linkage_compile(deviceID, context, queue, "linkage_import", prog_import);
+    err = test_linkage_compile(device, context, queue, "linkage_import",
+                               prog_import);
     SPIRV_CHECK_ERROR(err, "Failed to compile import program");
 
     cl_program progs[] = {prog_export, prog_import};
 
-    clProgramWrapper prog = clLinkProgram(context, 1, &deviceID, NULL, 2, progs, NULL, NULL, &err);
+    clProgramWrapper prog =
+        clLinkProgram(context, 1, &device, NULL, 2, progs, NULL, NULL, &err);
     SPIRV_CHECK_ERROR(err, "Failed to link programs");
 
     clKernelWrapper kernel = clCreateKernel(prog, "test_linkage", &err);
@@ -214,7 +217,7 @@ static int test_linkonce_odr_helper(cl_device_id deviceID, cl_context context,
 
 REGISTER_TEST(linkage_linkonce_odr)
 {
-    if (!is_extension_available(deviceID, "cl_khr_spirv_linkonce_odr"))
+    if (!is_extension_available(device, "cl_khr_spirv_linkonce_odr"))
     {
         log_info("Extension cl_khr_spirv_linkonce_odr not supported; skipping "
                  "tests.\n");
@@ -226,13 +229,13 @@ REGISTER_TEST(linkage_linkonce_odr)
     // For this test, use the default main module, which has an "a" function
     // with the linkonce_odr linkage type.  This ensures that having two "a"
     // functions with linkonce_odr works properly.
-    result |= test_linkonce_odr_helper(deviceID, context, queue,
+    result |= test_linkonce_odr_helper(device, context, queue,
                                        "linkage_linkonce_odr_main");
 
     // For this test, use a main module without the "a" function.  This ensures
     // that the "a" function is properly exported with the linkonce_odr linkage
     // type.
-    result |= test_linkonce_odr_helper(deviceID, context, queue,
+    result |= test_linkonce_odr_helper(device, context, queue,
                                        "linkage_linkonce_odr_noa_main");
 
     return result;

--- a/test_conformance/spirv_new/test_no_integer_wrap_decoration.cpp
+++ b/test_conformance/spirv_new/test_no_integer_wrap_decoration.cpp
@@ -229,14 +229,14 @@ int test_no_integer_wrap_decoration(cl_device_id deviceID, cl_context context,
     REGISTER_TEST(ext_cl_khr_spirv_no_integer_wrap_decoration_##FUNC##_##TYPE) \
     {                                                                          \
         if (!is_extension_available(                                           \
-                deviceID, "cl_khr_spirv_no_integer_wrap_decoration"))          \
+                device, "cl_khr_spirv_no_integer_wrap_decoration"))            \
         {                                                                      \
             log_info("Extension cl_khr_spirv_no_integer_wrap_decoration not "  \
                      "supported; skipping tests.\n");                          \
             return TEST_SKIPPED_ITSELF;                                        \
         }                                                                      \
         return test_no_integer_wrap_decoration<cl_##TYPE>(                     \
-            deviceID, context, queue,                                          \
+            device, context, queue,                                            \
             "ext_cl_khr_spirv_no_integer_wrap_decoration_" #FUNC "_" #TYPE,    \
             #FUNC, #TYPE);                                                     \
     }
@@ -254,13 +254,13 @@ TEST_FMATH_FUNC_KHR(uint, fshiftleft)
 #define TEST_FMATH_FUNC_14(TYPE, FUNC)                                         \
     REGISTER_TEST(spirv14_no_integer_wrap_decoration_##FUNC##_##TYPE)          \
     {                                                                          \
-        if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))               \
+        if (!is_spirv_version_supported(device, "SPIR-V_1.4"))                 \
         {                                                                      \
             log_info("SPIR-V 1.4 not supported; skipping tests.\n");           \
             return TEST_SKIPPED_ITSELF;                                        \
         }                                                                      \
         return test_no_integer_wrap_decoration<cl_##TYPE>(                     \
-            deviceID, context, queue,                                          \
+            device, context, queue,                                            \
             "spv1.4/no_integer_wrap_decoration_" #FUNC "_" #TYPE, #FUNC,       \
             #TYPE);                                                            \
     }

--- a/test_conformance/spirv_new/test_op_atomic.cpp
+++ b/test_conformance/spirv_new/test_op_atomic.cpp
@@ -90,13 +90,13 @@ int test_atomic(cl_device_id deviceID, cl_context context,
 REGISTER_TEST(op_atomic_inc_global)
 {
     int num = 1 << 16;
-    return test_atomic<cl_int>(deviceID, context, queue,
-                               "atomic_inc_global", num, true);
+    return test_atomic<cl_int>(device, context, queue, "atomic_inc_global", num,
+                               true);
 }
 
 REGISTER_TEST(op_atomic_dec_global)
 {
     int num = 1 << 16;
-    return test_atomic<cl_int>(deviceID, context, queue,
-                               "atomic_dec_global", num, false);
+    return test_atomic<cl_int>(device, context, queue, "atomic_dec_global", num,
+                               false);
 }

--- a/test_conformance/spirv_new/test_op_branch.cpp
+++ b/test_conformance/spirv_new/test_op_branch.cpp
@@ -75,7 +75,7 @@ int test_branch_simple(cl_device_id deviceID, cl_context context,
         {                                                                      \
             results[i] = genrand<cl_int>(seed);                                \
         }                                                                      \
-        return test_branch_simple(deviceID, context, queue, #NAME "_simple",   \
+        return test_branch_simple(device, context, queue, #NAME "_simple",     \
                                   results);                                    \
     }
 

--- a/test_conformance/spirv_new/test_op_branch_conditional.cpp
+++ b/test_conformance/spirv_new/test_op_branch_conditional.cpp
@@ -100,7 +100,7 @@ int test_branch_conditional(cl_device_id deviceID,
             out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);  \
         }                                                                      \
                                                                                \
-        return test_branch_conditional(deviceID, context, queue, #name, lhs,   \
+        return test_branch_conditional(device, context, queue, #name, lhs,     \
                                        rhs, out);                              \
     }
 

--- a/test_conformance/spirv_new/test_op_composite_construct.cpp
+++ b/test_conformance/spirv_new/test_op_composite_construct.cpp
@@ -60,7 +60,8 @@ REGISTER_TEST(op_composite_construct_int4)
 {
     cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
-    return test_composite_construct(deviceID, context, queue, "composite_construct_int4", results);
+    return test_composite_construct(device, context, queue,
+                                    "composite_construct_int4", results);
 }
 
 REGISTER_TEST(op_composite_construct_struct)
@@ -73,5 +74,6 @@ REGISTER_TEST(op_composite_construct_struct)
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);
-    return test_composite_construct(deviceID, context, queue, "composite_construct_struct", results);
+    return test_composite_construct(device, context, queue,
+                                    "composite_construct_struct", results);
 }

--- a/test_conformance/spirv_new/test_op_constant.cpp
+++ b/test_conformance/spirv_new/test_op_constant.cpp
@@ -68,7 +68,7 @@ int test_constant(cl_device_id deviceID, cl_context context,
     REGISTER_TEST(op_constant_##NAME##_simple)                                 \
     {                                                                          \
         std::vector<type> results(1024, (type)value);                          \
-        return test_constant(deviceID, context, queue,                         \
+        return test_constant(device, context, queue,                           \
                              "constant_" #NAME "_simple", results);            \
     }
 
@@ -101,14 +101,15 @@ REGISTER_TEST(op_constant_int4_simple)
 {
     cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
-    return test_constant(deviceID, context, queue, "constant_int4_simple", results);
+    return test_constant(device, context, queue, "constant_int4_simple",
+                         results);
 }
 
 REGISTER_TEST(op_constant_int3_simple)
 {
     cl_int3 value = { { 123, 122, 121, 0 } };
     std::vector<cl_int3> results(256, value);
-    return test_constant(deviceID, context, queue, "constant_int3_simple",
+    return test_constant(device, context, queue, "constant_int3_simple",
                          results, isVectorNotEqual<cl_int3, 3>);
 }
 
@@ -116,14 +117,16 @@ REGISTER_TEST(op_constant_struct_int_float_simple)
 {
     AbstractStruct2<int, float> value = {1024, 3.1415};
     std::vector<AbstractStruct2<int, float> > results(256, value);
-    return test_constant(deviceID, context, queue, "constant_struct_int_float_simple", results);
+    return test_constant(device, context, queue,
+                         "constant_struct_int_float_simple", results);
 }
 
 REGISTER_TEST(op_constant_struct_int_char_simple)
 {
     AbstractStruct2<int, char> value = { 2100483600, (char)128 };
     std::vector<AbstractStruct2<int, char> > results(256, value);
-    return test_constant(deviceID, context, queue, "constant_struct_int_char_simple", results);
+    return test_constant(device, context, queue,
+                         "constant_struct_int_char_simple", results);
 }
 
 REGISTER_TEST(op_constant_struct_struct_simple)
@@ -136,14 +139,14 @@ REGISTER_TEST(op_constant_struct_struct_simple)
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);
-    return test_constant(deviceID, context, queue, "constant_struct_struct_simple", results);
+    return test_constant(device, context, queue,
+                         "constant_struct_struct_simple", results);
 }
 
 REGISTER_TEST(op_constant_half_simple)
 {
-    PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);
+    PASSIVE_REQUIRE_FP16_SUPPORT(device);
     std::vector<cl_float> results(1024, 3.25);
-    return test_constant(deviceID, context, queue,
-                         "constant_half_simple",
+    return test_constant(device, context, queue, "constant_half_simple",
                          results);
 }

--- a/test_conformance/spirv_new/test_op_copy_object.cpp
+++ b/test_conformance/spirv_new/test_op_copy_object.cpp
@@ -68,7 +68,7 @@ int test_copy(cl_device_id deviceID, cl_context context,
     REGISTER_TEST(op_copy_##NAME##_simple)                                     \
     {                                                                          \
         std::vector<type> results(1024, (type)value);                          \
-        return test_copy(deviceID, context, queue, "copy_" #NAME "_simple",    \
+        return test_copy(device, context, queue, "copy_" #NAME "_simple",      \
                          results);                                             \
     }
 
@@ -97,29 +97,31 @@ REGISTER_TEST(op_copy_int4_simple)
 {
     cl_int4 value = { { 123, 122, 121, 119 } };
     std::vector<cl_int4> results(256, value);
-    return test_copy(deviceID, context, queue, "copy_int4_simple", results);
+    return test_copy(device, context, queue, "copy_int4_simple", results);
 }
 
 REGISTER_TEST(op_copy_int3_simple)
 {
     cl_int3 value = { { 123, 122, 121, 0 } };
     std::vector<cl_int3> results(256, value);
-    return test_copy(deviceID, context, queue, "copy_int3_simple",
-                     results, isVectorNotEqual<cl_int3, 3>);
+    return test_copy(device, context, queue, "copy_int3_simple", results,
+                     isVectorNotEqual<cl_int3, 3>);
 }
 
 REGISTER_TEST(op_copy_struct_int_float_simple)
 {
     AbstractStruct2<int, float> value = {1024, 3.1415};
     std::vector<AbstractStruct2<int, float> > results(256, value);
-    return test_copy(deviceID, context, queue, "copy_struct_int_float_simple", results);
+    return test_copy(device, context, queue, "copy_struct_int_float_simple",
+                     results);
 }
 
 REGISTER_TEST(op_copy_struct_int_char_simple)
 {
     AbstractStruct2<int, char> value = { 2100483600, (char)128 };
     std::vector<AbstractStruct2<int, char> > results(256, value);
-    return test_copy(deviceID, context, queue, "copy_struct_int_char_simple", results);
+    return test_copy(device, context, queue, "copy_struct_int_char_simple",
+                     results);
 }
 
 REGISTER_TEST(op_copy_struct_struct_simple)
@@ -132,14 +134,13 @@ REGISTER_TEST(op_copy_struct_struct_simple)
     CustomType2 value2 = {intvals, value1};
 
     std::vector<CustomType2> results(256, value2);
-    return test_copy(deviceID, context, queue, "copy_struct_struct_simple", results);
+    return test_copy(device, context, queue, "copy_struct_struct_simple",
+                     results);
 }
 
 REGISTER_TEST(op_copy_half_simple)
 {
-    PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);
+    PASSIVE_REQUIRE_FP16_SUPPORT(device);
     std::vector<cl_float> results(1024, 3.25);
-    return test_copy(deviceID, context, queue,
-                     "copy_half_simple",
-                     results);
+    return test_copy(device, context, queue, "copy_half_simple", results);
 }

--- a/test_conformance/spirv_new/test_op_fmath.cpp
+++ b/test_conformance/spirv_new/test_op_fmath.cpp
@@ -155,7 +155,7 @@ int test_fmath(cl_device_id deviceID,
     {                                                                          \
         if (sizeof(cl_##TYPE) == 2)                                            \
         {                                                                      \
-            PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);                            \
+            PASSIVE_REQUIRE_FP16_SUPPORT(device);                              \
         }                                                                      \
         const int num = 1 << 20;                                               \
         std::vector<cl_##TYPE> lhs(num);                                       \
@@ -170,7 +170,7 @@ int test_fmath(cl_device_id deviceID,
         }                                                                      \
                                                                                \
         const char *mode = #MODE;                                              \
-        return test_fmath(deviceID, context, queue, #FUNC "_" #TYPE, #FUNC,    \
+        return test_fmath(device, context, queue, #FUNC "_" #TYPE, #FUNC,      \
                           #TYPE, mode[0] == 'f', lhs, rhs);                    \
     }
 

--- a/test_conformance/spirv_new/test_op_function.cpp
+++ b/test_conformance/spirv_new/test_op_function.cpp
@@ -77,7 +77,7 @@ int test_function(cl_device_id deviceID,
         {                                                                      \
             in[i] = genrand<cl_float>(seed);                                   \
         }                                                                      \
-        return test_function(deviceID, context, queue, #TYPE, in);             \
+        return test_function(device, context, queue, #TYPE, in);               \
     }
 
 TEST_FUNCTION(none)

--- a/test_conformance/spirv_new/test_op_lifetime.cpp
+++ b/test_conformance/spirv_new/test_op_lifetime.cpp
@@ -100,8 +100,7 @@ int test_op_lifetime(cl_device_id deviceID,
             out[i] = lhs[i] - rhs[i];                                          \
         }                                                                      \
                                                                                \
-        return test_op_lifetime(deviceID, context, queue, #name, lhs, rhs,     \
-                                out);                                          \
+        return test_op_lifetime(device, context, queue, #name, lhs, rhs, out); \
     }
 
 TEST_LIFETIME(lifetime_simple)

--- a/test_conformance/spirv_new/test_op_loop_merge.cpp
+++ b/test_conformance/spirv_new/test_op_loop_merge.cpp
@@ -103,7 +103,7 @@ int test_selection_merge(cl_device_id deviceID,
             out[i] = res;                                                      \
         }                                                                      \
                                                                                \
-        return test_selection_merge(deviceID, context, queue,                  \
+        return test_selection_merge(device, context, queue,                    \
                                     "loop_merge_branch_" #control, in, out,    \
                                     rep);                                      \
     }

--- a/test_conformance/spirv_new/test_op_negate.cpp
+++ b/test_conformance/spirv_new/test_op_negate.cpp
@@ -95,7 +95,7 @@ int test_negation(cl_device_id deviceID,
         {                                                                      \
             in[i] = genrand<Tv>(seed);                                         \
         }                                                                      \
-        return test_negation<Tv>(deviceID, context, queue, #TYPE, #OP, in,     \
+        return test_negation<Tv>(device, context, queue, #TYPE, #OP, in,       \
                                  FUNC);                                        \
     }
 

--- a/test_conformance/spirv_new/test_op_opaque.cpp
+++ b/test_conformance/spirv_new/test_op_opaque.cpp
@@ -41,7 +41,7 @@ REGISTER_TEST(op_type_opaque_simple)
     else
     {
         cl_platform_id platform;
-        err = clGetDeviceInfo(deviceID, CL_DEVICE_PLATFORM,
+        err = clGetDeviceInfo(device, CL_DEVICE_PLATFORM,
                               sizeof(cl_platform_id), &platform, NULL);
         SPIRV_CHECK_ERROR(err,
                           "Failed to get platform info with clGetDeviceInfo");
@@ -61,7 +61,7 @@ REGISTER_TEST(op_type_opaque_simple)
             err, "Failed to create program with clCreateProgramWithILKHR");
     }
 
-    err = clCompileProgram(prog, 1, &deviceID,
+    err = clCompileProgram(prog, 1, &device,
                            NULL, // options
                            0, // num headers
                            NULL, // input headers

--- a/test_conformance/spirv_new/test_op_phi.cpp
+++ b/test_conformance/spirv_new/test_op_phi.cpp
@@ -98,7 +98,7 @@ REGISTER_TEST(op_phi_2_blocks)
         out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);
     }
 
-    return test_phi(deviceID, context, queue, "phi_2", lhs, rhs, out);
+    return test_phi(device, context, queue, "phi_2", lhs, rhs, out);
 }
 
 REGISTER_TEST(op_phi_3_blocks)
@@ -120,7 +120,7 @@ REGISTER_TEST(op_phi_3_blocks)
         }
     }
 
-    return test_phi(deviceID, context, queue, "phi_3", lhs, rhs, out);
+    return test_phi(device, context, queue, "phi_3", lhs, rhs, out);
 }
 
 REGISTER_TEST(op_phi_4_blocks)
@@ -142,5 +142,5 @@ REGISTER_TEST(op_phi_4_blocks)
         }
     }
 
-    return test_phi(deviceID, context, queue, "phi_4", lhs, rhs, out);
+    return test_phi(device, context, queue, "phi_4", lhs, rhs, out);
 }

--- a/test_conformance/spirv_new/test_op_selection_merge.cpp
+++ b/test_conformance/spirv_new/test_op_selection_merge.cpp
@@ -100,7 +100,7 @@ int test_selection_merge(cl_device_id deviceID,
             out[i] = lhs[i] < rhs[i] ? (rhs[i] - lhs[i]) : (lhs[i] - rhs[i]);  \
         }                                                                      \
                                                                                \
-        return test_selection_merge(deviceID, context, queue,                  \
+        return test_selection_merge(device, context, queue,                    \
                                     "select_if_" #control, lhs, rhs, out);     \
     }
 
@@ -125,7 +125,7 @@ TEST_SELECT_IF(dont_flatten)
             out[i] = (lhs[i] + rhs[i]) % 4;                                    \
         }                                                                      \
                                                                                \
-        return test_selection_merge(deviceID, context, queue,                  \
+        return test_selection_merge(device, context, queue,                    \
                                     "select_switch_" #control, lhs, rhs, out); \
     }
 

--- a/test_conformance/spirv_new/test_op_spec_constant.cpp
+++ b/test_conformance/spirv_new/test_op_spec_constant.cpp
@@ -120,7 +120,7 @@ int test_spec_constant(cl_device_id deviceID, cl_context context,
         type init_value = init_buffer;                                         \
         type final_value = init_value + spec_constant_value;                   \
         return test_spec_constant(                                             \
-            deviceID, context, queue, "op_spec_constant_" #NAME "_simple",     \
+            device, context, queue, "op_spec_constant_" #NAME "_simple",       \
             init_value, (type)spec_constant_value, final_value);               \
     }
 
@@ -144,7 +144,7 @@ REGISTER_TEST_VERSION(op_spec_constant_true_simple, Version(2, 2))
     cl_uchar value = (cl_uchar)7;
     cl_uchar init_value = value;
     cl_uchar final_value = value + 1;
-    return test_spec_constant<cl_uchar>(deviceID, context, queue,
+    return test_spec_constant<cl_uchar>(device, context, queue,
                                         "op_spec_constant_true_simple",
                                         init_value, 0, final_value);
 }
@@ -156,7 +156,7 @@ REGISTER_TEST_VERSION(op_spec_constant_false_simple, Version(2, 2))
     cl_uchar value = (cl_uchar)7;
     cl_uchar init_value = value;
     cl_uchar final_value = value + 1;
-    return test_spec_constant<cl_uchar>(deviceID, context, queue,
+    return test_spec_constant<cl_uchar>(device, context, queue,
                                         "op_spec_constant_false_simple",
                                         init_value, 1, final_value);
 }

--- a/test_conformance/spirv_new/test_op_undef.cpp
+++ b/test_conformance/spirv_new/test_op_undef.cpp
@@ -60,7 +60,7 @@ int test_undef(cl_device_id deviceID, cl_context context,
 #define TEST_UNDEF(NAME, TYPE)                                                 \
     REGISTER_TEST(op_undef_##NAME##_simple)                                    \
     {                                                                          \
-        return test_undef<TYPE>(deviceID, context, queue,                      \
+        return test_undef<TYPE>(device, context, queue,                        \
                                 "undef_" #NAME "_simple");                     \
     }
 
@@ -95,25 +95,27 @@ TEST_UNDEF(int3  , cl_int3)
 REGISTER_TEST(op_undef_struct_int_float_simple)
 {
     typedef AbstractStruct2<cl_int, cl_float> CustomType;
-    return test_undef<CustomType>(deviceID, context, queue, "undef_struct_int_float_simple");
+    return test_undef<CustomType>(device, context, queue,
+                                  "undef_struct_int_float_simple");
 }
 
 REGISTER_TEST(op_undef_struct_int_char_simple)
 {
     typedef AbstractStruct2<cl_int, cl_char> CustomType;
-    return test_undef<CustomType>(deviceID, context, queue, "undef_struct_int_char_simple");
+    return test_undef<CustomType>(device, context, queue,
+                                  "undef_struct_int_char_simple");
 }
 
 REGISTER_TEST(op_undef_struct_struct_simple)
 {
     typedef AbstractStruct2<cl_int, cl_char> CustomType1;
     typedef AbstractStruct2<cl_int2, CustomType1> CustomType2;
-    return test_undef<CustomType2>(deviceID, context, queue, "undef_struct_struct_simple");
+    return test_undef<CustomType2>(device, context, queue,
+                                   "undef_struct_struct_simple");
 }
 
 REGISTER_TEST(op_undef_half_simple)
 {
-    PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);
-    return test_undef<cl_float>(deviceID, context, queue,
-                                "undef_half_simple");
+    PASSIVE_REQUIRE_FP16_SUPPORT(device);
+    return test_undef<cl_float>(device, context, queue, "undef_half_simple");
 }

--- a/test_conformance/spirv_new/test_op_vector_extract.cpp
+++ b/test_conformance/spirv_new/test_op_vector_extract.cpp
@@ -95,7 +95,7 @@ int test_extract(cl_device_id deviceID, cl_context context,
     {                                                                          \
         if (sizeof(cl_##TYPE) == 2)                                            \
         {                                                                      \
-            PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);                            \
+            PASSIVE_REQUIRE_FP16_SUPPORT(device);                              \
         }                                                                      \
         typedef cl_##TYPE##N Tv;                                               \
         typedef cl_##TYPE Ts;                                                  \
@@ -110,7 +110,7 @@ int test_extract(cl_device_id deviceID, cl_context context,
             in[i] = genrand<Tv>(seed);                                         \
         }                                                                      \
                                                                                \
-        return test_extract<Tv, Ts>(deviceID, context, queue, name, in, N);    \
+        return test_extract<Tv, Ts>(device, context, queue, name, in, N);      \
     }
 
 TEST_VECTOR_EXTRACT(half, 8)

--- a/test_conformance/spirv_new/test_op_vector_insert.cpp
+++ b/test_conformance/spirv_new/test_op_vector_insert.cpp
@@ -113,7 +113,7 @@ int test_insert(cl_device_id deviceID, cl_context context,
     {                                                                          \
         if (sizeof(cl_##TYPE) == 2)                                            \
         {                                                                      \
-            PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);                            \
+            PASSIVE_REQUIRE_FP16_SUPPORT(device);                              \
         }                                                                      \
         typedef cl_##TYPE##N Tv;                                               \
         typedef cl_##TYPE Ts;                                                  \
@@ -128,7 +128,7 @@ int test_insert(cl_device_id deviceID, cl_context context,
             in[i] = genrand<Ts>(seed);                                         \
         }                                                                      \
                                                                                \
-        return test_insert<Ts, Tv>(deviceID, context, queue, name, in, N);     \
+        return test_insert<Ts, Tv>(device, context, queue, name, in, N);       \
     }
 
 TEST_VECTOR_INSERT(half, 8)

--- a/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
+++ b/test_conformance/spirv_new/test_op_vector_times_scalar.cpp
@@ -166,7 +166,7 @@ int test_vector_times_scalar(cl_device_id deviceID,
     {                                                                          \
         if (sizeof(cl_##TYPE) == 2)                                            \
         {                                                                      \
-            PASSIVE_REQUIRE_FP16_SUPPORT(deviceID);                            \
+            PASSIVE_REQUIRE_FP16_SUPPORT(device);                              \
         }                                                                      \
         typedef cl_##TYPE##N Tv;                                               \
         typedef cl_##TYPE Ts;                                                  \
@@ -182,8 +182,8 @@ int test_vector_times_scalar(cl_device_id deviceID,
             rhs[i] = genrandReal<cl_##TYPE>(seed);                             \
         }                                                                      \
                                                                                \
-        return test_vector_times_scalar<Tv, Ts>(deviceID, context, queue,      \
-                                                #TYPE, lhs, rhs);              \
+        return test_vector_times_scalar<Tv, Ts>(device, context, queue, #TYPE, \
+                                                lhs, rhs);                     \
     }
 
 

--- a/test_conformance/spirv_new/test_spirv_14.cpp
+++ b/test_conformance/spirv_new/test_spirv_14.cpp
@@ -92,22 +92,22 @@ static int test_image_operand_helper(cl_device_id deviceID, cl_context context,
 
 REGISTER_TEST(spirv14_image_operand_signextend)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_image_operand_helper(deviceID, context, queue, true);
+    return test_image_operand_helper(device, context, queue, true);
 }
 
 REGISTER_TEST(spirv14_image_operand_zeroextend)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_image_operand_helper(deviceID, context, queue, false);
+    return test_image_operand_helper(device, context, queue, false);
 }
 
 static int test_loop_control_helper(cl_device_id deviceID, cl_context context,
@@ -157,62 +157,62 @@ static int test_loop_control_helper(cl_device_id deviceID, cl_context context,
 
 REGISTER_TEST(spirv14_loop_control_miniterations)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_loop_control_helper(deviceID, context, queue,
+    return test_loop_control_helper(device, context, queue,
                                     "loop_control_miniterations");
 }
 
 REGISTER_TEST(spirv14_loop_control_maxiterations)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_loop_control_helper(deviceID, context, queue,
+    return test_loop_control_helper(device, context, queue,
                                     "loop_control_maxiterations");
 }
 
 REGISTER_TEST(spirv14_loop_control_iterationmultiple)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_loop_control_helper(deviceID, context, queue,
+    return test_loop_control_helper(device, context, queue,
                                     "loop_control_iterationmultiple");
 }
 
 REGISTER_TEST(spirv14_loop_control_peelcount)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_loop_control_helper(deviceID, context, queue,
+    return test_loop_control_helper(device, context, queue,
                                     "loop_control_peelcount");
 }
 
 REGISTER_TEST(spirv14_loop_control_partialcount)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
-    return test_loop_control_helper(deviceID, context, queue,
+    return test_loop_control_helper(device, context, queue,
                                     "loop_control_partialcount");
 }
 
 REGISTER_TEST(spirv14_ptrops)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
@@ -221,7 +221,7 @@ REGISTER_TEST(spirv14_ptrops)
     cl_int error = CL_SUCCESS;
 
     clProgramWrapper prog;
-    error = get_program_with_il(prog, deviceID, context, "spv1.4/ptrops");
+    error = get_program_with_il(prog, device, context, "spv1.4/ptrops");
     SPIRV_CHECK_ERROR(error, "Failed to compile spv program");
 
     clKernelWrapper kernel = clCreateKernel(prog, "ptrops_test", &error);
@@ -333,29 +333,29 @@ static int test_usersemantic_decoration(cl_device_id deviceID,
 
 REGISTER_TEST(spirv14_usersemantic_decoratestring)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
 
-    return test_usersemantic_decoration(deviceID, context, queue, false);
+    return test_usersemantic_decoration(device, context, queue, false);
 }
 
 REGISTER_TEST(spirv14_usersemantic_memberdecoratestring)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
 
-    return test_usersemantic_decoration(deviceID, context, queue, true);
+    return test_usersemantic_decoration(device, context, queue, true);
 }
 
 REGISTER_TEST(spirv14_nonwriteable_decoration)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
@@ -365,7 +365,7 @@ REGISTER_TEST(spirv14_nonwriteable_decoration)
 
     clProgramWrapper prog;
     error = get_program_with_il(
-        prog, deviceID, context,
+        prog, device, context,
         "spv1.4/nonwriteable_decoration_function_storage_class");
     SPIRV_CHECK_ERROR(error, "Failed to compile spv program");
 
@@ -401,7 +401,7 @@ REGISTER_TEST(spirv14_nonwriteable_decoration)
 
 REGISTER_TEST(spirv14_copymemory_memory_operands)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
@@ -410,7 +410,7 @@ REGISTER_TEST(spirv14_copymemory_memory_operands)
     cl_int error = CL_SUCCESS;
 
     clProgramWrapper prog;
-    error = get_program_with_il(prog, deviceID, context,
+    error = get_program_with_il(prog, device, context,
                                 "spv1.4/copymemory_memory_operands");
     SPIRV_CHECK_ERROR(error, "Failed to compile spv program");
 
@@ -454,7 +454,7 @@ REGISTER_TEST(spirv14_select_composite)
 {
     constexpr size_t global_size = 16;
 
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
@@ -463,8 +463,7 @@ REGISTER_TEST(spirv14_select_composite)
     cl_int error = CL_SUCCESS;
 
     clProgramWrapper prog;
-    error =
-        get_program_with_il(prog, deviceID, context, "spv1.4/select_struct");
+    error = get_program_with_il(prog, device, context, "spv1.4/select_struct");
     SPIRV_CHECK_ERROR(error, "Failed to compile spv program");
 
     clKernelWrapper kernel = clCreateKernel(prog, "select_struct_test", &error);
@@ -514,7 +513,7 @@ REGISTER_TEST(spirv14_select_composite)
 
 REGISTER_TEST(spirv14_copylogical)
 {
-    if (!is_spirv_version_supported(deviceID, "SPIR-V_1.4"))
+    if (!is_spirv_version_supported(device, "SPIR-V_1.4"))
     {
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
@@ -522,8 +521,8 @@ REGISTER_TEST(spirv14_copylogical)
 
     cl_int error = CL_SUCCESS;
     clProgramWrapper prog;
-    error = get_program_with_il(prog, deviceID, context,
-                                "spv1.4/copylogical_struct");
+    error =
+        get_program_with_il(prog, device, context, "spv1.4/copylogical_struct");
     SPIRV_CHECK_ERROR(error, "Failed to compile spv program");
 
     clKernelWrapper kernel = clCreateKernel(prog, "copylogical_test", &error);


### PR DESCRIPTION
The code base uses a mix of 'device' and 'deviceID'. I suggest we standardise on 'device' which is shorter and slightly more prevalent.

Contributes to #2181