### PR TITLE
spirv_new: remove invalid `Aligned 0` decorations

### DIFF
--- a/test_conformance/spirv_new/spirv_asm/atomic_dec_global.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/atomic_dec_global.spvasm32
@@ -28,7 +28,7 @@
         %val = OpFunctionParameter %_ptr_CrossWorkgroup_uint
     %counter = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3uint %__spirv_GlobalInvocationId Aligned 0
+         %14 = OpLoad %v3uint %__spirv_GlobalInvocationId
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpAtomicIDecrement %uint %counter %uint_1 %uint_512
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %val %15

--- a/test_conformance/spirv_new/spirv_asm/atomic_dec_global.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/atomic_dec_global.spvasm64
@@ -31,7 +31,7 @@
         %val = OpFunctionParameter %_ptr_CrossWorkgroup_uint
     %counter = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %15 = OpLabel
-         %16 = OpLoad %v3ulong %__spirv_GlobalInvocationId Aligned 0
+         %16 = OpLoad %v3ulong %__spirv_GlobalInvocationId
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/atomic_inc_global.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/atomic_inc_global.spvasm32
@@ -28,7 +28,7 @@
         %val = OpFunctionParameter %_ptr_CrossWorkgroup_uint
     %counter = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3uint %__spirv_GlobalInvocationId Aligned 0
+         %14 = OpLoad %v3uint %__spirv_GlobalInvocationId
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpAtomicIIncrement %uint %counter %uint_1 %uint_512
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %val %15

--- a/test_conformance/spirv_new/spirv_asm/atomic_inc_global.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/atomic_inc_global.spvasm64
@@ -31,7 +31,7 @@
         %val = OpFunctionParameter %_ptr_CrossWorkgroup_uint
     %counter = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %15 = OpLabel
-         %16 = OpLoad %v3ulong %__spirv_GlobalInvocationId Aligned 0
+         %16 = OpLoad %v3ulong %__spirv_GlobalInvocationId
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/branch_conditional_weighted.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/branch_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/branch_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %10 %13

--- a/test_conformance/spirv_new/spirv_asm/branch_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/branch_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/composite_construct_int4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/composite_construct_int4.spvasm32
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpCompositeConstruct %v4uint %uint_123 %uint_122 %uint_121 %uint_119
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %17

--- a/test_conformance/spirv_new/spirv_asm/composite_construct_int4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/composite_construct_int4.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/composite_construct_struct.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/composite_construct_struct.spvasm32
@@ -35,7 +35,7 @@
          %19 = OpLabel
          %20 = OpCompositeConstruct %_struct_10 %uint_2100483600 %uchar_128
          %21 = OpCompositeConstruct %_struct_11 %18 %20
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_11 %in %23
                OpStore %24 %21

--- a/test_conformance/spirv_new/spirv_asm/composite_construct_struct.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/composite_construct_struct.spvasm64
@@ -38,7 +38,7 @@
          %21 = OpLabel
          %22 = OpCompositeConstruct %_struct_11 %uint_2100483600 %uchar_128
          %23 = OpCompositeConstruct %_struct_12 %20 %22
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_char_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
                OpStore %15 %uchar_20

--- a/test_conformance/spirv_new/spirv_asm/constant_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_char_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_double_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_double_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %14
                OpStore %15 %double_3_1415926535897931

--- a/test_conformance/spirv_new/spirv_asm/constant_double_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_double_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_false_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_false_simple.spvasm32
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %14 = OpLabel
          %15 = OpSelect %uint %false %uint_1 %uint_0
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %17
                OpStore %18 %15

--- a/test_conformance/spirv_new/spirv_asm/constant_false_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_false_simple.spvasm64
@@ -31,7 +31,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpSelect %uint %false %uint_1 %uint_0
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_float_simple.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %14
                OpStore %15 %float_3_14159274

--- a/test_conformance/spirv_new/spirv_asm/constant_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_float_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_half_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_half_simple.spvasm32
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %13 = OpLabel
          %14 = OpFConvert %float %half_0x1_ap_1
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
                OpStore %17 %14

--- a/test_conformance/spirv_new/spirv_asm/constant_half_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_half_simple.spvasm64
@@ -30,7 +30,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %14 = OpLabel
          %15 = OpFConvert %float %half_0x1_ap_1
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_int3_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_int3_simple.spvasm32
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v3uint %in %16
                OpStore %17 %13 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/constant_int3_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_int3_simple.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_int4_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_int4_simple.spvasm32
@@ -29,7 +29,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %18
                OpStore %19 %15 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/constant_int4_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_int4_simple.spvasm64
@@ -32,7 +32,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %18 = OpLabel
-         %19 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %19 = OpLoad %v3ulong %gl_GlobalInvocationID
          %20 = OpCompositeExtract %ulong %19 0
          %21 = OpShiftLeftLogical %ulong %20 %ulong_32
          %22 = OpShiftRightArithmetic %ulong %21 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_int_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_int_simple.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
                OpStore %14 %uint_123

