### PR TITLE
printf: Fix printf 'mixed_format_random'

### DIFF
--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -247,7 +247,7 @@ cl_program makeMixedFormatPrintfProgram(cl_kernel* kernel_ptr,
     };
 
     std::array<std::vector<std::string>, 2> formats = {
-        { { "%f", "%e", "%g", "%a", "%F", "%E", "%G", "%A" },
+        { { "%f", "%e", "%g", "%13a", "%F", "%E", "%G", "%13A" },
           { "%d", "%i", "%u", "%x", "%o", "%X" } }
     };
     std::vector<char> data_before(2 + genrand_int32(gMTdata) % 8);


### PR DESCRIPTION
%a or %A with printf on MSVC platforms have a default precision of 13, which is in contrast to OpenCL C specification for printf which only allows for exact digits required if precision is not specified.