### PR TITLE
Vulkan multiimport diffctx fix

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -1133,14 +1133,14 @@ int run_test_with_multi_import_diff_ctx(
                                 deviceId, false);
         CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore, vkCl2VkSemaphore,
                                 context, vkExternalSemaphoreHandleType,
-                                deviceId, false);
+                                deviceId, true);
 
         CREATE_OPENCL_SEMAPHORE(clVk2CLExternalSemaphore2, vkVk2CLSemaphore,
                                 context2, vkExternalSemaphoreHandleType,
                                 deviceId, false);
         CREATE_OPENCL_SEMAPHORE(clCl2VkExternalSemaphore2, vkCl2VkSemaphore,
                                 context2, vkExternalSemaphoreHandleType,
-                                deviceId, false);
+                                deviceId, true);
     }
 
     const uint32_t maxIter = innerIterations;


### PR DESCRIPTION
The multi import diff ctx portion of the Vulkan test mistakenly instantiates clExternalImportableSemaphore objects as wrappers for semaphores that will be exported (vkCl2VkSemaphore). This change corrects this and mirrors the correct behavior found in the multi import same ctx test. 