--- a/test_conformance/spirv_new/spirv_asm/constant_int_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_int_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_long_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_long_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
                OpStore %15 %ulong_34359738368

--- a/test_conformance/spirv_new/spirv_asm/constant_long_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_long_simple.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_short_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_short_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
                OpStore %15 %ushort_32000

--- a/test_conformance/spirv_new/spirv_asm/constant_short_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_short_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_int_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_int_char_simple.spvasm32
@@ -29,7 +29,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %17
                OpStore %18 %14

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_int_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_int_char_simple.spvasm64
@@ -32,7 +32,7 @@
           %1 = OpFunction %void None %12
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_int_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_int_float_simple.spvasm32
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %17
                OpStore %18 %14

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_int_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_int_float_simple.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %12
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_struct_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_struct_simple.spvasm32
@@ -35,7 +35,7 @@
           %1 = OpFunction %void None %13
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_11
          %21 = OpLabel
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_11 %in %23
                OpStore %24 %20

--- a/test_conformance/spirv_new/spirv_asm/constant_struct_struct_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_struct_struct_simple.spvasm64
@@ -38,7 +38,7 @@
           %1 = OpFunction %void None %14
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_12
          %23 = OpLabel
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_true_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_true_simple.spvasm32
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %14 = OpLabel
          %15 = OpSelect %uint %true %uint_1 %uint_0
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %17
                OpStore %18 %15 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/constant_true_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_true_simple.spvasm64
@@ -31,7 +31,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpSelect %uint %true %uint_1 %uint_0
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_uchar_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_uchar_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
                OpStore %15 %uchar_19

--- a/test_conformance/spirv_new/spirv_asm/constant_uchar_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_uchar_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_uint_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_uint_simple.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
                OpStore %14 %uint_54321

--- a/test_conformance/spirv_new/spirv_asm/constant_uint_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_uint_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_ulong_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_ulong_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
                OpStore %15 %ulong_9223372036854775810

--- a/test_conformance/spirv_new/spirv_asm/constant_ulong_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_ulong_simple.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/constant_ushort_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/constant_ushort_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
                OpStore %15 %ushort_65000

--- a/test_conformance/spirv_new/spirv_asm/constant_ushort_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/constant_ushort_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_char_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
          %16 = OpCopyObject %uchar %uchar_20

--- a/test_conformance/spirv_new/spirv_asm/copy_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_char_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_double_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_double_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %14
          %16 = OpCopyObject %double %double_3_1415926535897931

--- a/test_conformance/spirv_new/spirv_asm/copy_double_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_double_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_float_simple.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %14
          %16 = OpCopyObject %float %float_3_14159274

--- a/test_conformance/spirv_new/spirv_asm/copy_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_float_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_half_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_half_simple.spvasm32
@@ -29,7 +29,7 @@
          %13 = OpLabel
          %14 = OpCopyObject %half %half_0x1_ap_1
          %15 = OpFConvert %float %14
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %17
                OpStore %18 %15

--- a/test_conformance/spirv_new/spirv_asm/copy_half_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_half_simple.spvasm64
@@ -31,7 +31,7 @@
          %14 = OpLabel
          %15 = OpCopyObject %half %half_0x1_ap_1
          %16 = OpFConvert %float %15
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_int3_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_int3_simple.spvasm32
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v3uint %in %16
          %18 = OpCopyObject %v3uint %13

--- a/test_conformance/spirv_new/spirv_asm/copy_int3_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_int3_simple.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_int4_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_int4_simple.spvasm32
@@ -29,7 +29,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %18
          %20 = OpCopyObject %v4uint %15

--- a/test_conformance/spirv_new/spirv_asm/copy_int4_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_int4_simple.spvasm64
@@ -32,7 +32,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %18 = OpLabel
-         %19 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %19 = OpLoad %v3ulong %gl_GlobalInvocationID
          %20 = OpCompositeExtract %ulong %19 0
          %21 = OpShiftLeftLogical %ulong %20 %ulong_32
          %22 = OpShiftRightArithmetic %ulong %21 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_int_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_int_simple.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
          %15 = OpCopyObject %uint %uint_123

--- a/test_conformance/spirv_new/spirv_asm/copy_int_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_int_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_long_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_long_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
          %16 = OpCopyObject %ulong %ulong_34359738368

--- a/test_conformance/spirv_new/spirv_asm/copy_long_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_long_simple.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_short_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_short_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
          %16 = OpCopyObject %ushort %ushort_32000

