### PR TITLE
bruteforce: Update ULP for half-precision divide to 1.0f

### DIFF
--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -425,7 +425,7 @@ const Func functionList[] = {
       { (void*)reference_relaxed_divide },
       2.5f,
       0.0f,
-      0.0f,
+      1.0f,
       3.0f,
       2.5f,
       INFINITY,


### PR DESCRIPTION
CTS test update to match proposed spec update https://github.com/KhronosGroup/OpenCL-Docs/issues/1278