### PR TITLE
Test printf - set more precisely printing floating point numbers

### DIFF
--- a/test_conformance/printf/test_printf.cpp
+++ b/test_conformance/printf/test_printf.cpp
@@ -247,7 +247,7 @@ cl_program makeMixedFormatPrintfProgram(cl_kernel* kernel_ptr,
     };
 
     std::array<std::vector<std::string>, 2> formats = {
-        { { "%f", "%e", "%g", "%.13a", "%F", "%E", "%G", "%.13A" },
+        { { "%.13f", "%e", "%g", "%.13a", "%.13F", "%E", "%G", "%.13A" },
           { "%d", "%i", "%u", "%x", "%o", "%X" } }
     };
     std::vector<char> data_before(2 + genrand_int32(gMTdata) % 8);


### PR DESCRIPTION
We noticed such issue 
 expected: ^(K{C, -30304.8, -22634.574219, 24476.882812, E4929EC2, 1467582223, 96vL.+
 got:      ^(K{C, -30304.8, -22634.574219, 24476.882813, E4929EC2, 1467582223, 96vL.+
The input value is 24476.882812 and cannot be precisely represented as a single-floating point, so compilers are allowed to round it to the nearest representable value. In this case, the closest representable value to 24476.882812 is 24476.8828125, which rounds to 24476.882813.
Even some versions of MSVC prints that value as 24476.882813 and some 24476.882812 : https://godbolt.org/z/5GhEf8KPT
The proposal is to set precisely how many number should be displayed to avoid rounding.