--- a/test_conformance/spirv_new/spirv_asm/copy_short_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_short_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_int_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_int_char_simple.spvasm32
@@ -29,7 +29,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %17
          %19 = OpCopyObject %_struct_9 %14

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_int_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_int_char_simple.spvasm64
@@ -32,7 +32,7 @@
           %1 = OpFunction %void None %12
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_int_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_int_float_simple.spvasm32
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %17
          %19 = OpCopyObject %_struct_9 %14

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_int_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_int_float_simple.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %12
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_struct_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_struct_simple.spvasm32
@@ -35,7 +35,7 @@
           %1 = OpFunction %void None %13
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_11
          %21 = OpLabel
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_11 %in %23
          %25 = OpCopyObject %_struct_11 %20

--- a/test_conformance/spirv_new/spirv_asm/copy_struct_struct_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_struct_struct_simple.spvasm64
@@ -38,7 +38,7 @@
           %1 = OpFunction %void None %14
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_12
          %23 = OpLabel
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_uchar_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_uchar_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
          %16 = OpCopyObject %uchar %uchar_19

--- a/test_conformance/spirv_new/spirv_asm/copy_uchar_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_uchar_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_uint_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_uint_simple.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
          %15 = OpCopyObject %uint %uint_54321

--- a/test_conformance/spirv_new/spirv_asm/copy_uint_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_uint_simple.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_ulong_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_ulong_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
          %16 = OpCopyObject %ulong %ulong_9223372036854775810

--- a/test_conformance/spirv_new/spirv_asm/copy_ulong_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_ulong_simple.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/copy_ushort_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/copy_ushort_simple.spvasm32
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
          %16 = OpCopyObject %ushort %ushort_65000

--- a/test_conformance/spirv_new/spirv_asm/copy_ushort_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/copy_ushort_simple.spvasm64
@@ -28,7 +28,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_aliased.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_aliased.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %15
          %17 = OpLoad %uint %16 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_aliased.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_aliased.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_alignment.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_alignment.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %15
          %17 = OpLoad %uint %16 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_alignment.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_alignment.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_constant.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_constant.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %15
          %17 = OpLoad %uint %16 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_constant.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_constant.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_constant_fail.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_constant_fail.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %15
          %17 = OpLoad %uint %16 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_constant_fail.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_constant_fail.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_cpacked.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_cpacked.spvasm32
@@ -30,7 +30,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_4
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_4 %in %17
                OpStore %18 %14

--- a/test_conformance/spirv_new/spirv_asm/decorate_cpacked.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_cpacked.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %12
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_4
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_restrict.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_restrict.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %15
          %17 = OpLoad %uint %16 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_restrict.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_restrict.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_double_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_double_long.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_double_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_double_long.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_float_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_float_int.spvasm32
@@ -28,7 +28,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
          %18 = OpLoad %float %17 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_float_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_float_int.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_half_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_half_short.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %16
          %18 = OpLoad %half %17 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_half_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rte_half_short.spvasm64
@@ -33,7 +33,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_double_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_double_long.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_double_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_double_long.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_float_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_float_int.spvasm32
@@ -28,7 +28,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
          %18 = OpLoad %float %17 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_float_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_float_int.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_half_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_half_short.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %17
          %19 = OpLoad %half %18 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_half_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtn_half_short.spvasm64
@@ -33,7 +33,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_double_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_double_long.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_double_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_double_long.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_float_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_float_int.spvasm32
@@ -28,7 +28,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
          %18 = OpLoad %float %17 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_float_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_float_int.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_half_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_half_short.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %17
          %19 = OpLoad %half %18 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_half_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtp_half_short.spvasm64
@@ -33,7 +33,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_double_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_double_long.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_double_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_double_long.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_float_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_float_int.spvasm32
@@ -28,7 +28,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
          %18 = OpLoad %float %17 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_float_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_float_int.spvasm64
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_half_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_half_short.spvasm32
@@ -31,7 +31,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %17
          %19 = OpLoad %half %18 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_half_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_rounding_rtz_half_short.spvasm64
@@ -33,7 +33,7 @@
         %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_int.spvasm32
@@ -31,7 +31,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_int.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_uint.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_uint.spvasm32
@@ -31,7 +31,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_uint.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_double_to_uint.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_char.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_char.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %18
          %20 = OpLoad %float %19 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_char.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_char.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_short.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %18
          %20 = OpLoad %float %19 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_short.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_uchar.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_uchar.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %18
          %20 = OpLoad %float %19 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_uchar.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_uchar.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_ushort.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_ushort.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %18
          %20 = OpLoad %float %19 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_ushort.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_float_to_ushort.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_char.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_char.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %18
          %20 = OpLoad %half %19 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_char.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_char.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_uchar.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_uchar.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %18
          %20 = OpLoad %half %19 Aligned 2

