### PR TITLE
basic: fix Wformat warnings

### DIFF
--- a/test_conformance/basic/CMakeLists.txt
+++ b/test_conformance/basic/CMakeLists.txt
@@ -71,6 +71,6 @@ if(APPLE)
     list(APPEND ${MODULE_NAME}_SOURCES test_queue_priority.cpp)
 endif(APPLE)
 
-set_gnulike_module_compile_flags("-Wno-sign-compare -Wno-format")
+set_gnulike_module_compile_flags("-Wno-sign-compare")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/basic/test_bufferreadwriterect.cpp
+++ b/test_conformance/basic/test_bufferreadwriterect.cpp
@@ -21,6 +21,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "testBase.h"
 
 #define CL_EXIT_ERROR(cmd,format,...)                \
@@ -352,7 +354,7 @@ REGISTER_TEST(bufferreadwriterect)
     // Compute a maximum buffer size based on the number of test images and the device maximum.
     cl_ulong max_mem_alloc_size = 0;
     CL_EXIT_ERROR(clGetDeviceInfo(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof(cl_ulong), &max_mem_alloc_size, NULL),"Could not get device info");
-    log_info("CL_DEVICE_MAX_MEM_ALLOC_SIZE = %llu bytes.\n", max_mem_alloc_size);
+    log_info("CL_DEVICE_MAX_MEM_ALLOC_SIZE = %" PRIu64 " bytes.\n", max_mem_alloc_size);
 
     // Confirm that the maximum allocation size is not zero.
     if (max_mem_alloc_size == 0) {
@@ -390,7 +392,7 @@ REGISTER_TEST(bufferreadwriterect)
         // Check to see if adequately sized buffers were found.
         if (tries >= max_tries) {
             log_error("Error: Could not find random buffer sized less than "
-                      "%llu bytes in %zu tries.\n",
+                      "%" PRIu64 " bytes in %zu tries.\n",
                       max_mem_alloc_size, max_tries);
             return -1;
         }

--- a/test_conformance/basic/test_bufferreadwriterect.cpp
+++ b/test_conformance/basic/test_bufferreadwriterect.cpp
@@ -354,7 +354,8 @@ REGISTER_TEST(bufferreadwriterect)
     // Compute a maximum buffer size based on the number of test images and the device maximum.
     cl_ulong max_mem_alloc_size = 0;
     CL_EXIT_ERROR(clGetDeviceInfo(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof(cl_ulong), &max_mem_alloc_size, NULL),"Could not get device info");
-    log_info("CL_DEVICE_MAX_MEM_ALLOC_SIZE = %" PRIu64 " bytes.\n", max_mem_alloc_size);
+    log_info("CL_DEVICE_MAX_MEM_ALLOC_SIZE = %" PRIu64 " bytes.\n",
+             max_mem_alloc_size);
 
     // Confirm that the maximum allocation size is not zero.
     if (max_mem_alloc_size == 0) {

--- a/test_conformance/basic/test_constant.cpp
+++ b/test_conformance/basic/test_constant.cpp
@@ -117,7 +117,8 @@ REGISTER_TEST(constant)
     err = clGetDeviceInfo(device, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,
                           sizeof(maxSize), &maxSize, 0);
     test_error(err, "Unable to get max constant buffer size");
-    log_info("Device reports CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE %" PRIu64 " bytes.\n",
+    log_info("Device reports CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE %" PRIu64
+             " bytes.\n",
              maxSize);
 
     // Limit test buffer size to 1/4 of CL_DEVICE_GLOBAL_MEM_SIZE

--- a/test_conformance/basic/test_constant.cpp
+++ b/test_conformance/basic/test_constant.cpp
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <vector>
 
 #include "testBase.h"
@@ -116,7 +117,7 @@ REGISTER_TEST(constant)
     err = clGetDeviceInfo(device, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,
                           sizeof(maxSize), &maxSize, 0);
     test_error(err, "Unable to get max constant buffer size");
-    log_info("Device reports CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE %llu bytes.\n",
+    log_info("Device reports CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE %" PRIu64 " bytes.\n",
              maxSize);
 
     // Limit test buffer size to 1/4 of CL_DEVICE_GLOBAL_MEM_SIZE

--- a/test_conformance/basic/test_intmath.cpp
+++ b/test_conformance/basic/test_intmath.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <cinttypes>
 #include <functional>
 #include <string>
 #include <vector>
@@ -182,13 +183,13 @@ static int test_intmath(cl_device_id device, cl_context context,
             if (r != output[i])
             {
                 log_error("\n\nverification failed at index %d\n", i);
-                log_error("-> inputs: %llu, %llu, %llu\n",
-                          static_cast<cl_uint>(inputA[i]),
-                          static_cast<cl_uint>(inputB[i]),
-                          static_cast<cl_uint>(inputC[i]));
-                log_error("-> expected %llu, got %llu\n\n",
-                          static_cast<cl_uint>(r),
-                          static_cast<cl_uint>(output[i]));
+                log_error("-> inputs: %" PRIu64 "%" PRIu64 "%" PRIu64 "\n",
+                          static_cast<cl_ulong>(inputA[i]),
+                          static_cast<cl_ulong>(inputB[i]),
+                          static_cast<cl_ulong>(inputC[i]));
+                log_error("-> expected %" PRIu64 "%" PRIu64 "\n\n",
+                          static_cast<cl_ulong>(r),
+                          static_cast<cl_ulong>(output[i]));
                 return TEST_FAIL;
             }
         }

--- a/test_conformance/basic/test_kernel_memory_alignment.cpp
+++ b/test_conformance/basic/test_kernel_memory_alignment.cpp
@@ -317,9 +317,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 6; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64
+                                  " is not properly aligned.\n",
+                                  1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%" PRIx64
+                                     " is properly aligned.\n",
+                                     1 << i, results_data[i]);
                     }
                 }
             }
