### PR TITLE
Added support for cl_ext_float_atomics in CBasicTestFetchAdd with atomic_half

### DIFF
--- a/test_conformance/c11_atomics/common.cpp
+++ b/test_conformance/c11_atomics/common.cpp
@@ -58,27 +58,26 @@ cl_uint AtomicTypeInfo::Size(cl_device_id device)
 {
   switch(_type)
   {
-  case TYPE_ATOMIC_INT:
-  case TYPE_ATOMIC_UINT:
-  case TYPE_ATOMIC_FLOAT:
-  case TYPE_ATOMIC_FLAG:
-    return sizeof(cl_int);
-  case TYPE_ATOMIC_LONG:
-  case TYPE_ATOMIC_ULONG:
-  case TYPE_ATOMIC_DOUBLE:
-    return sizeof(cl_long);
-  case TYPE_ATOMIC_INTPTR_T:
-  case TYPE_ATOMIC_UINTPTR_T:
-  case TYPE_ATOMIC_SIZE_T:
-  case TYPE_ATOMIC_PTRDIFF_T:
-    {
-      int error;
-      cl_uint addressBits = 0;
+      case TYPE_ATOMIC_HALF: return sizeof(cl_half);
+      case TYPE_ATOMIC_INT:
+      case TYPE_ATOMIC_UINT:
+      case TYPE_ATOMIC_FLOAT:
+      case TYPE_ATOMIC_FLAG: return sizeof(cl_int);
+      case TYPE_ATOMIC_LONG:
+      case TYPE_ATOMIC_ULONG:
+      case TYPE_ATOMIC_DOUBLE: return sizeof(cl_long);
+      case TYPE_ATOMIC_INTPTR_T:
+      case TYPE_ATOMIC_UINTPTR_T:
+      case TYPE_ATOMIC_SIZE_T:
+      case TYPE_ATOMIC_PTRDIFF_T: {
+          int error;
+          cl_uint addressBits = 0;
 
-      error = clGetDeviceInfo(device, CL_DEVICE_ADDRESS_BITS, sizeof(addressBits), &addressBits, 0);
-      test_error_ret(error, "clGetDeviceInfo", 0);
+          error = clGetDeviceInfo(device, CL_DEVICE_ADDRESS_BITS,
+                                  sizeof(addressBits), &addressBits, 0);
+          test_error_ret(error, "clGetDeviceInfo", 0);
 
-      return addressBits/8;
+          return addressBits / 8;
     }
   default:
     return 0;
@@ -93,6 +92,7 @@ const char *AtomicTypeInfo::AtomicTypeName()
     return "atomic_int";
   case TYPE_ATOMIC_UINT:
     return "atomic_uint";
+  case TYPE_ATOMIC_HALF: return "atomic_half";
   case TYPE_ATOMIC_FLOAT:
     return "atomic_float";
   case TYPE_ATOMIC_FLAG:
@@ -124,6 +124,7 @@ const char *AtomicTypeInfo::RegularTypeName()
     return "int";
   case TYPE_ATOMIC_UINT:
     return "uint";
+  case TYPE_ATOMIC_HALF: return "half";
   case TYPE_ATOMIC_FLOAT:
     return "float";
   case TYPE_ATOMIC_FLAG:
@@ -163,29 +164,30 @@ int AtomicTypeInfo::IsSupported(cl_device_id device)
 {
   switch(_type)
   {
-  case TYPE_ATOMIC_INT:
-  case TYPE_ATOMIC_UINT:
-  case TYPE_ATOMIC_FLOAT:
-  case TYPE_ATOMIC_FLAG:
-    return 1;
-  case TYPE_ATOMIC_LONG:
-  case TYPE_ATOMIC_ULONG:
-    return is_extension_available(device, "cl_khr_int64_base_atomics") &&
-      is_extension_available(device, "cl_khr_int64_extended_atomics");
-  case TYPE_ATOMIC_DOUBLE:
-    return is_extension_available(device, "cl_khr_int64_base_atomics") &&
-      is_extension_available(device, "cl_khr_int64_extended_atomics") &&
-      is_extension_available(device, "cl_khr_fp64");
-  case TYPE_ATOMIC_INTPTR_T:
-  case TYPE_ATOMIC_UINTPTR_T:
-  case TYPE_ATOMIC_SIZE_T:
-  case TYPE_ATOMIC_PTRDIFF_T:
-    if(Size(device) == 4)
-      return 1;
-    return is_extension_available(device, "cl_khr_int64_base_atomics") &&
-      is_extension_available(device, "cl_khr_int64_extended_atomics");
-  default:
-    return 0;
+      case TYPE_ATOMIC_HALF:
+          return is_extension_available(device, "cl_khr_fp16");
+      case TYPE_ATOMIC_INT:
+      case TYPE_ATOMIC_UINT:
+      case TYPE_ATOMIC_FLOAT:
+      case TYPE_ATOMIC_FLAG: return 1;
+      case TYPE_ATOMIC_LONG:
+      case TYPE_ATOMIC_ULONG:
+          return is_extension_available(device, "cl_khr_int64_base_atomics")
+              && is_extension_available(device,
+                                        "cl_khr_int64_extended_atomics");
+      case TYPE_ATOMIC_DOUBLE:
+          return is_extension_available(device, "cl_khr_int64_base_atomics")
+              && is_extension_available(device, "cl_khr_int64_extended_atomics")
+              && is_extension_available(device, "cl_khr_fp64");
+      case TYPE_ATOMIC_INTPTR_T:
+      case TYPE_ATOMIC_UINTPTR_T:
+      case TYPE_ATOMIC_SIZE_T:
+      case TYPE_ATOMIC_PTRDIFF_T:
+          if (Size(device) == 4) return 1;
+          return is_extension_available(device, "cl_khr_int64_base_atomics")
+              && is_extension_available(device,
+                                        "cl_khr_int64_extended_atomics");
+      default: return 0;
   }
 }
 

--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -22,6 +22,8 @@
 
 #include "host_atomics.h"
 
+#include "CL/cl_half.h"
+
 #include <vector>
 #include <sstream>
 
@@ -38,6 +40,7 @@ enum TExplicitAtomicType
     TYPE_ATOMIC_UINT,
     TYPE_ATOMIC_LONG,
     TYPE_ATOMIC_ULONG,
+    TYPE_ATOMIC_HALF,
     TYPE_ATOMIC_FLOAT,
     TYPE_ATOMIC_DOUBLE,
     TYPE_ATOMIC_INTPTR_T,
@@ -71,6 +74,9 @@ extern int
     gMaxDeviceThreads; // maximum number of threads executed on OCL device
 extern cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+extern cl_half_rounding_mode gHalfRoundingMode;
+extern bool gFloatAtomicsSupported;
+extern cl_device_fp_atomic_capabilities_ext gHalfAtomicCaps;
 
 extern const char *
 get_memory_order_type_name(TExplicitMemoryOrderType orderType);
@@ -168,6 +174,13 @@ public:
     {
         return false;
     }
+    virtual bool VerifyExpected(const HostDataType &expected,
+                                const HostAtomicType *const testValue,
+                                cl_uint whichDestValue)
+    {
+        if (testValue != nullptr) return expected != testValue[whichDestValue];
+        return true;
+    }
     virtual bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
                               MTdata d)
     {
@@ -240,13 +253,13 @@ public:
         int error = 0;
         if (_maxDeviceThreads > 0 && !UseSVM())
         {
-            LocalMemory(true);
+            SetLocalMemory(true);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
         if (_maxDeviceThreads + MaxHostThreads() > 0)
         {
-            LocalMemory(false);
+            SetLocalMemory(false);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
@@ -401,7 +414,7 @@ public:
     bool UseSVM() { return _useSVM; }
     void StartValue(HostDataType startValue) { _startValue = startValue; }
     HostDataType StartValue() { return _startValue; }
-    void LocalMemory(bool local) { _localMemory = local; }
+    void SetLocalMemory(bool local) { _localMemory = local; }
     bool LocalMemory() { return _localMemory; }
     void DeclaredInProgram(bool declaredInProgram)
     {
@@ -781,6 +794,8 @@ CBasicTest<HostAtomicType, HostDataType>::PragmaHeader(cl_device_id deviceID)
     }
     if (_dataType == TYPE_ATOMIC_DOUBLE)
         pragma += "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n";
+    if (_dataType == TYPE_ATOMIC_HALF)
+        pragma += "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n";
     return pragma;
 }
 
@@ -1434,7 +1449,7 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(
                            startRefValues.size() ? &startRefValues[0] : 0, i))
             break; // no expected value function provided
 
-        if (expected != destItems[i])
+        if (VerifyExpected(expected, destItems.data(), i))
         {
             std::stringstream logLine;
             logLine << "ERROR: Result " << i

--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -14,8 +14,11 @@
 // limitations under the License.
 //
 #include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+#include "harness/kernelHelpers.h"
 #include <iostream>
 #include <string>
+#include "CL/cl_half.h"
 
 bool gHost = false; // flag for testing native host threads (test verification)
 bool gOldAPI = false; // flag for testing with old API (OpenCL 1.2) - test verification
@@ -28,6 +31,9 @@ int gInternalIterations = 10000; // internal test iterations for atomic operatio
 int gMaxDeviceThreads = 1024; // maximum number of threads executed on OCL device
 cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+cl_half_rounding_mode gHalfRoundingMode = CL_HALF_RTE;
+bool gFloatAtomicsSupported = false;
+cl_device_fp_atomic_capabilities_ext gHalfAtomicCaps = 0;
 
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
@@ -121,6 +127,34 @@ test_status InitCL(cl_device_id device) {
             | CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM
             | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE
             | CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES;
+    }
+
+    if (is_extension_available(device, "cl_ext_float_atomics"))
+    {
+        gFloatAtomicsSupported = true;
+        if (is_extension_available(device, "cl_khr_fp16"))
+        {
+            cl_int error = clGetDeviceInfo(
+                device, CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT,
+                sizeof(gHalfAtomicCaps), &gHalfAtomicCaps, nullptr);
+            test_error_ret(error, "clGetDeviceInfo failed!", TEST_FAIL);
+
+            const cl_device_fp_config fpConfigHalf =
+                get_default_rounding_mode(device, CL_DEVICE_HALF_FP_CONFIG);
+            if ((fpConfigHalf & CL_FP_ROUND_TO_NEAREST) != 0)
+            {
+                gHalfRoundingMode = CL_HALF_RTE;
+            }
+            else if ((fpConfigHalf & CL_FP_ROUND_TO_ZERO) != 0)
+            {
+                gHalfRoundingMode = CL_HALF_RTZ;
+            }
+            else
+            {
+                log_error("Error while acquiring half rounding mode\n");
+                return TEST_FAIL;
+            }
+        }
     }
 
     return TEST_PASS;

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -16,10 +16,13 @@
 #include "harness/testHarness.h"
 #include "harness/kernelHelpers.h"
 #include "harness/typeWrappers.h"
+#include "harness/conversions.h"
 
 #include "common.h"
 #include "host_atomics.h"
 
+#include <algorithm>
+#include <numeric>
 #include <sstream>
 #include <vector>
 
@@ -1037,60 +1040,236 @@ REGISTER_TEST(svm_atomic_compare_exchange_weak)
 template <typename HostAtomicType, typename HostDataType>
 class CBasicTestFetchAdd
     : public CBasicTestMemOrderScope<HostAtomicType, HostDataType> {
+
+    double min_range;
+    double max_range;
+    double max_error;
+    std::vector<HostDataType> ref_vals;
+
 public:
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::MemoryOrder;
     using CBasicTestMemOrderScope<HostAtomicType,
                                   HostDataType>::MemoryOrderScopeStr;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::StartValue;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::DataType;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::LocalMemory;
     CBasicTestFetchAdd(TExplicitAtomicType dataType, bool useSVM)
         : CBasicTestMemOrderScope<HostAtomicType, HostDataType>(dataType,
-                                                                useSVM)
-    {}
-    virtual std::string ProgramCore()
+                                                                useSVM),
+          min_range(-999.0), max_range(999.0), max_error(0.0)
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            StartValue(0);
+            CBasicTestMemOrderScope<HostAtomicType,
+                                    HostDataType>::OldValueCheck(false);
+        }
+    }
+    template <typename Iterator> float accum_halfs(Iterator begin, Iterator end)
+    {
+        cl_half sum = 0;
+        for (auto it = begin; it != end; ++it)
+        {
+            sum = cl_half_from_float(cl_half_to_float(sum)
+                                         + cl_half_to_float(*it),
+                                     gHalfRoundingMode);
+        }
+        return cl_half_to_float(sum);
+    }
+    bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
+                      MTdata d) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            if (threadCount > ref_vals.size())
+            {
+                ref_vals.resize(threadCount);
+
+                for (cl_uint i = 0; i < threadCount; i++)
+                    ref_vals[i] = cl_half_from_float(
+                        get_random_float(min_range, max_range, d),
+                        gHalfRoundingMode);
+
+                memcpy(startRefValues, ref_vals.data(),
+                       sizeof(HostDataType) * ref_vals.size());
+
+                // Estimate highest possible summation error for given set.
+                std::vector<float> sums;
+                std::sort(ref_vals.begin(), ref_vals.end(),
+                          [](cl_half a, cl_half b) {
+                              return cl_half_to_float(a) < cl_half_to_float(b);
+                          });
+
+                sums.push_back(accum_halfs(ref_vals.begin(), ref_vals.end()));
+                sums.push_back(accum_halfs(ref_vals.rbegin(), ref_vals.rend()));
+
+                std::sort(ref_vals.begin(), ref_vals.end(),
+                          [](cl_half a, cl_half b) {
+                              return std::abs(cl_half_to_float(a))
+                                  < std::abs(cl_half_to_float(b));
+                          });
+
+                float precise = 0.f;
+                for (auto elem : ref_vals) precise += cl_half_to_float(elem);
+                sums.push_back(precise);
+
+                sums.push_back(accum_halfs(ref_vals.begin(), ref_vals.end()));
+                sums.push_back(accum_halfs(ref_vals.rbegin(), ref_vals.rend()));
+
+                std::sort(sums.begin(), sums.end());
+                max_error = std::abs(sums.front() - sums.back());
+
+                // restore unsorted order
+                memcpy(ref_vals.data(), startRefValues,
+                       sizeof(HostDataType) * ref_vals.size());
+            }
+            else
+            {
+                memcpy(startRefValues, ref_vals.data(),
+                       sizeof(HostDataType) * threadCount);
+            }
+            return true;
+        }
+        return false;
+    }
+    std::string ProgramCore() override
     {
         std::string memoryOrderScope = MemoryOrderScopeStr();
         std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
-        return "  oldValues[tid] = atomic_fetch_add" + postfix
-            + "(&destMemory[0], (" + DataType().AddSubOperandTypeName()
-            + ")tid + 3" + memoryOrderScope + ");\n" + "  atomic_fetch_add"
-            + postfix + "(&destMemory[0], ("
-            + DataType().AddSubOperandTypeName() + ")tid + 3" + memoryOrderScope
-            + ");\n"
-              "  atomic_fetch_add"
-            + postfix + "(&destMemory[0], ("
-            + DataType().AddSubOperandTypeName() + ")tid + 3" + memoryOrderScope
-            + ");\n"
-              "  atomic_fetch_add"
-            + postfix + "(&destMemory[0], (("
-            + DataType().AddSubOperandTypeName() + ")tid + 3) << (sizeof("
-            + DataType().AddSubOperandTypeName() + ")-1)*8" + memoryOrderScope
-            + ");\n";
+
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            return "  atomic_fetch_add" + postfix + "(&destMemory[0], ("
+                + DataType().AddSubOperandTypeName() + ")oldValues[tid]"
+                + memoryOrderScope + ");\n"
+                + "  oldValues[tid] = atomic_fetch_add" + postfix
+                + "(&destMemory[tid], (" + DataType().AddSubOperandTypeName()
+                + ")0" + memoryOrderScope + ");\n";
+        }
+        else
+        {
+            return "  oldValues[tid] = atomic_fetch_add" + postfix
+                + "(&destMemory[0], (" + DataType().AddSubOperandTypeName()
+                + ")tid + 3" + memoryOrderScope + ");\n" + "  atomic_fetch_add"
+                + postfix + "(&destMemory[0], ("
+                + DataType().AddSubOperandTypeName() + ")tid + 3"
+                + memoryOrderScope
+                + ");\n"
+                  "  atomic_fetch_add"
+                + postfix + "(&destMemory[0], ("
+                + DataType().AddSubOperandTypeName() + ")tid + 3"
+                + memoryOrderScope
+                + ");\n"
+                  "  atomic_fetch_add"
+                + postfix + "(&destMemory[0], (("
+                + DataType().AddSubOperandTypeName() + ")tid + 3) << (sizeof("
+                + DataType().AddSubOperandTypeName() + ")-1)*8"
+                + memoryOrderScope + ");\n";
+        }
     }
