### PR TITLE
Refactor clCopyImage and clFillImage tests

### DIFF
--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -126,6 +126,7 @@ typedef struct
     const cl_image_format *format;
     cl_mem buffer;
     cl_mem_object_type type;
+    cl_mem_flags mem_flags;
     cl_uint num_mip_levels;
 } image_descriptor;
 

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -18,32 +18,41 @@
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
+                            image_descriptor *srcImageInfo,
+                            image_descriptor *dstImageInfo, MTdata d)
 {
   size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
   int ret = 0, retCode;
-    size_t src_lod = 0, src_width_lod = imageInfo->width, src_row_pitch_lod;
-    size_t dst_lod = 0, dst_width_lod = imageInfo->width, dst_row_pitch_lod;
-    size_t width_lod = imageInfo->width;
-    size_t max_mip_level = 0;
+  size_t src_lod = 0, src_width_lod = srcImageInfo->width, src_row_pitch_lod;
+  size_t dst_lod = 0, dst_width_lod = srcImageInfo->width, dst_row_pitch_lod;
+  size_t width_lod = srcImageInfo->width;
+  size_t max_mip_level = 0;
 
-    if( gTestMipmaps )
-    {
-        max_mip_level = imageInfo->num_mip_levels;
-        // Work at a random mip level
-        src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-        dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
-        width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
-        src_row_pitch_lod = src_width_lod * get_pixel_size( imageInfo->format );
-        dst_row_pitch_lod = dst_width_lod * get_pixel_size( imageInfo->format );
-    }
+  if (gTestMipmaps)
+  {
+      max_mip_level = srcImageInfo->num_mip_levels;
+      // Work at a random mip level
+      src_lod =
+          (size_t)random_in_range(0, max_mip_level ? max_mip_level - 1 : 0, d);
+      dst_lod =
+          (size_t)random_in_range(0, max_mip_level ? max_mip_level - 1 : 0, d);
+      src_width_lod = (srcImageInfo->width >> src_lod)
+          ? (srcImageInfo->width >> src_lod)
+          : 1;
+      dst_width_lod = (dstImageInfo->width >> dst_lod)
+          ? (dstImageInfo->width >> dst_lod)
+          : 1;
+      width_lod =
+          (src_width_lod > dst_width_lod) ? dst_width_lod : src_width_lod;
+      src_row_pitch_lod = src_width_lod * get_pixel_size(srcImageInfo->format);
+      dst_row_pitch_lod = dst_width_lod * get_pixel_size(dstImageInfo->format);
+  }
 
     // First, try just a full covering region
     sourcePos[ 0 ] = sourcePos[ 1 ] = sourcePos[ 2 ] = 0;
     destPos[ 0 ] = destPos[ 1 ] = destPos[ 2 ] = 0;
-    regionSize[ 0 ] = imageInfo->width;
+    regionSize[0] = dstImageInfo->width;
     regionSize[ 1 ] = 1;
     regionSize[ 2 ] = 1;
 
@@ -54,7 +63,9 @@ int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_d
         regionSize[ 0 ] = width_lod;
     }
 
-    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d);
     if( retCode < 0 )
       return retCode;
     else
@@ -68,8 +79,12 @@ int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_d
         // Work at a random mip level
         src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
         dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-        dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
+        src_width_lod = (srcImageInfo->width >> src_lod)
+            ? (srcImageInfo->width >> src_lod)
+            : 1;
+        dst_width_lod = (dstImageInfo->width >> dst_lod)
+            ? (dstImageInfo->width >> dst_lod)
+            : 1;
         width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
         sourcePos[ 1 ] = src_lod;
         destPos[ 1 ] = dst_lod;
@@ -83,7 +98,9 @@ int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_d
 
 
       // Go for it!
-      retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+      retCode =
+          test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                  sourcePos, destPos, regionSize, d);
       if( retCode < 0 )
         return retCode;
       else
@@ -93,18 +110,25 @@ int test_copy_image_size_1D( cl_context context, cl_command_queue queue, image_d
       return ret;
 }
 
-int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_copy_image_set_1D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_mem_flags src_flags,
+                           cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                           cl_mem_object_type dst_type, cl_image_format *format)
 {
+    assert(dst_type == src_type); // This test expects to copy 1D -> 1D images
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
-    image_descriptor imageInfo = { 0 };
+    image_descriptor srcImageInfo = { 0 };
+    image_descriptor dstImageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    imageInfo.format = format;
-    imageInfo.height = imageInfo.depth = imageInfo.arraySize = imageInfo.slicePitch = 0;
-    imageInfo.type = CL_MEM_OBJECT_IMAGE1D;
-    pixelSize = get_pixel_size( imageInfo.format );
+    srcImageInfo.format = format;
+    srcImageInfo.height = srcImageInfo.depth = srcImageInfo.arraySize =
+        srcImageInfo.slicePitch = 0;
+    srcImageInfo.type = src_type;
+    srcImageInfo.mem_flags = src_flags;
+    pixelSize = get_pixel_size(srcImageInfo.format);
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof( maxAllocSize ), &maxAllocSize, NULL );
@@ -118,28 +142,33 @@ int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_
 
     if( gTestSmallImages )
     {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
+        for (srcImageInfo.width = 1; srcImageInfo.width < 13;
+             srcImageInfo.width++)
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
-            if( gDebugTrace )
-                log_info( "   at size %d\n", (int)imageInfo.width );
+      if (gDebugTrace) log_info("   at size %d\n", (int)srcImageInfo.width);
 
-            int ret = test_copy_image_size_1D( context, queue, &imageInfo, seed );
-            if( ret )
-                return -1;
+      dstImageInfo = srcImageInfo;
+      dstImageInfo.mem_flags = dst_flags;
+      int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
+                                        &dstImageInfo, seed);
+      if (ret) return -1;
         }
     }
     else if( gTestMaxImages )
@@ -148,29 +177,37 @@ int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_
         size_t numbeOfSizes;
         size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D, imageInfo.format);
+        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1,
+                      maxAllocSize, memSize, src_type, srcImageInfo.format);
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.width = sizes[idx][0];
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if( test_copy_image_size_1D( context, queue, &imageInfo, seed ) )
+
+            dstImageInfo = srcImageInfo;
+            dstImageInfo.mem_flags = dst_flags;
+            if (test_copy_image_size_1D(context, queue, &srcImageInfo,
+                                        &dstImageInfo, seed))
                 return -1;
         }
     }
