### PR TITLE
Fix inconsistent variable name in REGISTER_TEST and REQUIRE_EXTENSION

### DIFF
--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -153,7 +153,7 @@ template <typename T> T *register_test(const char *name, Version version)
 #define REQUIRE_EXTENSION(name)                                                \
     do                                                                         \
     {                                                                          \
-        if (!is_extension_available(deviceID, name))                           \
+        if (!is_extension_available(device, name))                             \
         {                                                                      \
             log_info(name                                                      \
                      " is not supported on this device. Skipping test.\n");    \


### PR DESCRIPTION
Both `REGISTER_TEST` and `REQUIRE_EXTENSION` expect cl_device_id variable but the variable name is inconsistent which makes both macros unusable together.

This change renames `deviceID` in `REQUIRE_EXTENSION` to `device` to be consistent with `REGISTER_TEST`.