-    virtual void HostFunction(cl_uint tid, cl_uint threadCount,
-                              volatile HostAtomicType *destMemory,
-                              HostDataType *oldValues)
+    void HostFunction(cl_uint tid, cl_uint threadCount,
+                      volatile HostAtomicType *destMemory,
+                      HostDataType *oldValues) override
     {
-        oldValues[tid] = host_atomic_fetch_add(
-            &destMemory[0], (HostDataType)tid + 3, MemoryOrder());
-        host_atomic_fetch_add(&destMemory[0], (HostDataType)tid + 3,
-                              MemoryOrder());
-        host_atomic_fetch_add(&destMemory[0], (HostDataType)tid + 3,
-                              MemoryOrder());
-        host_atomic_fetch_add(&destMemory[0],
-                              ((HostDataType)tid + 3)
-                                  << (sizeof(HostDataType) - 1) * 8,
-                              MemoryOrder());
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            host_atomic_fetch_add(&destMemory[0], (HostDataType)oldValues[tid],
+                                  MemoryOrder());
+            oldValues[tid] = host_atomic_fetch_add(
+                &destMemory[0], (HostDataType)0, MemoryOrder());
+        }
+        else
+        {
+            oldValues[tid] = host_atomic_fetch_add(
+                &destMemory[0], (HostDataType)tid + 3, MemoryOrder());
+            host_atomic_fetch_add(&destMemory[0], (HostDataType)tid + 3,
+                                  MemoryOrder());
+            host_atomic_fetch_add(&destMemory[0], (HostDataType)tid + 3,
+                                  MemoryOrder());
+            host_atomic_fetch_add(&destMemory[0], GetTypeDependentAddition(tid),
+                                  MemoryOrder());
+        }
     }
