### PR TITLE
fix error message in work_item_functions_out_of_range

### DIFF
--- a/test_conformance/basic/test_work_item_functions.cpp
+++ b/test_conformance/basic/test_work_item_functions.cpp
@@ -439,7 +439,7 @@ struct TestWorkItemFnsOutOfRange
                         "ERROR: get_enqueued_local_size(%d) did not return "
                         "proper value for the argument out of range "
                         "(expected 1, got %d)\n",
-                        (int)dim, (int)testData[q].globalSize);
+                        (int)dim, (int)testData[q].enqueuedLocalSize);
                     return false;
                 }
             }


### PR DESCRIPTION
The value printed in the error message is not the correct one (used in the comparison statement)