### PR TITLE
basic: fix size_t Wformat warnings

### DIFF
--- a/test_conformance/basic/test_async_copy2D.cpp
+++ b/test_conformance/basic/test_async_copy2D.cpp
@@ -120,7 +120,7 @@ int test_copy2D(const cl_device_id deviceID, const cl_context context,
 {
     int error;
 
-    log_info("Testing %d byte element with srcMargin = %d, dstMargin = %d\n",
+    log_info("Testing %zu byte element with srcMargin = %d, dstMargin = %d\n",
              elementSize, srcMargin, dstMargin);
 
     cl_long max_local_mem_size;
@@ -235,8 +235,8 @@ int test_copy2D(const cl_device_id deviceID, const cl_context context,
 
     if ((localBufferSize / 4) > max_work_group_size)
     {
-        log_info("Skipping due to resource requirements local:%db  "
-                 "max_work_group_size:%d\n",
+        log_info("Skipping due to resource requirements local:%zub  "
+                 "max_work_group_size:%zu\n",
                  localBufferSize, max_work_group_size);
         return 0;
     }

--- a/test_conformance/basic/test_async_copy3D.cpp
+++ b/test_conformance/basic/test_async_copy3D.cpp
@@ -133,7 +133,7 @@ int test_copy3D(const cl_device_id deviceID, const cl_context context,
     int error;
 
     log_info(
-        "Testing %d byte element with srcLineMargin = %d, dstLineMargin = %d, "
+        "Testing %zu byte element with srcLineMargin = %d, dstLineMargin = %d, "
         "srcPlaneMargin = %d, dstPlaneMargin = %d\n",
         elementSize, srcLineMargin, dstLineMargin, srcPlaneMargin,
         dstPlaneMargin);
@@ -255,8 +255,8 @@ int test_copy3D(const cl_device_id deviceID, const cl_context context,
 
     if ((localBufferSize / 4) > max_work_group_size)
     {
-        log_info("Skipping due to resource requirements local:%db  "
-                 "max_work_group_size:%d\n",
+        log_info("Skipping due to resource requirements local:%zub  "
+                 "max_work_group_size:%zu\n",
                  localBufferSize, max_work_group_size);
         return 0;
     }

--- a/test_conformance/basic/test_bufferreadwriterect.cpp
+++ b/test_conformance/basic/test_bufferreadwriterect.cpp
@@ -72,7 +72,7 @@ static void initialize_image(BufferType* ptr, size_t w, size_t h, size_t d, MTda
 
 // This function prints the contents of a buffer to standard error.
 void print_buffer(BufferType* buf, size_t w, size_t h, size_t d) {
-    log_error("Size = %lux%lux%lu (%lu total)\n",w,h,d,w*h*d);
+    log_error("Size = %zux%zux%zu (%zu total)\n", w, h, d, w * h * d);
     for (unsigned k=0; k!=d;++k) {
         log_error("Slice: %u\n",k);
         for (unsigned j=0; j!=h;++j) {
@@ -218,7 +218,9 @@ int verify_region(BufferType* device, size_t src, size_t soffset[3], size_t sreg
         size_t d_idx = (doffset[2]+sz)*dslice + (doffset[1]+sy)*dpitch + doffset[0]+sx;
 
         if (device[d_idx] != verify[src][s_idx]) {
-            log_error("Verify failed on comparsion %lu: coordinate (%lu, %lu, %lu) of region\n",i,sx,sy,sz);
+            log_error("Verify failed on comparsion %zu: coordinate (%zu, %zu, "
+                      "%zu) of region\n",
+                      i, sx, sy, sz);
             log_error("0x%02x != 0x%02x\n", device[d_idx], verify[src][s_idx]);
 #if 0
             // Uncomment this section to print buffers.
@@ -369,7 +371,7 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
         max_mem_alloc_dim = max_mem_alloc_size;
     }
 
-    log_info("Using maximum dimension      = %lu.\n", max_mem_alloc_dim);
+    log_info("Using maximum dimension      = %zu.\n", max_mem_alloc_dim);
 
     // Create pairs of cl buffers and host buffers on which operations will be mirrored.
     log_info("Creating %u pairs of random sized host and cl buffers.\n", TotalImages);
@@ -392,7 +394,8 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
 
         // Check to see if adequately sized buffers were found.
         if (tries >= max_tries) {
-            log_error("Error: Could not find random buffer sized less than %llu bytes in %lu tries.\n",
+            log_error("Error: Could not find random buffer sized less than "
+                      "%llu bytes in %zu tries.\n",
                       max_mem_alloc_size, max_tries);
             return -1;
         }
@@ -401,10 +404,11 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
         max_size = (size_bytes > max_size) ? size_bytes : max_size;
         total_bytes += size_bytes;
 
-        log_info("Buffer[%u] is (%lu,%lu,%lu) = %lu MB (truncated)\n",i,width[i],height[i],depth[i],(size_bytes)/1048576);
+        log_info("Buffer[%u] is (%zu,%zu,%zu) = %zu MB (truncated)\n", i,
+                 width[i], height[i], depth[i], (size_bytes) / 1048576);
     }
 
-    log_info( "Total size: %lu MB (truncated)\n", total_bytes/1048576 );
+    log_info("Total size: %zu MB (truncated)\n", total_bytes / 1048576);
 
     // Allocate a temporary buffer for read and write operations.
     tmp_buffer_size  = max_size;
@@ -491,32 +495,32 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
 
         switch (operation) {
             case 0:
-                log_info("%lu Copy %lu offset (%lu,%lu,%lu) -> %lu offset (%lu,%lu,%lu) region (%lux%lux%lu = %lu)\n",
-                         iter,
-                         src, soffset[0], soffset[1], soffset[2],
-                         dst, doffset[0], doffset[1], doffset[2],
-                         sregion[0], sregion[1], sregion[2],
-                         sregion[0]*sregion[1]*sregion[2]);
+                log_info("%zu Copy %zu offset (%zu,%zu,%zu) -> %zu offset "
+                         "(%zu,%zu,%zu) region (%zux%zux%zu = %zu)\n",
+                         iter, src, soffset[0], soffset[1], soffset[2], dst,
+                         doffset[0], doffset[1], doffset[2], sregion[0],
+                         sregion[1], sregion[2],
+                         sregion[0] * sregion[1] * sregion[2]);
                 if ((err = copy_region(src, soffset, sregion, dst, doffset, dregion)))
                     return err;
                 break;
             case 1:
-                log_info("%lu Read %lu offset (%lu,%lu,%lu) -> %lu offset (%lu,%lu,%lu) region (%lux%lux%lu = %lu)\n",
-                         iter,
-                         src, soffset[0], soffset[1], soffset[2],
-                         dst, doffset[0], doffset[1], doffset[2],
-                         sregion[0], sregion[1], sregion[2],
-                         sregion[0]*sregion[1]*sregion[2]);
+                log_info("%zu Read %zu offset (%zu,%zu,%zu) -> %zu offset "
+                         "(%zu,%zu,%zu) region (%zux%zux%zu = %zu)\n",
+                         iter, src, soffset[0], soffset[1], soffset[2], dst,
+                         doffset[0], doffset[1], doffset[2], sregion[0],
+                         sregion[1], sregion[2],
+                         sregion[0] * sregion[1] * sregion[2]);
                 if ((err = read_verify_region(src, soffset, sregion, dst, doffset, dregion)))
                     return err;
                 break;
             case 2:
-                log_info("%lu Write %lu offset (%lu,%lu,%lu) -> %lu offset (%lu,%lu,%lu) region (%lux%lux%lu = %lu)\n",
-                         iter,
-                         src, soffset[0], soffset[1], soffset[2],
-                         dst, doffset[0], doffset[1], doffset[2],
-                         sregion[0], sregion[1], sregion[2],
-                         sregion[0]*sregion[1]*sregion[2]);
+                log_info("%zu Write %zu offset (%zu,%zu,%zu) -> %zu offset "
+                         "(%zu,%zu,%zu) region (%zux%zux%zu = %zu)\n",
+                         iter, src, soffset[0], soffset[1], soffset[2], dst,
+                         doffset[0], doffset[1], doffset[2], sregion[0],
+                         sregion[1], sregion[2],
+                         sregion[0] * sregion[1] * sregion[2]);
                 if ((err = write_region(src, soffset, sregion, dst, doffset, dregion)))
                     return err;
                 break;
@@ -526,11 +530,11 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
         // Uncomment this section to verify each operation.
         // If commented out, verification won't occur until the end of the
         // test, and it will not be possible to determine which operation failed.
-        log_info("Verify src %lu offset (%u,%u,%u) region (%lux%lux%lu)\n", src, 0, 0, 0, width[src], height[src], depth[src]);
+        log_info("Verify src %zu offset (%u,%u,%u) region (%zux%zux%zu)\n", src, 0, 0, 0, width[src], height[src], depth[src]);
         if (err = map_verify_region(src))
             return err;
 
-        log_info("Verify dst %lu offset (%u,%u,%u) region (%lux%lux%lu)\n", dst, 0, 0, 0, width[dst], height[dst], depth[dst]);
+        log_info("Verify dst %zu offset (%u,%u,%u) region (%zux%zux%zu)\n", dst, 0, 0, 0, width[dst], height[dst], depth[dst]);
         if (err = map_verify_region(dst))
             return err;
 
@@ -540,7 +544,8 @@ test_bufferreadwriterect(cl_device_id device, cl_context context, cl_command_que
     } // end main for loop.
 
     for (unsigned i=0;i<TotalImages;++i) {
-        log_info("Verify %u offset (%u,%u,%u) region (%lux%lux%lu)\n", i, 0, 0, 0, width[i], height[i], depth[i]);
+        log_info("Verify %u offset (%u,%u,%u) region (%zux%zux%zu)\n", i, 0, 0,
+                 0, width[i], height[i], depth[i]);
         if ((err = map_verify_region(i)))
             return err;
     }

--- a/test_conformance/basic/test_constant.cpp
+++ b/test_conformance/basic/test_constant.cpp
@@ -140,8 +140,8 @@ int test_constant(cl_device_id device, cl_context context,
 
 
     log_info(
-        "Test will attempt to use %lu bytes with one %lu byte constant int "
-        "buffer and one %lu byte constant float buffer.\n",
+        "Test will attempt to use %zu bytes with one %zu byte constant int "
+        "buffer and one %zu byte constant float buffer.\n",
         constant_values * sizeof(cl_int) + constant_values * sizeof(cl_float),
         constant_values * sizeof(cl_int), constant_values * sizeof(cl_float));
 

--- a/test_conformance/basic/test_global_work_offsets.cpp
+++ b/test_conformance/basic/test_global_work_offsets.cpp
@@ -36,11 +36,12 @@ const char *work_offset_test[] = {
 #define NUM_TESTS 16
 #define MAX_OFFSET 256
 
-#define CHECK_RANGE( v, m, c ) \
-    if( ( v >= (cl_int)m ) || ( v < 0 ) ) \
-    {    \
-        log_error( "ERROR: ouputID_%c[%lu]: %d is < 0 or >= %lu\n", c, i, v, m ); \
-        return -1;    \
+#define CHECK_RANGE(v, m, c)                                                   \
+    if ((v >= (cl_int)m) || (v < 0))                                           \
+    {                                                                          \
+        log_error("ERROR: ouputID_%c[%zu]: %d is < 0 or >= %zu\n", c, i, v,    \
+                  m);                                                          \
+        return -1;                                                             \
     }
 
 int check_results( size_t threads[], size_t offsets[], cl_int outputA[], cl_int outputB[], cl_int outputC[] )
@@ -76,13 +77,17 @@ int check_results( size_t threads[], size_t offsets[], cl_int outputA[], cl_int 
                     if( counts[ x ][ y ][ z ] < 1 )
                     {
                         if( missed < 3 )
-                            log_error( "ERROR: Map value (%ld,%ld,%ld) was missed%s\n", x, y, z, ( missed == 2 ) ? limitMsg : "" );
+                            log_error(
+                                "ERROR: Map value (%zu,%zu,%zu) was missed%s\n",
+                                x, y, z, (missed == 2) ? limitMsg : "");
                         missed++;
                     }
                     else if( counts[ x ][ y ][ z ] > 1 )
                     {
                         if( multiple < 3 )
-                            log_error( "ERROR: Map value (%ld,%ld,%ld) was returned multiple times%s\n", x, y, z, ( multiple == 2 ) ? limitMsg : "" );
+                            log_error("ERROR: Map value (%zu,%zu,%zu) was "
+                                      "returned multiple times%s\n",
+                                      x, y, z, (multiple == 2) ? limitMsg : "");
                         multiple++;
                     }
                 }
@@ -91,7 +96,9 @@ int check_results( size_t threads[], size_t offsets[], cl_int outputA[], cl_int 
                     if( counts[ x ][ y ][ z ] > 0 )
                     {
                         if( errored < 3 )
-                            log_error( "ERROR: Map value (%ld,%ld,%ld) was erroneously returned%s\n", x, y, z, ( errored == 2 ) ? limitMsg : "" );
+                            log_error("ERROR: Map value (%zu,%zu,%zu) was "
+                                      "erroneously returned%s\n",
+                                      x, y, z, (errored == 2) ? limitMsg : "");
                         errored++;
                     }
                 }
@@ -161,9 +168,11 @@ int test_global_work_offsets(cl_device_id deviceID, cl_context context, cl_comma
         for( int j = 0; j < 3; j++ )
             offsets[ j ] = random_in_range( 0, MAX_OFFSET, seed );
 
-        log_info( "\tTesting %ld,%ld,%ld (%ld,%ld,%ld) with offsets (%ld,%ld,%ld)...\n",
-                 threads[ 0 ], threads[ 1 ], threads[ 2 ], localThreads[ 0 ], localThreads[ 1 ], localThreads[ 2 ],
-                 offsets[ 0 ], offsets[ 1 ], offsets[ 2 ] );
+        log_info("\tTesting %zu,%zu,%zu (%zu,%zu,%zu) with offsets "
+                 "(%zu,%zu,%zu)...\n",
+                 threads[0], threads[1], threads[2], localThreads[0],
+                 localThreads[1], localThreads[2], offsets[0], offsets[1],
+                 offsets[2]);
 
         // Now set up and run
         for( int i = 0; i < 3; i++ )
@@ -187,9 +196,11 @@ int test_global_work_offsets(cl_device_id deviceID, cl_context context, cl_comma
         // but they won't be in order, so we need to construct a count map to determine what we got
         if( check_results( threads, offsets, outputA, outputB, outputC ) )
         {
-            log_error( "\t(Test failed for global dim %ld,%ld,%ld, local dim %ld,%ld,%ld, offsets %ld,%ld,%ld)\n",
-                      threads[ 0 ], threads[ 1 ], threads[ 2 ], localThreads[ 0 ], localThreads[ 1 ], localThreads[ 2 ],
-                      offsets[ 0 ], offsets[ 1 ], offsets[ 2 ] );
+            log_error("\t(Test failed for global dim %zu,%zu,%zu, local dim "
+                      "%zu,%zu,%zu, offsets %zu,%zu,%zu)\n",
+                      threads[0], threads[1], threads[2], localThreads[0],
+                      localThreads[1], localThreads[2], offsets[0], offsets[1],
+                      offsets[2]);
             return -1;
         }
     }
@@ -252,9 +263,11 @@ int test_get_global_offset(cl_device_id deviceID, cl_context context, cl_command
         for( int j = 0; j < 3; j++ )
             offsets[ j ] = random_in_range( 0, MAX_OFFSET, seed );
 
-        log_info( "\tTesting %ld,%ld,%ld (%ld,%ld,%ld) with offsets (%ld,%ld,%ld)...\n",
-                 threads[ 0 ], threads[ 1 ], threads[ 2 ], localThreads[ 0 ], localThreads[ 1 ], localThreads[ 2 ],
-                 offsets[ 0 ], offsets[ 1 ], offsets[ 2 ] );
+        log_info("\tTesting %zu,%zu,%zu (%zu,%zu,%zu) with offsets "
+                 "(%zu,%zu,%zu)...\n",
+                 threads[0], threads[1], threads[2], localThreads[0],
+                 localThreads[1], localThreads[2], offsets[0], offsets[1],
+                 offsets[2]);
 
         // Now set up and run
         error = clSetKernelArg( kernel, 0, sizeof( streams[0] ), &streams[0] );
@@ -273,7 +286,9 @@ int test_get_global_offset(cl_device_id deviceID, cl_context context, cl_command
         {
             if( outOffsets[ j ] != (cl_int)offsets[ j ] )
             {
-                log_error( "ERROR: get_global_offset( %d ) did not return expected value (expected %ld, got %d)\n", j, offsets[ j ], outOffsets[ j ] );
+                log_error("ERROR: get_global_offset( %d ) did not return "
+                          "expected value (expected %zu, got %d)\n",
+                          j, offsets[j], outOffsets[j]);
                 errors++;
             }
         }

--- a/test_conformance/basic/test_imagearraycopy.cpp
+++ b/test_conformance/basic/test_imagearraycopy.cpp
@@ -125,7 +125,7 @@ int test_imagearraycopy_single_format(cl_device_id device, cl_context context,
         {
             if (memcmp(&inchar[i], &outchar[i], elem_size) != 0)
             {
-                log_error("%d(0x%x) -> expected [", i, i);
+                log_error("%zu(0x%zx) -> expected [", i, i);
                 for (size_t j = 0; j < elem_size; j++)
                     log_error("0x%02x ", inchar[i + j]);
                 log_error("] != actual [");

--- a/test_conformance/basic/test_imagedim.cpp
+++ b/test_conformance/basic/test_imagedim.cpp
@@ -68,7 +68,7 @@ int get_max_image_dimensions(cl_device_id device, size_t &max_img_width,
                           nullptr);
     test_error(err, "clGetDeviceInfo for CL_DEVICE_IMAGE2D_MAX_HEIGHT failed");
 
-    log_info("Device reported max image sizes of %lu x %lu, and max mem size "
+    log_info("Device reported max image sizes of %zu x %zu, and max mem size "
              "of %gMB.\n",
              max_image2d_width, max_image2d_height,
              max_mem_size / (1024.0 * 1024.0));
@@ -98,7 +98,7 @@ int get_max_image_dimensions(cl_device_id device, size_t &max_img_width,
     max_img_width = std::min(max_image2d_width, max_img_dim);
     max_img_height = std::min(max_image2d_height, max_img_dim);
 
-    log_info("Adjusted maximum image size to test is %d x %d, which is a max "
+    log_info("Adjusted maximum image size to test is %zu x %zu, which is a max "
              "mem size of %gMB.\n",
              max_img_width, max_img_height,
              (max_img_width * max_img_height * 4) / (1024.0 * 1024.0));
@@ -147,12 +147,12 @@ int test_imagedim_common(cl_context context, cl_command_queue queue,
 
     size_t threads[] = { img_width, img_height };
     if (local_threads)
-        log_info(
-            "Testing image dimensions %d x %d with local threads %d x %d.\n",
-            img_width, img_height, local_threads[0], local_threads[1]);
+        log_info("Testing image dimensions %zu x %zu with local threads %zu x "
+                 "%zu.\n",
+                 img_width, img_height, local_threads[0], local_threads[1]);
     else
         log_info(
-            "Testing image dimensions %d x %d with local threads nullptr.\n",
+            "Testing image dimensions %zu x %zu with local threads nullptr.\n",
             img_width, img_height);
     err = clEnqueueNDRangeKernel(queue, kernel, 2, nullptr, threads,
                                  local_threads, 0, nullptr, nullptr);
@@ -165,8 +165,8 @@ int test_imagedim_common(cl_context context, cl_command_queue queue,
     if (0 != memcmp(input.data(), output.data(), 4 * img_width * img_height))
     {
         total_errors++;
-        log_error("Image Dimension test failed.  image width = %d, "
-                  "image height = %d\n",
+        log_error("Image Dimension test failed.  image width = %zu, "
+                  "image height = %zu\n",
                   img_width, img_height);
     }
     return total_errors;

--- a/test_conformance/basic/test_local.cpp
+++ b/test_conformance/basic/test_local.cpp
@@ -198,8 +198,8 @@ int test_local_arg_def(cl_device_id device, cl_context context, cl_command_queue
 
   // Adjust the local thread size to fit and be a nice multiple.
   if (kwgsize < wgsize) {
-    log_info("Adjusting wgsize down from %lu to %lu.\n", wgsize, kwgsize);
-        local_threads[0] = kwgsize;
+      log_info("Adjusting wgsize down from %zu to %zu.\n", wgsize, kwgsize);
+      local_threads[0] = kwgsize;
   }
   while (global_threads[0] % local_threads[0] != 0)
     local_threads[0]--;
@@ -331,8 +331,8 @@ int test_local_kernel_def(cl_device_id device, cl_context context, cl_command_qu
 
   // Adjust the local thread size to fit and be a nice multiple.
   if (kwgsize < wgsize) {
-    log_info("Adjusting wgsize down from %lu to %lu.\n", wgsize, kwgsize);
-        local_threads[0] = kwgsize;
+      log_info("Adjusting wgsize down from %zu to %zu.\n", wgsize, kwgsize);
+      local_threads[0] = kwgsize;
   }
   while (global_threads[0] % local_threads[0] != 0)
     local_threads[0]--;

--- a/test_conformance/basic/test_local_kernel_scope.cpp
+++ b/test_conformance/basic/test_local_kernel_scope.cpp
@@ -82,7 +82,8 @@ int test_local_kernel_scope(cl_device_id device, cl_context context, cl_command_
     while( testSize < 1024 )
         testSize += workGroupSize;
     size_t numGroups = testSize / workGroupSize;
-    log_info( "\tTesting with %ld groups, %ld elements per group...\n", numGroups, workGroupSize );
+    log_info("\tTesting with %zu groups, %zu elements per group...\n",
+             numGroups, workGroupSize);
 
     // Create two buffers for operation
     cl_uint *inputData = (cl_uint*)malloc( testSize * sizeof(cl_uint) );
@@ -124,7 +125,9 @@ int test_local_kernel_scope(cl_device_id device, cl_context context, cl_command_
 
         if( outputData[ i ] != localMax )
         {
-            log_error( "ERROR: Local max validation failed! (expected %u, got %u for i=%lu)\n", localMax, outputData[ i ] , i );
+            log_error("ERROR: Local max validation failed! (expected %u, got "
+                      "%u for i=%zu)\n",
+                      localMax, outputData[i], i);
             free(inputData);
             free(outputData);
             return -1;

--- a/test_conformance/basic/test_simple_image_pitch.cpp
+++ b/test_conformance/basic/test_simple_image_pitch.cpp
@@ -69,12 +69,14 @@ int test_simple_read_image_pitch(cl_device_id device, cl_context cl_context_, cl
     for (size_t i=0;i<bufferW;++i) {
       char val = host_buffer[j*bufferW+i];
       if ((i<imageW*pixel_bytes) && (val != 0x1)) {
-        log_error("Bad value %x in image at (byte: %lu, row: %lu)\n",val,i,j);
-        ++errors;
+          log_error("Bad value %x in image at (byte: %zu, row: %zu)\n", val, i,
+                    j);
+          ++errors;
       }
       else if ((i>=imageW*pixel_bytes) && (val != 0xa)) {
-        log_error("Bad value %x outside image at (byte: %lu, row: %lu)\n",val,i,j);
-        ++errors;
+          log_error("Bad value %x outside image at (byte: %zu, row: %zu)\n",
+                    val, i, j);
+          ++errors;
       }
     }
   }
@@ -136,8 +138,9 @@ int test_simple_write_image_pitch(cl_device_id device, cl_context cl_context_, c
     for (size_t i=0;i<mapped_pitch;++i) {
       char val = mapped_image[j*mapped_pitch+i];
       if ((i<imageW*pixel_bytes) && (val != 0xa)) {
-        log_error("Bad value %x in image at (byte: %lu, row: %lu)\n",val,i,j);
-        ++errors;
+          log_error("Bad value %x in image at (byte: %zu, row: %zu)\n", val, i,
+                    j);
+          ++errors;
       }
     }
   }

--- a/test_conformance/basic/test_sizeof.cpp
+++ b/test_conformance/basic/test_sizeof.cpp
@@ -189,7 +189,7 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
             }
 
             char name[32];
-            sprintf( name, "%s%ld", vector_table[i].name, j );
+            sprintf(name, "%s%zu", vector_table[i].name, j);
 
             test = CL_ULONG_MAX;
             err = get_type_size( context, queue, name, &test, device  );
@@ -197,12 +197,16 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
                 return err;
             if( test != j * vector_table[i].size )
             {
-                log_error( "\nFAILED: Type %s has size %lld, but expected size %lld!\n", name, test, j * vector_table[i].size );
+                log_error(
+                    "\nFAILED: Type %s has size %lld, but expected size %zu!\n",
+                    name, test, j * vector_table[i].size);
                 return -1;
             }
             if( test != j * vector_table[i].cl_size )
             {
-                log_error( "\nFAILED: Type %s has size %lld, but cl_ size is %lld!\n", name, test, j * vector_table[i].cl_size );
+                log_error(
+                    "\nFAILED: Type %s has size %lld, but cl_ size is %zu!\n",
+                    name, test, j * vector_table[i].cl_size);
                 return -2;
             }
             log_info( "%16s", name );
@@ -317,7 +321,7 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
         for( j = 2; j <= 16; j *= 2 )
         {
             char name[32];
-            sprintf( name, "double%ld", j );
+            sprintf(name, "double%zu", j);
 
             test = CL_ULONG_MAX;
             err = get_type_size( context, queue, name, &test, device );
@@ -325,7 +329,8 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
                 return err;
             if( test != 8*j )
             {
-                log_error( "\nFAILED: %s has size %lld, but must be %ld!\n", name, test, 8 * j);
+                log_error("\nFAILED: %s has size %lld, but must be %zu!\n",
+                          name, test, 8 * j);
                 return -1;
             }
             log_info( "%16s", name );
@@ -352,7 +357,7 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
         for( j = 2; j <= 16; j *= 2 )
         {
             char name[32];
-            sprintf( name, "half%ld", j );
+            sprintf(name, "half%zu", j);
 
             test = CL_ULONG_MAX;
             err = get_type_size( context, queue, name, &test, device );
@@ -360,7 +365,8 @@ int test_sizeof(cl_device_id device, cl_context context, cl_command_queue queue,
                 return err;
             if( test != 2*j )
             {
-                log_error( "\nFAILED: %s has size %lld, but must be %ld!\n", name, test, 2 * j);
+                log_error("\nFAILED: %s has size %lld, but must be %zu!\n",
+                          name, test, 2 * j);
                 return -1;
             }
             log_info( "%16s", name );


### PR DESCRIPTION
Printing of a `size_t` requires the `%zu` specifier.