--- a/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_uchar.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/decorate_saturated_conversion_half_to_uchar.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fadd_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fadd_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/fadd_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fadd_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fadd_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fadd_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fadd_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fadd_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fadd_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fadd_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/fadd_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fadd_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fadd_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fadd_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fadd_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fadd_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fadd_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fadd_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/fadd_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fadd_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fdiv_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/fdiv_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fdiv_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fdiv_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fdiv_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/fdiv_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fdiv_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fdiv_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fdiv_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/fdiv_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fdiv_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmod_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmod_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/fmod_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmod_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmod_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmod_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fmod_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmod_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmod_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmod_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/fmod_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmod_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmod_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmod_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fmod_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmod_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmod_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmod_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/fmod_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmod_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmul_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmul_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/fmul_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmul_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmul_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmul_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fmul_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmul_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmul_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmul_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/fmul_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmul_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmul_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmul_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fmul_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmul_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fmul_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fmul_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/fmul_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fmul_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/frem_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/frem_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/frem_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/frem_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/frem_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/frem_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/frem_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/frem_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/frem_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/frem_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/frem_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/frem_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/frem_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/frem_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/frem_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/frem_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/frem_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/frem_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/frem_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/frem_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fsub_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fsub_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %lhs %17
          %19 = OpLoad %double %18 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/fsub_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fsub_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fsub_double2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fsub_double2.spvasm32
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %lhs %18
          %20 = OpLoad %v2double %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fsub_double2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fsub_double2.spvasm64
@@ -36,7 +36,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fsub_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fsub_float.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %lhs %17
          %19 = OpLoad %float %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/fsub_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fsub_float.spvasm64
@@ -34,7 +34,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fsub_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fsub_float4.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/fsub_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fsub_float4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
       %entry = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/fsub_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/fsub_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %lhs %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/fsub_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/fsub_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
       %entry = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/label_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/label_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %10 %13

--- a/test_conformance/spirv_new/spirv_asm/label_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/label_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/lifetime_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/lifetime_simple.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/lifetime_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/lifetime_simple.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/linkage_import.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/linkage_import.spvasm32
@@ -29,7 +29,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
          %18 = OpLoad %float %17

--- a/test_conformance/spirv_new/spirv_asm/linkage_import.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/linkage_import.spvasm64
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %15 = OpLabel
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_dont_unroll.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_dont_unroll.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_dont_unroll.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_dont_unroll.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_none.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_none.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_unroll.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_unroll.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_unroll.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_conditional_unroll.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_dont_unroll.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_dont_unroll.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_dont_unroll.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_dont_unroll.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_none.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_none.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_unroll.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_unroll.spvasm32
@@ -37,7 +37,7 @@
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
          %20 = OpVariable %_ptr_Function_uint Function
-         %21 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %21 = OpLoad %v3uint %gl_GlobalInvocationID
          %22 = OpCompositeExtract %uint %21 0
                OpStore %19 %uint_0 Aligned 4
                OpStore %20 %uint_0 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/loop_merge_branch_unroll.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/loop_merge_branch_unroll.spvasm64
@@ -40,7 +40,7 @@
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
          %22 = OpVariable %_ptr_Function_uint Function
-         %23 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %23 = OpLoad %v3ulong %gl_GlobalInvocationID
          %24 = OpCompositeExtract %ulong %23 0
          %25 = OpShiftLeftLogical %ulong %24 %ulong_32
          %26 = OpShiftRightArithmetic %ulong %25 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_const.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_const.spvasm32
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %18
          %20 = OpLoad %float %19

--- a/test_conformance/spirv_new/spirv_asm/op_function_const.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_const.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_inline.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_inline.spvasm32
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %18
          %20 = OpLoad %float %19

--- a/test_conformance/spirv_new/spirv_asm/op_function_inline.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_inline.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_noinline.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_noinline.spvasm32
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %18
          %20 = OpLoad %float %19

--- a/test_conformance/spirv_new/spirv_asm/op_function_noinline.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_noinline.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_none.spvasm32
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %18
          %20 = OpLoad %float %19

--- a/test_conformance/spirv_new/spirv_asm/op_function_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_none.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_pure.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_pure.spvasm32
@@ -31,7 +31,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %18
          %20 = OpLoad %float %19

--- a/test_conformance/spirv_new/spirv_asm/op_function_pure.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_pure.spvasm64
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_function_pure_ptr.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_function_pure_ptr.spvasm32
@@ -45,7 +45,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %27 = OpLabel
-         %28 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %28 = OpLoad %v3uint %gl_GlobalInvocationID
          %29 = OpCompositeExtract %uint %28 0
          %30 = OpFunctionCall %float %14 %in %29
          %31 = OpFunctionCall %void %21 %in %29 %30

--- a/test_conformance/spirv_new/spirv_asm/op_function_pure_ptr.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_function_pure_ptr.spvasm64
@@ -46,7 +46,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %27 = OpLabel
-         %28 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %28 = OpLoad %v3ulong %gl_GlobalInvocationID
          %29 = OpCompositeExtract %ulong %28 0
          %30 = OpShiftLeftLogical %ulong %29 %ulong_32
          %31 = OpShiftRightArithmetic %ulong %30 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_double.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %13
          %15 = OpLoad %double %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_double.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_float.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %13
          %15 = OpLoad %float %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_float.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_float4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_float4.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
          %12 = OpLabel
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %in %14
          %16 = OpLoad %v4float %15

