### PR TITLE
math_brute_force: fmin/fmax can return a qNaN if either input is a sNaN

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -220,6 +220,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     cl_double *s;
     cl_double *s2;
     cl_int copysign_test = 0;
+    int fminfmax_test = !strcmp(name, "fmin") || !strcmp(name, "fmax");
 
     Force64BitFPUPrecision();
 
@@ -405,6 +406,14 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
             // If we aren't getting the correctly rounded result
             if (t[j] != q[j])
             {
+                // For fmin/fmax, when either argument is a signaling NaN, a
+                // quiet NaN return is also acceptable, which is respect to
+                // C99, where signaling NaNs are supposed to get the same IEEE
+                // treatment.
+                if (fminfmax_test && IsDoubleQNaN(q[j]) &&
+                    (IsDoubleSNaN(p[j]) || IsDoubleSNaN(p2[j])))
+                    continue;
+
                 cl_double test = ((cl_double *)q)[j];
                 long double correct = ref_func(s[j], s2[j]);
                 float err = Bruteforce_Ulp_Error_Double(test, correct);

--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -410,8 +410,8 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
                 // quiet NaN return is also acceptable, which is respect to
                 // C99, where signaling NaNs are supposed to get the same IEEE
                 // treatment.
-                if (fminfmax_test && IsDoubleQNaN(q[j]) &&
-                    (IsDoubleSNaN(p[j]) || IsDoubleSNaN(p2[j])))
+                if (fminfmax_test && IsDoubleQNaN(q[j])
+                    && (IsDoubleSNaN(p[j]) || IsDoubleSNaN(p2[j])))
                     continue;
 
                 cl_double test = ((cl_double *)q)[j];

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -450,10 +450,10 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
                 {
                     // For fmin/fmax, when either argument is a signaling NaN, a
                     // quiet NaN return is also acceptable, which is respect to
-                    // C99, where signaling NaNs are supposed to get the same IEEE
-                    // treatment.
-                    if (fminfmax_test && IsFloatQNaN(q[j]) &&
-                        (IsFloatSNaN(p[j]) || IsFloatSNaN(p2[j])))
+                    // C99, where signaling NaNs are supposed to get the same
+                    // IEEE treatment.
+                    if (fminfmax_test && IsFloatQNaN(q[j])
+                        && (IsFloatSNaN(p[j]) || IsFloatSNaN(p2[j])))
                         continue;
 
                     float test = ((float *)q)[j];

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -216,6 +216,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
     cl_int copysign_test = 0;
     RoundingMode oldRoundMode;
     int skipVerification = 0;
+    int fminfmax_test = !strcmp(name, "fmin") || !strcmp(name, "fmax");
 
     if (relaxedMode)
     {
@@ -447,6 +448,14 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
                 // If we aren't getting the correctly rounded result
                 if (t[j] != q[j])
                 {
+                    // For fmin/fmax, when either argument is a signaling NaN, a
+                    // quiet NaN return is also acceptable, which is respect to
+                    // C99, where signaling NaNs are supposed to get the same IEEE
+                    // treatment.
+                    if (fminfmax_test && IsFloatQNaN(q[j]) &&
+                        (IsFloatSNaN(p[j]) || IsFloatSNaN(p2[j])))
+                        continue;
+
                     float test = ((float *)q)[j];
                     double correct = ref_func(s[j], s2[j]);
 

--- a/test_conformance/math_brute_force/binary_half.cpp
+++ b/test_conformance/math_brute_force/binary_half.cpp
@@ -325,8 +325,8 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
                 // quiet NaN return is also acceptable, which is respect to
                 // C99, where signaling NaNs are supposed to get the same IEEE
                 // treatment.
-                if (fminfmax_test && IsHalfQNaN(q[j]) &&
-                    (IsHalfSNaN(p[j]) || IsHalfSNaN(p2[j])))
+                if (fminfmax_test && IsHalfQNaN(q[j])
+                    && (IsHalfSNaN(p[j]) || IsHalfSNaN(p2[j])))
                     continue;
 
                 double correct;

--- a/test_conformance/math_brute_force/binary_half.cpp
+++ b/test_conformance/math_brute_force/binary_half.cpp
@@ -112,6 +112,7 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
     cl_half *r;
     std::vector<float> s(0), s2(0);
     cl_uint j = 0;
+    int fminfmax_test = !strcmp(name, "fmin") || !strcmp(name, "fmax");
 
     RoundingMode oldRoundMode;
     cl_int copysign_test = 0;
@@ -320,6 +321,14 @@ cl_int TestHalf(cl_uint job_id, cl_uint thread_id, void *data)
             // If we aren't getting the correctly rounded result
             if (t[j] != q[j])
             {
+                // For fmin/fmax, when either argument is a signaling NaN, a
+                // quiet NaN return is also acceptable, which is respect to
+                // C99, where signaling NaNs are supposed to get the same IEEE
+                // treatment.
+                if (fminfmax_test && IsHalfQNaN(q[j]) &&
+                    (IsHalfSNaN(p[j]) || IsHalfSNaN(p2[j])))
+                    continue;
+
                 double correct;
                 if (isNextafter)
                     correct = reference_nextafterh(s[j], s2[j]);

--- a/test_conformance/math_brute_force/utility.h
+++ b/test_conformance/math_brute_force/utility.h
@@ -186,14 +186,14 @@ inline int IsFloatQNaN(cl_uint u)
 
 inline int IsDoubleSNaN(cl_ulong u)
 {
-    return ((u & 0x7fffffffffffffffUL) > 0x7FF0000000000000UL) &&
-            ((u & (1UL << (CL_DBL_MANT_DIG - 2))) == 0);
+    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL) &&
+            ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) == 0);
 }
 
 inline int IsDoubleQNaN(cl_ulong u)
 {
-    return ((u & 0x7fffffffffffffffUL) > 0x7FF0000000000000UL) &&
-            ((u & (1UL << (CL_DBL_MANT_DIG - 2))) != 0);
+    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL) &&
+            ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) != 0);
 }
 
 inline int IsHalfSNaN(cl_ushort u)