@@ -184,41 +221,52 @@ int test_copy_image_set_1D( cl_device_id device, cl_context context, cl_command_
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
             {
-                imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
+                srcImageInfo.width =
+                    (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
 
-        if (gTestMipmaps)
-        {
-          imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
-          imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-          size = compute_mipmapped_image_size( imageInfo );
-          size = size*4;
-        }
+                if (gTestMipmaps)
+                {
+                    srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                        2,
+                        (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                        seed);
+                    srcImageInfo.rowPitch = srcImageInfo.width
+                        * get_pixel_size(srcImageInfo.format);
+                    size = compute_mipmapped_image_size(srcImageInfo);
+                    size = size * 4;
+                }
         else
         {
-          imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-          if (gEnablePitch)
-          {
-            do {
-              rowPadding++;
-              imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-            } while ((imageInfo.rowPitch % pixelSize) != 0);
-          }
+            if (gEnablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
-          size = (size_t)imageInfo.rowPitch * 4;
+            size = (size_t)srcImageInfo.rowPitch * 4;
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
       {
-        log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-        if ( gTestMipmaps )
-            log_info("   and %u mip levels\n", imageInfo.num_mip_levels);
+          log_info("   at size %d (row pitch %d) out of %d\n",
+                   (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
+                   (int)maxWidth);
+          if (gTestMipmaps)
+              log_info("   and %zu mip levels\n",
+                       (size_t)srcImageInfo.num_mip_levels);
       }
-
-            int ret = test_copy_image_size_1D( context, queue, &imageInfo, seed );
-            if( ret )
-                return -1;
+      dstImageInfo = srcImageInfo;
+      dstImageInfo.mem_flags = dst_flags;
+      int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
+                                        &dstImageInfo, seed);
+      if (ret) return -1;
         }
     }
 

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -18,33 +18,41 @@
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
+                                  image_descriptor *srcImageInfo,
+                                  image_descriptor *dstImageInfo, MTdata d)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
-    size_t src_lod = 0, src_width_lod = imageInfo->width, src_row_pitch_lod;
-    size_t dst_lod = 0, dst_width_lod = imageInfo->width, dst_row_pitch_lod;
-    size_t width_lod = imageInfo->width;
+    size_t src_lod = 0, src_width_lod = srcImageInfo->width, src_row_pitch_lod;
+    size_t dst_lod = 0, dst_width_lod = dstImageInfo->width, dst_row_pitch_lod;
+    size_t width_lod = srcImageInfo->width;
     size_t max_mip_level = 0;
 
     if( gTestMipmaps )
     {
-        max_mip_level = imageInfo->num_mip_levels;
+        max_mip_level = srcImageInfo->num_mip_levels;
         // Work at a random mip level
         src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
         dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-        dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
+        src_width_lod = (srcImageInfo->width >> src_lod)
+            ? (srcImageInfo->width >> src_lod)
+            : 1;
+        dst_width_lod = (dstImageInfo->width >> dst_lod)
+            ? (dstImageInfo->width >> dst_lod)
+            : 1;
         width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
-        src_row_pitch_lod = src_width_lod * get_pixel_size( imageInfo->format );
-        dst_row_pitch_lod = dst_width_lod * get_pixel_size( imageInfo->format );
+        src_row_pitch_lod =
+            src_width_lod * get_pixel_size(srcImageInfo->format);
+        dst_row_pitch_lod =
+            dst_width_lod * get_pixel_size(dstImageInfo->format);
     }
 
     // First, try just a full covering region
     sourcePos[ 0 ] = sourcePos[ 1 ] = sourcePos[ 2 ] = 0;
     destPos[ 0 ] = destPos[ 1 ] = destPos[ 2 ] = 0;
-    regionSize[ 0 ] = imageInfo->width;
-    regionSize[ 1 ] = imageInfo->arraySize;
+    regionSize[0] = srcImageInfo->width;
+    regionSize[1] = srcImageInfo->arraySize;
     regionSize[ 2 ] = 1;
 
     if(gTestMipmaps)
@@ -54,7 +62,9 @@ int test_copy_image_size_1D_array( cl_context context, cl_command_queue queue, i
         regionSize[ 0 ] = width_lod;
     }
 
-    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d);
     if( retCode < 0 )
         return retCode;
     else
@@ -68,27 +78,41 @@ int test_copy_image_size_1D_array( cl_context context, cl_command_queue queue, i
             // Work at a random mip level
             src_lod = (size_t) ( max_mip_level > 1 )? random_in_range( 0,  max_mip_level - 1 , d ) : 0;
             dst_lod = (size_t) ( max_mip_level > 1 )? random_in_range( 0,  max_mip_level - 1 , d ) : 0;
-            src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-            dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
+            src_width_lod = (srcImageInfo->width >> src_lod)
+                ? (srcImageInfo->width >> src_lod)
+                : 1;
+            dst_width_lod = (dstImageInfo->width >> dst_lod)
+                ? (dstImageInfo->width >> dst_lod)
+                : 1;
             width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
             sourcePos[ 2 ] = src_lod;
             destPos[ 2 ] = dst_lod;
         }
         // Pick a random size
         regionSize[ 0 ] = ( width_lod > 8 ) ? (size_t)random_in_range( 8, (int)width_lod - 1, d ) : (int)width_lod;
-        regionSize[ 1 ] = ( imageInfo->arraySize > 8 ) ? (size_t)random_in_range( 8, (int)imageInfo->arraySize - 1, d ) : imageInfo->arraySize;
+        regionSize[1] = (srcImageInfo->arraySize > 8)
+            ? (size_t)random_in_range(8, (int)srcImageInfo->arraySize - 1, d)
+            : srcImageInfo->arraySize;
 
         // Now pick positions within valid ranges
         sourcePos[ 0 ] = ( width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
-        sourcePos[ 1 ] = ( imageInfo->arraySize > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - regionSize[ 1 ] - 1 ), d ) : 0;
+        sourcePos[1] = (srcImageInfo->arraySize > regionSize[1])
+            ? (size_t)random_in_range(
+                0, (int)(srcImageInfo->arraySize - regionSize[1] - 1), d)
+            : 0;
 
 
         destPos[ 0 ] = ( width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
-        destPos[ 1 ] = ( imageInfo->arraySize > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - regionSize[ 1 ] - 1 ), d ) : 0;
+        destPos[1] = (dstImageInfo->arraySize > regionSize[1])
+            ? (size_t)random_in_range(
+                0, (int)(dstImageInfo->arraySize - regionSize[1] - 1), d)
+            : 0;
 
 
         // Go for it!
-        retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+        retCode =
+            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                    sourcePos, destPos, regionSize, d);
         if( retCode < 0 )
             return retCode;
         else
@@ -98,17 +122,27 @@ int test_copy_image_size_1D_array( cl_context context, cl_command_queue queue, i
     return ret;
 }
 
