### PR TITLE
semaphore: fix Wformat warning

### DIFF
--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
@@ -277,7 +277,7 @@ struct SemaphoreOutOfOrderOps : public SemaphoreTestBase
             {
                 if (pattern != host_buffer[i])
                 {
-                    log_error("Expected %d was %d at index %zu\n", pattern,
+                    log_error("Expected %d was %d at index %d\n", pattern,
                               host_buffer[i], i);
                     return false;
                 }


### PR DESCRIPTION
`i` is an `int`, so shouldn't use the `%zu` specifier for printing.