### PR TITLE
fix profiling profiling_timebase

### DIFF
--- a/test_conformance/profiling/profiling_timebase.cpp
+++ b/test_conformance/profiling/profiling_timebase.cpp
@@ -51,8 +51,9 @@ REGISTER_TEST(profiling_timebase)
     err = clGetDeviceAndHostTimer(device, &deviceTimeBeforeQueue, &hostTime);
     test_error(err, "Unable to get starting device time");
 
-    err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, NULL, NULL, 1, &uEvent,
-                                 &kEvent);
+    size_t global_size = 1;
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size, NULL, 1,
+                                 &uEvent, &kEvent);
     test_error(err, "clEnqueueNDRangeKernel failed");
 
     cl_ulong deviceTimeAfterQueue;


### PR DESCRIPTION
Use explicit work_group_size of 1

Fix #2240