### PR TITLE
Change relaxed exp exp2 embedded error to 4 + floor(fabs(2x))

### DIFF
--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -294,7 +294,7 @@ const Func functionList[] = {
     // floor(fabs(2*x)) is added to the relaxed error in unary.c
     ENTRY_EXT(exp, 3.0f, 4.0f, 2.0f, 3.0f, 3.0f, FTZ_OFF, unaryF, 4.0f),
 
-    // 3+floor(fabs(2*x)) is added to the relaxed error in unary.c
+    // floor(fabs(2*x)) is added to the relaxed error in unary.c
     ENTRY_EXT(exp2, 3.0f, 4.0f, 2.0f, 3.0f, 3.0f, FTZ_OFF, unaryF, 4.0f),
 
     // in non-derived mode it uses the ulp error for half_exp10.

--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -291,7 +291,7 @@ const Func functionList[] = {
     ENTRY(erfc, 16.0f, 16.0f, 4.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY(erf,  16.0f, 16.0f, 4.0f, 4.0f, FTZ_OFF, unaryF),
 
-    // 3+floor(fabs(2*x)) is added to the relaxed error in unary.c
+    // floor(fabs(2*x)) is added to the relaxed error in unary.c
     ENTRY_EXT(exp, 3.0f, 4.0f, 2.0f, 3.0f, 3.0f, FTZ_OFF, unaryF, 4.0f),
 
     // 3+floor(fabs(2*x)) is added to the relaxed error in unary.c

--- a/test_conformance/math_brute_force/function_list.cpp
+++ b/test_conformance/math_brute_force/function_list.cpp
@@ -291,13 +291,12 @@ const Func functionList[] = {
     ENTRY(erfc, 16.0f, 16.0f, 4.0f, 4.0f, FTZ_OFF, unaryF),
     ENTRY(erf,  16.0f, 16.0f, 4.0f, 4.0f, FTZ_OFF, unaryF),
 
-    // relaxed error is overwritten in unary.c as it is 3+floor(fabs(2*x))
+    // 3+floor(fabs(2*x)) is added to the relaxed error in unary.c
     ENTRY_EXT(exp, 3.0f, 4.0f, 2.0f, 3.0f, 3.0f, FTZ_OFF, unaryF, 4.0f),
 
-    // relaxed error is overwritten in unary.c as it is 3+floor(fabs(2*x))
+    // 3+floor(fabs(2*x)) is added to the relaxed error in unary.c
     ENTRY_EXT(exp2, 3.0f, 4.0f, 2.0f, 3.0f, 3.0f, FTZ_OFF, unaryF, 4.0f),
 
-    // relaxed error is overwritten in unary.c as it is 3+floor(fabs(2*x)) in derived mode;
     // in non-derived mode it uses the ulp error for half_exp10.
     ENTRY_EXT(exp10, 3.0f, 4.0f, 2.0f, 3.0f, 8192.0f, FTZ_OFF, unaryF, 8192.0f),
 

--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -300,13 +300,7 @@ cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)
 
                     if (strcmp(fname, "exp") == 0 || strcmp(fname, "exp2") == 0)
                     {
-                        // For full profile, ULP depends on input value.
-                        // For embedded profile, ULP comes from functionList.
-                        if (!gIsEmbedded)
-                        {
-                            ulps = 3.0f + floor(fabs(2 * s[j]));
-                        }
-
+                        ulps += floor(fabs(2 * s[j]));
                         fail = !(fabsf(err) <= ulps);
                     }
                     if (strcmp(fname, "tan") == 0)


### PR DESCRIPTION
Reflects the changes to the specification: https://github.com/KhronosGroup/OpenCL-Docs/pull/1318

Relaxed embedded exp and exp2 ulps will be 4 + floor(fabs(2 * x)).

Reciprocal and divide are unchanged because the code already handles the embedded profile case, see unary_float.c and binary_operator_float.c.