### PR TITLE
Check command-buffer extension version for equality

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -104,11 +104,10 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
         cl_version extension_version =
             get_extension_version(device, "cl_khr_command_buffer");
 
-        if (extension_version < CL_MAKE_VERSION(0, 9, 5))
+        if (extension_version != CL_MAKE_VERSION(0, 9, 5))
         {
 
-            log_info("cl_khr_command_buffer version 0.9.5 or later is required "
-                     "to run "
+            log_info("cl_khr_command_buffer version 0.9.5 is required to run "
                      "the test, skipping.\n ");
             return TEST_SKIPPED_ITSELF;
         }

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_basic.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_basic.h
@@ -80,20 +80,24 @@ struct BasicMutableCommandBufferTest : BasicCommandBufferTest
                                    "cl_khr_command_buffer_mutable_dispatch")
             == true;
 
-        if (extension_avaliable) {
-         // API breaking changes occur at revision 0.9.2, check implementation
-         // matches tested API
-         Version device_version = get_device_cl_version(device);
-         if ((device_version >= Version(3, 0))
-            || is_extension_available(device, "cl_khr_extended_versioning")) {
+        if (extension_avaliable)
+        {
+            Version device_version = get_device_cl_version(device);
+            if ((device_version >= Version(3, 0))
+                || is_extension_available(device, "cl_khr_extended_versioning"))
+            {
 
-           cl_version extension_version =
-            get_extension_version(device, "cl_khr_command_buffer_mutable_dispatch");
+                cl_version extension_version = get_extension_version(
+                    device, "cl_khr_command_buffer_mutable_dispatch");
 
-          if (extension_version < CL_MAKE_VERSION(0, 9, 2)) {
-            extension_avaliable = false;
-          }
-         }
+                if (extension_version != CL_MAKE_VERSION(0, 9, 3))
+                {
+                    log_info("cl_khr_command_buffer_mutable_dispatch version "
+                             "0.9.3 is "
+                             "required to run the test, skipping.\n ");
+                    extension_avaliable = false;
+                }
+            }
         }
 
         cl_mutable_dispatch_fields_khr mutable_capabilities;

--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -127,8 +127,10 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
             cl_version extension_version = get_extension_version(
                 device, "cl_khr_command_buffer_mutable_dispatch");
 
-            if (extension_version < CL_MAKE_VERSION(0, 9, 3))
+            if (extension_version != CL_MAKE_VERSION(0, 9, 3))
             {
+                log_info("cl_khr_command_buffer_mutable_dispatch version 0.9.3 "
+                         "is required to run the test, skipping.\n ");
                 return true;
             }
         }


### PR DESCRIPTION
As described in Issue https://github.com/KhronosGroup/OpenCL-CTS/issues/2152 we currently check the provisional extension version supported by a vendor is the same or older than a test specified version. However, it was discussed in the WG that this should be a check for equality to avoid hitting issues when a implementation tests against an older version of the CTS using a lower extension version, with API breaking changes having occurred since.

The tests for the command-buffer family of extensions are the only provisional KHR tests using this versioning check, so this PR updates all those cases to equality.