### PR TITLE
Remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.7z filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
We don't use git lfs. We have no .7z files in the repo.