### PR TITLE
Always enable beta extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_2_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_1_APIS=1)
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_0_APIS=1)
 add_definitions(-DCL_NO_EXTENSION_PROTOTYPES)
+add_definitions(-DCL_ENABLE_BETA_EXTENSIONS)
 
 option(USE_CL_EXPERIMENTAL "Use Experimental definitions" OFF)
 if(USE_CL_EXPERIMENTAL)


### PR DESCRIPTION
`CL_ENABLE_BETA_EXTENSIONS` was just introduced in https://github.com/KhronosGroup/OpenCL-Headers/pull/276
to guard provisional and other experimental extensions. The CTS currently assumes
all definitions are always present.