### PR TITLE
Added support for cl_ext_float_atomics in CBasicTestFetchMin/Max with atomic_double

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -71,6 +71,8 @@ extern int
     gMaxDeviceThreads; // maximum number of threads executed on OCL device
 extern cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+extern bool gFloatAtomicsSupported;
+extern cl_device_fp_atomic_capabilities_ext gDoubleAtomicCaps;
 
 extern const char *
 get_memory_order_type_name(TExplicitMemoryOrderType orderType);
@@ -168,6 +170,13 @@ public:
     {
         return false;
     }
+    virtual bool VerifyExpected(const HostDataType &expected,
+                                const HostAtomicType *const testValue,
+                                cl_uint whichDestValue)
+    {
+        if (testValue != nullptr) return expected != testValue[whichDestValue];
+        return true;
+    }
     virtual bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
                               MTdata d)
     {
@@ -240,13 +249,13 @@ public:
         int error = 0;
         if (_maxDeviceThreads > 0 && !UseSVM())
         {
-            LocalMemory(true);
+            SetLocalMemory(true);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
         if (_maxDeviceThreads + MaxHostThreads() > 0)
         {
-            LocalMemory(false);
+            SetLocalMemory(false);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
@@ -401,7 +410,7 @@ public:
     bool UseSVM() { return _useSVM; }
     void StartValue(HostDataType startValue) { _startValue = startValue; }
     HostDataType StartValue() { return _startValue; }
-    void LocalMemory(bool local) { _localMemory = local; }
+    void SetLocalMemory(bool local) { _localMemory = local; }
     bool LocalMemory() { return _localMemory; }
     void DeclaredInProgram(bool declaredInProgram)
     {
@@ -1434,7 +1443,7 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(
                            startRefValues.size() ? &startRefValues[0] : 0, i))
             break; // no expected value function provided
 
-        if (expected != destItems[i])
+        if (VerifyExpected(expected, destItems.data(), i))
         {
             std::stringstream logLine;
             logLine << "ERROR: Result " << i

--- a/test_conformance/c11_atomics/host_atomics.h
+++ b/test_conformance/c11_atomics/host_atomics.h
@@ -17,6 +17,7 @@
 #define HOST_ATOMICS_H_
 
 #include "harness/testHarness.h"
+#include <mutex>
 
 #ifdef WIN32
 #include "Windows.h"
@@ -138,19 +139,52 @@ bool host_atomic_compare_exchange(volatile AtomicType *a, CorrespondingType *exp
                                   TExplicitMemoryOrderType order_success,
                                   TExplicitMemoryOrderType order_failure)
 {
-  CorrespondingType tmp;
-#if defined( _MSC_VER ) || (defined( __INTEL_COMPILER ) && defined(WIN32))
-  tmp = InterlockedCompareExchange(a, desired, *expected);
+    CorrespondingType tmp;
+    if (std::is_same<AtomicType, HOST_ATOMIC_DOUBLE>::value)
+    {
+        static std::mutex mtx;
+        std::lock_guard<std::mutex> lock(mtx);
+        tmp = *reinterpret_cast<volatile float *>(a);
+        if (tmp == *expected)
+        {
+            *a = desired;
+            return true;
+        }
+        *expected = tmp;
+    }
+    else
+    {
+#if defined(_MSC_VER) || (defined(__INTEL_COMPILER) && defined(WIN32))
+
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value
+            || std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            tmp = InterlockedCompareExchange((volatile cl_uint *)a, desired,
+                                             *expected);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value
+                 || std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            tmp = InterlockedCompareExchange((volatile cl_ulong *)a, desired,
+                                             *expected);
 #elif defined(__GNUC__)
-  tmp = __sync_val_compare_and_swap(a, *expected, desired);
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_int *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_uint *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_long *)a, *expected,
+                                              desired);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            tmp = __sync_val_compare_and_swap((volatile cl_ulong *)a, *expected,
+                                              desired);
 #else
-  log_info("Host function not implemented: atomic_compare_exchange\n");
-  tmp = 0;
+        log_info("Host function not implemented: atomic_compare_exchange\n");
+        tmp = 0;
 #endif
-  if(tmp == *expected)
-    return true;
-  *expected = tmp;
-  return false;
+        if (tmp == *expected) return true;
+        *expected = tmp;
+    }
+    return false;
 }
 
 template <typename AtomicType, typename CorrespondingType>

--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+#include "harness/kernelHelpers.h"
 #include <iostream>
 #include <string>
 
@@ -28,6 +30,8 @@ int gInternalIterations = 10000; // internal test iterations for atomic operatio
 int gMaxDeviceThreads = 1024; // maximum number of threads executed on OCL device
 cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+bool gFloatAtomicsSupported = false;
+cl_device_fp_atomic_capabilities_ext gDoubleAtomicCaps = 0;
 
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
@@ -121,6 +125,18 @@ test_status InitCL(cl_device_id device) {
             | CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM
             | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE
             | CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES;
+    }
+
+    if (is_extension_available(device, "cl_ext_float_atomics"))
+    {
+        gFloatAtomicsSupported = true;
+        if (is_extension_available(device, "cl_khr_fp64"))
+        {
+            cl_int error = clGetDeviceInfo(
+                device, CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT,
+                sizeof(gDoubleAtomicCaps), &gDoubleAtomicCaps, nullptr);
+            test_error_ret(error, "clGetDeviceInfo failed!", TEST_FAIL);
+        }
     }
 
     return TEST_PASS;

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -16,6 +16,7 @@
 #include "harness/testHarness.h"
 #include "harness/kernelHelpers.h"
 #include "harness/typeWrappers.h"
+#include "harness/conversions.h"
 
 #include "common.h"
 #include "host_atomics.h"
@@ -2096,46 +2097,65 @@ REGISTER_TEST(svm_atomic_fetch_xor2)
 template <typename HostAtomicType, typename HostDataType>
 class CBasicTestFetchMin
     : public CBasicTestMemOrderScope<HostAtomicType, HostDataType> {
+    double min_range;
+    double max_range;
+
 public:
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::StartValue;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::DataType;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::MemoryOrder;
     using CBasicTestMemOrderScope<HostAtomicType,
                                   HostDataType>::MemoryOrderScopeStr;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::LocalMemory;
     CBasicTestFetchMin(TExplicitAtomicType dataType, bool useSVM)
         : CBasicTestMemOrderScope<HostAtomicType, HostDataType>(dataType,
-                                                                useSVM)
+                                                                useSVM),
+          min_range(-999.0), max_range(999.0)
     {
         StartValue(DataType().MaxValue());
     }
-    virtual std::string ProgramCore()
+    std::string ProgramCore() override
     {
         std::string memoryOrderScope = MemoryOrderScopeStr();
         std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
         return "  oldValues[tid] = atomic_fetch_min" + postfix
             + "(&destMemory[0], oldValues[tid] " + memoryOrderScope + ");\n";
     }
-    virtual void HostFunction(cl_uint tid, cl_uint threadCount,
-                              volatile HostAtomicType *destMemory,
-                              HostDataType *oldValues)
+    void HostFunction(cl_uint tid, cl_uint threadCount,
+                      volatile HostAtomicType *destMemory,
+                      HostDataType *oldValues) override
     {
         oldValues[tid] = host_atomic_fetch_min(&destMemory[0], oldValues[tid],
                                                MemoryOrder());
     }
-    virtual bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
-                              MTdata d)
+    bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
+                      MTdata d) override
     {
-        for (cl_uint i = 0; i < threadCount; i++)
+        if (std::is_same<HostDataType, HOST_ATOMIC_DOUBLE>::value)
         {
-            startRefValues[i] = genrand_int32(d);
-            if (sizeof(HostDataType) >= 8)
-                startRefValues[i] |= (HostDataType)genrand_int32(d) << 16;
+            for (cl_uint i = 0; i < threadCount; i++)
+            {
+                startRefValues[i] = get_random_double(min_range, max_range, d);
+            }
+        }
+        else
+        {
+            for (cl_uint i = 0; i < threadCount; i++)
+            {
+                startRefValues[i] = genrand_int32(d);
+                if (sizeof(HostDataType) >= 8)
+                {
+                    cl_ulong v = startRefValues[i];
+                    v |= (cl_ulong)genrand_int32(d) << 16;
+                    startRefValues[i] = v;
+                }
+            }
         }
         return true;
     }
