### PR TITLE
Add tests for cl_ext_immutable_memory_objects

### DIFF
--- a/test_conformance/api/CMakeLists.txt
+++ b/test_conformance/api/CMakeLists.txt
@@ -4,6 +4,7 @@ set(${MODULE_NAME}_SOURCES
          main.cpp
          negative_platform.cpp
          negative_queue.cpp
+         negative_enqueue_map_image.cpp
          test_api_consistency.cpp
          test_bool.cpp
          test_retain.cpp

--- a/test_conformance/api/negative_enqueue_map_image.cpp
+++ b/test_conformance/api/negative_enqueue_map_image.cpp
@@ -1,0 +1,191 @@
+//
+// Copyright (c) 2024 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testBase.h"
+#include "harness/clImageHelper.h"
+
+#include <array>
+#include <vector>
+#include <memory>
+
+static constexpr cl_mem_object_type image_types[] = {
+    CL_MEM_OBJECT_IMAGE2D, CL_MEM_OBJECT_IMAGE3D, CL_MEM_OBJECT_IMAGE2D_ARRAY,
+    CL_MEM_OBJECT_IMAGE1D, CL_MEM_OBJECT_IMAGE1D_ARRAY
+};
+
+REGISTER_TEST(negative_enqueue_map_image)
+{
+    constexpr size_t image_dim = 32;
+
+    REQUIRE_EXTENSION("cl_ext_immutable_memory_objects");
+
+    static constexpr cl_mem_flags mem_flags[]{
+        CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR,
+        CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+        CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR | CL_MEM_ALLOC_HOST_PTR
+    };
+
+    static constexpr const char *mem_flags_string[]{
+        "CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR",
+        "CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR",
+        "CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR | "
+        "CL_MEM_ALLOC_HOST_PTR"
+    };
+
+    static_assert(ARRAY_SIZE(mem_flags) == ARRAY_SIZE(mem_flags_string),
+                  "mem_flags and mem_flags_string must be of the same size");
+
+    using CLUCharPtr = std::unique_ptr<cl_uchar, decltype(&free)>;
+
+    for (size_t index = 0; index < ARRAY_SIZE(mem_flags); ++index)
+    {
+        cl_mem_flags mem_flag = mem_flags[index];
+
+        log_info("Testing memory flag: %s\n", mem_flags_string[index]);
+        for (cl_mem_object_type image_type : image_types)
+        {
+            // find supported image formats
+            cl_uint num_formats = 0;
+
+            cl_int error = clGetSupportedImageFormats(
+                context, mem_flag, image_type, 0, nullptr, &num_formats);
+            test_error(error,
+                       "clGetSupportedImageFormats failed to return supported "
+                       "formats");
+
+            std::vector<cl_image_format> formats(num_formats);
+            error = clGetSupportedImageFormats(context, mem_flag, image_type,
+                                               num_formats, formats.data(),
+                                               nullptr);
+            test_error(error,
+                       "clGetSupportedImageFormats failed to return supported "
+                       "formats");
+
+            clMemWrapper image;
+            for (cl_image_format &fmt : formats)
+            {
+                log_info("Testing %s %s\n",
+                         GetChannelOrderName(fmt.image_channel_order),
+                         GetChannelTypeName(fmt.image_channel_data_type));
+
+                RandomSeed seed(gRandomSeed);
+                size_t origin[3] = { 0, 0, 0 };
+                size_t region[3] = { image_dim, image_dim, image_dim };
+                switch (image_type)
+                {
+                    case CL_MEM_OBJECT_IMAGE1D: {
+                        const size_t pixel_size = get_pixel_size(&fmt);
+                        const size_t image_size =
+                            image_dim * pixel_size * sizeof(cl_uchar);
+                        CLUCharPtr imgptr{ static_cast<cl_uchar *>(
+                                               create_random_data(kUChar, seed,
+                                                                  image_size)),
+                                           free };
+                        image =
+                            create_image_1d(context, mem_flag, &fmt, image_dim,
+                                            0, imgptr.get(), nullptr, &error);
+                        region[1] = 1;
+                        region[2] = 1;
+                        break;
+                    }
+                    case CL_MEM_OBJECT_IMAGE2D: {
+                        const size_t pixel_size = get_pixel_size(&fmt);
+                        const size_t image_size = image_dim * image_dim
+                            * pixel_size * sizeof(cl_uchar);
+                        CLUCharPtr imgptr{ static_cast<cl_uchar *>(
+                                               create_random_data(kUChar, seed,
+                                                                  image_size)),
+                                           free };
+                        image =
+                            create_image_2d(context, mem_flag, &fmt, image_dim,
+                                            image_dim, 0, imgptr.get(), &error);
+                        region[2] = 1;
+                        break;
+                    }
+                    case CL_MEM_OBJECT_IMAGE3D: {
+                        const size_t pixel_size = get_pixel_size(&fmt);
+                        const size_t image_size = image_dim * image_dim
+                            * image_dim * pixel_size * sizeof(cl_uchar);
+                        CLUCharPtr imgptr{ static_cast<cl_uchar *>(
+                                               create_random_data(kUChar, seed,
+                                                                  image_size)),
+                                           free };
+                        image = create_image_3d(context, mem_flag, &fmt,
+                                                image_dim, image_dim, image_dim,
+                                                0, 0, imgptr.get(), &error);
+                        break;
+                    }
+                    case CL_MEM_OBJECT_IMAGE1D_ARRAY: {
+                        const size_t pixel_size = get_pixel_size(&fmt);
+                        const size_t image_size = image_dim * image_dim
+                            * pixel_size * sizeof(cl_uchar);
+                        CLUCharPtr imgptr{ static_cast<cl_uchar *>(
+                                               create_random_data(kUChar, seed,
+                                                                  image_size)),
+                                           free };
+                        image = create_image_1d_array(context, mem_flag, &fmt,
+                                                      image_dim, image_dim, 0,
+                                                      0, imgptr.get(), &error);
+                        region[1] = 1;
+                        region[2] = 1;
+                        break;
+                    }
+                    case CL_MEM_OBJECT_IMAGE2D_ARRAY: {
+                        const size_t pixel_size = get_pixel_size(&fmt);
+                        const size_t image_size = image_dim * image_dim
+                            * image_dim * pixel_size * sizeof(cl_uchar);
+                        CLUCharPtr imgptr{ static_cast<cl_uchar *>(
+                                               create_random_data(kUChar, seed,
+                                                                  image_size)),
+                                           free };
+                        image = create_image_2d_array(
+                            context, mem_flag, &fmt, image_dim, image_dim,
+                            image_dim, 0, 0, imgptr.get(), &error);
+                        region[2] = 1;
+                        break;
+                    }
+                }
+                test_error(error, "Failed to create image");
+
+                void *map = clEnqueueMapImage(
+                    queue, image, CL_TRUE, CL_MAP_WRITE, origin, region,
+                    nullptr, nullptr, 0, nullptr, nullptr, &error);
+
+                constexpr const char *write_err_msg =
+                    "clEnqueueMapImage should return CL_INVALID_OPERATION "
+                    "when: \"image has been created with CL_MEM_IMMUTABLE_EXT "
+                    "and CL_MAP_WRITE is set in map_flags\"";
+                test_assert_error(map == nullptr, write_err_msg);
+                test_failure_error_ret(error, CL_INVALID_OPERATION,
+                                       write_err_msg, TEST_FAIL);
+
+                map = clEnqueueMapImage(queue, image, CL_TRUE,
+                                        CL_MAP_WRITE_INVALIDATE_REGION, origin,
+                                        region, nullptr, nullptr, 0, nullptr,
+                                        nullptr, &error);
+
+                constexpr const char *write_invalidate_err_msg =
+                    "clEnqueueMapImage should return CL_INVALID_OPERATION "
+                    "when: \"image has been created with CL_MEM_IMMUTABLE_EXT "
+                    "and CL_MAP_WRITE_INVALIDATE_REGION is set in map_flags\"";
+                test_assert_error(map == nullptr, write_invalidate_err_msg);
+                test_failure_error_ret(error, CL_INVALID_OPERATION,
+                                       write_invalidate_err_msg, TEST_FAIL);
+            }
+        }
+    }
+
+    return TEST_PASS;
+}

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_with_immutable_memory.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_with_immutable_memory.h
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2024 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "basic_command_buffer.h"
+#include <type_traits>
+
+template <class TBase>
+struct CommandBufferWithImmutableMemoryObjectsTest : public TBase
+{
+    using TBase::TBase;
+
+    static_assert(std::is_base_of<BasicCommandBufferTest, TBase>::value,
+                  "TBase must be BasicCommandBufferTest or a derived class");
+
+    bool Skip() override
+    {
+        bool is_immutable_memory_objects_supported = is_extension_available(
+            BasicCommandBufferTest::device, "cl_ext_immutable_memory_objects");
+
+        return !is_immutable_memory_objects_supported || TBase::Skip();
+    }
+};

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_copy.cpp
@@ -14,6 +14,9 @@
 // limitations under the License.
 //
 #include "basic_command_buffer.h"
+#include "command_buffer_with_immutable_memory.h"
+#include "imageHelpers.h"
+#include <vector>
 
 //--------------------------------------------------------------------------
 template <bool check_image_support>
@@ -577,6 +580,252 @@ struct CommandBufferCopyImageMutableHandleNotNull
         return CL_SUCCESS;
     }
 };