-int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue, cl_mem_flags src_flags,
+                                 cl_mem_object_type src_type,
+                                 cl_mem_flags dst_flags,
+                                 cl_mem_object_type dst_type,
+                                 cl_image_format *format)
 {
+    assert(
+        dst_type
+        == src_type); // This test expects to copy 1D array -> 1D array images
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
-    image_descriptor imageInfo = { 0 };
+    image_descriptor srcImageInfo = { 0 };
+    image_descriptor dstImageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    imageInfo.format = format;
-    imageInfo.type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
-    pixelSize = get_pixel_size( imageInfo.format );
+    srcImageInfo.format = format;
+    srcImageInfo.type = src_type;
+    srcImageInfo.mem_flags = src_flags;
+    pixelSize = get_pixel_size(srcImageInfo.format);
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, sizeof( maxArraySize ), &maxArraySize, NULL );
@@ -123,33 +157,41 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_co
 
     if( gTestSmallImages )
     {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
+        for (srcImageInfo.width = 1; srcImageInfo.width < 13;
+             srcImageInfo.width++)
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
 
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
-            imageInfo.slicePitch = imageInfo.rowPitch;
-            for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
-            {
-                if( gDebugTrace )
-                    log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
+      srcImageInfo.slicePitch = srcImageInfo.rowPitch;
+      for (srcImageInfo.arraySize = 2; srcImageInfo.arraySize < 9;
+           srcImageInfo.arraySize++)
+      {
+          if (gDebugTrace)
+              log_info("   at size %d,%d\n", (int)srcImageInfo.width,
+                       (int)srcImageInfo.arraySize);
 
-                int ret = test_copy_image_size_1D_array( context, queue, &imageInfo, seed );
-                if( ret )
-                    return -1;
-            }
+          dstImageInfo = srcImageInfo;
+          dstImageInfo.mem_flags = dst_flags;
+          int ret = test_copy_image_size_1D_array(context, queue, &srcImageInfo,
+                                                  &dstImageInfo, seed);
+          if (ret) return -1;
+      }
         }
     }
     else if( gTestMaxImages )
@@ -158,33 +200,42 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_co
         size_t numbeOfSizes;
         size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, maxArraySize, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D_ARRAY, imageInfo.format);
+        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, maxArraySize,
+                      maxAllocSize, memSize, src_type, srcImageInfo.format);
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
 
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.arraySize = sizes[ idx ][ 2 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.width = sizes[idx][0];
+      srcImageInfo.arraySize = sizes[idx][2];
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
-            imageInfo.slicePitch = imageInfo.rowPitch;
-            log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if( gDebugTrace )
-                log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if( test_copy_image_size_1D_array( context, queue, &imageInfo, seed ) )
-                return -1;
+      srcImageInfo.slicePitch = srcImageInfo.rowPitch;
+      log_info("Testing %d x %d\n", (int)sizes[idx][0], (int)sizes[idx][2]);
+      if (gDebugTrace)
+          log_info("   at max size %d,%d\n", (int)sizes[idx][0],
+                   (int)sizes[idx][2]);
+
+      dstImageInfo = srcImageInfo;
+      dstImageInfo.mem_flags = dst_flags;
+      if (test_copy_image_size_1D_array(context, queue, &srcImageInfo,
+                                        &dstImageInfo, seed))
+          return -1;
         }
     }
     else
@@ -197,39 +248,55 @@ int test_copy_image_set_1D_array( cl_device_id device, cl_context context, cl_co
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
             {
-                imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
-                imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
-        imageInfo.height = imageInfo.depth = 0;
+                srcImageInfo.width =
+                    (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
+                srcImageInfo.arraySize = (size_t)random_log_in_range(
+                    16, (int)maxArraySize / 32, seed);
+                srcImageInfo.height = srcImageInfo.depth = 0;
 
-        if (gTestMipmaps)
-        {
-          imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
-          imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-          imageInfo.slicePitch = imageInfo.rowPitch;
-          size = compute_mipmapped_image_size( imageInfo );
-          size = size*4;
-        }
+                if (gTestMipmaps)
+                {
+                    srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                        2,
+                        (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                        seed);
+                    srcImageInfo.rowPitch = srcImageInfo.width
+                        * get_pixel_size(srcImageInfo.format);
+                    srcImageInfo.slicePitch = srcImageInfo.rowPitch;
+                    size = compute_mipmapped_image_size(srcImageInfo);
+                    size = size * 4;
+                }
         else
         {
-          imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-          if (gEnablePitch)
-          {
-            do {
-              rowPadding++;
-              imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-            } while ((imageInfo.rowPitch % pixelSize) != 0);
-          }
+            if (gEnablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
-          imageInfo.slicePitch = imageInfo.rowPitch;
+            srcImageInfo.slicePitch = srcImageInfo.rowPitch;
 
-          size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.arraySize * 4;
+            size = (size_t)srcImageInfo.rowPitch
+                * (size_t)srcImageInfo.arraySize * 4;
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
       if( gDebugTrace )
-        log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-      int ret = test_copy_image_size_1D_array( context, queue, &imageInfo, seed );
+          log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
+                   (int)srcImageInfo.width, (int)srcImageInfo.arraySize,
+                   (int)srcImageInfo.rowPitch, (int)maxWidth,
+                   (int)maxArraySize);
+
+      dstImageInfo = srcImageInfo;
+      dstImageInfo.mem_flags = dst_flags;
+      int ret = test_copy_image_size_1D_array(context, queue, &srcImageInfo,
+                                              &dstImageInfo, seed);
       if( ret )
         return -1;
     }

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -18,38 +18,50 @@
 extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
                                    const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
 
-int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, MTdata d )
+int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
+                            image_descriptor *srcImageInfo,
+                            image_descriptor *dstImageInfo, MTdata d)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
-    size_t src_lod = 0, src_width_lod = imageInfo->width, src_row_pitch_lod;
-    size_t src_height_lod = imageInfo->height;
-    size_t dst_lod = 0, dst_width_lod = imageInfo->width, dst_row_pitch_lod;
-    size_t dst_height_lod = imageInfo->height;
-    size_t width_lod = imageInfo->width, height_lod = imageInfo->height;
+    size_t src_lod = 0, src_width_lod = srcImageInfo->width, src_row_pitch_lod;
+    size_t src_height_lod = srcImageInfo->height;
+    size_t dst_lod = 0, dst_width_lod = dstImageInfo->width, dst_row_pitch_lod;
+    size_t dst_height_lod = dstImageInfo->height;
+    size_t width_lod = srcImageInfo->width, height_lod = srcImageInfo->height;
     size_t max_mip_level = 0;
 
     if( gTestMipmaps )
     {
-        max_mip_level = imageInfo->num_mip_levels;
+        max_mip_level = srcImageInfo->num_mip_levels;
         // Work at a random mip level
         src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
         dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-        dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
-        src_height_lod = ( imageInfo->height >> src_lod )? ( imageInfo->height >> src_lod ) : 1;
-        dst_height_lod = ( imageInfo->height >> dst_lod )? ( imageInfo->height >> dst_lod ) : 1;
+        src_width_lod = (srcImageInfo->width >> src_lod)
+            ? (srcImageInfo->width >> src_lod)
+            : 1;
+        dst_width_lod = (dstImageInfo->width >> dst_lod)
+            ? (dstImageInfo->width >> dst_lod)
+            : 1;
+        src_height_lod = (srcImageInfo->height >> src_lod)
+            ? (srcImageInfo->height >> src_lod)
+            : 1;
+        dst_height_lod = (dstImageInfo->height >> dst_lod)
+            ? (dstImageInfo->height >> dst_lod)
+            : 1;
         width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
         height_lod  = ( src_height_lod > dst_height_lod ) ? dst_height_lod : src_height_lod;
-        src_row_pitch_lod = src_width_lod * get_pixel_size( imageInfo->format );
-        dst_row_pitch_lod = dst_width_lod * get_pixel_size( imageInfo->format );
+        src_row_pitch_lod =
+            src_width_lod * get_pixel_size(srcImageInfo->format);
+        dst_row_pitch_lod =
+            dst_width_lod * get_pixel_size(srcImageInfo->format);
     }
 
     // First, try just a full covering region
     sourcePos[ 0 ] = sourcePos[ 1 ] = sourcePos[ 2 ] = 0;
     destPos[ 0 ] = destPos[ 1 ] = destPos[ 2 ] = 0;
-    regionSize[ 0 ] = imageInfo->width;
-    regionSize[ 1 ] = imageInfo->height;
+    regionSize[0] = srcImageInfo->width;
+    regionSize[1] = srcImageInfo->height;
     regionSize[ 2 ] = 1;
 
     if(gTestMipmaps)
@@ -60,7 +72,9 @@ int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_d
         regionSize[ 1 ] = height_lod;
     }
 
