### PR TITLE
spirv_new: print build log in get_program_with_il

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -555,6 +555,39 @@ float Ulp_Error_Double(double test, long double reference)
     return result;
 }
 
+cl_int OutputBuildLog(cl_program program, const cl_device_id device)
+{
+    size_t size_ret;
+
+    // Get the build status
+    cl_build_status build_status;
+    cl_int error =
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_STATUS,
+                              sizeof(build_status), &build_status, &size_ret);
+    test_error(error, "Unable to query build status");
+
+    // If the build failed then print the status, obtain the build log and
+    // print it.
+    if (build_status != CL_BUILD_SUCCESS)
+    {
+        log_error("ERROR: CL_PROGRAM_BUILD_STATUS=%d\n", (int)build_status);
+        error = clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0,
+                                      nullptr, &size_ret);
+        test_error(error, "Unable to query build log size");
+
+        char *build_log = (char *)malloc(size_ret);
+        error = clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG,
+                                      size_ret, build_log, &size_ret);
+        test_error(error, "Unable to query build log");
+
+        log_error("ERROR: CL_PROGRAM_BUILD_LOG:\n%s\n", build_log);
+
+        free(build_log);
+    }
+
+    return CL_SUCCESS;
+}
+
 cl_int OutputBuildLogs(cl_program program, cl_uint num_devices,
                        cl_device_id *device_list)
 {
@@ -594,33 +627,8 @@ cl_int OutputBuildLogs(cl_program program, cl_uint num_devices,
         unsigned int i;
         for (i = 0; i < num_devices; i++)
         {
-
-            // Get the build status
-            cl_build_status build_status;
-            error = clGetProgramBuildInfo(
-                program, device_list[i], CL_PROGRAM_BUILD_STATUS,
-                sizeof(build_status), &build_status, &size_ret);
-            test_error(error, "Unable to query build status");
-
-            // If the build failed then log the status, and allocate the build
-            // log, log it and free it
-            if (build_status != CL_BUILD_SUCCESS)
-            {
-
-                log_error("ERROR: CL_PROGRAM_BUILD_STATUS=%d\n",
-                          (int)build_status);
-                error = clGetProgramBuildInfo(program, device_list[i],
-                                              CL_PROGRAM_BUILD_LOG, 0, NULL,
-                                              &size_ret);
-                test_error(error, "Unable to query build log size");
-                char *build_log = (char *)malloc(size_ret);
-                error = clGetProgramBuildInfo(program, device_list[i],
-                                              CL_PROGRAM_BUILD_LOG, size_ret,
-                                              build_log, &size_ret);
-                test_error(error, "Unable to query build log");
-                log_error("ERROR: CL_PROGRAM_BUILD_LOG:\n%s\n", build_log);
-                free(build_log);
-            }
+            error = OutputBuildLog(program, device_list[i]);
+            test_error(error, "OutputBuildLog failed");
         }
 
         // Was the number of devices given

--- a/test_common/harness/errorHelpers.h
+++ b/test_common/harness/errorHelpers.h
@@ -198,6 +198,7 @@ extern const char *GetQueuePropertyName(cl_command_queue_properties properties);
 
 extern const char *GetDeviceTypeName(cl_device_type type);
 bool check_functions_for_offline_compiler(const char *subtestname);
+cl_int OutputBuildLog(cl_program program, const cl_device_id device);
 cl_int OutputBuildLogs(cl_program program, cl_uint num_devices,
                        cl_device_id *device_list);
 

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -172,7 +172,12 @@ int get_program_with_il(clProgramWrapper &prog, const cl_device_id deviceID,
     }
 
     err = clBuildProgram(prog, 1, &deviceID, NULL, NULL, NULL);
-    SPIRV_CHECK_ERROR(err, "Failed to build program");
+    if (err != CL_SUCCESS)
+    {
+        cl_int outputErr = OutputBuildLog(prog, deviceID);
+        SPIRV_CHECK_ERROR(outputErr, "OutputBuildLog failed");
+        return err;
+    }
 
     return err;
 }


### PR DESCRIPTION
Print the build log when building the program in `get_program_with_il` fails, to make it easier to investigate spirv_new test failures.

Factor out a global helper function `OutputBuildLog` for printing the build log for a single device.