+
+struct CommandBufferCopyToImmutableImage
+    : public CommandBufferWithImmutableMemoryObjectsTest<
+          CommandBufferCopyBaseTest<true>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, src_image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
+
+        test_error(error, "clCommandFillImageKHR failed");
+
+        error = clCommandCopyImageKHR(command_buffer, nullptr, nullptr,
+                                      src_image, dst_image, origin, origin,
+                                      region, 0, 0, nullptr, nullptr);
+
+        test_failure_error_ret(error, CL_INVALID_OPERATION,
+                               "clCommandCopyImageKHR is supposed to fail "
+                               "with CL_INVALID_OPERATION when dst_image is "
+                               "created with CL_MEM_IMMUTABLE_EXT",
+                               TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        src_image = create_image_2d(context, CL_MEM_READ_ONLY, &format,
+                                    img_width, img_height, 0, nullptr, &error);
+        test_error(error, "create_image_2d failed");
+
+        size_t pixel_size = get_pixel_size(&format);
+        size_t image_size =
+            pixel_size * sizeof(cl_uchar) * img_width * img_height;
+
+        std::vector<cl_uchar> imgptr(image_size);
+
+        dst_image = create_image_2d(
+            context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR, &format,
+            img_width, img_height, 0, imgptr.data(), &error);
+        test_error(error, "create_image_2d failed");
+
+        return CL_SUCCESS;
+    }
+
+    clMemWrapper dst_image;
+    clMemWrapper src_image;
+    static constexpr cl_uint pattern_1 = 0x05;
+    const cl_uint fill_color_1[4] = { pattern_1, pattern_1, pattern_1,
+                                      pattern_1 };
+};
+
+struct CommandBufferCopyToImmutableBuffer
+    : public CommandBufferWithImmutableMemoryObjectsTest<
+          CommandBufferCopyBaseTest<false>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandCopyBufferKHR(command_buffer, nullptr, nullptr,
+                                              in_mem, buffer, 0, 0, data_size,
+                                              0, nullptr, nullptr, nullptr);
+        test_failure_error_ret(error, CL_INVALID_OPERATION,
+                               "clCommandCopyBufferKHR is supposed to fail "
+                               "with CL_INVALID_OPERATION when dst_buffer is "
+                               "created with CL_MEM_IMMUTABLE_EXT",
+                               TEST_FAIL);
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        in_mem = clCreateBuffer(context, CL_MEM_READ_ONLY, data_size, nullptr,
+                                &error);
+        test_error(error, "clCreateBuffer failed");
+
+        std::vector<cl_uchar> data(data_size);
+
+        buffer =
+            clCreateBuffer(context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                           data_size, data.data(), &error);
+        test_error(error, "clCreateBuffer failed");
+
+        return CL_SUCCESS;
+    }
+};
+
+struct CommandBufferCopyBufferToImmutableImage
+    : public CommandBufferWithImmutableMemoryObjectsTest<
+          CommandBufferCopyBaseTest<true>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, buffer, &pattern_1,
+            sizeof(pattern_1), 0, data_size, 0, nullptr, nullptr, nullptr);
+
+        test_error(error, "clCommandFillBufferKHR failed");
+
+        error = clCommandCopyBufferToImageKHR(command_buffer, nullptr, nullptr,
+                                              buffer, image, 0, origin, region,
+                                              0, 0, nullptr, nullptr);
+
+        test_failure_error_ret(
+            error, CL_INVALID_OPERATION,
+            "clCommandCopyBufferToImageKHR is supposed to fail "
+            "with CL_INVALID_OPERATION when dst_image is "
+            "created with CL_MEM_IMMUTABLE_EXT",
+            TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, data_size, nullptr,
+                                &error);
+        test_error(error, "Unable to create buffer");
+
+        size_t pixel_size = get_pixel_size(&format);
+        size_t image_size =
+            pixel_size * sizeof(cl_uchar) * img_width * img_height;
+
+        std::vector<cl_uchar> imgptr(image_size);
+
+        image = create_image_2d(
+            context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR, &format,
+            img_width, img_height, 0, imgptr.data(), &error);
+        test_error(error, "create_image_2d failed");
+
+        return CL_SUCCESS;
+    }
+
+    const uint8_t pattern_1 = 0x05;
+};
+
+struct CommandBufferCopyImageToImmutableBuffer
+    : public CommandBufferWithImmutableMemoryObjectsTest<
+          CommandBufferCopyBaseTest<true>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
+
+        test_error(error, "clCommandFillImageKHR failed");
+
+        error = clCommandCopyImageToBufferKHR(command_buffer, nullptr, nullptr,
+                                              image, buffer, origin, region, 0,
+                                              0, nullptr, nullptr, nullptr);
+
+        test_failure_error_ret(
+            error, CL_INVALID_OPERATION,
+            "clCommandCopyImageToBufferKHR is supposed to fail "
+            "with CL_INVALID_OPERATION when dst_buffer is "
+            "created with CL_MEM_IMMUTABLE_EXT",
+            TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        image = create_image_2d(context, CL_MEM_READ_WRITE, &format, img_width,
+                                img_height, 0, NULL, &error);
+        test_error(error, "create_image_2d failed");
+
+        std::vector<cl_uchar> data(data_size);
+
+        buffer =
+            clCreateBuffer(context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                           data_size, data.data(), &error);
+        test_error(error, "Unable to create buffer");
+
+        return CL_SUCCESS;
+    }
+
+    static constexpr cl_uint pattern_1 = 0x12;
+    const cl_uint fill_color_1[4] = { pattern_1, pattern_1, pattern_1,
+                                      pattern_1 };
+};
+
+struct CommandBufferCopyToImmutableBufferRect
+    : public CommandBufferWithImmutableMemoryObjectsTest<
+          CommandBufferCopyBaseTest<false>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandCopyBufferRectKHR(
+            command_buffer, nullptr, nullptr, in_mem, buffer, origin, origin,
+            region, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr);
+        test_failure_error_ret(error, CL_INVALID_OPERATION,
+                               "clCommandCopyBufferRectKHR is supposed to fail "
+                               "with CL_INVALID_OPERATION when dst_buffer is "
+                               "created with CL_MEM_IMMUTABLE_EXT",
+                               TEST_FAIL);
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        in_mem = clCreateBuffer(context, CL_MEM_READ_ONLY, data_size, nullptr,
+                                &error);
+        test_error(error, "clCreateBuffer failed");
+
+        std::vector<cl_uchar> data(data_size);
+
+        buffer =
+            clCreateBuffer(context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                           data_size, data.data(), &error);
+        test_error(error, "clCreateBuffer failed");
+
+        return CL_SUCCESS;
+    }
+};
 }
 
 REGISTER_TEST(negative_command_buffer_command_copy_buffer_queue_not_null)