--- a/test_conformance/spirv_new/spirv_asm/op_neg_float4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_float4.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_half.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %13
          %15 = OpLoad %half %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_half.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_int.spvasm32
@@ -23,7 +23,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpLabel
-         %11 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %11 = OpLoad %v3uint %gl_GlobalInvocationID
          %12 = OpCompositeExtract %uint %11 0
          %13 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %12
          %14 = OpLoad %uint %13

--- a/test_conformance/spirv_new/spirv_asm/op_neg_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_int.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_int4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_int4.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %13
          %15 = OpLoad %v4uint %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_int4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_int4.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_long.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %13
          %15 = OpLoad %ulong %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_long.spvasm64
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
-         %12 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3ulong %gl_GlobalInvocationID
          %13 = OpCompositeExtract %ulong %12 0
          %14 = OpShiftLeftLogical %ulong %13 %ulong_32
          %15 = OpShiftRightArithmetic %ulong %14 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_neg_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_short.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %13
          %15 = OpLoad %ushort %14

--- a/test_conformance/spirv_new/spirv_asm/op_neg_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_neg_short.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_not_int.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_not_int.spvasm32
@@ -23,7 +23,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpLabel
-         %11 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %11 = OpLoad %v3uint %gl_GlobalInvocationID
          %12 = OpCompositeExtract %uint %11 0
          %13 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %12
          %14 = OpLoad %uint %13

--- a/test_conformance/spirv_new/spirv_asm/op_not_int.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_not_int.spvasm64
@@ -26,7 +26,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_not_int4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_not_int4.spvasm32
@@ -24,7 +24,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %13
          %15 = OpLoad %v4uint %14

--- a/test_conformance/spirv_new/spirv_asm/op_not_int4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_not_int4.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %11
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_not_long.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_not_long.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %13
          %15 = OpLoad %ulong %14

--- a/test_conformance/spirv_new/spirv_asm/op_not_long.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_not_long.spvasm64
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %9
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
-         %12 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3ulong %gl_GlobalInvocationID
          %13 = OpCompositeExtract %ulong %12 0
          %14 = OpShiftLeftLogical %ulong %13 %ulong_32
          %15 = OpShiftRightArithmetic %ulong %14 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/op_not_short.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/op_not_short.spvasm32
@@ -25,7 +25,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %13
          %15 = OpLoad %ushort %14

--- a/test_conformance/spirv_new/spirv_asm/op_not_short.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/op_not_short.spvasm64
@@ -27,7 +27,7 @@
           %1 = OpFunction %void None %10
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/opaque.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/opaque.spvasm32
@@ -33,7 +33,7 @@
           %1 = OpFunction %void None %13
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_Opaque_opaque_t
          %18 = OpLabel
-         %19 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %19 = OpLoad %v3uint %gl_GlobalInvocationID
          %20 = OpCompositeExtract %uint %19 0
          %21 = OpFunctionCall %void %4 %in %20 %float_3_14159274
                OpReturn

--- a/test_conformance/spirv_new/spirv_asm/opaque.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/opaque.spvasm64
@@ -35,7 +35,7 @@
           %1 = OpFunction %void None %14
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_Opaque_opaque_t
          %19 = OpLabel
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/phi_2.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_2.spvasm32
@@ -30,7 +30,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %16
          %18 = OpLoad %uint %17 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/phi_2.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_2.spvasm64
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/phi_3.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_3.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %17
          %19 = OpLoad %uint %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/phi_3.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_3.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/phi_4.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/phi_4.spvasm32
@@ -32,7 +32,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %17
          %19 = OpLoad %uint %18 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/phi_4.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/phi_4.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_dont_flatten.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_flatten.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm32
@@ -33,7 +33,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %16 = OpLabel
          %17 = OpVariable %_ptr_Function_uint Function
-         %18 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3uint %gl_GlobalInvocationID
          %19 = OpCompositeExtract %uint %18 0
          %20 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %19
          %21 = OpLoad %uint %20 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_if_none.spvasm64
@@ -36,7 +36,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %18 = OpLabel
          %19 = OpVariable %_ptr_Function_uint Function
-         %20 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %20 = OpLoad %v3ulong %gl_GlobalInvocationID
          %21 = OpCompositeExtract %ulong %20 0
          %22 = OpShiftLeftLogical %ulong %21 %ulong_32
          %23 = OpShiftRightArithmetic %ulong %22 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_switch_dont_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_dont_flatten.spvasm32
@@ -37,7 +37,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %23
          %25 = OpLoad %uint %24 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_switch_dont_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_dont_flatten.spvasm64
@@ -40,7 +40,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %22 = OpLabel
          %23 = OpVariable %_ptr_Function_uint Function
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_switch_flatten.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_flatten.spvasm32
@@ -37,7 +37,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %23
          %25 = OpLoad %uint %24 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_switch_flatten.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_flatten.spvasm64
