### PR TITLE
[NFC] math_brute_force: use getAllowedUlpError for double

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -605,7 +605,7 @@ int TestFunc_Double_Double_Double(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->double_ulps;
+    test_info.ulps = getAllowedUlpError(f, kdouble, relaxedMode);
     test_info.ftz = f->ftz || gForceFTZ;
     test_info.relaxedMode = relaxedMode;
 

--- a/test_conformance/math_brute_force/binary_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_i_double.cpp
@@ -522,7 +522,7 @@ int TestFunc_Double_Double_Int(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->double_ulps;
+    test_info.ulps = getAllowedUlpError(f, kdouble, relaxedMode);
     test_info.ftz = f->ftz || gForceFTZ;
     test_info.relaxedMode = relaxedMode;
 

--- a/test_conformance/math_brute_force/binary_operator_double.cpp
+++ b/test_conformance/math_brute_force/binary_operator_double.cpp
@@ -571,7 +571,7 @@ int TestFunc_Double_Double_Double_Operator(const Func *f, MTdata d,
     }
 
     test_info.f = f;
-    test_info.ulps = f->double_ulps;
+    test_info.ulps = getAllowedUlpError(f, kdouble, relaxedMode);
     test_info.ftz = f->ftz || gForceFTZ;
 
     test_info.tinfo.resize(test_info.threadCount);

--- a/test_conformance/math_brute_force/binary_two_results_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_two_results_i_double.cpp
@@ -91,6 +91,7 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
     cl_uint threadCount = GetThreadCount();
 
     Force64BitFPUPrecision();
+    float double_ulps = getAllowedUlpError(f, kdouble, relaxedMode);
 
     int testingRemquo = !strcmp(f->name, "remquo");
 
@@ -256,6 +257,7 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
         // Verify data
         uint64_t *t = (uint64_t *)gOut_Ref;
         int32_t *t2 = (int32_t *)gOut_Ref2;
+
         for (size_t j = 0; j < BUFFER_SIZE / sizeof(double); j++)
         {
             for (auto k = gMinVectorSizeIndex; k < gMaxVectorSizeIndex; k++)
@@ -294,11 +296,11 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                     || isnan(((double *)gIn)[j]);
                 if (iptrUndefined) iErr = 0;
 
-                int fail = !(fabsf(err) <= f->double_ulps && iErr == 0);
+                int fail = !(fabsf(err) <= double_ulps && iErr == 0);
                 if ((ftz || relaxedMode) && fail)
                 {
                     // retry per section 6.5.3.2
-                    if (IsDoubleResultSubnormal(correct, f->double_ulps))
+                    if (IsDoubleResultSubnormal(correct, double_ulps))
                     {
                         fail = fail && !(test == 0.0f && iErr == 0);
                         if (!fail) err = 0.0f;
@@ -319,8 +321,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                         int64_t iErr3 = (long long)q2[j] - (long long)correct3i;
                         int64_t iErr4 = (long long)q2[j] - (long long)correct4i;
                         fail = fail
-                            && ((!(fabsf(err2) <= f->double_ulps && iErr3 == 0))
-                                && (!(fabsf(err3) <= f->double_ulps
+                            && ((!(fabsf(err2) <= double_ulps && iErr3 == 0))
+                                && (!(fabsf(err3) <= double_ulps
                                       && iErr4 == 0)));
                         if (fabsf(err2) < fabsf(err)) err = err2;
                         if (fabsf(err3) < fabsf(err)) err = err3;
@@ -328,9 +330,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                         if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
 
                         // retry per section 6.5.3.4
-                        if (IsDoubleResultSubnormal(correct2, f->double_ulps)
-                            || IsDoubleResultSubnormal(correct3,
-                                                       f->double_ulps))
+                        if (IsDoubleResultSubnormal(correct2, double_ulps)
+                            || IsDoubleResultSubnormal(correct3, double_ulps))
                         {
                             fail = fail
                                 && !(test == 0.0f
@@ -361,13 +362,13 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                             int64_t iErr8 =
                                 (long long)q2[j] - (long long)correct8i;
                             fail = fail
-                                && ((!(fabsf(err2) <= f->double_ulps
+                                && ((!(fabsf(err2) <= double_ulps
                                        && iErr3 == 0))
-                                    && (!(fabsf(err3) <= f->double_ulps
+                                    && (!(fabsf(err3) <= double_ulps
                                           && iErr4 == 0))
-                                    && (!(fabsf(err4) <= f->double_ulps
+                                    && (!(fabsf(err4) <= double_ulps
                                           && iErr7 == 0))
-                                    && (!(fabsf(err5) <= f->double_ulps
+                                    && (!(fabsf(err5) <= double_ulps
                                           && iErr8 == 0)));
                             if (fabsf(err2) < fabsf(err)) err = err2;
                             if (fabsf(err3) < fabsf(err)) err = err3;
@@ -379,14 +380,13 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                             if (llabs(iErr8) < llabs(iErr)) iErr = iErr8;
 
                             // retry per section 6.5.3.4
-                            if (IsDoubleResultSubnormal(correct3,
-                                                        f->double_ulps)
+                            if (IsDoubleResultSubnormal(correct3, double_ulps)
                                 || IsDoubleResultSubnormal(correct4,
-                                                           f->double_ulps)
+                                                           double_ulps)
                                 || IsDoubleResultSubnormal(correct7,
-                                                           f->double_ulps)
+                                                           double_ulps)
                                 || IsDoubleResultSubnormal(correct8,
-                                                           f->double_ulps))
+                                                           double_ulps))
                             {
                                 fail = fail
                                     && !(test == 0.0f
@@ -410,8 +410,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                         int64_t iErr3 = (long long)q2[j] - (long long)correct3i;
                         int64_t iErr4 = (long long)q2[j] - (long long)correct4i;
                         fail = fail
-                            && ((!(fabsf(err2) <= f->double_ulps && iErr3 == 0))
-                                && (!(fabsf(err3) <= f->double_ulps
+                            && ((!(fabsf(err2) <= double_ulps && iErr3 == 0))
+                                && (!(fabsf(err3) <= double_ulps
                                       && iErr4 == 0)));
                         if (fabsf(err2) < fabsf(err)) err = err2;
                         if (fabsf(err3) < fabsf(err)) err = err3;
@@ -419,9 +419,8 @@ int TestFunc_DoubleI_Double_Double(const Func *f, MTdata d, bool relaxedMode)
                         if (llabs(iErr4) < llabs(iErr)) iErr = iErr4;
 
                         // retry per section 6.5.3.4
-                        if (IsDoubleResultSubnormal(correct2, f->double_ulps)
-                            || IsDoubleResultSubnormal(correct3,
-                                                       f->double_ulps))
+                        if (IsDoubleResultSubnormal(correct2, double_ulps)
+                            || IsDoubleResultSubnormal(correct3, double_ulps))
                         {
                             fail = fail
                                 && !(test == 0.0f

--- a/test_conformance/math_brute_force/ternary_double.cpp
+++ b/test_conformance/math_brute_force/ternary_double.cpp
@@ -127,6 +127,8 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
     double maxErrorVal3 = 0.0f;
     uint64_t step = getTestStep(sizeof(double), BUFFER_SIZE);
 
+    float double_ulps = getAllowedUlpError(f, kdouble, relaxedMode);
+
     logFunctionInfo(f->name, sizeof(cl_double), relaxedMode);
 
     Force64BitFPUPrecision();
@@ -295,7 +297,7 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                     double test = ((double *)q)[j];
                     long double correct = f->dfunc.f_fff(s[j], s2[j], s3[j]);
                     float err = Bruteforce_Ulp_Error_Double(test, correct);
-                    int fail = !(fabsf(err) <= f->double_ulps);
+                    int fail = !(fabsf(err) <= double_ulps);
 
                     if (fail && (ftz || relaxedMode))
                     {
@@ -318,16 +320,15 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                             float err3 =
                                 Bruteforce_Ulp_Error_Double(test, correct3);
                             fail = fail
-                                && ((!(fabsf(err2) <= f->double_ulps))
-                                    && (!(fabsf(err3) <= f->double_ulps)));
+                                && ((!(fabsf(err2) <= double_ulps))
+                                    && (!(fabsf(err3) <= double_ulps)));
                             if (fabsf(err2) < fabsf(err)) err = err2;
                             if (fabsf(err3) < fabsf(err)) err = err3;
 
                             // retry per section 6.5.3.4
-                            if (IsDoubleResultSubnormal(correct2,
-                                                        f->double_ulps)
+                            if (IsDoubleResultSubnormal(correct2, double_ulps)
                                 || IsDoubleResultSubnormal(correct3,
-                                                           f->double_ulps))
+                                                           double_ulps))
                             { // look at me now,
                                 fail = fail && (test != 0.0f);
                                 if (!fail) err = 0.0f;
@@ -351,10 +352,10 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                                 float err5 =
                                     Bruteforce_Ulp_Error_Double(test, correct5);
                                 fail = fail
-                                    && ((!(fabsf(err2) <= f->double_ulps))
-                                        && (!(fabsf(err3) <= f->double_ulps))
-                                        && (!(fabsf(err4) <= f->double_ulps))
-                                        && (!(fabsf(err5) <= f->double_ulps)));
+                                    && ((!(fabsf(err2) <= double_ulps))
+                                        && (!(fabsf(err3) <= double_ulps))
+                                        && (!(fabsf(err4) <= double_ulps))
+                                        && (!(fabsf(err5) <= double_ulps)));
                                 if (fabsf(err2) < fabsf(err)) err = err2;
                                 if (fabsf(err3) < fabsf(err)) err = err3;
                                 if (fabsf(err4) < fabsf(err)) err = err4;
@@ -362,13 +363,13 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
 
                                 // retry per section 6.5.3.4
                                 if (IsDoubleResultSubnormal(correct2,
-                                                            f->double_ulps)
+                                                            double_ulps)
                                     || IsDoubleResultSubnormal(correct3,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct4,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct5,
-                                                               f->double_ulps))
+                                                               double_ulps))
                                 {
                                     fail = fail && (test != 0.0f);
                                     if (!fail) err = 0.0f;
@@ -405,21 +406,14 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                                     float err9 = Bruteforce_Ulp_Error_Double(
                                         test, correct9);
                                     fail = fail
-                                        && ((!(fabsf(err2) <= f->double_ulps))
-                                            && (!(fabsf(err3)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err4)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err5)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err5)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err6)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err7)
-                                                  <= f->double_ulps))
-                                            && (!(fabsf(err8)
-                                                  <= f->double_ulps)));
+                                        && ((!(fabsf(err2) <= double_ulps))
+                                            && (!(fabsf(err3) <= double_ulps))
+                                            && (!(fabsf(err4) <= double_ulps))
+                                            && (!(fabsf(err5) <= double_ulps))
+                                            && (!(fabsf(err5) <= double_ulps))
+                                            && (!(fabsf(err6) <= double_ulps))
+                                            && (!(fabsf(err7) <= double_ulps))
+                                            && (!(fabsf(err8) <= double_ulps)));
                                     if (fabsf(err2) < fabsf(err)) err = err2;
                                     if (fabsf(err3) < fabsf(err)) err = err3;
                                     if (fabsf(err4) < fabsf(err)) err = err4;
@@ -431,21 +425,21 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
 
                                     // retry per section 6.5.3.4
                                     if (IsDoubleResultSubnormal(correct2,
-                                                                f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct3, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct4, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct5, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct6, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct7, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct8, f->double_ulps)
-                                        || IsDoubleResultSubnormal(
-                                            correct9, f->double_ulps))
+                                                                double_ulps)
+                                        || IsDoubleResultSubnormal(correct3,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct4,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct5,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct6,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct7,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct8,
+                                                                   double_ulps)
+                                        || IsDoubleResultSubnormal(correct9,
+                                                                   double_ulps))
                                     {
                                         fail = fail && (test != 0.0f);
                                         if (!fail) err = 0.0f;
@@ -469,10 +463,10 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                                 float err5 =
                                     Bruteforce_Ulp_Error_Double(test, correct5);
                                 fail = fail
-                                    && ((!(fabsf(err2) <= f->double_ulps))
-                                        && (!(fabsf(err3) <= f->double_ulps))
-                                        && (!(fabsf(err4) <= f->double_ulps))
-                                        && (!(fabsf(err5) <= f->double_ulps)));
+                                    && ((!(fabsf(err2) <= double_ulps))
+                                        && (!(fabsf(err3) <= double_ulps))
+                                        && (!(fabsf(err4) <= double_ulps))
+                                        && (!(fabsf(err5) <= double_ulps)));
                                 if (fabsf(err2) < fabsf(err)) err = err2;
                                 if (fabsf(err3) < fabsf(err)) err = err3;
                                 if (fabsf(err4) < fabsf(err)) err = err4;
@@ -480,13 +474,13 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
 
                                 // retry per section 6.5.3.4
                                 if (IsDoubleResultSubnormal(correct2,
-                                                            f->double_ulps)
+                                                            double_ulps)
                                     || IsDoubleResultSubnormal(correct3,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct4,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct5,
-                                                               f->double_ulps))
+                                                               double_ulps))
                                 {
                                     fail = fail && (test != 0.0f);
                                     if (!fail) err = 0.0f;
@@ -504,16 +498,15 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                             float err3 =
                                 Bruteforce_Ulp_Error_Double(test, correct3);
                             fail = fail
-                                && ((!(fabsf(err2) <= f->double_ulps))
-                                    && (!(fabsf(err3) <= f->double_ulps)));
+                                && ((!(fabsf(err2) <= double_ulps))
+                                    && (!(fabsf(err3) <= double_ulps)));
                             if (fabsf(err2) < fabsf(err)) err = err2;
                             if (fabsf(err3) < fabsf(err)) err = err3;
 
                             // retry per section 6.5.3.4
-                            if (IsDoubleResultSubnormal(correct2,
-                                                        f->double_ulps)
+                            if (IsDoubleResultSubnormal(correct2, double_ulps)
                                 || IsDoubleResultSubnormal(correct3,
-                                                           f->double_ulps))
+                                                           double_ulps))
                             {
                                 fail = fail && (test != 0.0f);
                                 if (!fail) err = 0.0f;
@@ -537,10 +530,10 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                                 float err5 =
                                     Bruteforce_Ulp_Error_Double(test, correct5);
                                 fail = fail
-                                    && ((!(fabsf(err2) <= f->double_ulps))
-                                        && (!(fabsf(err3) <= f->double_ulps))
-                                        && (!(fabsf(err4) <= f->double_ulps))
-                                        && (!(fabsf(err5) <= f->double_ulps)));
+                                    && ((!(fabsf(err2) <= double_ulps))
+                                        && (!(fabsf(err3) <= double_ulps))
+                                        && (!(fabsf(err4) <= double_ulps))
+                                        && (!(fabsf(err5) <= double_ulps)));
                                 if (fabsf(err2) < fabsf(err)) err = err2;
                                 if (fabsf(err3) < fabsf(err)) err = err3;
                                 if (fabsf(err4) < fabsf(err)) err = err4;
@@ -548,13 +541,13 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
 
                                 // retry per section 6.5.3.4
                                 if (IsDoubleResultSubnormal(correct2,
-                                                            f->double_ulps)
+                                                            double_ulps)
                                     || IsDoubleResultSubnormal(correct3,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct4,
-                                                               f->double_ulps)
+                                                               double_ulps)
                                     || IsDoubleResultSubnormal(correct5,
-                                                               f->double_ulps))
+                                                               double_ulps))
                                 {
                                     fail = fail && (test != 0.0f);
                                     if (!fail) err = 0.0f;
@@ -572,16 +565,15 @@ int TestFunc_Double_Double_Double_Double(const Func *f, MTdata d,
                             float err3 =
                                 Bruteforce_Ulp_Error_Double(test, correct3);
                             fail = fail
-                                && ((!(fabsf(err2) <= f->double_ulps))
-                                    && (!(fabsf(err3) <= f->double_ulps)));
+                                && ((!(fabsf(err2) <= double_ulps))
+                                    && (!(fabsf(err3) <= double_ulps)));
                             if (fabsf(err2) < fabsf(err)) err = err2;
                             if (fabsf(err3) < fabsf(err)) err = err3;
 
                             // retry per section 6.5.3.4
-                            if (IsDoubleResultSubnormal(correct2,
-                                                        f->double_ulps)
+                            if (IsDoubleResultSubnormal(correct2, double_ulps)
                                 || IsDoubleResultSubnormal(correct3,
-                                                           f->double_ulps))
+                                                           double_ulps))
                             {
                                 fail = fail && (test != 0.0f);
                                 if (!fail) err = 0.0f;

--- a/test_conformance/math_brute_force/unary_double.cpp
+++ b/test_conformance/math_brute_force/unary_double.cpp
@@ -354,7 +354,7 @@ int TestFunc_Double_Double(const Func *f, MTdata d, bool relaxedMode)
     }
 
     test_info.f = f;
-    test_info.ulps = f->double_ulps;
+    test_info.ulps = getAllowedUlpError(f, kdouble, relaxedMode);
     test_info.ftz = f->ftz || gForceFTZ;
     test_info.relaxedMode = relaxedMode;
 

--- a/test_conformance/math_brute_force/unary_two_results_double.cpp
+++ b/test_conformance/math_brute_force/unary_two_results_double.cpp
@@ -56,6 +56,7 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
     logFunctionInfo(f->name, sizeof(cl_double), relaxedMode);
 
     Force64BitFPUPrecision();
+    float double_ulps = getAllowedUlpError(f, kdouble, relaxedMode);
 
     // Init the kernels
     BuildKernelInfo build_info{ 1, kernels, programs, f->nameInCode,
@@ -214,15 +215,14 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
                     long double correct = f->dfunc.f_fpf(s[j], &correct2);
                     float err = Bruteforce_Ulp_Error_Double(test, correct);
                     float err2 = Bruteforce_Ulp_Error_Double(test2, correct2);
-                    int fail = !(fabsf(err) <= f->double_ulps
-                                 && fabsf(err2) <= f->double_ulps);
+                    int fail = !(fabsf(err) <= double_ulps
+                                 && fabsf(err2) <= double_ulps);
                     if (ftz || relaxedMode)
                     {
                         // retry per section 6.5.3.2
-                        if (IsDoubleResultSubnormal(correct, f->double_ulps))
+                        if (IsDoubleResultSubnormal(correct, double_ulps))
                         {
-                            if (IsDoubleResultSubnormal(correct2,
-                                                        f->double_ulps))
+                            if (IsDoubleResultSubnormal(correct2, double_ulps))
                             {
                                 fail = fail && !(test == 0.0f && test2 == 0.0f);
                                 if (!fail)
@@ -235,16 +235,15 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
                             {
                                 fail = fail
                                     && !(test == 0.0f
-                                         && fabsf(err2) <= f->double_ulps);
+                                         && fabsf(err2) <= double_ulps);
                                 if (!fail) err = 0.0f;
                             }
                         }
-                        else if (IsDoubleResultSubnormal(correct2,
-                                                         f->double_ulps))
+                        else if (IsDoubleResultSubnormal(correct2, double_ulps))
                         {
                             fail = fail
                                 && !(test2 == 0.0f
-                                     && fabsf(err) <= f->double_ulps);
+                                     && fabsf(err) <= double_ulps);
                             if (!fail) err2 = 0.0f;
                         }
 
@@ -265,26 +264,24 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
                             float err2n =
                                 Bruteforce_Ulp_Error_Double(test, correct2n);
                             fail = fail
-                                && ((!(fabsf(errp) <= f->double_ulps))
-                                    && (!(fabsf(err2p) <= f->double_ulps))
-                                    && ((!(fabsf(errn) <= f->double_ulps))
-                                        && (!(fabsf(err2n)
-                                              <= f->double_ulps))));
+                                && ((!(fabsf(errp) <= double_ulps))
+                                    && (!(fabsf(err2p) <= double_ulps))
+                                    && ((!(fabsf(errn) <= double_ulps))
+                                        && (!(fabsf(err2n) <= double_ulps))));
                             if (fabsf(errp) < fabsf(err)) err = errp;
                             if (fabsf(errn) < fabsf(err)) err = errn;
                             if (fabsf(err2p) < fabsf(err2)) err2 = err2p;
                             if (fabsf(err2n) < fabsf(err2)) err2 = err2n;
 
                             // retry per section 6.5.3.4
-                            if (IsDoubleResultSubnormal(correctp,
-                                                        f->double_ulps)
+                            if (IsDoubleResultSubnormal(correctp, double_ulps)
                                 || IsDoubleResultSubnormal(correctn,
-                                                           f->double_ulps))
+                                                           double_ulps))
                             {
                                 if (IsDoubleResultSubnormal(correct2p,
-                                                            f->double_ulps)
+                                                            double_ulps)
                                     || IsDoubleResultSubnormal(correct2n,
-                                                               f->double_ulps))
+                                                               double_ulps))
                                 {
                                     fail = fail
                                         && !(test == 0.0f && test2 == 0.0f);
@@ -294,18 +291,18 @@ int TestFunc_Double2_Double(const Func *f, MTdata d, bool relaxedMode)
                                 {
                                     fail = fail
                                         && !(test == 0.0f
-                                             && fabsf(err2) <= f->double_ulps);
+                                             && fabsf(err2) <= double_ulps);
                                     if (!fail) err = 0.0f;
                                 }
                             }
                             else if (IsDoubleResultSubnormal(correct2p,
-                                                             f->double_ulps)
+                                                             double_ulps)
                                      || IsDoubleResultSubnormal(correct2n,
-                                                                f->double_ulps))
+                                                                double_ulps))
                             {
                                 fail = fail
                                     && !(test2 == 0.0f
-                                         && (fabsf(err) <= f->double_ulps));
+                                         && (fabsf(err) <= double_ulps));
                                 if (!fail) err2 = 0.0f;
                             }
                         }

--- a/test_conformance/math_brute_force/unary_u_double.cpp
+++ b/test_conformance/math_brute_force/unary_u_double.cpp
@@ -56,6 +56,7 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
     logFunctionInfo(f->name, sizeof(cl_double), relaxedMode);
 
     Force64BitFPUPrecision();
+    float double_ulps = getAllowedUlpError(f, kdouble, relaxedMode);
 
     // Init the kernels
     BuildKernelInfo build_info{ 1, kernels, programs, f->nameInCode,
@@ -167,15 +168,14 @@ int TestFunc_Double_ULong(const Func *f, MTdata d, bool relaxedMode)
                     double test = ((double *)q)[j];
                     long double correct = f->dfunc.f_u(s[j]);
                     float err = Bruteforce_Ulp_Error_Double(test, correct);
-                    int fail = !(fabsf(err) <= f->double_ulps);
+                    int fail = !(fabsf(err) <= double_ulps);
 
                     if (fail)
                     {
                         if (ftz || relaxedMode)
                         {
                             // retry per section 6.5.3.2
-                            if (IsDoubleResultSubnormal(correct,
-                                                        f->double_ulps))
+                            if (IsDoubleResultSubnormal(correct, double_ulps))
                             {
                                 fail = fail && (test != 0.0);
                                 if (!fail) err = 0.0f;


### PR DESCRIPTION
Call `getAllowedUlpError` to obtain the allowed ULP error for all of the double type (fp64) tests.  The aim is to standardise obtaining the desired ULP requirement and pave the way for adding the Embedded Profile ULP errors.

Contributes to https://github.com/KhronosGroup/OpenCL-CTS/issues/867