### PR TITLE
Report external sharing tests as skipped instead of failed when not supported

### DIFF
--- a/test_conformance/vulkan/vulkan_test_base.h
+++ b/test_conformance/vulkan/vulkan_test_base.h
@@ -43,15 +43,6 @@ struct VulkanTestBase
         vkDevice.reset(
             new VulkanDevice(getAssociatedVulkanPhysicalDevice(device)));
 
-        if (!(is_extension_available(device, "cl_khr_external_memory")
-              && is_extension_available(device, "cl_khr_external_semaphore")))
-        {
-            log_info("Device does not support cl_khr_external_memory "
-                     "or cl_khr_external_semaphore\n");
-            log_info(" TEST SKIPPED\n");
-            throw std::runtime_error("VulkanTestBase not supported");
-        }
-
         cl_platform_id platform;
         cl_int error = clGetDeviceInfo(device, CL_DEVICE_PLATFORM,
                                        sizeof(cl_platform_id), &platform, NULL);
@@ -101,6 +92,15 @@ template <class T>
 int MakeAndRunTest(cl_device_id device, cl_context context,
                    cl_command_queue queue, cl_int nelems)
 {
+    if (!(is_extension_available(device, "cl_khr_external_memory")
+          && is_extension_available(device, "cl_khr_external_semaphore")))
+    {
+        log_info("Device does not support cl_khr_external_memory "
+                 "or cl_khr_external_semaphore\n");
+        log_info(" TEST SKIPPED\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
     if (!checkVkSupport())
     {
         log_info("Vulkan supported GPU not found \n");


### PR DESCRIPTION
Throwing an exception in the constructor for VulkanTestBase was always reported as an error.