@@ -330,9 +335,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 6; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not "
+                                  "properly aligned.\n",
+                                  1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%x is "
+                                     "properly aligned.\n",
+                                     1 << i, results_data_no_long[i]);
                     }
                 }
             }
@@ -385,9 +395,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64
+                                  " is not properly aligned.\n",
+                                  1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%" PRIx64
+                                     " is properly aligned.\n",
+                                     1 << i, results_data[i]);
                     }
                 }
             }
@@ -398,9 +413,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not "
+                                  "properly aligned.\n",
+                                  1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%x is "
+                                     "properly aligned.\n",
+                                     1 << i, results_data_no_long[i]);
                     }
                 }
             }
@@ -457,9 +477,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64
+                                  " is not properly aligned.\n",
+                                  1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%" PRIx64
+                                     " is properly aligned.\n",
+                                     1 << i, results_data[i]);
                     }
                 }
             }
@@ -470,9 +495,14 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not "
+                                  "properly aligned.\n",
+                                  1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG)
+                            log_info("\tVector size %d passed: 0x%x is "
+                                     "properly aligned.\n",
+                                     1 << i, results_data_no_long[i]);
                     }
                 }
             }

--- a/test_conformance/basic/test_kernel_memory_alignment.cpp
+++ b/test_conformance/basic/test_kernel_memory_alignment.cpp
@@ -17,6 +17,8 @@
 #include <unistd.h>
 #endif
 
+#include <cinttypes>
+
 #include "harness/conversions.h"
 #include "harness/typeWrappers.h"
 #include "harness/errorHelpers.h"
@@ -315,9 +317,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 6; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
                     }
                 }
             }
@@ -328,9 +330,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 6; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
                     }
                 }
             }
@@ -383,9 +385,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
                     }
                 }
             }
@@ -396,9 +398,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
                     }
                 }
             }
@@ -455,9 +457,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data[i]);
+                        log_error("\tVector size %d failed: 0x%" PRIx64 " is not properly aligned.\n", 1 << i, results_data[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%" PRIx64 " is properly aligned.\n", 1 << i, results_data[i]);
                     }
                 }
             }