-    retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d);
     if( retCode < 0 )
         return retCode;
     else
@@ -74,10 +88,18 @@ int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_d
             // Work at a random mip level
             src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
             dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-            src_width_lod = ( imageInfo->width >> src_lod )? ( imageInfo->width >> src_lod ) : 1;
-            dst_width_lod = ( imageInfo->width >> dst_lod )? ( imageInfo->width >> dst_lod ) : 1;
-            src_height_lod = ( imageInfo->height >> src_lod )? ( imageInfo->height >> src_lod ) : 1;
-            dst_height_lod = ( imageInfo->height >> dst_lod )? ( imageInfo->height >> dst_lod ) : 1;
+            src_width_lod = (srcImageInfo->width >> src_lod)
+                ? (srcImageInfo->width >> src_lod)
+                : 1;
+            dst_width_lod = (dstImageInfo->width >> dst_lod)
+                ? (dstImageInfo->width >> dst_lod)
+                : 1;
+            src_height_lod = (srcImageInfo->height >> src_lod)
+                ? (srcImageInfo->height >> src_lod)
+                : 1;
+            dst_height_lod = (dstImageInfo->height >> dst_lod)
+                ? (dstImageInfo->height >> dst_lod)
+                : 1;
             width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
             height_lod  = ( src_height_lod > dst_height_lod ) ? dst_height_lod : src_height_lod;
             sourcePos[ 2 ] = src_lod;
@@ -95,7 +117,9 @@ int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_d
         destPos[ 1 ] = ( height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_copy_image_generic( context, queue, imageInfo, imageInfo, sourcePos, destPos, regionSize, d );
+        retCode =
+            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                    sourcePos, destPos, regionSize, d);
         if( retCode < 0 )
             return retCode;
         else
@@ -105,17 +129,23 @@ int test_copy_image_size_2D( cl_context context, cl_command_queue queue, image_d
     return ret;
 }
 
-int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format )
+int test_copy_image_set_2D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_mem_flags src_flags,
+                           cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                           cl_mem_object_type dst_type, cl_image_format *format)
 {
+    assert(dst_type == src_type); // This test expects to copy 2D -> 2D images
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
-    image_descriptor imageInfo = { 0 };
+    image_descriptor srcImageInfo = { 0 };
+    image_descriptor dstImageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    imageInfo.format = format;
-    imageInfo.type = CL_MEM_OBJECT_IMAGE2D;
-    pixelSize = get_pixel_size( imageInfo.format );
+    srcImageInfo.format = format;
+    srcImageInfo.type = src_type;
+    srcImageInfo.mem_flags = src_flags;
+    pixelSize = get_pixel_size(srcImageInfo.format);
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof( maxHeight ), &maxHeight, NULL );
@@ -130,32 +160,43 @@ int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_
 
     if( gTestSmallImages )
     {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
+        for (srcImageInfo.width = 1; srcImageInfo.width < 13;
+             srcImageInfo.width++)
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
 
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2,
+              (int)compute_max_mip_levels(srcImageInfo.width,
+                                          srcImageInfo.height, 0),
+              seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
-            for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
-            {
-                if( gDebugTrace )
-                    log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
+      for (srcImageInfo.height = 1; srcImageInfo.height < 9;
+           srcImageInfo.height++)
+      {
+          if (gDebugTrace)
+              log_info("   at size %d,%d\n", (int)srcImageInfo.width,
+                       (int)srcImageInfo.height);
 
-                int ret = test_copy_image_size_2D( context, queue, &imageInfo, seed );
-                if( ret )
-                    return -1;
-            }
+          dstImageInfo = srcImageInfo;
+          dstImageInfo.mem_flags = dst_flags;
+          int ret = test_copy_image_size_2D(context, queue, &srcImageInfo,
+                                            &dstImageInfo, seed);
+          if (ret) return -1;
+      }
         }
     }
     else if( gTestMaxImages )
@@ -164,31 +205,42 @@ int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_
         size_t numbeOfSizes;
         size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE2D, imageInfo.format);
+        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1, 1,
+                      maxAllocSize, memSize, src_type, srcImageInfo.format);
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
       size_t rowPadding = gEnablePitch ? 48 : 0;
 
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.height = sizes[ idx ][ 1 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
+      srcImageInfo.width = sizes[idx][0];
+      srcImageInfo.height = sizes[idx][1];
+      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
+      if (gTestMipmaps)
+          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2,
+              (int)compute_max_mip_levels(srcImageInfo.width,
+                                          srcImageInfo.height, 0),
+              seed);
 
-            if (gEnablePitch)
-            {
-                do {
-                    rowPadding++;
-                    imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-                } while ((imageInfo.rowPitch % pixelSize) != 0);
-            }
+      if (gEnablePitch)
+      {
+          do
+          {
+              rowPadding++;
+              srcImageInfo.rowPitch =
+                  srcImageInfo.width * pixelSize + rowPadding;
+          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+      }
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             if( gDebugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if( test_copy_image_size_2D( context, queue, &imageInfo, seed ) )
+
+            dstImageInfo = srcImageInfo;
+            dstImageInfo.mem_flags = dst_flags;
+            if (test_copy_image_size_2D(context, queue, &srcImageInfo,
+                                        &dstImageInfo, seed))
                 return -1;
         }
     }
