### PR TITLE
svm: finish all queues in svm_pointer_passing

### DIFF
--- a/test_conformance/SVM/test_pointer_passing.cpp
+++ b/test_conformance/SVM/test_pointer_passing.cpp
@@ -127,10 +127,10 @@ REGISTER_TEST(svm_pointer_passing)
                     return -1;
                 }
             }
-        }
 
-        error = clFinish(cmdq);
-        test_error(error, "clFinish failed");
+            error = clFinish(cmdq);
+            test_error(error, "clFinish failed");
+        }
     }
 
 


### PR DESCRIPTION
The `svm_pointer_passing` test has unflushed buffer unmap commands queued, which a runtime might process after the `clSVMFree` calls at the end of the test (through implicit flushing when destroying the queues at e.g. program exit handlers).

This is only an issue when running the test with multiple devices.

However I think this was caused by a simple typo given the `clFinish` was simply in the wrong block.