@@ -40,7 +40,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %22 = OpLabel
          %23 = OpVariable %_ptr_Function_uint Function
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/select_switch_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_none.spvasm32
@@ -37,7 +37,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %20 = OpLabel
          %21 = OpVariable %_ptr_Function_uint Function
-         %22 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %22 = OpLoad %v3uint %gl_GlobalInvocationID
          %23 = OpCompositeExtract %uint %22 0
          %24 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %lhs %23
          %25 = OpLoad %uint %24 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/select_switch_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/select_switch_none.spvasm64
@@ -40,7 +40,7 @@
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %22 = OpLabel
          %23 = OpVariable %_ptr_Function_uint Function
-         %24 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %24 = OpLoad %v3ulong %gl_GlobalInvocationID
          %25 = OpCompositeExtract %ulong %24 0
          %26 = OpShiftLeftLogical %ulong %25 %ulong_32
          %27 = OpShiftRightArithmetic %ulong %26 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_char_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %11 = OpLabel
          %12 = OpUndef %uchar
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_char_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
          %13 = OpUndef %uchar
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_double_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_double_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %11 = OpLabel
          %12 = OpUndef %double
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_double_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_double_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %12 = OpLabel
          %13 = OpUndef %double
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_false_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_false_simple.spvasm32
@@ -28,7 +28,7 @@
          %13 = OpLabel
          %14 = OpUndef %bool
          %15 = OpSelect %uint %14 %uint_1 %uint_0
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %17
                OpStore %18 %15

--- a/test_conformance/spirv_new/spirv_asm/undef_false_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_false_simple.spvasm64
@@ -31,7 +31,7 @@
          %15 = OpLabel
          %16 = OpUndef %bool
          %17 = OpSelect %uint %16 %uint_1 %uint_0
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_float_simple.spvasm32
@@ -25,7 +25,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %11 = OpLabel
          %12 = OpUndef %float
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_float_simple.spvasm64
@@ -27,7 +27,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %12 = OpLabel
          %13 = OpUndef %float
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_half_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_half_simple.spvasm32
@@ -28,7 +28,7 @@
          %12 = OpLabel
          %13 = OpUndef %half
          %14 = OpFConvert %float %13
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %16
                OpStore %17 %14

--- a/test_conformance/spirv_new/spirv_asm/undef_half_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_half_simple.spvasm64
@@ -30,7 +30,7 @@
          %13 = OpLabel
          %14 = OpUndef %half
          %15 = OpFConvert %float %14
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_int3_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_int3_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %10 = OpLabel
          %11 = OpUndef %v3uint
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v3uint %in %13
                OpStore %14 %11 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/undef_int3_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_int3_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v3uint
          %13 = OpLabel
          %14 = OpUndef %v3uint
-         %15 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3ulong %gl_GlobalInvocationID
          %16 = OpCompositeExtract %ulong %15 0
          %17 = OpShiftLeftLogical %ulong %16 %ulong_32
          %18 = OpShiftRightArithmetic %ulong %17 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_int4_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_int4_simple.spvasm32
@@ -25,7 +25,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %11 = OpLabel
          %12 = OpUndef %v4uint
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %14
                OpStore %15 %12 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/undef_int4_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_int4_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %13 = OpLabel
          %14 = OpUndef %v4uint
-         %15 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3ulong %gl_GlobalInvocationID
          %16 = OpCompositeExtract %ulong %15 0
          %17 = OpShiftLeftLogical %ulong %16 %ulong_32
          %18 = OpShiftRightArithmetic %ulong %17 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_int_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_int_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpLabel
          %11 = OpUndef %uint
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
                OpStore %14 %11

--- a/test_conformance/spirv_new/spirv_asm/undef_int_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_int_simple.spvasm64
@@ -27,7 +27,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %12 = OpLabel
          %13 = OpUndef %uint
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_long_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_long_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
          %12 = OpUndef %ulong
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_long_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_long_simple.spvasm64
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
          %12 = OpUndef %ulong
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_short_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_short_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %11 = OpLabel
          %12 = OpUndef %ushort
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_short_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_short_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
          %13 = OpUndef %ushort
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_int_char_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_int_char_simple.spvasm32
@@ -27,7 +27,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %12 = OpLabel
          %13 = OpUndef %_struct_9
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %15
                OpStore %16 %13

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_int_char_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_int_char_simple.spvasm64
@@ -30,7 +30,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %14 = OpLabel
          %15 = OpUndef %_struct_10
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_int_float_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_int_float_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_9
          %12 = OpLabel
          %13 = OpUndef %_struct_9
-         %14 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3uint %gl_GlobalInvocationID
          %15 = OpCompositeExtract %uint %14 0
          %16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_9 %in %15
                OpStore %16 %13

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_int_float_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_int_float_simple.spvasm64
@@ -29,7 +29,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_10
          %14 = OpLabel
          %15 = OpUndef %_struct_10
