### PR TITLE
fix negative_create_command_buffer_not_supported_properties test

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -225,7 +225,7 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
         }
 
         // If we can't find multiple supported flags, still set a bitfield but
-        // expect CL_INVALID_PROPERTY to be returned on creation.
+        // expect CL_INVALID_VALUE to be returned on creation.
         if (num_flags_set < 2)
         {
             flags = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR
@@ -246,8 +246,8 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
         else
         {
             test_failure_error_ret(
-                error, CL_INVALID_PROPERTY,
-                "clCreateCommandBufferKHR should return CL_INVALID_PROPERTY",
+                error, CL_INVALID_VALUE,
+                "clCreateCommandBufferKHR should return CL_INVALID_VALUE",
                 TEST_FAIL);
         }
 

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -210,7 +210,8 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
             num_flags_set++;
         }
 
-        if (device_side_enqueue_support)
+        if (is_extension_available(
+                device, CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME))
         {
             flags |= CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR;
             num_flags_set++;

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.cpp
@@ -198,8 +198,6 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
     cl_int Run() override
     {
         cl_command_buffer_properties_khr flags = 0;
-        size_t num_flags_set = 0;
-        bool multi_flags_supported = true;
         cl_int error = CL_SUCCESS;
 
         // First try to find multiple flags that are supported by the driver and
@@ -207,31 +205,18 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
         if (simultaneous_use_support)
         {
             flags |= CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
-            num_flags_set++;
         }
 
         if (is_extension_available(
                 device, CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME))
         {
             flags |= CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR;
-            num_flags_set++;
         }
 
         if (is_extension_available(
                 device, CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME))
         {
             flags |= CL_COMMAND_BUFFER_MUTABLE_KHR;
-            num_flags_set++;
-        }
-
-        // If we can't find multiple supported flags, still set a bitfield but
-        // expect CL_INVALID_VALUE to be returned on creation.
-        if (num_flags_set < 2)
-        {
-            flags = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR
-                | CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR;
-
-            multi_flags_supported = false;
         }
 
         cl_command_buffer_properties_khr props[] = {
@@ -239,17 +224,7 @@ struct MultiFlagCreationTest : public BasicCommandBufferTest
         };
 
         command_buffer = clCreateCommandBufferKHR(1, &queue, props, &error);
-        if (multi_flags_supported)
-        {
-            test_error(error, "clCreateCommandBufferKHR failed");
-        }
-        else
-        {
-            test_failure_error_ret(
-                error, CL_INVALID_VALUE,
-                "clCreateCommandBufferKHR should return CL_INVALID_VALUE",
-                TEST_FAIL);
-        }
+        test_error(error, "clCreateCommandBufferKHR failed");
 
         return CL_SUCCESS;
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -190,11 +190,6 @@ struct CreateCommandBufferNotSupportedProperties : public BasicCommandBufferTest
             unsupported_prop = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
             skip = false;
         }
-        else if (!device_side_enqueue_support)
-        {
-            unsupported_prop = CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR;
-            skip = false;
-        }
 
         return skip;
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_create.cpp
@@ -137,7 +137,8 @@ struct CreateCommandBufferRepeatedProperties : public BasicCommandBufferTest
             rep_prop = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
             skip = false;
         }
-        else if (device_side_enqueue_support)
+        else if (is_extension_available(
+                     device, CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME))
         {
             rep_prop = CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR;
             skip = false;


### PR DESCRIPTION
fixes #2247 

* For the `negative_create_command_buffer_not_supported_properties` test, the only property we can check for is simultaneous use.  All other properties are part of other extensions and hence will generate `CL_INVALID_VALUE`, not `CL_INVALID_PROPERTY`.
* Checks whether the `cl_khr_command_buffer_multi_device` extension is supported when using `CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR`, instead of `device_side_enqueue_support`.
* If the `cl_khr_command_buffer_multi_device` extension is NOT supported and the `CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR` command buffer creation flag is used, the expected error code is `CL_INVALID_VALUE`, not `CL_INVALID_PROPERTY`.
