### PR TITLE
cmake: remove global -Wno-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang"
         # Enable more warnings if not doing a release build.
         add_cxx_flag_if_supported(-Wall)
     endif()
-    add_cxx_flag_if_supported(-Wno-format)
     add_cxx_flag_if_supported(-Wno-error=cpp) # Allow #warning directive
     add_cxx_flag_if_supported(-Wno-unknown-pragmas) # Issue #785
     add_cxx_flag_if_supported(-Wno-error=asm-operand-widths) # Issue #784

--- a/test_conformance/basic/CMakeLists.txt
+++ b/test_conformance/basic/CMakeLists.txt
@@ -71,6 +71,6 @@ if(APPLE)
     list(APPEND ${MODULE_NAME}_SOURCES test_queue_priority.cpp)
 endif(APPLE)
 
-set_gnulike_module_compile_flags("-Wno-sign-compare")
+set_gnulike_module_compile_flags("-Wno-sign-compare -Wno-format")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/c11_atomics/CMakeLists.txt
+++ b/test_conformance/c11_atomics/CMakeLists.txt
@@ -7,6 +7,6 @@ set(${MODULE_NAME}_SOURCES
     test_atomics.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-sign-compare")
+set_gnulike_module_compile_flags("-Wno-sign-compare -Wno-format")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/commonfns/CMakeLists.txt
+++ b/test_conformance/commonfns/CMakeLists.txt
@@ -10,4 +10,6 @@ set(${MODULE_NAME}_SOURCES
     test_binary_fn.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-format")
+
 include(../CMakeCommon.txt)

--- a/test_conformance/conversions/CMakeLists.txt
+++ b/test_conformance/conversions/CMakeLists.txt
@@ -12,6 +12,6 @@ if("${CLConform_TARGET_ARCH}" STREQUAL "ARM" OR "${CLConform_TARGET_ARCH}" STREQ
     list(APPEND ${MODULE_NAME}_SOURCES fplib.cpp)
 endif()
 
-set_gnulike_module_compile_flags("-Wno-sign-compare")
+set_gnulike_module_compile_flags("-Wno-sign-compare -Wno-format")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/relationals/CMakeLists.txt
+++ b/test_conformance/relationals/CMakeLists.txt
@@ -7,5 +7,7 @@ set(${MODULE_NAME}_SOURCES
     test_shuffles.cpp
 )
 
+set_gnulike_module_compile_flags("-Wno-format")
+
 include(../CMakeCommon.txt)
 


### PR DESCRIPTION
Move the global `-Wno-format` compiler option to the individual tests that still trigger Wformat warnings.  The majority of the tests now compile cleanly with `-Wformat` enabled.