@@ -655,5 +904,35 @@ REGISTER_TEST(
     negative_command_buffer_command_copy_image_mutable_handle_not_null)
 {
     return MakeAndRunTest<CommandBufferCopyImageMutableHandleNotNull>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_copy_to_immutable_buffer)
+{
+    return MakeAndRunTest<CommandBufferCopyToImmutableBuffer>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_copy_to_immutable_buffer_rect)
+{
+    return MakeAndRunTest<CommandBufferCopyToImmutableBufferRect>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_copy_image_to_immutable_buffer)
+{
+    return MakeAndRunTest<CommandBufferCopyImageToImmutableBuffer>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_copy_to_immutable_image)
+{
+    return MakeAndRunTest<CommandBufferCopyToImmutableImage>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_copy_buffer_to_immutable_image)
+{
+    return MakeAndRunTest<CommandBufferCopyBufferToImmutableImage>(
         device, context, queue, num_elements);
 }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_fill.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include "basic_command_buffer.h"
+#include "command_buffer_with_immutable_memory.h"
+#include "imageHelpers.h"
 #include <vector>
 
 //--------------------------------------------------------------------------
@@ -456,6 +458,89 @@ struct CommandBufferCommandFillImageMutableHandleNotNull
     }
 };
 
+// CL_INVALID_OPERATION if destination buffer is immutable memory
+struct CommandBufferCommandFillImmutableBuffer
+    : CommandBufferWithImmutableMemoryObjectsTest<CommandFillBaseTest<false>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, buffer, &pattern_1,
+            sizeof(pattern_1), 0, buffer_size, 0, nullptr, nullptr, nullptr);
+
+        test_failure_error_ret(error, CL_INVALID_OPERATION,
+                               "clCommandFillBufferKHR is supposed to fail "
+                               "with CL_INVALID_OPERATION when buffer is "
+                               "created with CL_MEM_IMMUTABLE_EXT",
+                               TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        std::vector<cl_uchar> data(buffer_size);
+
+        buffer =
+            clCreateBuffer(context, CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                           buffer_size, data.data(), &error);
+        test_error(error, "clCreateBuffer failed");
+
+        return CL_SUCCESS;
+    }
+
+    clMemWrapper buffer;
+    const size_t buffer_size = 512;
+    const uint8_t pattern_1 = 0x0f;
+};
+
+struct CommandBufferCommandFillImmutableImage
+    : CommandBufferWithImmutableMemoryObjectsTest<CommandFillBaseTest<true>>
+{
+    using CommandBufferWithImmutableMemoryObjectsTest::
+        CommandBufferWithImmutableMemoryObjectsTest;
+
+    cl_int Run() override
+    {
+        cl_int error = clCommandFillImageKHR(
+            command_buffer, nullptr, nullptr, image, fill_color_1, origin,
+            region, 0, nullptr, nullptr, nullptr);
+
+        test_failure_error_ret(error, CL_INVALID_OPERATION,
+                               "clCommandFillImageKHR is supposed to fail "
+                               "with CL_INVALID_OPERATION when image is "
+                               "created with CL_MEM_IMMUTABLE_EXT",
+                               TEST_FAIL);
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        size_t pixel_size = get_pixel_size(&formats);
+        size_t image_size = pixel_size * sizeof(cl_uchar) * 512 * 512;
+
+        std::vector<cl_uchar> imgptr(image_size);
+
+        image = create_image_2d(context,
+                                CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                                &formats, 512, 512, 0, imgptr.data(), &error);
+        test_error(error, "create_image_2d failed");
+
+        return CL_SUCCESS;
+    }
+
+    clMemWrapper image;
+};
 }
 
 REGISTER_TEST(negative_command_buffer_command_fill_buffer_queue_not_null)
@@ -535,5 +620,17 @@ REGISTER_TEST(
     negative_command_buffer_command_fill_image_mutable_handle_not_null)
 {
     return MakeAndRunTest<CommandBufferCommandFillImageMutableHandleNotNull>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_fill_immutable_image)
+{
+    return MakeAndRunTest<CommandBufferCommandFillImmutableImage>(
+        device, context, queue, num_elements);
+}
+
+REGISTER_TEST(negative_fill_immutable_buffer)
+{
+    return MakeAndRunTest<CommandBufferCommandFillImmutableBuffer>(
         device, context, queue, num_elements);
 }


### PR DESCRIPTION
This change provides partial test coverage for KhronosGroup/OpenCL-Docs#1280

Adding CTS tests for:
1. clEnqueueMapBuffer, clEnqueueMapImage.
2. Command buffer negative tests.
3. clSetKernelArgs negative tests.

The bulk of the tests is to make sure that the CL driver does not allow writing to a memory object that is created with `CL_MEM_IMMUTABLE_EXT` flag when used with the above APIs.