-         %16 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3ulong %gl_GlobalInvocationID
          %17 = OpCompositeExtract %ulong %16 0
          %18 = OpShiftLeftLogical %ulong %17 %ulong_32
          %19 = OpShiftRightArithmetic %ulong %18 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_struct_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_struct_simple.spvasm32
@@ -29,7 +29,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_11
          %14 = OpLabel
          %15 = OpUndef %_struct_11
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup__struct_11 %in %17
                OpStore %18 %15

--- a/test_conformance/spirv_new/spirv_asm/undef_struct_struct_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_struct_struct_simple.spvasm64
@@ -32,7 +32,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup__struct_12
          %16 = OpLabel
          %17 = OpUndef %_struct_12
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_true_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_true_simple.spvasm32
@@ -28,7 +28,7 @@
          %13 = OpLabel
          %14 = OpUndef %bool
          %15 = OpSelect %uint %14 %uint_1 %uint_0
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %17
                OpStore %18 %15 Aligned 4

--- a/test_conformance/spirv_new/spirv_asm/undef_true_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_true_simple.spvasm64
@@ -31,7 +31,7 @@
          %15 = OpLabel
          %16 = OpUndef %bool
          %17 = OpSelect %uint %16 %uint_1 %uint_0
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_uchar_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_uchar_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %11 = OpLabel
          %12 = OpUndef %uchar
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_uchar_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_uchar_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %12 = OpLabel
          %13 = OpUndef %uchar
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_uint_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_uint_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpLabel
          %11 = OpUndef %uint
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
                OpStore %14 %11

--- a/test_conformance/spirv_new/spirv_asm/undef_uint_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_uint_simple.spvasm64
@@ -27,7 +27,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %12 = OpLabel
          %13 = OpUndef %uint
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_ulong_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_ulong_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
          %12 = OpUndef %ulong
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_ulong_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_ulong_simple.spvasm64
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %11 = OpLabel
          %12 = OpUndef %ulong
-         %13 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3ulong %gl_GlobalInvocationID
          %14 = OpCompositeExtract %ulong %13 0
          %15 = OpShiftLeftLogical %ulong %14 %ulong_32
          %16 = OpShiftRightArithmetic %ulong %15 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/undef_ushort_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/undef_ushort_simple.spvasm32
@@ -26,7 +26,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %11 = OpLabel
          %12 = OpUndef %ushort
-         %13 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %13 = OpLoad %v3uint %gl_GlobalInvocationID
          %14 = OpCompositeExtract %uint %13 0
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ushort %in %14
                OpStore %15 %12

--- a/test_conformance/spirv_new/spirv_asm/undef_ushort_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/undef_ushort_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
          %12 = OpLabel
          %13 = OpUndef %ushort
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/unreachable_simple.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/unreachable_simple.spvasm32
@@ -24,7 +24,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %10 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %11 = OpLabel
-         %12 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %12 = OpLoad %v3uint %gl_GlobalInvocationID
          %13 = OpCompositeExtract %uint %12 0
          %14 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %13
          %15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %10 %13

--- a/test_conformance/spirv_new/spirv_asm/unreachable_simple.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/unreachable_simple.spvasm64
@@ -28,7 +28,7 @@
          %in = OpFunctionParameter %_ptr_CrossWorkgroup_uint
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpLabel
-         %14 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %14 = OpLoad %v3ulong %gl_GlobalInvocationID
          %15 = OpCompositeExtract %ulong %14 0
          %16 = OpShiftLeftLogical %ulong %15 %ulong_32
          %17 = OpShiftRightArithmetic %ulong %16 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_char16_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_char16_extract.spvasm32
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v16uchar %in %17
          %19 = OpLoad %v16uchar %18

--- a/test_conformance/spirv_new/spirv_asm/vector_char16_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_char16_extract.spvasm64
@@ -34,7 +34,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_char16_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_char16_insert.spvasm32
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v16uchar
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %in %17
          %19 = OpLoad %uchar %18

--- a/test_conformance/spirv_new/spirv_asm/vector_char16_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_char16_insert.spvasm64
@@ -34,7 +34,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v16uchar
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_double2_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_double2_extract.spvasm32
@@ -30,7 +30,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2double %in %17
          %19 = OpLoad %v2double %18

--- a/test_conformance/spirv_new/spirv_asm/vector_double2_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_double2_extract.spvasm64
@@ -33,7 +33,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_double2_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_double2_insert.spvasm32
@@ -30,7 +30,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %in %17
          %19 = OpLoad %double %18

--- a/test_conformance/spirv_new/spirv_asm/vector_double2_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_double2_insert.spvasm64
@@ -33,7 +33,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v2double
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_float4_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_float4_extract.spvasm32
@@ -29,7 +29,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %in %17
          %19 = OpLoad %v4float %18

