### PR TITLE
Added support for cl_ext_float_atomics in CBasicTestFetchMin/Max with atomic_float

### DIFF
--- a/test_conformance/c11_atomics/host_atomics.h
+++ b/test_conformance/c11_atomics/host_atomics.h
@@ -17,6 +17,7 @@
 #define HOST_ATOMICS_H_
 
 #include "harness/testHarness.h"
+#include <mutex>
 
 #ifdef WIN32
 #include "Windows.h"
@@ -138,19 +139,52 @@ bool host_atomic_compare_exchange(volatile AtomicType *a, CorrespondingType *exp
                                   TExplicitMemoryOrderType order_success,
                                   TExplicitMemoryOrderType order_failure)
 {
-  CorrespondingType tmp;
-#if defined( _MSC_VER ) || (defined( __INTEL_COMPILER ) && defined(WIN32))
-  tmp = InterlockedCompareExchange(a, desired, *expected);
+    CorrespondingType tmp;
+    if (std::is_same<AtomicType, HOST_ATOMIC_FLOAT>::value)
+    {
+        static std::mutex mtx;
+        std::lock_guard<std::mutex> lock(mtx);
+        tmp = *reinterpret_cast<volatile float *>(a);
+        if (tmp == *expected)
+        {
+            *reinterpret_cast<volatile float *>(a) = desired;
+            return true;
+        }
+        *expected = tmp;
+    }
+    else
+    {
+#if defined(_MSC_VER) || (defined(__INTEL_COMPILER) && defined(WIN32))
+
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value
+            || std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            tmp = InterlockedCompareExchange((volatile cl_uint *)a, desired,
+                                             *expected);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value
+                 || std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            tmp = InterlockedCompareExchange((volatile cl_long *)a, desired,
+                                             *expected);
 #elif defined(__GNUC__)
-  tmp = __sync_val_compare_and_swap(a, *expected, desired);
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_int *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_uint *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_long *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_ulong *)a, *expected,
+                                              desired);
 #else
-  log_info("Host function not implemented: atomic_compare_exchange\n");
-  tmp = 0;
+        log_info("Host function not implemented: atomic_compare_exchange\n");
+        tmp = 0;
 #endif
-  if(tmp == *expected)
-    return true;
-  *expected = tmp;
-  return false;
+        if (tmp == *expected) return true;
+        *expected = tmp;
+    }
+    return false;
 }
 
 template <typename AtomicType, typename CorrespondingType>

--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+#include "harness/kernelHelpers.h"
 #include <iostream>
 #include <string>
 
@@ -28,6 +30,8 @@ int gInternalIterations = 10000; // internal test iterations for atomic operatio
 int gMaxDeviceThreads = 1024; // maximum number of threads executed on OCL device
 cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+bool gFloatAtomicsSupported = false;
+cl_device_fp_atomic_capabilities_ext gFloatAtomicCaps = 0;
 
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
@@ -121,6 +125,16 @@ test_status InitCL(cl_device_id device) {
             | CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM
             | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE
             | CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES;
+    }
+
+    if (is_extension_available(device, "cl_ext_float_atomics"))
+    {
+        gFloatAtomicsSupported = true;
+
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT,
+            sizeof(gFloatAtomicCaps), &gFloatAtomicCaps, nullptr);
+        test_error_ret(error, "clGetDeviceInfo failed!", TEST_FAIL);
     }
 
     return TEST_PASS;


### PR DESCRIPTION
Related to #2142, according to the work plan, extending `CBasicTestFetchMin`/`CBasicTestFetchMax` with support for atomic_float.