@@ -202,34 +254,51 @@ int test_copy_image_set_2D( cl_device_id device, cl_context context, cl_command_
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
             {
-                imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
-                imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
+                srcImageInfo.width =
+                    (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
+                srcImageInfo.height =
+                    (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
 
-        if (gTestMipmaps)
-        {
-          imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
-          imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-          size = compute_mipmapped_image_size( imageInfo );
-          size = size*4;
-        }
+                if (gTestMipmaps)
+                {
+                    srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                        2,
+                        (int)compute_max_mip_levels(srcImageInfo.width,
+                                                    srcImageInfo.height, 0),
+                        seed);
+                    srcImageInfo.rowPitch = srcImageInfo.width
+                        * get_pixel_size(srcImageInfo.format);
+                    size = compute_mipmapped_image_size(srcImageInfo);
+                    size = size * 4;
+                }
         else
         {
-          imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-          if (gEnablePitch)
-          {
-            do {
-              rowPadding++;
-              imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
-            } while ((imageInfo.rowPitch % pixelSize) != 0);
-          }
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            if (gEnablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
-          size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.height * 4;
+            size =
+                (size_t)srcImageInfo.rowPitch * (size_t)srcImageInfo.height * 4;
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
             if( gDebugTrace )
-                log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_copy_image_size_2D( context, queue, &imageInfo, seed );
+                log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
+                         (int)srcImageInfo.width, (int)srcImageInfo.height,
+                         (int)srcImageInfo.rowPitch, (int)maxWidth,
+                         (int)maxHeight);
+
+            dstImageInfo = srcImageInfo;
+            dstImageInfo.mem_flags = dst_flags;
+            int ret = test_copy_image_size_2D(context, queue, &srcImageInfo,
+                                              &dstImageInfo, seed);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -36,14 +36,12 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
         } while ((imageInfo->rowPitch % pixelSize) != 0);
     }
 
-    if (arraySize == 0)
+    if (imageInfo->type == CL_MEM_OBJECT_IMAGE2D)
     {
-        imageInfo->type = CL_MEM_OBJECT_IMAGE2D;
         imageInfo->slicePitch = 0;
     }
     else
     {
-        imageInfo->type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
         imageInfo->slicePitch = imageInfo->rowPitch * (imageInfo->height + slicePadding);
     }
 }
@@ -205,15 +203,31 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
 }
 
 
-int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, bool reverse = false )
+int test_copy_image_set_2D_2D_array(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
+    cl_mem_object_type dst_type, cl_image_format *format)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
-    image_descriptor srcImageInfo = { 0 };
-    image_descriptor dstImageInfo = { 0 };
+    const bool reverse = (src_type == CL_MEM_OBJECT_IMAGE2D_ARRAY);
+    image_descriptor imageInfo2D = { 0 };
+    image_descriptor imageInfo2Darray = { 0 };
     RandomSeed  seed( gRandomSeed );
 
-    srcImageInfo.format = dstImageInfo.format = format;
+    imageInfo2D.format = imageInfo2Darray.format = format;
+    imageInfo2D.type = CL_MEM_OBJECT_IMAGE2D;
+    imageInfo2Darray.type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+    if (reverse)
+    {
+        imageInfo2Darray.mem_flags = src_flags;
+        imageInfo2D.mem_flags = dst_flags;
+    }
+    else
+    {
+        imageInfo2D.mem_flags = src_flags;
+        imageInfo2Darray.mem_flags = dst_flags;
+    }
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );
     error |= clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof( maxHeight ), &maxHeight, NULL );
