### PR TITLE
add option to bruteforce test to force count of worker threads

### DIFF
--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -379,6 +379,7 @@ static int ParseArgs(int argc, const char **argv)
     gTestNames.push_back("");
 
     int singleThreaded = 0;
+    int forcedWorkerThreads = 0;
 
     { // Extract the app name
         strncpy(appName, argv[0], MAXPATHLEN - 1);
@@ -429,6 +430,11 @@ static int ParseArgs(int argc, const char **argv)
                     case 'l': gSkipCorrectnessTesting ^= 1; break;
 
                     case 'm': singleThreaded ^= 1; break;
+
+                    case 't':
+                        forcedWorkerThreads = atoi(argv[++i]);
+                        vlog(" %d", forcedWorkerThreads);
+                        break;
 
                     case 'g': gHasHalf ^= 1; break;
 
@@ -540,7 +546,17 @@ static int ParseArgs(int argc, const char **argv)
              gWimpyReductionFactor);
     }
 
-    if (singleThreaded) SetThreadCount(1);
+    if (singleThreaded)
+    {
+        vlog("*** WARNING: Force 1 worker thread                      ***\n");
+        SetThreadCount(1);
+    }
+    else if (forcedWorkerThreads > 0)
+    {
+        vlog("*** WARNING: Force %d worker threads                    ***\n",
+             forcedWorkerThreads);
+        SetThreadCount(forcedWorkerThreads);
+    }
 
     return 0;
 }


### PR DESCRIPTION
- to be able to have deterministic results it is useful to have a mechanism
  to force the same count of workers
- this commit doesn't change the default settings but expands
  functionality

Signed-off-by: Katarzyna Cencelewska <katarzyna.cencelewska@intel.com>