--- a/test_conformance/math_brute_force/utility.h
+++ b/test_conformance/math_brute_force/utility.h
@@ -172,6 +172,42 @@ inline int IsFloatNaN(double x)
     return ((u.u & 0x7fffffffU) > 0x7F800000U);
 }
 
+inline int IsFloatSNaN(cl_uint u)
+{
+    return ((u & 0x7fffffff) > 0x7F800000) &&
+            ((u & (1 << (CL_FLT_MANT_DIG - 2))) == 0);
+}
+
+inline int IsFloatQNaN(cl_uint u)
+{
+    return ((u & 0x7fffffff) > 0x7F800000) &&
+            ((u & (1 << (CL_FLT_MANT_DIG - 2))) != 0);
+}
+
+inline int IsDoubleSNaN(cl_ulong u)
+{
+    return ((u & 0x7fffffffffffffffUL) > 0x7FF0000000000000UL) &&
+            ((u & (1UL << (CL_DBL_MANT_DIG - 2))) == 0);
+}
+
+inline int IsDoubleQNaN(cl_ulong u)
+{
+    return ((u & 0x7fffffffffffffffUL) > 0x7FF0000000000000UL) &&
+            ((u & (1UL << (CL_DBL_MANT_DIG - 2))) != 0);
+}
+
+inline int IsHalfSNaN(cl_ushort u)
+{
+    return ((u & 0x7FFF) > 0x7C00) &&
+            ((u & (1 << (CL_HALF_MANT_DIG - 2))) == 0);
+}
+
+inline int IsHalfQNaN(cl_ushort u)
+{
+    return ((u & 0x7FFF) > 0x7C00) &&
+            ((u & (1 << (CL_HALF_MANT_DIG - 2))) != 0);
+}
+
 inline bool IsHalfNaN(const cl_half v)
 {
     // Extract FP16 exponent and mantissa

--- a/test_conformance/math_brute_force/utility.h
+++ b/test_conformance/math_brute_force/utility.h
@@ -174,38 +174,38 @@ inline int IsFloatNaN(double x)
 
 inline int IsFloatSNaN(cl_uint u)
 {
-    return ((u & 0x7fffffff) > 0x7F800000) &&
-            ((u & (1 << (CL_FLT_MANT_DIG - 2))) == 0);
+    return ((u & 0x7fffffff) > 0x7F800000)
+        && ((u & (1 << (CL_FLT_MANT_DIG - 2))) == 0);
 }
 
 inline int IsFloatQNaN(cl_uint u)
 {
-    return ((u & 0x7fffffff) > 0x7F800000) &&
-            ((u & (1 << (CL_FLT_MANT_DIG - 2))) != 0);
+    return ((u & 0x7fffffff) > 0x7F800000)
+        && ((u & (1 << (CL_FLT_MANT_DIG - 2))) != 0);
 }
 
 inline int IsDoubleSNaN(cl_ulong u)
 {
-    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL) &&
-            ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) == 0);
+    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL)
+        && ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) == 0);
 }
 
 inline int IsDoubleQNaN(cl_ulong u)
 {
-    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL) &&
-            ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) != 0);
+    return ((u & 0x7fffffffffffffffULL) > 0x7FF0000000000000ULL)
+        && ((u & (1ULL << (CL_DBL_MANT_DIG - 2))) != 0);
 }
 
 inline int IsHalfSNaN(cl_ushort u)
 {
-    return ((u & 0x7FFF) > 0x7C00) &&
-            ((u & (1 << (CL_HALF_MANT_DIG - 2))) == 0);
+    return ((u & 0x7FFF) > 0x7C00)
+        && ((u & (1 << (CL_HALF_MANT_DIG - 2))) == 0);
 }
 
 inline int IsHalfQNaN(cl_ushort u)
 {
-    return ((u & 0x7FFF) > 0x7C00) &&
-            ((u & (1 << (CL_HALF_MANT_DIG - 2))) != 0);
+    return ((u & 0x7FFF) > 0x7C00)
+        && ((u & (1 << (CL_HALF_MANT_DIG - 2))) != 0);
 }
 
 inline bool IsHalfNaN(const cl_half v)


### PR DESCRIPTION
  For fmin/fmax, when either argument is a signaling NaN, a quiet NaN return is also acceptable, which is respect to C99, where signaling NaNs are supposed to get the same IEEE treatment.