### PR TITLE
bugfix nan test for basic fpmath

### DIFF
--- a/test_conformance/basic/test_fpmath.cpp
+++ b/test_conformance/basic/test_fpmath.cpp
@@ -110,6 +110,7 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
             both_nan = std::isnan(r) && std::isnan(output[i]);
         }
 
+        // If not both nan, check if the result is the same
         if (!both_nan && (r != output[i]))
         {
             log_error("FP math test for type: %s, vec size: %zu, failed at "

--- a/test_conformance/basic/test_fpmath.cpp
+++ b/test_conformance/basic/test_fpmath.cpp
@@ -98,14 +98,19 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
     auto &inB = input[1];
     for (size_t i = 0; i < output.size(); i++)
     {
-        bool nan_test = true;
-
         T r = test.ref(inA[i], inB[i]);
+        bool both_nan = false;
 
         if (std::is_same<T, cl_half>::value)
-            nan_test = (isHalfNan(r) != isHalfNan(output[i]));
+        {
+            both_nan = isHalfNan(r) && isHalfNan(output[i]);
+        }
+        else if (std::is_floating_point<T>::value)
+        {
+            both_nan = std::isnan(r) && std::isnan(output[i]);
+        }
 
-        if (r != output[i] && !nan_test)
+        if (!both_nan && (r != output[i]))
         {
             log_error("FP math test for type: %s, vec size: %zu, failed at "
                       "index %zu, %a '%c' %a, expected %a, get %a\n",

--- a/test_conformance/basic/test_fpmath.cpp
+++ b/test_conformance/basic/test_fpmath.cpp
@@ -98,14 +98,14 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
     auto &inB = input[1];
     for (size_t i = 0; i < output.size(); i++)
     {
-        bool nan_test = false;
+        bool nan_test = true;
 
         T r = test.ref(inA[i], inB[i]);
 
         if (std::is_same<T, cl_half>::value)
-            nan_test = !(isHalfNan(r) && isHalfNan(output[i]));
+            nan_test = (isHalfNan(r) != isHalfNan(output[i]));
 
-        if (r != output[i] && nan_test)
+        if (r != output[i] && !nan_test)
         {
             log_error("FP math test for type: %s, vec size: %zu, failed at "
                       "index %zu, %a '%c' %a, expected %a, get %a\n",


### PR DESCRIPTION
This PR fixes the validation logic for cases where the data type is not half. Because the variable nan_test is always false, types like float never trigger a validation failure.