@@ -229,42 +243,77 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl
 
     if( gTestSmallImages )
     {
-        for( dstImageInfo.width = 4; dstImageInfo.width < 17; dstImageInfo.width++ )
+        for (imageInfo2Darray.width = 4; imageInfo2Darray.width < 17;
+             imageInfo2Darray.width++)
         {
-            for( dstImageInfo.height = 4; dstImageInfo.height < 13; dstImageInfo.height++ )
+            for (imageInfo2Darray.height = 4; imageInfo2Darray.height < 13;
+                 imageInfo2Darray.height++)
             {
-                for( dstImageInfo.arraySize = 4; dstImageInfo.arraySize < 9; dstImageInfo.arraySize++ )
+                for (imageInfo2Darray.arraySize = 4;
+                     imageInfo2Darray.arraySize < 9;
+                     imageInfo2Darray.arraySize++)
                 {
                     size_t rowPadding = gEnablePitch ? 256 : 0;
                     size_t slicePadding = gEnablePitch ? 3 : 0;
 
-                    set_image_dimensions( &dstImageInfo, dstImageInfo.width, dstImageInfo.height, dstImageInfo.arraySize, rowPadding, slicePadding );
-                    set_image_dimensions( &srcImageInfo, dstImageInfo.width, dstImageInfo.height, 0, rowPadding, slicePadding );
+                    set_image_dimensions(
+                        &imageInfo2Darray, imageInfo2Darray.width,
+                        imageInfo2Darray.height, imageInfo2Darray.arraySize,
+                        rowPadding, slicePadding);
+                    set_image_dimensions(&imageInfo2D, imageInfo2Darray.width,
+                                         imageInfo2Darray.height, 0, rowPadding,
+                                         slicePadding);
 
                     if (gTestMipmaps)
                     {
-                      srcImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(srcImageInfo.width, srcImageInfo.height, 0), seed);
-                      srcImageInfo.type = CL_MEM_OBJECT_IMAGE2D;
-                      dstImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(dstImageInfo.width, dstImageInfo.height, 0), seed);
-                      dstImageInfo.type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-                      srcImageInfo.rowPitch = srcImageInfo.width * get_pixel_size( srcImageInfo.format );
-                      srcImageInfo.slicePitch = 0;
-                      dstImageInfo.rowPitch = dstImageInfo.width * get_pixel_size( dstImageInfo.format );
-                      dstImageInfo.slicePitch = dstImageInfo.rowPitch * dstImageInfo.height;
+                        imageInfo2D.num_mip_levels =
+                            (cl_uint)random_log_in_range(
+                                2,
+                                (int)compute_max_mip_levels(
+                                    imageInfo2D.width, imageInfo2D.height, 0),
+                                seed);
+                        imageInfo2Darray.num_mip_levels =
+                            (cl_uint)random_log_in_range(
+                                2,
+                                (int)compute_max_mip_levels(
+                                    imageInfo2Darray.width,
+                                    imageInfo2Darray.height, 0),
+                                seed);
+                        imageInfo2D.rowPitch = imageInfo2D.width
+                            * get_pixel_size(imageInfo2D.format);
+                        imageInfo2D.slicePitch = 0;
+                        imageInfo2Darray.rowPitch = imageInfo2Darray.width
+                            * get_pixel_size(imageInfo2Darray.format);
+                        imageInfo2Darray.slicePitch =
+                            imageInfo2Darray.rowPitch * imageInfo2Darray.height;
                     }
 
                     if( gDebugTrace )
                     {
                         if (reverse)
-                            log_info( "   at size %d,%d,%d to %d,%d\n", (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize, (int)srcImageInfo.width, (int)srcImageInfo.height );
+                            log_info("   at size %d,%d,%d to %d,%d\n",
+                                     (int)imageInfo2Darray.width,
+                                     (int)imageInfo2Darray.height,
+                                     (int)imageInfo2Darray.arraySize,
+                                     (int)imageInfo2D.width,
+                                     (int)imageInfo2D.height);
                         else
-                            log_info( "   at size %d,%d to %d,%d,%d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize );
+                            log_info("   at size %d,%d to %d,%d,%d\n",
+                                     (int)imageInfo2D.width,
+                                     (int)imageInfo2D.height,
+                                     (int)imageInfo2Darray.width,
+                                     (int)imageInfo2Darray.height,
+                                     (int)imageInfo2Darray.arraySize);
                     }
                     int ret;
                     if( reverse )
-                        ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
+                        ret = test_copy_image_size_2D_2D_array(
+                            context, queue, &imageInfo2Darray, &imageInfo2D,
+                            seed);
                     else
-                        ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
+                        ret = test_copy_image_size_2D_2D_array(
+                            context, queue, &imageInfo2D, &imageInfo2Darray,
+                            seed);
                     if( ret )
                         return -1;
                 }
@@ -278,8 +327,12 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl
         size_t sizes2DArray[100][3], sizes2D[100][3];
 
         // Try to allocate a bit smaller images because we need the 2D ones as well for the copy.
-        get_max_sizes(&numberOfSizes2DArray, 100, sizes2DArray, maxWidth, maxHeight, 1, maxArraySize, maxAllocSize/2, memSize/2, CL_MEM_OBJECT_IMAGE2D_ARRAY, dstImageInfo.format);
-        get_max_sizes(&numberOfSizes2D, 100, sizes2D, maxWidth, maxHeight, 1, 1, maxAllocSize/2, memSize/2, CL_MEM_OBJECT_IMAGE2D, dstImageInfo.format);
+        get_max_sizes(&numberOfSizes2DArray, 100, sizes2DArray, maxWidth,
+                      maxHeight, 1, maxArraySize, maxAllocSize / 2, memSize / 2,
+                      CL_MEM_OBJECT_IMAGE2D_ARRAY, imageInfo2Darray.format);
+        get_max_sizes(&numberOfSizes2D, 100, sizes2D, maxWidth, maxHeight, 1, 1,
+                      maxAllocSize / 2, memSize / 2, CL_MEM_OBJECT_IMAGE2D,
+                      imageInfo2Darray.format);
 
         for( size_t i = 0; i < numberOfSizes2D; i++ )
         {
@@ -288,56 +341,94 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl
             size_t rowPadding = gEnablePitch ? 256 : 0;
             size_t slicePadding = gEnablePitch ? 3 : 0;
 
-            set_image_dimensions( &dstImageInfo, sizes2DArray[ j ][ 0 ], sizes2DArray[ j ][ 1 ], sizes2DArray[ j ][ 2 ], rowPadding, slicePadding );
-            set_image_dimensions( &srcImageInfo, sizes2D[ i ][ 0 ], sizes2D[ i ][ 1 ], 0, rowPadding, slicePadding );
+            set_image_dimensions(&imageInfo2Darray, sizes2DArray[j][0],
+                                 sizes2DArray[j][1], sizes2DArray[j][2],
+                                 rowPadding, slicePadding);
+            set_image_dimensions(&imageInfo2D, sizes2D[i][0], sizes2D[i][1], 0,
+                                 rowPadding, slicePadding);
 
-            cl_ulong dstSize = get_image_size(&dstImageInfo);
-            cl_ulong srcSize = get_image_size(&srcImageInfo);
+            cl_ulong dstSize = get_image_size(&imageInfo2Darray);
+            cl_ulong srcSize = get_image_size(&imageInfo2D);
 
             if (gTestMipmaps)
             {
-              srcImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(srcImageInfo.width, srcImageInfo.height, 0), seed);
-              srcImageInfo.type = CL_MEM_OBJECT_IMAGE2D;
-              dstImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(dstImageInfo.width, dstImageInfo.height, 0), seed);
-              dstImageInfo.type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-              srcImageInfo.rowPitch = srcImageInfo.width * get_pixel_size( srcImageInfo.format );
-              srcImageInfo.slicePitch = 0;
-              dstImageInfo.rowPitch = dstImageInfo.width * get_pixel_size( dstImageInfo.format );
-              dstImageInfo.slicePitch = dstImageInfo.rowPitch * dstImageInfo.height;
-              dstSize = 4 * compute_mipmapped_image_size( dstImageInfo );
-              srcSize = 4 * compute_mipmapped_image_size( srcImageInfo );
+                imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
+                    2,
+                    (int)compute_max_mip_levels(imageInfo2D.width,
+                                                imageInfo2D.height, 0),
+                    seed);
+                imageInfo2Darray.num_mip_levels = (cl_uint)random_log_in_range(
+                    2,
+                    (int)compute_max_mip_levels(imageInfo2Darray.width,
+                                                imageInfo2Darray.height, 0),
+                    seed);
+                imageInfo2D.rowPitch =
+                    imageInfo2D.width * get_pixel_size(imageInfo2D.format);
+                imageInfo2D.slicePitch = 0;
+                imageInfo2Darray.rowPitch = imageInfo2Darray.width
+                    * get_pixel_size(imageInfo2Darray.format);
+                imageInfo2Darray.slicePitch =
+                    imageInfo2Darray.rowPitch * imageInfo2Darray.height;
+                dstSize = 4 * compute_mipmapped_image_size(imageInfo2Darray);
+                srcSize = 4 * compute_mipmapped_image_size(imageInfo2D);
             }
 
             if( dstSize < maxAllocSize && dstSize < ( memSize / 3 ) && srcSize < maxAllocSize && srcSize < ( memSize / 3 ) )
             {
               if (reverse)
-                log_info( "Testing %d x %d x %d to %d x %d\n", (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize, (int)srcImageInfo.width, (int)srcImageInfo.height );
+                  log_info("Testing %d x %d x %d to %d x %d\n",
+                           (int)imageInfo2Darray.width,
+                           (int)imageInfo2Darray.height,
+                           (int)imageInfo2Darray.arraySize,
+                           (int)imageInfo2D.width, (int)imageInfo2D.height);
               else
-                log_info( "Testing %d x %d to %d x %d x %d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize );
+                  log_info("Testing %d x %d to %d x %d x %d\n",
+                           (int)imageInfo2D.width, (int)imageInfo2D.height,
+                           (int)imageInfo2Darray.width,
+                           (int)imageInfo2Darray.height,
+                           (int)imageInfo2Darray.arraySize);
 
               if( gDebugTrace )
               {
                 if (reverse)
-                  log_info( "   at max size %d,%d,%d to %d,%d\n", (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize, (int)srcImageInfo.width, (int)srcImageInfo.height );
+                    log_info("   at max size %d,%d,%d to %d,%d\n",
+                             (int)imageInfo2Darray.width,
+                             (int)imageInfo2Darray.height,
+                             (int)imageInfo2Darray.arraySize,
+                             (int)imageInfo2D.width, (int)imageInfo2D.height);
                 else
-                  log_info( "   at max size %d,%d to %d,%d,%d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize );
+                    log_info("   at max size %d,%d to %d,%d,%d\n",
+                             (int)imageInfo2D.width, (int)imageInfo2D.height,
+                             (int)imageInfo2Darray.width,
+                             (int)imageInfo2Darray.height,
+                             (int)imageInfo2Darray.arraySize);
               }
               int ret;
               if( reverse )
-                ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
+                  ret = test_copy_image_size_2D_2D_array(
+                      context, queue, &imageInfo2Darray, &imageInfo2D, seed);
               else
-                ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
+                  ret = test_copy_image_size_2D_2D_array(
+                      context, queue, &imageInfo2D, &imageInfo2Darray, seed);
               if( ret )
                 return -1;
             }
             else
             {
               if (reverse)
-                log_info("Not testing max size %d x %d x %d to %d x %d due to memory constraints.\n",
-                (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize, (int)srcImageInfo.width, (int)srcImageInfo.height);
+                  log_info("Not testing max size %d x %d x %d to %d x %d due "
+                           "to memory constraints.\n",
+                           (int)imageInfo2Darray.width,
+                           (int)imageInfo2Darray.height,
+                           (int)imageInfo2Darray.arraySize,
+                           (int)imageInfo2D.width, (int)imageInfo2D.height);
               else
-                log_info("Not testing max size %d x %d to %d x %d x %d due to memory constraints.\n",
-                (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize);
+                  log_info("Not testing max size %d x %d to %d x %d x %d due "
+                           "to memory constraints.\n",
+                           (int)imageInfo2D.width, (int)imageInfo2D.height,
+                           (int)imageInfo2Darray.width,
+                           (int)imageInfo2Darray.height,
+                           (int)imageInfo2Darray.arraySize);
             }
 
           }
@@ -354,47 +445,81 @@ int test_copy_image_set_2D_2D_array( cl_device_id device, cl_context context, cl
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
             {
-                dstImageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
-                dstImageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
-                dstImageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
-                srcImageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
-                srcImageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
+                imageInfo2Darray.width =
+                    (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
+                imageInfo2Darray.height =
+                    (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
+                imageInfo2Darray.arraySize = (size_t)random_log_in_range(
+                    16, (int)maxArraySize / 32, seed);
+                imageInfo2D.width =
+                    (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
+                imageInfo2D.height =
+                    (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
 
                 if (gTestMipmaps)
                 {
-                    srcImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(srcImageInfo.width, srcImageInfo.height, 0), seed);
-                    srcImageInfo.type = CL_MEM_OBJECT_IMAGE2D;
-                    dstImageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(dstImageInfo.width, dstImageInfo.height, 0), seed);
-                    dstImageInfo.type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
-                    srcImageInfo.rowPitch = srcImageInfo.width * get_pixel_size( srcImageInfo.format );
-                    srcImageInfo.slicePitch = 0;
-                    dstImageInfo.rowPitch = dstImageInfo.width * get_pixel_size( dstImageInfo.format );
-                    dstImageInfo.slicePitch = dstImageInfo.rowPitch * dstImageInfo.height;
-                    srcSize = 4 * compute_mipmapped_image_size( srcImageInfo );
-                    dstSize = 4 * compute_mipmapped_image_size( dstImageInfo );
+                    imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
+                        2,
+                        (int)compute_max_mip_levels(imageInfo2D.width,
+                                                    imageInfo2D.height, 0),
+                        seed);
+                    imageInfo2Darray.num_mip_levels =
+                        (cl_uint)random_log_in_range(
+                            2,
+                            (int)compute_max_mip_levels(imageInfo2Darray.width,
+                                                        imageInfo2Darray.height,
+                                                        0),
+                            seed);
+                    imageInfo2D.rowPitch =
+                        imageInfo2D.width * get_pixel_size(imageInfo2D.format);
+                    imageInfo2D.slicePitch = 0;
+                    imageInfo2Darray.rowPitch = imageInfo2Darray.width
+                        * get_pixel_size(imageInfo2Darray.format);
+                    imageInfo2Darray.slicePitch =
+                        imageInfo2Darray.rowPitch * imageInfo2Darray.height;
+                    srcSize = 4 * compute_mipmapped_image_size(imageInfo2D);
+                    dstSize =
+                        4 * compute_mipmapped_image_size(imageInfo2Darray);
                 }
                 else
                 {
-                    set_image_dimensions( &srcImageInfo, srcImageInfo.width, srcImageInfo.height, 0, rowPadding, slicePadding );
-                    set_image_dimensions( &dstImageInfo, dstImageInfo.width, dstImageInfo.height, dstImageInfo.arraySize, rowPadding, slicePadding );
+                    set_image_dimensions(&imageInfo2D, imageInfo2D.width,
+                                         imageInfo2D.height, 0, rowPadding,
+                                         slicePadding);
+                    set_image_dimensions(
+                        &imageInfo2Darray, imageInfo2Darray.width,
+                        imageInfo2Darray.height, imageInfo2Darray.arraySize,
+                        rowPadding, slicePadding);
 
-                    srcSize = (cl_ulong)srcImageInfo.rowPitch * (cl_ulong)srcImageInfo.height * 4;
-                    dstSize = (cl_ulong)dstImageInfo.slicePitch * (cl_ulong)dstImageInfo.arraySize * 4;
+                    srcSize = (cl_ulong)imageInfo2D.rowPitch
+                        * (cl_ulong)imageInfo2D.height * 4;
+                    dstSize = (cl_ulong)imageInfo2Darray.slicePitch
+                        * (cl_ulong)imageInfo2Darray.arraySize * 4;
                 }
             } while( srcSize > maxAllocSize || ( srcSize * 3 ) > memSize || dstSize > maxAllocSize || ( dstSize * 3 ) > memSize);
 
             if( gDebugTrace )
             {
                 if (reverse)
-                    log_info( "   at size %d,%d,%d to %d,%d\n", (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize, (int)srcImageInfo.width, (int)srcImageInfo.height );
+                    log_info("   at size %d,%d,%d to %d,%d\n",
+                             (int)imageInfo2Darray.width,
+                             (int)imageInfo2Darray.height,
+                             (int)imageInfo2Darray.arraySize,
+                             (int)imageInfo2D.width, (int)imageInfo2D.height);
                 else
-                    log_info( "   at size %d,%d to %d,%d,%d\n", (int)srcImageInfo.width, (int)srcImageInfo.height, (int)dstImageInfo.width, (int)dstImageInfo.height, (int)dstImageInfo.arraySize );
+                    log_info("   at size %d,%d to %d,%d,%d\n",
+                             (int)imageInfo2D.width, (int)imageInfo2D.height,
+                             (int)imageInfo2Darray.width,
+                             (int)imageInfo2Darray.height,
+                             (int)imageInfo2Darray.arraySize);
             }
             int ret;
             if( reverse )
-                ret = test_copy_image_size_2D_2D_array( context, queue, &dstImageInfo, &srcImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array(
+                    context, queue, &imageInfo2Darray, &imageInfo2D, seed);
             else
-                ret = test_copy_image_size_2D_2D_array( context, queue, &srcImageInfo, &dstImageInfo, seed );
+                ret = test_copy_image_size_2D_2D_array(
+                    context, queue, &imageInfo2D, &imageInfo2Darray, seed);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_1D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D.cpp
@@ -58,7 +58,9 @@ int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_d
 }
 
 
-int test_fill_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_1D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags mem_flags, ExplicitType outputType)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -71,6 +73,7 @@ int test_fill_image_set_1D( cl_device_id device, cl_context context, cl_command_
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE1D;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );

--- a/test_conformance/images/clFillImage/test_fill_1D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_array.cpp
@@ -60,7 +60,11 @@ int test_fill_image_size_1D_array( cl_context context, cl_command_queue queue, i
 }
 
 
-int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 cl_image_format *format,
+                                 cl_mem_flags mem_flags,
+                                 ExplicitType outputType)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -73,6 +77,7 @@ int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_co
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );

--- a/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
@@ -71,6 +71,7 @@ int test_fill_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
+                                  cl_mem_flags mem_flags,
                                   ExplicitType outputType)
 {
     size_t maxWidth;
@@ -84,6 +85,7 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size(imageInfo.format);
 
     int error = clGetDeviceInfo(device, CL_DEVICE_IMAGE_MAX_BUFFER_SIZE,

--- a/test_conformance/images/clFillImage/test_fill_2D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D.cpp
@@ -60,7 +60,9 @@ int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_d
 }
 
 
-int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_2D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags mem_flags, ExplicitType outputType)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -73,6 +75,7 @@ int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_command_
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE2D;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );

--- a/test_conformance/images/clFillImage/test_fill_2D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D_array.cpp
@@ -62,7 +62,11 @@ static int test_fill_image_2D_array( cl_context context, cl_command_queue queue,
 }
 
 
-int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 cl_image_format *format,
+                                 cl_mem_flags mem_flags,
+                                 ExplicitType outputType)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -76,6 +80,7 @@ int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_co
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );

--- a/test_conformance/images/clFillImage/test_fill_3D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_3D.cpp
@@ -62,7 +62,9 @@ int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descri
 }
 
 
-int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType )
+int test_fill_image_set_3D(cl_device_id device, cl_context context,
+                           cl_command_queue queue, cl_image_format *format,
+                           cl_mem_flags mem_flags, ExplicitType outputType)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -76,6 +78,7 @@ int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
     imageInfo.type = CL_MEM_OBJECT_IMAGE3D;
     imageInfo.format = format;