-    virtual bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
-                               HostDataType *startRefValues,
-                               cl_uint whichDestValue)
+    bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
+                       HostDataType *startRefValues,
+                       cl_uint whichDestValue) override
     {
         expected = StartValue();
         for (cl_uint i = 0; i < threadCount; i++)
@@ -2143,6 +2163,25 @@ public:
             if (startRefValues[i] < expected) expected = startRefValues[i];
         }
         return true;
+    }
+    int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_DOUBLE>::value)
+        {
+            if (LocalMemory()
+                && (gDoubleAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT)
+                    == 0)
+                return 0; // skip test - not applicable
+
+            if (!LocalMemory()
+                && (gDoubleAtomicCaps & CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT)
+                    == 0)
+                return 0;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::ExecuteSingleTest(deviceID, context,
+                                                             queue);
     }
 };
 
@@ -2168,6 +2207,15 @@ static int test_atomic_fetch_min_generic(cl_device_id deviceID,
         TYPE_ATOMIC_ULONG, useSVM);
     EXECUTE_TEST(error,
                  test_ulong.Execute(deviceID, context, queue, num_elements));
+
+    if (gFloatAtomicsSupported)
+    {
+        CBasicTestFetchMin<HOST_ATOMIC_DOUBLE, HOST_DOUBLE> test_double(
+            TYPE_ATOMIC_DOUBLE, useSVM);
+        EXECUTE_TEST(
+            error, test_double.Execute(deviceID, context, queue, num_elements));
+    }
+
     if (AtomicTypeInfo(TYPE_ATOMIC_SIZE_T).Size(deviceID) == 4)
     {
         CBasicTestFetchMin<HOST_ATOMIC_INTPTR_T32, HOST_INTPTR_T32>
@@ -2230,46 +2278,65 @@ REGISTER_TEST(svm_atomic_fetch_min)
 template <typename HostAtomicType, typename HostDataType>
 class CBasicTestFetchMax
     : public CBasicTestMemOrderScope<HostAtomicType, HostDataType> {
+    double min_range;
+    double max_range;
+
 public:
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::StartValue;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::DataType;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::MemoryOrder;
     using CBasicTestMemOrderScope<HostAtomicType,
                                   HostDataType>::MemoryOrderScopeStr;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::LocalMemory;
     CBasicTestFetchMax(TExplicitAtomicType dataType, bool useSVM)
         : CBasicTestMemOrderScope<HostAtomicType, HostDataType>(dataType,
-                                                                useSVM)
+                                                                useSVM),
+          min_range(-999.0), max_range(999.0)
     {
         StartValue(DataType().MinValue());
     }
-    virtual std::string ProgramCore()
+    std::string ProgramCore() override
     {
         std::string memoryOrderScope = MemoryOrderScopeStr();
         std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
         return "  oldValues[tid] = atomic_fetch_max" + postfix
             + "(&destMemory[0], oldValues[tid] " + memoryOrderScope + ");\n";
     }
-    virtual void HostFunction(cl_uint tid, cl_uint threadCount,
-                              volatile HostAtomicType *destMemory,
-                              HostDataType *oldValues)
+    void HostFunction(cl_uint tid, cl_uint threadCount,
+                      volatile HostAtomicType *destMemory,
+                      HostDataType *oldValues) override
     {
         oldValues[tid] = host_atomic_fetch_max(&destMemory[0], oldValues[tid],
                                                MemoryOrder());
     }
-    virtual bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
-                              MTdata d)
+    bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
+                      MTdata d) override
     {
-        for (cl_uint i = 0; i < threadCount; i++)
+        if (std::is_same<HostDataType, HOST_ATOMIC_DOUBLE>::value)
         {
-            startRefValues[i] = genrand_int32(d);
-            if (sizeof(HostDataType) >= 8)
-                startRefValues[i] |= (HostDataType)genrand_int32(d) << 16;
+            for (cl_uint i = 0; i < threadCount; i++)
+            {
+                startRefValues[i] = get_random_double(min_range, max_range, d);
+            }
+        }
+        else
+        {
+            for (cl_uint i = 0; i < threadCount; i++)
+            {
+                startRefValues[i] = genrand_int32(d);
+                if (sizeof(HostDataType) >= 8)
+                {
+                    cl_ulong v = startRefValues[i];
+                    v |= (cl_ulong)genrand_int32(d) << 16;
+                    startRefValues[i] = v;
+                }
+            }
         }
         return true;
     }