@@ -468,9 +470,9 @@ static int test_kernel_memory_alignment(cl_device_id device, cl_context context,
                 for (int i = 0; i < 5; i++) {
                     if ((results_data_no_long[i] & alignments[i]) != 0) {
                         total_errors++;
-                        log_error("\tVector size %d failed: 0x%llx is not properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        log_error("\tVector size %d failed: 0x%x is not properly aligned.\n", 1 << i, results_data_no_long[i]);
                     } else {
-                        if (DEBUG) log_info("\tVector size %d passed: 0x%llx is properly aligned.\n", 1 << i, results_data_no_long[i]);
+                        if (DEBUG) log_info("\tVector size %d passed: 0x%x is properly aligned.\n", 1 << i, results_data_no_long[i]);
                     }
                 }
             }

--- a/test_conformance/basic/test_numeric_constants.cpp
+++ b/test_conformance/basic/test_numeric_constants.cpp
@@ -15,6 +15,8 @@
 //
 #include "testBase.h"
 
+#include <cinttypes>
+
 #define TEST_VALUE_POSITIVE( string_name, name, value ) \
 { \
 if (name < value) { \
@@ -528,7 +530,7 @@ const char *kernel_constant_double_limits[] = {
 };
 
 #define TEST_FLOAT_ASSERTION( a, msg, f ) if( !( a ) ) { log_error( "ERROR: Float constant failed requirement: %s (bitwise value is 0x%8.8x)\n", msg, *( (uint32_t *)&f ) ); return -1; }
-#define TEST_DOUBLE_ASSERTION( a, msg, f ) if( !( a ) ) { log_error( "ERROR: Double constant failed requirement: %s (bitwise value is 0x%16.16llx)\n", msg, *( (uint64_t *)&f ) ); return -1; }
+#define TEST_DOUBLE_ASSERTION( a, msg, f ) if( !( a ) ) { log_error( "ERROR: Double constant failed requirement: %s (bitwise value is 0x%16.16" PRIx64 ")\n", msg, *( (uint64_t *)&f ) ); return -1; }
 
 REGISTER_TEST(kernel_limit_constants)
 {

--- a/test_conformance/basic/test_numeric_constants.cpp
+++ b/test_conformance/basic/test_numeric_constants.cpp
@@ -530,7 +530,14 @@ const char *kernel_constant_double_limits[] = {
 };
 
 #define TEST_FLOAT_ASSERTION( a, msg, f ) if( !( a ) ) { log_error( "ERROR: Float constant failed requirement: %s (bitwise value is 0x%8.8x)\n", msg, *( (uint32_t *)&f ) ); return -1; }
-#define TEST_DOUBLE_ASSERTION( a, msg, f ) if( !( a ) ) { log_error( "ERROR: Double constant failed requirement: %s (bitwise value is 0x%16.16" PRIx64 ")\n", msg, *( (uint64_t *)&f ) ); return -1; }
+#define TEST_DOUBLE_ASSERTION(a, msg, f)                                       \
+    if (!(a))                                                                  \
+    {                                                                          \
+        log_error("ERROR: Double constant failed requirement: %s (bitwise "    \
+                  "value is 0x%16.16" PRIx64 ")\n",                            \
+                  msg, *((uint64_t *)&f));                                     \
+        return -1;                                                             \
+    }
 
 REGISTER_TEST(kernel_limit_constants)
 {

--- a/test_conformance/basic/test_sizeof.cpp
+++ b/test_conformance/basic/test_sizeof.cpp
@@ -21,6 +21,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cinttypes>
+
 #include "testBase.h"
 
 cl_int get_type_size( cl_context context, cl_command_queue queue, const char *type, cl_ulong *size, cl_device_id device  )
@@ -161,12 +163,12 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != scalar_table[i].size )
         {
-            log_error( "\nFAILED: Type %s has size %lld, but expected size %lld!\n", scalar_table[i].name, test, scalar_table[i].size );
+            log_error( "\nFAILED: Type %s has size %" PRId64 ", but expected size %" PRId64 "!\n", scalar_table[i].name, test, scalar_table[i].size );
             return -1;
         }
         if( test != scalar_table[i].cl_size )
         {
-            log_error( "\nFAILED: Type %s has size %lld, but cl_ size is %lld!\n", scalar_table[i].name, test, scalar_table[i].cl_size );
+            log_error( "\nFAILED: Type %s has size %" PRId64 ", but cl_ size is %" PRId64 "!\n", scalar_table[i].name, test, scalar_table[i].cl_size );
             return -2;
         }
         log_info( "%16s", scalar_table[i].name );
@@ -197,14 +199,14 @@ REGISTER_TEST(sizeof)
             if( test != j * vector_table[i].size )
             {
                 log_error(
-                    "\nFAILED: Type %s has size %lld, but expected size %zu!\n",
+                    "\nFAILED: Type %s has size %" PRId64 ", but expected size %" PRIu64 "!\n",
                     name, test, j * vector_table[i].size);
                 return -1;
             }
             if( test != j * vector_table[i].cl_size )
             {
                 log_error(
-                    "\nFAILED: Type %s has size %lld, but cl_ size is %zu!\n",
+                    "\nFAILED: Type %s has size %" PRId64 ", but cl_ size is %" PRIu64 "!\n",
                     name, test, j * vector_table[i].cl_size);
                 return -2;
             }
@@ -222,7 +224,7 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != ptr_size )
         {
-            log_error( "\nFAILED: Type %s has size %lld, but expected size %u!\n", ptr_table[i], test, ptr_size );
+            log_error( "\nFAILED: Type %s has size %" PRId64 ", but expected size %u!\n", ptr_table[i], test, ptr_size );
             return -1;
         }
         log_info( "%16s", ptr_table[i] );
@@ -235,12 +237,12 @@ REGISTER_TEST(sizeof)
         return err;
     if( test < ptr_size )
     {
-        log_error( "\nFAILED: intptr_t has size %lld, but must be at least %u!\n", test, ptr_size );
+        log_error( "\nFAILED: intptr_t has size %" PRId64 ", but must be at least %u!\n", test, ptr_size );
         return -1;
     }
     if( ! IsPowerOfTwo( test ) )
     {
-        log_error( "\nFAILED: sizeof(intptr_t) is %lld, but must be a power of two!\n", test );
+        log_error( "\nFAILED: sizeof(intptr_t) is %" PRId64 ", but must be a power of two!\n", test );
         return -2;
     }
     log_info( "%16s", "intptr_t" );
@@ -252,12 +254,12 @@ REGISTER_TEST(sizeof)
         return err;
     if( test < ptr_size )
     {
-        log_error( "\nFAILED: uintptr_t has size %lld, but must be at least %u!\n", test, ptr_size );
+        log_error( "\nFAILED: uintptr_t has size %" PRId64 ", but must be at least %u!\n", test, ptr_size );
         return -1;
     }
     if( ! IsPowerOfTwo( test ) )
     {
-        log_error( "\nFAILED: sizeof(uintptr_t) is %lld, but must be a power of two!\n", test );
+        log_error( "\nFAILED: sizeof(uintptr_t) is %" PRId64 ", but must be a power of two!\n", test );
         return -2;
     }
     log_info( "%16s\n", "uintptr_t" );
@@ -293,7 +295,7 @@ REGISTER_TEST(sizeof)
             return err;
         if( ! IsPowerOfTwo( test ) )
         {
-            log_error( "\nFAILED: Type %s has size %lld, which is not a power of two (section 6.1.5)!\n", other_types[i], test );
+            log_error( "\nFAILED: Type %s has size %" PRId64 ", which is not a power of two (section 6.1.5)!\n", other_types[i], test );
             return -1;
         }
         log_info( "%16s", other_types[i] );
@@ -311,7 +313,7 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != 8 )
         {
-            log_error( "\nFAILED: double has size %lld, but must be 8!\n", test );
+            log_error( "\nFAILED: double has size %" PRId64 ", but must be 8!\n", test );
             return -1;
         }
         log_info( "%16s", "double" );
@@ -328,7 +330,7 @@ REGISTER_TEST(sizeof)
                 return err;
             if( test != 8*j )
             {
-                log_error("\nFAILED: %s has size %lld, but must be %zu!\n",
+                log_error("\nFAILED: %s has size %" PRId64 ", but must be %zu!\n",
                           name, test, 8 * j);
                 return -1;
             }
@@ -347,7 +349,7 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != 2 )
         {
-            log_error( "\nFAILED: half has size %lld, but must be 2!\n", test );
+            log_error( "\nFAILED: half has size %" PRId64 ", but must be 2!\n", test );
             return -1;
         }
         log_info( "%16s", "half" );
@@ -364,7 +366,7 @@ REGISTER_TEST(sizeof)
                 return err;
             if( test != 2*j )
             {
-                log_error("\nFAILED: %s has size %lld, but must be %zu!\n",
+                log_error("\nFAILED: %s has size %" PRId64 ", but must be %zu!\n",
                           name, test, 2 * j);
                 return -1;
             }

--- a/test_conformance/basic/test_sizeof.cpp
+++ b/test_conformance/basic/test_sizeof.cpp
@@ -163,12 +163,16 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != scalar_table[i].size )
         {
-            log_error( "\nFAILED: Type %s has size %" PRId64 ", but expected size %" PRId64 "!\n", scalar_table[i].name, test, scalar_table[i].size );
+            log_error("\nFAILED: Type %s has size %" PRId64
+                      ", but expected size %" PRId64 "!\n",
+                      scalar_table[i].name, test, scalar_table[i].size);
             return -1;
         }
         if( test != scalar_table[i].cl_size )
         {
-            log_error( "\nFAILED: Type %s has size %" PRId64 ", but cl_ size is %" PRId64 "!\n", scalar_table[i].name, test, scalar_table[i].cl_size );
+            log_error("\nFAILED: Type %s has size %" PRId64
+                      ", but cl_ size is %" PRId64 "!\n",
+                      scalar_table[i].name, test, scalar_table[i].cl_size);
             return -2;
         }
         log_info( "%16s", scalar_table[i].name );
@@ -198,16 +202,16 @@ REGISTER_TEST(sizeof)
                 return err;
             if( test != j * vector_table[i].size )
             {
-                log_error(
-                    "\nFAILED: Type %s has size %" PRId64 ", but expected size %" PRIu64 "!\n",
-                    name, test, j * vector_table[i].size);
+                log_error("\nFAILED: Type %s has size %" PRId64
+                          ", but expected size %" PRIu64 "!\n",
+                          name, test, j * vector_table[i].size);
                 return -1;
             }
             if( test != j * vector_table[i].cl_size )
             {
-                log_error(
-                    "\nFAILED: Type %s has size %" PRId64 ", but cl_ size is %" PRIu64 "!\n",
-                    name, test, j * vector_table[i].cl_size);
+                log_error("\nFAILED: Type %s has size %" PRId64
+                          ", but cl_ size is %" PRIu64 "!\n",
+                          name, test, j * vector_table[i].cl_size);
                 return -2;
             }
             log_info( "%16s", name );
@@ -224,7 +228,9 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != ptr_size )
         {
-            log_error( "\nFAILED: Type %s has size %" PRId64 ", but expected size %u!\n", ptr_table[i], test, ptr_size );
+            log_error("\nFAILED: Type %s has size %" PRId64
+                      ", but expected size %u!\n",
+                      ptr_table[i], test, ptr_size);
             return -1;
         }
         log_info( "%16s", ptr_table[i] );
@@ -237,12 +243,16 @@ REGISTER_TEST(sizeof)
         return err;
     if( test < ptr_size )
     {
-        log_error( "\nFAILED: intptr_t has size %" PRId64 ", but must be at least %u!\n", test, ptr_size );
+        log_error("\nFAILED: intptr_t has size %" PRId64
+                  ", but must be at least %u!\n",
+                  test, ptr_size);
         return -1;
     }
     if( ! IsPowerOfTwo( test ) )
     {
-        log_error( "\nFAILED: sizeof(intptr_t) is %" PRId64 ", but must be a power of two!\n", test );
+        log_error("\nFAILED: sizeof(intptr_t) is %" PRId64
+                  ", but must be a power of two!\n",
+                  test);
         return -2;
     }
     log_info( "%16s", "intptr_t" );
@@ -254,12 +264,16 @@ REGISTER_TEST(sizeof)
         return err;
     if( test < ptr_size )
     {
-        log_error( "\nFAILED: uintptr_t has size %" PRId64 ", but must be at least %u!\n", test, ptr_size );
+        log_error("\nFAILED: uintptr_t has size %" PRId64
+                  ", but must be at least %u!\n",
+                  test, ptr_size);
         return -1;
     }
     if( ! IsPowerOfTwo( test ) )
     {
-        log_error( "\nFAILED: sizeof(uintptr_t) is %" PRId64 ", but must be a power of two!\n", test );
+        log_error("\nFAILED: sizeof(uintptr_t) is %" PRId64
+                  ", but must be a power of two!\n",
+                  test);
         return -2;
     }
     log_info( "%16s\n", "uintptr_t" );
@@ -295,7 +309,9 @@ REGISTER_TEST(sizeof)
             return err;
         if( ! IsPowerOfTwo( test ) )
         {
-            log_error( "\nFAILED: Type %s has size %" PRId64 ", which is not a power of two (section 6.1.5)!\n", other_types[i], test );
+            log_error("\nFAILED: Type %s has size %" PRId64
+                      ", which is not a power of two (section 6.1.5)!\n",
+                      other_types[i], test);
             return -1;
         }
         log_info( "%16s", other_types[i] );
@@ -313,7 +329,8 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != 8 )
         {
-            log_error( "\nFAILED: double has size %" PRId64 ", but must be 8!\n", test );
+            log_error("\nFAILED: double has size %" PRId64 ", but must be 8!\n",
+                      test);
             return -1;
         }
         log_info( "%16s", "double" );
