### PR TITLE
Fix broken CI on MacOS

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Vulkan SDK
         uses: humbletim/install-vulkan-sdk@main
         with:
-          version: 1.3.275.0
+          version: 1.4.309.0
           cache: true
       - name: Install Android NDK
         if: ${{ matrix.arch == 'android-arm' || matrix.arch == 'android-aarch64' }}


### PR DESCRIPTION
LunarG has changed the SDK file hosted for MacOS v1.3.275.0 from a .zip file to a .dmg file with the old hyperlink transparently redirecting to the new one.

The script expects a .zip archive so it fails when it downloads a .dmg file.

Bump the Vulkan SDK version to 1.4.309.0, which is the latest version and is provided as a .zip archive.