### PR TITLE
WIP: SPV_EXT_arithmetic_fence

### DIFF
--- a/test_conformance/spirv_new/CMakeLists.txt
+++ b/test_conformance/spirv_new/CMakeLists.txt
@@ -8,6 +8,7 @@ set(${MODULE_NAME}_SOURCES
   test_get_program_il.cpp
   test_linkage.cpp
   test_no_integer_wrap_decoration.cpp
+  test_op_arithmetic_fence.cpp
   test_op_atomic.cpp
   test_op_branch_conditional.cpp
   test_op_branch.cpp

--- a/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_double.spvasm64
@@ -1,0 +1,149 @@
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Vector16
+               OpCapability Float64
+               OpCapability ArithmeticFenceEXT
+               OpExtension "SPV_EXT_arithmetic_fence"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test_ext_arithmetic_fence_double"
+               OpDecorate %add FPFastMathMode Fast
+               OpDecorate %scalar_res FPFastMathMode Fast
+               OpDecorate %add2 FPFastMathMode Fast
+               OpDecorate %vec2_res FPFastMathMode Fast
+               OpDecorate %add3 FPFastMathMode Fast
+               OpDecorate %vec3_res FPFastMathMode Fast
+               OpDecorate %add4 FPFastMathMode Fast
+               OpDecorate %vec4_res FPFastMathMode Fast
+               OpDecorate %add8 FPFastMathMode Fast
+               OpDecorate %vec8_res FPFastMathMode Fast
+               OpDecorate %add16 FPFastMathMode Fast
+               OpDecorate %vec16_res FPFastMathMode Fast
+       %void = OpTypeVoid
+     %double = OpTypeFloat 64
+    %double2 = OpTypeVector %double 2
+    %double3 = OpTypeVector %double 3
+    %double4 = OpTypeVector %double 4
+    %double8 = OpTypeVector %double 8
+   %double16 = OpTypeVector %double 16
+%gptr_double = OpTypePointer CrossWorkgroup %double
+ %kernel_sig = OpTypeFunction %void %gptr_double %double %double
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %gptr_double
+        %big = OpFunctionParameter %double
+      %small = OpFunctionParameter %double
+      %entry = OpLabel
+; Note: without the arithmetic fence, most compilers will reassociated the
+; expression "big + small - big" to "big - big + small" and therefore just
+; "small".  The arithmetic fence prevents this reassociation.
+
+; Scalar arithmetic fence:
+        %add = OpFAdd %double %big %small
+ %fenced_add = OpArithmeticFenceEXT %double %add
+ %scalar_res = OpFSub %double %fenced_add %big
+
+; Vec2 arithmetic fence:
+       %big2 = OpCompositeConstruct %double2 %big %big
+     %small2 = OpCompositeConstruct %double2 %small %small
+       %add2 = OpFAdd %double2 %big2 %small2
+%fenced_add2 = OpArithmeticFenceEXT %double2 %add2
+   %vec2_res = OpFSub %double2 %fenced_add2 %big2
+ %vec2_res_0 = OpCompositeExtract %double %vec2_res 0
+ %vec2_res_1 = OpCompositeExtract %double %vec2_res 1
+   %vec2_sum = OpFAdd %double %vec2_res_0 %vec2_res_1
+
+; Vec3 arithmetic fence:
+       %big3 = OpCompositeConstruct %double3 %big %big %big
+     %small3 = OpCompositeConstruct %double3 %small %small %small
+       %add3 = OpFAdd %double3 %big3 %small3
+%fenced_add3 = OpArithmeticFenceEXT %double3 %add3
+   %vec3_res = OpFSub %double3 %fenced_add3 %big3
+ %vec3_res_0 = OpCompositeExtract %double %vec3_res 0
+ %vec3_res_1 = OpCompositeExtract %double %vec3_res 1
+ %vec3_res_2 = OpCompositeExtract %double %vec3_res 2
+  %vec3_sum0 = OpFAdd %double %vec3_res_0 %vec3_res_1
+   %vec3_sum = OpFAdd %double %vec3_sum0 %vec3_res_2
+
+; Vec4 arithmetic fence:
+       %big4 = OpCompositeConstruct %double4 %big %big %big %big
+     %small4 = OpCompositeConstruct %double4 %small %small %small %small
+       %add4 = OpFAdd %double4 %big4 %small4
+%fenced_add4 = OpArithmeticFenceEXT %double4 %add4
+   %vec4_res = OpFSub %double4 %fenced_add4 %big4
+ %vec4_res_0 = OpCompositeExtract %double %vec4_res 0
+ %vec4_res_1 = OpCompositeExtract %double %vec4_res 1
+ %vec4_res_2 = OpCompositeExtract %double %vec4_res 2
+ %vec4_res_3 = OpCompositeExtract %double %vec4_res 3
+  %vec4_sum0 = OpFAdd %double %vec4_res_0 %vec4_res_1
+  %vec4_sum1 = OpFAdd %double %vec4_sum0 %vec4_res_2
+   %vec4_sum = OpFAdd %double %vec4_sum1 %vec4_res_3
+
+; Vec8 arithmetic fence:
+       %big8 = OpCompositeConstruct %double8 %big %big %big %big %big %big %big %big
+     %small8 = OpCompositeConstruct %double8 %small %small %small %small %small %small %small %small
+       %add8 = OpFAdd %double8 %big8 %small8
+%fenced_add8 = OpArithmeticFenceEXT %double8 %add8
+   %vec8_res = OpFSub %double8 %fenced_add8 %big8
+ %vec8_res_0 = OpCompositeExtract %double %vec8_res 0
+ %vec8_res_1 = OpCompositeExtract %double %vec8_res 1
+ %vec8_res_2 = OpCompositeExtract %double %vec8_res 2
+ %vec8_res_3 = OpCompositeExtract %double %vec8_res 3
+ %vec8_res_4 = OpCompositeExtract %double %vec8_res 4
+ %vec8_res_5 = OpCompositeExtract %double %vec8_res 5
+ %vec8_res_6 = OpCompositeExtract %double %vec8_res 6
+ %vec8_res_7 = OpCompositeExtract %double %vec8_res 7
+  %vec8_sum0 = OpFAdd %double %vec8_res_0 %vec8_res_1
+  %vec8_sum1 = OpFAdd %double %vec8_sum0 %vec8_res_2
+  %vec8_sum2 = OpFAdd %double %vec8_sum1 %vec8_res_3
+  %vec8_sum3 = OpFAdd %double %vec8_sum2 %vec8_res_4
+  %vec8_sum4 = OpFAdd %double %vec8_sum3 %vec8_res_5
+  %vec8_sum5 = OpFAdd %double %vec8_sum4 %vec8_res_6
+   %vec8_sum = OpFAdd %double %vec8_sum5 %vec8_res_7
+
+; Vec16 arithmetic fence:
+      %big16 = OpCompositeConstruct %double16 %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big
+    %small16 = OpCompositeConstruct %double16 %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small
+      %add16 = OpFAdd %double16 %big16 %small16
+%fenced_add16 = OpArithmeticFenceEXT %double16 %add16
+  %vec16_res = OpFSub %double16 %fenced_add16 %big16
+%vec16_res_0 = OpCompositeExtract %double %vec16_res 0
+%vec16_res_1 = OpCompositeExtract %double %vec16_res 1
+%vec16_res_2 = OpCompositeExtract %double %vec16_res 2
+%vec16_res_3 = OpCompositeExtract %double %vec16_res 3
+%vec16_res_4 = OpCompositeExtract %double %vec16_res 4
+%vec16_res_5 = OpCompositeExtract %double %vec16_res 5
+%vec16_res_6 = OpCompositeExtract %double %vec16_res 6
+%vec16_res_7 = OpCompositeExtract %double %vec16_res 7
+%vec16_res_8 = OpCompositeExtract %double %vec16_res 8
+%vec16_res_9 = OpCompositeExtract %double %vec16_res 9
+%vec16_res_a = OpCompositeExtract %double %vec16_res 10
+%vec16_res_b = OpCompositeExtract %double %vec16_res 11
+%vec16_res_c = OpCompositeExtract %double %vec16_res 12
+%vec16_res_d = OpCompositeExtract %double %vec16_res 13
+%vec16_res_e = OpCompositeExtract %double %vec16_res 14
+%vec16_res_f = OpCompositeExtract %double %vec16_res 15
+ %vec16_sum0 = OpFAdd %double %vec16_res_0 %vec16_res_1
+ %vec16_sum1 = OpFAdd %double %vec16_sum0 %vec16_res_2
+ %vec16_sum2 = OpFAdd %double %vec16_sum1 %vec16_res_3
+ %vec16_sum3 = OpFAdd %double %vec16_sum2 %vec16_res_4
+ %vec16_sum4 = OpFAdd %double %vec16_sum3 %vec16_res_5
+ %vec16_sum5 = OpFAdd %double %vec16_sum4 %vec16_res_6
+ %vec16_sum6 = OpFAdd %double %vec16_sum5 %vec16_res_7
+ %vec16_sum7 = OpFAdd %double %vec16_sum6 %vec16_res_8
+ %vec16_sum8 = OpFAdd %double %vec16_sum7 %vec16_res_9
+ %vec16_sum9 = OpFAdd %double %vec16_sum8 %vec16_res_a
+ %vec16_suma = OpFAdd %double %vec16_sum9 %vec16_res_b
+ %vec16_sumb = OpFAdd %double %vec16_suma %vec16_res_c
+ %vec16_sumc = OpFAdd %double %vec16_sumb %vec16_res_d
+ %vec16_sumd = OpFAdd %double %vec16_sumc %vec16_res_e
+  %vec16_sum = OpFAdd %double %vec16_sumd %vec16_res_f
+
+; Add up the results and store:
+       %res0 = OpFAdd %double %scalar_res %vec2_sum
+       %res1 = OpFAdd %double %res0 %vec3_sum
+       %res2 = OpFAdd %double %res1 %vec4_sum
+       %res3 = OpFAdd %double %res2 %vec8_sum
+        %res = OpFAdd %double %res3 %vec16_sum
+               OpStore %dst %res Aligned 4
+
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_float.spvasm64
@@ -1,0 +1,148 @@
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Vector16
+               OpCapability ArithmeticFenceEXT
+               OpExtension "SPV_EXT_arithmetic_fence"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test_ext_arithmetic_fence_float"
+               OpDecorate %add FPFastMathMode Fast
+               OpDecorate %scalar_res FPFastMathMode Fast
+               OpDecorate %add2 FPFastMathMode Fast
+               OpDecorate %vec2_res FPFastMathMode Fast
+               OpDecorate %add3 FPFastMathMode Fast
+               OpDecorate %vec3_res FPFastMathMode Fast
+               OpDecorate %add4 FPFastMathMode Fast
+               OpDecorate %vec4_res FPFastMathMode Fast
+               OpDecorate %add8 FPFastMathMode Fast
+               OpDecorate %vec8_res FPFastMathMode Fast
+               OpDecorate %add16 FPFastMathMode Fast
+               OpDecorate %vec16_res FPFastMathMode Fast
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+     %float2 = OpTypeVector %float 2
+     %float3 = OpTypeVector %float 3
+     %float4 = OpTypeVector %float 4
+     %float8 = OpTypeVector %float 8
+    %float16 = OpTypeVector %float 16
+%gptr_float = OpTypePointer CrossWorkgroup %float
+ %kernel_sig = OpTypeFunction %void %gptr_float %float %float
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %gptr_float
+        %big = OpFunctionParameter %float
+      %small = OpFunctionParameter %float
+      %entry = OpLabel
+; Note: without the arithmetic fence, most compilers will reassociated the
+; expression "big + small - big" to "big - big + small" and therefore just
+; "small".  The arithmetic fence prevents this reassociation.
+
+; Scalar arithmetic fence:
+        %add = OpFAdd %float %big %small
+ %fenced_add = OpArithmeticFenceEXT %float %add
+ %scalar_res = OpFSub %float %fenced_add %big
+
+; Vec2 arithmetic fence:
+       %big2 = OpCompositeConstruct %float2 %big %big
+     %small2 = OpCompositeConstruct %float2 %small %small
+       %add2 = OpFAdd %float2 %big2 %small2
+%fenced_add2 = OpArithmeticFenceEXT %float2 %add2
+   %vec2_res = OpFSub %float2 %fenced_add2 %big2
+ %vec2_res_0 = OpCompositeExtract %float %vec2_res 0
+ %vec2_res_1 = OpCompositeExtract %float %vec2_res 1
+   %vec2_sum = OpFAdd %float %vec2_res_0 %vec2_res_1
+
+; Vec3 arithmetic fence:
+       %big3 = OpCompositeConstruct %float3 %big %big %big
+     %small3 = OpCompositeConstruct %float3 %small %small %small
+       %add3 = OpFAdd %float3 %big3 %small3
+%fenced_add3 = OpArithmeticFenceEXT %float3 %add3
+   %vec3_res = OpFSub %float3 %fenced_add3 %big3
+ %vec3_res_0 = OpCompositeExtract %float %vec3_res 0
+ %vec3_res_1 = OpCompositeExtract %float %vec3_res 1
+ %vec3_res_2 = OpCompositeExtract %float %vec3_res 2
+  %vec3_sum0 = OpFAdd %float %vec3_res_0 %vec3_res_1
+   %vec3_sum = OpFAdd %float %vec3_sum0 %vec3_res_2
+
+; Vec4 arithmetic fence:
+       %big4 = OpCompositeConstruct %float4 %big %big %big %big
+     %small4 = OpCompositeConstruct %float4 %small %small %small %small
+       %add4 = OpFAdd %float4 %big4 %small4
+%fenced_add4 = OpArithmeticFenceEXT %float4 %add4
+   %vec4_res = OpFSub %float4 %fenced_add4 %big4
+ %vec4_res_0 = OpCompositeExtract %float %vec4_res 0
+ %vec4_res_1 = OpCompositeExtract %float %vec4_res 1
+ %vec4_res_2 = OpCompositeExtract %float %vec4_res 2
+ %vec4_res_3 = OpCompositeExtract %float %vec4_res 3
+  %vec4_sum0 = OpFAdd %float %vec4_res_0 %vec4_res_1
+  %vec4_sum1 = OpFAdd %float %vec4_sum0 %vec4_res_2
+   %vec4_sum = OpFAdd %float %vec4_sum1 %vec4_res_3
+
+; Vec8 arithmetic fence:
+       %big8 = OpCompositeConstruct %float8 %big %big %big %big %big %big %big %big
+     %small8 = OpCompositeConstruct %float8 %small %small %small %small %small %small %small %small
+       %add8 = OpFAdd %float8 %big8 %small8
+%fenced_add8 = OpArithmeticFenceEXT %float8 %add8
+   %vec8_res = OpFSub %float8 %fenced_add8 %big8
+ %vec8_res_0 = OpCompositeExtract %float %vec8_res 0
+ %vec8_res_1 = OpCompositeExtract %float %vec8_res 1
+ %vec8_res_2 = OpCompositeExtract %float %vec8_res 2
+ %vec8_res_3 = OpCompositeExtract %float %vec8_res 3
+ %vec8_res_4 = OpCompositeExtract %float %vec8_res 4
+ %vec8_res_5 = OpCompositeExtract %float %vec8_res 5
+ %vec8_res_6 = OpCompositeExtract %float %vec8_res 6
+ %vec8_res_7 = OpCompositeExtract %float %vec8_res 7
+  %vec8_sum0 = OpFAdd %float %vec8_res_0 %vec8_res_1
+  %vec8_sum1 = OpFAdd %float %vec8_sum0 %vec8_res_2
+  %vec8_sum2 = OpFAdd %float %vec8_sum1 %vec8_res_3
+  %vec8_sum3 = OpFAdd %float %vec8_sum2 %vec8_res_4
+  %vec8_sum4 = OpFAdd %float %vec8_sum3 %vec8_res_5
+  %vec8_sum5 = OpFAdd %float %vec8_sum4 %vec8_res_6
+   %vec8_sum = OpFAdd %float %vec8_sum5 %vec8_res_7
+
+; Vec16 arithmetic fence:
+      %big16 = OpCompositeConstruct %float16 %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big
+    %small16 = OpCompositeConstruct %float16 %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small
+      %add16 = OpFAdd %float16 %big16 %small16
+%fenced_add16 = OpArithmeticFenceEXT %float16 %add16
+  %vec16_res = OpFSub %float16 %fenced_add16 %big16
+%vec16_res_0 = OpCompositeExtract %float %vec16_res 0
+%vec16_res_1 = OpCompositeExtract %float %vec16_res 1
+%vec16_res_2 = OpCompositeExtract %float %vec16_res 2
+%vec16_res_3 = OpCompositeExtract %float %vec16_res 3
+%vec16_res_4 = OpCompositeExtract %float %vec16_res 4
+%vec16_res_5 = OpCompositeExtract %float %vec16_res 5
+%vec16_res_6 = OpCompositeExtract %float %vec16_res 6
+%vec16_res_7 = OpCompositeExtract %float %vec16_res 7
+%vec16_res_8 = OpCompositeExtract %float %vec16_res 8
+%vec16_res_9 = OpCompositeExtract %float %vec16_res 9
+%vec16_res_a = OpCompositeExtract %float %vec16_res 10
+%vec16_res_b = OpCompositeExtract %float %vec16_res 11
+%vec16_res_c = OpCompositeExtract %float %vec16_res 12
+%vec16_res_d = OpCompositeExtract %float %vec16_res 13
+%vec16_res_e = OpCompositeExtract %float %vec16_res 14
+%vec16_res_f = OpCompositeExtract %float %vec16_res 15
+ %vec16_sum0 = OpFAdd %float %vec16_res_0 %vec16_res_1
+ %vec16_sum1 = OpFAdd %float %vec16_sum0 %vec16_res_2
+ %vec16_sum2 = OpFAdd %float %vec16_sum1 %vec16_res_3
+ %vec16_sum3 = OpFAdd %float %vec16_sum2 %vec16_res_4
+ %vec16_sum4 = OpFAdd %float %vec16_sum3 %vec16_res_5
+ %vec16_sum5 = OpFAdd %float %vec16_sum4 %vec16_res_6
+ %vec16_sum6 = OpFAdd %float %vec16_sum5 %vec16_res_7
+ %vec16_sum7 = OpFAdd %float %vec16_sum6 %vec16_res_8
+ %vec16_sum8 = OpFAdd %float %vec16_sum7 %vec16_res_9
+ %vec16_sum9 = OpFAdd %float %vec16_sum8 %vec16_res_a
+ %vec16_suma = OpFAdd %float %vec16_sum9 %vec16_res_b
+ %vec16_sumb = OpFAdd %float %vec16_suma %vec16_res_c
+ %vec16_sumc = OpFAdd %float %vec16_sumb %vec16_res_d
+ %vec16_sumd = OpFAdd %float %vec16_sumc %vec16_res_e
+  %vec16_sum = OpFAdd %float %vec16_sumd %vec16_res_f
+
+; Add up the results and store:
+       %res0 = OpFAdd %float %scalar_res %vec2_sum
+       %res1 = OpFAdd %float %res0 %vec3_sum
+       %res2 = OpFAdd %float %res1 %vec4_sum
+       %res3 = OpFAdd %float %res2 %vec8_sum
+        %res = OpFAdd %float %res3 %vec16_sum
+               OpStore %dst %res Aligned 4
+
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/ext_arithmetic_fence_half.spvasm64
@@ -1,0 +1,153 @@
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Vector16
+               OpCapability Float16
+               OpCapability ArithmeticFenceEXT
+               OpExtension "SPV_EXT_arithmetic_fence"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test_ext_arithmetic_fence_half"
+               OpDecorate %add FPFastMathMode Fast
+               OpDecorate %scalar_res FPFastMathMode Fast
+               OpDecorate %add2 FPFastMathMode Fast
+               OpDecorate %vec2_res FPFastMathMode Fast
+               OpDecorate %add3 FPFastMathMode Fast
+               OpDecorate %vec3_res FPFastMathMode Fast
+               OpDecorate %add4 FPFastMathMode Fast
+               OpDecorate %vec4_res FPFastMathMode Fast
+               OpDecorate %add8 FPFastMathMode Fast
+               OpDecorate %vec8_res FPFastMathMode Fast
+               OpDecorate %add16 FPFastMathMode Fast
+               OpDecorate %vec16_res FPFastMathMode Fast
+       %void = OpTypeVoid
+       %half = OpTypeFloat 16
+      %half2 = OpTypeVector %half 2
+      %half3 = OpTypeVector %half 3
+      %half4 = OpTypeVector %half 4
+      %half8 = OpTypeVector %half 8
+     %half16 = OpTypeVector %half 16
+      %float = OpTypeFloat 32
+  %gptr_half = OpTypePointer CrossWorkgroup %float
+ %kernel_sig = OpTypeFunction %void %gptr_half %float %float
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %gptr_half
+       %fbig = OpFunctionParameter %float
+     %fsmall = OpFunctionParameter %float
+      %entry = OpLabel
+        %big = OpFConvert %half %fbig
+      %small = OpFConvert %half %fsmall
+; Note: without the arithmetic fence, most compilers will reassociated the
+; expression "big + small - big" to "big - big + small" and therefore just
+; "small".  The arithmetic fence prevents this reassociation.
+
+; Scalar arithmetic fence:
+        %add = OpFAdd %half %big %small
+ %fenced_add = OpArithmeticFenceEXT %half %add
+ %scalar_res = OpFSub %half %fenced_add %big
+
+; Vec2 arithmetic fence:
+       %big2 = OpCompositeConstruct %half2 %big %big
+     %small2 = OpCompositeConstruct %half2 %small %small
+       %add2 = OpFAdd %half2 %big2 %small2
+%fenced_add2 = OpArithmeticFenceEXT %half2 %add2
+   %vec2_res = OpFSub %half2 %fenced_add2 %big2
+ %vec2_res_0 = OpCompositeExtract %half %vec2_res 0
+ %vec2_res_1 = OpCompositeExtract %half %vec2_res 1
+   %vec2_sum = OpFAdd %half %vec2_res_0 %vec2_res_1
+
+; Vec3 arithmetic fence:
+       %big3 = OpCompositeConstruct %half3 %big %big %big
+     %small3 = OpCompositeConstruct %half3 %small %small %small
+       %add3 = OpFAdd %half3 %big3 %small3
+%fenced_add3 = OpArithmeticFenceEXT %half3 %add3
+   %vec3_res = OpFSub %half3 %fenced_add3 %big3
+ %vec3_res_0 = OpCompositeExtract %half %vec3_res 0
+ %vec3_res_1 = OpCompositeExtract %half %vec3_res 1
+ %vec3_res_2 = OpCompositeExtract %half %vec3_res 2
+  %vec3_sum0 = OpFAdd %half %vec3_res_0 %vec3_res_1
+   %vec3_sum = OpFAdd %half %vec3_sum0 %vec3_res_2
+
+; Vec4 arithmetic fence:
+       %big4 = OpCompositeConstruct %half4 %big %big %big %big
+     %small4 = OpCompositeConstruct %half4 %small %small %small %small
+       %add4 = OpFAdd %half4 %big4 %small4
+%fenced_add4 = OpArithmeticFenceEXT %half4 %add4
+   %vec4_res = OpFSub %half4 %fenced_add4 %big4
+ %vec4_res_0 = OpCompositeExtract %half %vec4_res 0
+ %vec4_res_1 = OpCompositeExtract %half %vec4_res 1
+ %vec4_res_2 = OpCompositeExtract %half %vec4_res 2
+ %vec4_res_3 = OpCompositeExtract %half %vec4_res 3
+  %vec4_sum0 = OpFAdd %half %vec4_res_0 %vec4_res_1
+  %vec4_sum1 = OpFAdd %half %vec4_sum0 %vec4_res_2
+   %vec4_sum = OpFAdd %half %vec4_sum1 %vec4_res_3
+
+; Vec8 arithmetic fence:
+       %big8 = OpCompositeConstruct %half8 %big %big %big %big %big %big %big %big
+     %small8 = OpCompositeConstruct %half8 %small %small %small %small %small %small %small %small
+       %add8 = OpFAdd %half8 %big8 %small8
+%fenced_add8 = OpArithmeticFenceEXT %half8 %add8
+   %vec8_res = OpFSub %half8 %fenced_add8 %big8
+ %vec8_res_0 = OpCompositeExtract %half %vec8_res 0
+ %vec8_res_1 = OpCompositeExtract %half %vec8_res 1
+ %vec8_res_2 = OpCompositeExtract %half %vec8_res 2
+ %vec8_res_3 = OpCompositeExtract %half %vec8_res 3
+ %vec8_res_4 = OpCompositeExtract %half %vec8_res 4
+ %vec8_res_5 = OpCompositeExtract %half %vec8_res 5
+ %vec8_res_6 = OpCompositeExtract %half %vec8_res 6
+ %vec8_res_7 = OpCompositeExtract %half %vec8_res 7
+  %vec8_sum0 = OpFAdd %half %vec8_res_0 %vec8_res_1
+  %vec8_sum1 = OpFAdd %half %vec8_sum0 %vec8_res_2
+  %vec8_sum2 = OpFAdd %half %vec8_sum1 %vec8_res_3
+  %vec8_sum3 = OpFAdd %half %vec8_sum2 %vec8_res_4
+  %vec8_sum4 = OpFAdd %half %vec8_sum3 %vec8_res_5
+  %vec8_sum5 = OpFAdd %half %vec8_sum4 %vec8_res_6
+   %vec8_sum = OpFAdd %half %vec8_sum5 %vec8_res_7
+
+; Vec16 arithmetic fence:
+      %big16 = OpCompositeConstruct %half16 %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big %big
+    %small16 = OpCompositeConstruct %half16 %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small %small
+      %add16 = OpFAdd %half16 %big16 %small16
+%fenced_add16 = OpArithmeticFenceEXT %half16 %add16
+  %vec16_res = OpFSub %half16 %fenced_add16 %big16
+%vec16_res_0 = OpCompositeExtract %half %vec16_res 0
+%vec16_res_1 = OpCompositeExtract %half %vec16_res 1
+%vec16_res_2 = OpCompositeExtract %half %vec16_res 2
+%vec16_res_3 = OpCompositeExtract %half %vec16_res 3
+%vec16_res_4 = OpCompositeExtract %half %vec16_res 4
+%vec16_res_5 = OpCompositeExtract %half %vec16_res 5
+%vec16_res_6 = OpCompositeExtract %half %vec16_res 6
+%vec16_res_7 = OpCompositeExtract %half %vec16_res 7
+%vec16_res_8 = OpCompositeExtract %half %vec16_res 8
+%vec16_res_9 = OpCompositeExtract %half %vec16_res 9
+%vec16_res_a = OpCompositeExtract %half %vec16_res 10
+%vec16_res_b = OpCompositeExtract %half %vec16_res 11
+%vec16_res_c = OpCompositeExtract %half %vec16_res 12
+%vec16_res_d = OpCompositeExtract %half %vec16_res 13
+%vec16_res_e = OpCompositeExtract %half %vec16_res 14
+%vec16_res_f = OpCompositeExtract %half %vec16_res 15
+ %vec16_sum0 = OpFAdd %half %vec16_res_0 %vec16_res_1
+ %vec16_sum1 = OpFAdd %half %vec16_sum0 %vec16_res_2
+ %vec16_sum2 = OpFAdd %half %vec16_sum1 %vec16_res_3
+ %vec16_sum3 = OpFAdd %half %vec16_sum2 %vec16_res_4
+ %vec16_sum4 = OpFAdd %half %vec16_sum3 %vec16_res_5
+ %vec16_sum5 = OpFAdd %half %vec16_sum4 %vec16_res_6
+ %vec16_sum6 = OpFAdd %half %vec16_sum5 %vec16_res_7
+ %vec16_sum7 = OpFAdd %half %vec16_sum6 %vec16_res_8
+ %vec16_sum8 = OpFAdd %half %vec16_sum7 %vec16_res_9
+ %vec16_sum9 = OpFAdd %half %vec16_sum8 %vec16_res_a
+ %vec16_suma = OpFAdd %half %vec16_sum9 %vec16_res_b
+ %vec16_sumb = OpFAdd %half %vec16_suma %vec16_res_c
+ %vec16_sumc = OpFAdd %half %vec16_sumb %vec16_res_d
+ %vec16_sumd = OpFAdd %half %vec16_sumc %vec16_res_e
+  %vec16_sum = OpFAdd %half %vec16_sumd %vec16_res_f
+
+; Add up the results and store:
+       %res0 = OpFAdd %half %scalar_res %vec2_sum
+       %res1 = OpFAdd %half %res0 %vec3_sum
+       %res2 = OpFAdd %half %res1 %vec4_sum
+       %res3 = OpFAdd %half %res2 %vec8_sum
+        %res = OpFAdd %half %res3 %vec16_sum
+       %fres = OpFConvert %float %res
+               OpStore %dst %fres Aligned 4
+
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/testBase.h
+++ b/test_conformance/spirv_new/testBase.h
@@ -38,4 +38,9 @@
     #undef min
 #endif
 
+// Some Windows headers also define small
+#if defined(small)
+#undef small
+#endif
+
 #endif // _testBase_h

--- a/test_conformance/spirv_new/test_op_arithmetic_fence.cpp
+++ b/test_conformance/spirv_new/test_op_arithmetic_fence.cpp
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2025 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testBase.h"
+
+template <typename T> struct TestInfo
+{
+};
+template <> struct TestInfo<cl_half>
+{
+    // Note: for the half test, we will still pass floats as the kernel
+    // arguments, and we will convert from float <-> half in the kernel.
+    using argType = cl_float;
+    static constexpr const char* typeName = "half";
+    static constexpr const char* filename = "ext_arithmetic_fence_half";
+    static constexpr const char* testName = "test_ext_arithmetic_fence_half";
+    static constexpr argType big = 65000.0f;
+    static constexpr argType small = 1e-3f;
+};
+template <> struct TestInfo<cl_float>
+{
+    using argType = cl_float;
+    static constexpr const char* typeName = "float";
+    static constexpr const char* filename = "ext_arithmetic_fence_float";
+    static constexpr const char* testName = "test_ext_arithmetic_fence_float";
+    static constexpr argType big = 1e20f;
+    static constexpr argType small = 1e-3f;
+};
+template <> struct TestInfo<cl_double>
+{
+    using argType = cl_double;
+    static constexpr const char* typeName = "double";
+    static constexpr const char* filename = "ext_arithmetic_fence_double";
+    static constexpr const char* testName = "test_ext_arithmetic_fence_double";
+    static constexpr argType big = 1e200;
+    static constexpr argType small = 1e-30;
+};
+
+
+template <typename T>
+int arithmetic_fence_helper(cl_context context, cl_device_id device,
+                            cl_command_queue queue)
+{
+    using ArgType = typename TestInfo<T>::argType;
+
+    log_info("    testing type %s\n", TestInfo<T>::typeName);
+
+    cl_int error = CL_SUCCESS;
+
+    clProgramWrapper prog;
+    error = get_program_with_il(prog, device, context, TestInfo<T>::filename);
+    test_error(error, "Unable to build SPIR-V program");
+
+    clKernelWrapper kernel =
+        clCreateKernel(prog, TestInfo<T>::testName, &error);
+    test_error(error, "Unable to create SPIR-V kernel");
+
+    clMemWrapper dst =
+        clCreateBuffer(context, 0, sizeof(ArgType), NULL, &error);
+    test_error(error, "Unable to create destination buffer");
+
+    const auto big = TestInfo<T>::big;
+    const auto small = TestInfo<T>::small;
+
+    error |= clSetKernelArg(kernel, 0, sizeof(dst), &dst);
+    error |= clSetKernelArg(kernel, 1, sizeof(big), &big);
+    error |= clSetKernelArg(kernel, 2, sizeof(small), &small);
+    test_error(error, "Unable to set kernel arguments");
+
+    size_t global = 1;
+    error = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0,
+                                   NULL, NULL);
+    test_error(error, "Unable to enqueue kernel");
+
+    ArgType value = TestInfo<T>::big;
+    error = clEnqueueReadBuffer(queue, dst, CL_TRUE, 0, sizeof(value), &value,
+                                0, NULL, NULL);
+    test_error(error, "Unable to read destination buffer");
+
+    // The read back value should be zero.  If it is not, then the arithmetic
+    // fence is probably ignored.
+    test_assert_error(value == 0, "read value is incorrect");
+
+    return TEST_PASS;
+}
+
+REGISTER_TEST(op_arithmetic_fence)
+{
+    if (false)
+    {
+        log_info("SPV_EXT_arithmetic_fence is not supported; skipping test.\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    int result = TEST_PASS;
+
+    if (is_extension_available(device, "cl_khr_fp16"))
+    {
+        result |= arithmetic_fence_helper<cl_half>(context, device, queue);
+    }
+    result |= arithmetic_fence_helper<cl_float>(context, device, queue);
+    if (is_extension_available(device, "cl_khr_fp64"))
+    {
+        result |= arithmetic_fence_helper<cl_double>(context, device, queue);
+    }
+
+    return result;
+}


### PR DESCRIPTION
This PR includes initial testing for the SPV_EXT_arithmetic_fence extension.

This test works by performing the calculation `big + small - big`, where `big` is a large floating-point number and `small` is a small floating-point number.  Both the add and the subtract have the `FPFastMathMode=Fast` decoration, so absent any arithmetic fences, many implementations will reassociate this calculation to `big - big + small`, and further optimize it to just `small`.

The test puts an arithmetic fence around `big + small`, so the calculation is actually `arithmetic_fence(big + small) - big`.  Since the arithmetic fence blocks reassociation, and there is not enough precision to represent `big + small`, with the artihmetic fence the calculation must produce `0`.  If any of the calculations produce a nonzero result, then the arithmetic fence is probably ignored, and the test fails.

There are separate test cases for fp32, fp64, and fp16 arithmetic fences, depending on the floating-point types supported by the device.  Each test case tests the arithmetic fence on scalars and all supported vector sizes.

I'll keep this PR as a draft while we work out how to check whether the SPV_EXT_arithmetic_fence extension is supported.