### PR TITLE
Fix cl_khr_semaphore semaphores_ooo_ops_cross_queue

### DIFF
--- a/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
+++ b/test_conformance/extensions/cl_khr_semaphore/test_semaphores_cross_queue.cpp
@@ -266,6 +266,9 @@ struct SemaphoreOutOfOrderOps : public SemaphoreTestBase
         err = clEnqueueBarrierWithWaitList(consumer_queue, 0, nullptr, nullptr);
         test_error(err, " clEnqueueBarrierWithWaitList ");
 
+        err = clFlush(producer_queue);
+        test_error(err, " clFlush ");
+
         std::vector<cl_int> host_buffer(num_elems, 0);
         auto verify_result = [&](const cl_mem &out_mem, const cl_int pattern) {
             err = clEnqueueReadBuffer(consumer_queue, out_mem, CL_TRUE, 0,


### PR DESCRIPTION
The test calls clEnqueueSignalSemaphoresKHR using the producer queue, and clEnqueueWaitSemaphoresKHR using the consumer queue.

It only flushes only the consumer queue (blocking clEnqueueReadBuffer), but never the producer queue which causes the test to never finish as the semaphore is never signalled.