+    imageInfo.mem_flags = mem_flags;
     pixelSize = get_pixel_size( imageInfo.format );
 
     int error = clGetDeviceInfo( device, CL_DEVICE_IMAGE3D_MAX_WIDTH, sizeof( maxWidth ), &maxWidth, NULL );

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -18,19 +18,38 @@
 
 extern int gTypesToTest;
 
-extern int test_fill_image_set_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_2D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_image_format *format, ExplicitType outputType );
-extern int test_fill_image_set_1D_buffer(cl_device_id device,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         cl_image_format *format,
-                                         ExplicitType outputType);
+extern int test_fill_image_set_1D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  cl_mem_flags mem_flags,
+                                  ExplicitType outputType);
+extern int test_fill_image_set_2D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  cl_mem_flags mem_flags,
+                                  ExplicitType outputType);
+extern int test_fill_image_set_3D(cl_device_id device, cl_context context,
+                                  cl_command_queue queue,
+                                  cl_image_format *format,
+                                  cl_mem_flags mem_flags,
+                                  ExplicitType outputType);
+extern int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        cl_mem_flags mem_flags,
+                                        ExplicitType outputType);
+extern int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
+                                        cl_command_queue queue,
+                                        cl_image_format *format,
+                                        cl_mem_flags mem_flags,
+                                        ExplicitType outputType);
+extern int
+test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
+                              cl_command_queue queue, cl_image_format *format,
+                              cl_mem_flags mem_flags, ExplicitType outputType);
 typedef int (*test_func)(cl_device_id device, cl_context context,
                          cl_command_queue queue, cl_image_format *format,
-                         ExplicitType outputType);
+                         cl_mem_flags mem_flags, ExplicitType outputType);
 
 int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
 {
@@ -105,7 +124,7 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
                     gTestCount++;
 
                     int test_return =
-                        test_fn(device, context, queue, &formatList[i],
+                        test_fn(device, context, queue, &formatList[i], flags,
                                 test.explicitType);
                     if (test_return)
                     {
@@ -128,8 +147,12 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod )
 {
     int ret = 0;
-
-    ret += test_image_type( device, context, queue, testMethod, CL_MEM_READ_ONLY );
+    cl_mem_flags flags = CL_MEM_READ_ONLY;
+    if (gEnablePitch && testMethod != k1DBuffer)
+    {
+        flags |= CL_MEM_USE_HOST_PTR;
+    }
+    ret += test_image_type(device, context, queue, testMethod, flags);
 
     return ret;
 }

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -173,7 +173,6 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
 {
     cl_mem img;
     cl_image_desc imageDesc;
-    cl_mem_flags mem_flags = CL_MEM_READ_ONLY;
     void *host_ptr = nullptr;
     bool is_host_ptr_aligned = false;
 
@@ -310,21 +309,17 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
                       imageInfo->depth * imageInfo->slicePitch);
             return nullptr;
         }
-        if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
-        {
-            mem_flags = CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR;
-        }
     }
 
     if (imageInfo->type != CL_MEM_OBJECT_IMAGE1D_BUFFER)
     {
-        img = clCreateImage(context, mem_flags, imageInfo->format, &imageDesc,
-                            host_ptr, error);
+        img = clCreateImage(context, imageInfo->mem_flags, imageInfo->format,
+                            &imageDesc, host_ptr, error);
     }
     else
     {
-        img = clCreateImage(context, mem_flags, imageInfo->format, &imageDesc,
-                            nullptr, error);
+        img = clCreateImage(context, imageInfo->mem_flags, imageInfo->format,
+                            &imageDesc, nullptr, error);
     }
 
     if (enable_pitch)


### PR DESCRIPTION
This change mainly extends `clFillImage` and `clCopyImage` test function to include memory flags to be used during creating the image instead of hard-coding these values. The memory flags are also different parameters for source and destination images in `clCopyImage` tests.