--- a/test_conformance/spirv_new/spirv_asm/vector_float4_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_float4_extract.spvasm64
@@ -32,7 +32,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_float4_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_float4_insert.spvasm32
@@ -29,7 +29,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_float %in %17
          %19 = OpLoad %float %18

--- a/test_conformance/spirv_new/spirv_asm/vector_float4_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_float4_insert.spvasm64
@@ -32,7 +32,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_half8_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_half8_extract.spvasm32
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v8half %in %17
          %19 = OpLoad %v8half %18

--- a/test_conformance/spirv_new/spirv_asm/vector_half8_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_half8_extract.spvasm64
@@ -34,7 +34,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_half8_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_half8_insert.spvasm32
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v8half
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_half %in %17
          %19 = OpLoad %half %18

--- a/test_conformance/spirv_new/spirv_asm/vector_half8_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_half8_insert.spvasm64
@@ -34,7 +34,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v8half
          %16 = OpFunctionParameter %uint
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_int4_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_int4_extract.spvasm32
@@ -28,7 +28,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %13 = OpFunctionParameter %uint
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4uint %in %16
          %18 = OpLoad %v4uint %17

--- a/test_conformance/spirv_new/spirv_asm/vector_int4_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_int4_extract.spvasm64
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
          %15 = OpFunctionParameter %uint
          %16 = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_int4_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_int4_insert.spvasm32
@@ -28,7 +28,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %13 = OpFunctionParameter %uint
          %14 = OpLabel
-         %15 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %15 = OpLoad %v3uint %gl_GlobalInvocationID
          %16 = OpCompositeExtract %uint %15 0
          %17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %in %16
          %18 = OpLoad %uint %17

--- a/test_conformance/spirv_new/spirv_asm/vector_int4_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_int4_insert.spvasm64
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v4uint
          %15 = OpFunctionParameter %uint
          %16 = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_long2_extract.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_long2_extract.spvasm32
@@ -30,7 +30,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2ulong %in %17
          %19 = OpLoad %v2ulong %18

--- a/test_conformance/spirv_new/spirv_asm/vector_long2_extract.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_long2_extract.spvasm64
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
          %15 = OpFunctionParameter %uint
          %16 = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_long2_insert.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_long2_insert.spvasm32
@@ -30,7 +30,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v2ulong
          %14 = OpFunctionParameter %uint
          %15 = OpLabel
-         %16 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %16 = OpLoad %v3uint %gl_GlobalInvocationID
          %17 = OpCompositeExtract %uint %16 0
          %18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %in %17
          %19 = OpLoad %ulong %18

--- a/test_conformance/spirv_new/spirv_asm/vector_long2_insert.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_long2_insert.spvasm64
@@ -31,7 +31,7 @@
           %4 = OpFunctionParameter %_ptr_CrossWorkgroup_v2ulong
          %15 = OpFunctionParameter %uint
          %16 = OpLabel
-         %17 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3ulong %gl_GlobalInvocationID
          %18 = OpCompositeExtract %ulong %17 0
          %19 = OpShiftLeftLogical %ulong %18 %ulong_32
          %20 = OpShiftRightArithmetic %ulong %19 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_double.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_double.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4double %lhs %18
          %20 = OpLoad %v4double %19 Aligned 32

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_double.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_double.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4double
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_double
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_float.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_float.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4float %lhs %18
          %20 = OpLoad %v4float %19 Aligned 16

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_float.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_float.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4float
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_float
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_half.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_half.spvasm32
@@ -33,7 +33,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %16 = OpLabel
-         %17 = OpLoad %v3uint %gl_GlobalInvocationID Aligned 0
+         %17 = OpLoad %v3uint %gl_GlobalInvocationID
          %18 = OpCompositeExtract %uint %17 0
          %19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4half %lhs %18
          %20 = OpLoad %v4half %19 Aligned 8

--- a/test_conformance/spirv_new/spirv_asm/vector_times_scalar_half.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/vector_times_scalar_half.spvasm64
@@ -35,7 +35,7 @@
         %lhs = OpFunctionParameter %_ptr_CrossWorkgroup_v4half
         %rhs = OpFunctionParameter %_ptr_CrossWorkgroup_half
          %17 = OpLabel
-         %18 = OpLoad %v3ulong %gl_GlobalInvocationID Aligned 0
+         %18 = OpLoad %v3ulong %gl_GlobalInvocationID
          %19 = OpCompositeExtract %ulong %18 0
          %20 = OpShiftLeftLogical %ulong %19 %ulong_32
          %21 = OpShiftRightArithmetic %ulong %20 %ulong_32


### PR DESCRIPTION
After https://github.com/KhronosGroup/SPIRV-Tools/pull/6027 spirv-val is now rejecting `Aligned 0` Memory Operands.  This causes the spirv_new test binary to no longer build with a recent SPIRV-Tools version.

Mechanically remove all occurrences of `Aligned 0` in the SPIR-V assembly files.