-    virtual bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
-                               HostDataType *startRefValues,
-                               cl_uint whichDestValue)
+    bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
+                       HostDataType *startRefValues,
+                       cl_uint whichDestValue) override
     {
         expected = StartValue();
-        for (cl_uint i = 0; i < threadCount; i++)
-            expected += ((HostDataType)i + 3) * 3
-                + (((HostDataType)i + 3) << (sizeof(HostDataType) - 1) * 8);
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            if (whichDestValue == 0)
+            {
+                for (cl_uint i = 0; i < threadCount; i++)
+                {
+                    expected = cl_half_from_float(
+                        cl_half_to_float(expected)
+                            + cl_half_to_float(startRefValues[i]),
+                        gHalfRoundingMode);
+                }
+            }
+        }
+        else
+        {
+            for (cl_uint i = 0; i < threadCount; i++)
+                expected +=
+                    ((HostDataType)i + 3) * 3 + GetTypeDependentAddition(i);
+        }
+
         return true;
+    }
+    bool VerifyExpected(const HostDataType &expected,
+                        const HostAtomicType *const testValue,
+                        cl_uint whichDestValue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            if (whichDestValue == 0 && testValue != nullptr)
+                return std::abs(cl_half_to_float(expected)
+                                - cl_half_to_float(testValue[whichDestValue]))
+                    > max_error;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::VerifyExpected(expected, testValue,
+                                                          whichDestValue);
+    }
+    HostDataType GetTypeDependentAddition(cl_uint id)
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_INT>::value)
+            return (((cl_int)id + 3) << (sizeof(cl_int) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_UINT>::value)
+            return (((cl_uint)id + 3) << (sizeof(cl_uint) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_LONG>::value)
+            return (((cl_long)id + 3) << (sizeof(cl_long) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_ULONG>::value)
+            return (((cl_ulong)id + 3) << (sizeof(cl_ulong) - 1) * 8);
+        return (HostDataType)0;
+    }
+    int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            if (LocalMemory()
+                && (gHalfAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0; // skip test - not applicable
+
+            if (!LocalMemory()
+                && (gHalfAtomicCaps & CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::ExecuteSingleTest(deviceID, context,
+                                                             queue);
+    }
+    cl_uint NumResults(cl_uint threadCount, cl_device_id deviceID) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_HALF>::value)
+        {
+            return threadCount;
+        }
+        return CBasicTestMemOrderScope<HostAtomicType,
+                                       HostDataType>::NumResults(threadCount,
+                                                                 deviceID);
     }
 };
 
@@ -1116,6 +1295,15 @@ static int test_atomic_fetch_add_generic(cl_device_id deviceID,
         TYPE_ATOMIC_ULONG, useSVM);
     EXECUTE_TEST(error,
                  test_ulong.Execute(deviceID, context, queue, num_elements));
+
+    if (gFloatAtomicsSupported)
+    {
+        CBasicTestFetchAdd<HOST_ATOMIC_HALF, HOST_HALF> test_half(
+            TYPE_ATOMIC_HALF, useSVM);
+        EXECUTE_TEST(error,
+                     test_half.Execute(deviceID, context, queue, num_elements));
+    }
+
     if (AtomicTypeInfo(TYPE_ATOMIC_SIZE_T).Size(deviceID) == 4)
     {
         CBasicTestFetchAdd<HOST_ATOMIC_INTPTR_T32, HOST_INTPTR_T32>


### PR DESCRIPTION
Related to https://github.com/KhronosGroup/OpenCL-CTS/issues/2142, according to the work plan, extending CBasicTestFetchAdd with support for atomic_half.

I wasn't able to test that PR completely due to missing `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`/`CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` capabilities for atomic_half. I appreciate reviewers' attention, thanks.