@@ -330,7 +347,8 @@ REGISTER_TEST(sizeof)
                 return err;
             if( test != 8*j )
             {
-                log_error("\nFAILED: %s has size %" PRId64 ", but must be %zu!\n",
+                log_error("\nFAILED: %s has size %" PRId64
+                          ", but must be %zu!\n",
                           name, test, 8 * j);
                 return -1;
             }
@@ -349,7 +367,8 @@ REGISTER_TEST(sizeof)
             return err;
         if( test != 2 )
         {
-            log_error( "\nFAILED: half has size %" PRId64 ", but must be 2!\n", test );
+            log_error("\nFAILED: half has size %" PRId64 ", but must be 2!\n",
+                      test);
             return -1;
         }
         log_info( "%16s", "half" );
@@ -366,7 +385,8 @@ REGISTER_TEST(sizeof)
                 return err;
             if( test != 2*j )
             {
-                log_error("\nFAILED: %s has size %" PRId64 ", but must be %zu!\n",
+                log_error("\nFAILED: %s has size %" PRId64
+                          ", but must be %zu!\n",
                           name, test, 2 * j);
                 return -1;
             }

--- a/test_conformance/basic/test_vector_swizzle.cpp
+++ b/test_conformance/basic/test_vector_swizzle.cpp
@@ -605,7 +605,7 @@ template <typename T, size_t N>
 static int test_vectype(const char* type_name, cl_device_id device,
                         cl_context context, cl_command_queue queue)
 {
-    log_info("    testing type %s%d\n", type_name, N);
+    log_info("    testing type %s%zu\n", type_name, N);
 
     cl_int error = CL_SUCCESS;
     int result = TEST_PASS;


### PR DESCRIPTION
Fix all `-Wformat` warnings in the basic test suite, and re-enable the warning.