### PR TITLE
Fix signalling and waiting on semaphore from two queues

### DIFF
--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
@@ -266,6 +266,15 @@ struct SemaphoreOutOfOrderOps : public SemaphoreTestBase
         err = clEnqueueBarrierWithWaitList(consumer_queue, 0, nullptr, nullptr);
         test_error(err, " clEnqueueBarrierWithWaitList ");
 
+        if (!single_queue)
+        {
+            // Both producer and consumer queues run independently.
+            // A blocking call to clEnqueueReadBuffer in consumer_queue will not
+            // flush the producer queue.
+            err = clFinish(producer_queue);
+            test_error(err, "clFinish failed");
+        }
+
         std::vector<cl_int> host_buffer(num_elems, 0);
         auto verify_result = [&](const cl_mem &out_mem, const cl_int pattern) {
             err = clEnqueueReadBuffer(consumer_queue, out_mem, CL_TRUE, 0,


### PR DESCRIPTION
`semaphores_ooo_ops_cross_queue` uses two OOO command queues to run the test. In one queue, a semaphore is signalled and the semahpore is waited on in the other queue.

The CL specification requires the application to synchronize the queues if objects are shared.