### PR TITLE
add missing Float16 capability

### DIFF
--- a/test_conformance/spirv_new/spirv_asm/op_spec_constant_half_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_spec_constant_half_simple.spvasm32
@@ -5,6 +5,7 @@
 ; Schema: 0
                OpCapability Addresses
                OpCapability Kernel
+               OpCapability Float16
                OpCapability Float16Buffer
           %1 = OpExtInstImport "OpenCL.std"
                OpMemoryModel Physical32 OpenCL

--- a/test_conformance/spirv_new/spirv_asm/op_spec_constant_half_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_spec_constant_half_simple.spvasm64
@@ -5,6 +5,7 @@
 ; Schema: 0
                OpCapability Addresses
                OpCapability Kernel
+               OpCapability Float16
                OpCapability Float16Buffer
           %1 = OpExtInstImport "OpenCL.std"
                OpMemoryModel Physical64 OpenCL


### PR DESCRIPTION
A recent improvement to the SPIR-V validator added checks to ensure the **Float16** capability is declared when directly operating on fp16 values, which identified issues in one of our SPIR-V test files.  This PR fixes the SPIR-V files to add the missing capability.