### PR TITLE
fix test_api min_max_image_buffer_size

### DIFF
--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -1066,8 +1066,7 @@ REGISTER_TEST(min_max_image_buffer_size)
     PASSIVE_REQUIRE_IMAGE_SUPPORT(device);
 
     /* Get the max memory allocation size, divide it */
-    maxAllocSize = get_device_info_max_mem_alloc_size(
-        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    maxAllocSize = get_device_info_max_mem_alloc_size(device, 1);
 
     /* Get the max image array width */
     error =


### PR DESCRIPTION
This is fixing it for device exposing a big
CL_DEVICE_IMAGE_MAX_BUFFER_SIZE (more than
CL_DEVICE_MAX_MEM_ALLOC_SIZE/2)

Fix #2245