-    virtual bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
-                               HostDataType *startRefValues,
-                               cl_uint whichDestValue)
+    bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
+                       HostDataType *startRefValues,
+                       cl_uint whichDestValue) override
     {
         expected = StartValue();
         for (cl_uint i = 0; i < threadCount; i++)
@@ -2277,6 +2344,25 @@ public:
             if (startRefValues[i] > expected) expected = startRefValues[i];
         }
         return true;
+    }
+    int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_DOUBLE>::value)
+        {
+            if (LocalMemory()
+                && (gDoubleAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT)
+                    == 0)
+                return 0; // skip test - not applicable
+
+            if (!LocalMemory()
+                && (gDoubleAtomicCaps & CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT)
+                    == 0)
+                return 0;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::ExecuteSingleTest(deviceID, context,
+                                                             queue);
     }
 };
 
@@ -2302,6 +2388,15 @@ static int test_atomic_fetch_max_generic(cl_device_id deviceID,
         TYPE_ATOMIC_ULONG, useSVM);
     EXECUTE_TEST(error,
                  test_ulong.Execute(deviceID, context, queue, num_elements));
+
+    if (gFloatAtomicsSupported)
+    {
+        CBasicTestFetchMax<HOST_ATOMIC_DOUBLE, HOST_DOUBLE> test_double(
+            TYPE_ATOMIC_DOUBLE, useSVM);
+        EXECUTE_TEST(
+            error, test_double.Execute(deviceID, context, queue, num_elements));
+    }
+
     if (AtomicTypeInfo(TYPE_ATOMIC_SIZE_T).Size(deviceID) == 4)
     {
         CBasicTestFetchMax<HOST_ATOMIC_INTPTR_T32, HOST_INTPTR_T32>


### PR DESCRIPTION
Related to #2142, according to the work plan, extending CBasicTestFetchMin/CBasicTestFetchMax with support for atomic_double.