### PR TITLE
Fix derived command-buffer Skip() checks

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -129,8 +129,9 @@ struct CreateCommandBufferRepeatedProperties : public BasicCommandBufferTest
 
     bool Skip() override
     {
-        bool skip = true;
+        if (BasicCommandBufferTest::Skip()) return true;
 
+        bool skip = true;
         if (simultaneous_use_support)
         {
             rep_prop = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
@@ -181,8 +182,9 @@ struct CreateCommandBufferNotSupportedProperties : public BasicCommandBufferTest
 
     bool Skip() override
     {
-        bool skip = true;
+        if (BasicCommandBufferTest::Skip()) return true;
 
+        bool skip = true;
         if (!simultaneous_use_support)
         {
             unsupported_prop = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
@@ -223,6 +225,8 @@ struct CreateCommandBufferQueueWithoutMinProperties
 
     bool Skip() override
     {
+        if (BasicCommandBufferTest::Skip()) return true;
+
         cl_command_queue_properties required_properties;
         cl_int error = clGetDeviceInfo(
             device, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR,
@@ -287,7 +291,7 @@ struct CreateCommandBufferDeviceDoesNotSupportOutOfOderQueue
 
     bool Skip() override
     {
-        BasicCommandBufferTest::Skip();
+        if (BasicCommandBufferTest::Skip()) return true;
 
         // If device does not support out of order queue or if device supports
         // out of order command buffer test should be skipped

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_nd_range_kernel.cpp
@@ -273,6 +273,8 @@ struct CommandNDRangeKernelNotSupportPrintf : public BasicCommandBufferTest
 
     bool Skip() override
     {
+        if (BasicCommandBufferTest::Skip()) return true;
+
         cl_device_command_buffer_capabilities_khr capabilities;
         cl_int error =
             clGetDeviceInfo(device, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
@@ -353,6 +355,8 @@ struct CommandNDRangeKernelWithKernelEnqueueCall : public BasicCommandBufferTest
 
     bool Skip() override
     {
+        if (BasicCommandBufferTest::Skip()) return true;
+
         bool has_device_enqueue = false;
         bool cl_version_2_0_or_higher = false;
 


### PR DESCRIPTION
It was noticed during another PR review https://github.com/KhronosGroup/OpenCL-CTS/pull/2207/files#r1903921283 that there 
was a case where the return value of a `Skip()` check was ignored, this is fixed in this PR.

I've also tracking down occurrences of derived class overriding the `Skip()` test fixture method, but not calling the parents class `Skip()` check inside of the method. I believe omitting this parent skip check wasn't intentional, it's clearer to explicitly respect the parent classes skip conditions, even if we've got away with not needing too due to the way the derived class skip conditions have been defined.
