### PR TITLE
fix negative_create_command_buffer_device_does_not_support_out_of_ord…

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -27,7 +27,7 @@ BasicCommandBufferTest::BasicCommandBufferTest(cl_device_id device,
                                                cl_command_queue queue)
     : CommandBufferTestBase(device), context(context), queue(nullptr),
       num_elements(0), simultaneous_use_support(false),
-      out_of_order_support(false),
+      out_of_order_support(false), queue_out_of_order_support(false),
       // try to use simultaneous path by default
       simultaneous_use_requested(true),
       // due to simultaneous cases extend buffer size
@@ -57,7 +57,8 @@ bool BasicCommandBufferTest::Skip()
                                   sizeof(queue_properties), &queue_properties,
                                   NULL);
     test_error(error, "Unable to query CL_QUEUE_PROPERTIES");
-
+    queue_out_of_order_support =
+        queue_properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
 
     // Query if device supports simultaneous use
     cl_device_command_buffer_capabilities_khr capabilities;

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -75,6 +75,7 @@ protected:
     // Device support query results
     bool simultaneous_use_support;
     bool out_of_order_support;
+    bool queue_out_of_order_support;
     bool device_side_enqueue_support;
 
     // user request for simultaneous use

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -291,7 +291,7 @@ struct CreateCommandBufferDeviceDoesNotSupportOutOfOderQueue
 
         // If device does not support out of order queue or if device supports
         // out of order command buffer test should be skipped
-        return queue_out_of_order_support && !out_of_order_support;
+        return !queue_out_of_order_support || out_of_order_support;
     }
 
     clCommandQueueWrapper out_of_order_queue;

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -289,8 +289,9 @@ struct CreateCommandBufferDeviceDoesNotSupportOutOfOderQueue
     {
         BasicCommandBufferTest::Skip();
 
-        // If device supports out of order queues test should be skipped
-        return out_of_order_support != 0;
+        // If device does not support out of order queue or if device supports
+        // out of order command buffer test should be skipped
+        return queue_out_of_order_support && !out_of_order_support;
     }
 
     clCommandQueueWrapper out_of_order_queue;


### PR DESCRIPTION
…er_queue

Test should be skipped if device does not support out of order queue or if device supports out of order command buffer.

Fix #2204 