### PR TITLE
Refactor imagecopy and imagereadwrite tests

### DIFF
--- a/test_conformance/basic/test_imagecopy.cpp
+++ b/test_conformance/basic/test_imagecopy.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,212 +20,216 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <memory>
 
 #include "testBase.h"
 
-static unsigned char *
-generate_rgba8_image(int w, int h, MTdata d)
+static std::unique_ptr<unsigned char[]> generate_rgba8_image(int w, int h,
+                                                             MTdata d)
 {
-    unsigned char   *ptr = (unsigned char*)malloc(w * h * 4);
-    int             i;
+    std::unique_ptr<unsigned char[]> ptr{ new unsigned char[w * h * 4] };
 
-    for (i=0; i<w*h*4; i++)
+    for (int i = 0; i < w * h * 4; i++)
         ptr[i] = (unsigned char)genrand_int32(d);
 
     return ptr;
 }
 
-static int
-verify_rgba8_image(unsigned char *image, unsigned char *outptr, int w, int h)
+static int verify_rgba8_image(const unsigned char *image,
+                              const unsigned char *outptr, int w, int h)
 {
-    int     i;
+    int i;
 
-    for (i=0; i<w*h*4; i++)
+    for (i = 0; i < w * h * 4; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
 
-static unsigned short *
-generate_rgba16_image(int w, int h, MTdata d)
+static std::unique_ptr<unsigned short[]> generate_rgba16_image(int w, int h,
+                                                               MTdata d)
 {
-    unsigned short    *ptr = (unsigned short *)malloc(w * h * 4 * sizeof(unsigned short));
-    int             i;
+    std::unique_ptr<unsigned short[]> ptr{ new unsigned short[w * h * 4] };
 
-    for (i=0; i<w*h*4; i++)
+    for (int i = 0; i < w * h * 4; i++)
         ptr[i] = (unsigned short)genrand_int32(d);
 
     return ptr;
 }
 
-static int
-verify_rgba16_image(unsigned short *image, unsigned short *outptr, int w, int h)
+static int verify_rgba16_image(const unsigned short *image,
+                               const unsigned short *outptr, int w, int h)
 {
-    int     i;
+    int i;
 
-    for (i=0; i<w*h*4; i++)
+    for (i = 0; i < w * h * 4; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
 
-static float *
-generate_rgbafp_image(int w, int h, MTdata d)
+static std::unique_ptr<float[]> generate_rgbafp_image(int w, int h, MTdata d)
 {
-    float   *ptr = (float*)malloc(w * h * 4 * sizeof(float));
-    int     i;
+    std::unique_ptr<float[]> ptr{ new float[w * h * 4] };
 
-    for (i=0; i<w*h*4; i++)
+    for (int i = 0; i < w * h * 4; i++)
         ptr[i] = get_random_float(-0x40000000, 0x40000000, d);
 
     return ptr;
 }
 
-static int
-verify_rgbafp_image(float *image, float *outptr, int w, int h)
+static int verify_rgbafp_image(const float *image, const float *outptr, int w,
+                               int h)
 {
-    int     i;
+    int i;
 
-    for (i=0; i<w*h*4; i++)
+    for (i = 0; i < w * h * 4; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
+static constexpr cl_image_format image_formats[] = { { CL_RGBA, CL_UNORM_INT8 },
+                                                     { CL_RGBA,
+                                                       CL_UNORM_INT16 },
+                                                     { CL_RGBA, CL_FLOAT } };
 
-REGISTER_TEST(imagecopy)
+static int test_imagecopy_impl(cl_device_id device, cl_context context,
+                               cl_command_queue queue, int num_elements,
+                               cl_mem_flags src_image_flags)
 {
-    cl_image_format    img_format;
-    unsigned char    *rgba8_inptr, *rgba8_outptr;
-    unsigned short    *rgba16_inptr, *rgba16_outptr;
-    float            *rgbafp_inptr, *rgbafp_outptr;
-    clMemWrapper            streams[6];
-    int                img_width = 512;
-    int                img_height = 512;
-    int                i, err;
-    MTdata          d;
+    constexpr size_t image_formats_count = ARRAY_SIZE(image_formats);
+    std::unique_ptr<unsigned char[]> rgba8_inptr, rgba8_outptr;
+    std::unique_ptr<unsigned short[]> rgba16_inptr, rgba16_outptr;
+    std::unique_ptr<float[]> rgbafp_inptr, rgbafp_outptr;
+    clMemWrapper streams[6];
+    int img_width = 512;
+    int img_height = 512;
+    int i, err;
+    MTdataHolder d(gRandomSeed);
 
-    PASSIVE_REQUIRE_IMAGE_SUPPORT( device )
+    rgba8_inptr = generate_rgba8_image(img_width, img_height, d);
+    rgba16_inptr = generate_rgba16_image(img_width, img_height, d);
+    rgbafp_inptr = generate_rgbafp_image(img_width, img_height, d);
 
-    d = init_genrand( gRandomSeed );
-    rgba8_inptr = (unsigned char *)generate_rgba8_image(img_width, img_height, d);
-    rgba16_inptr = (unsigned short *)generate_rgba16_image(img_width, img_height, d);
-    rgbafp_inptr = (float *)generate_rgbafp_image(img_width, img_height, d);
-    free_mtdata(d); d = NULL;
+    rgba8_outptr.reset(new unsigned char[4 * img_width * img_height]);
+    rgba16_outptr.reset(new unsigned short[4 * img_width * img_height]);
+    rgbafp_outptr.reset(new float[4 * img_width * img_height]);
 
-    rgba8_outptr = (unsigned char*)malloc(sizeof(unsigned char) * 4 * img_width * img_height);
-    rgba16_outptr = (unsigned short*)malloc(sizeof(unsigned short) * 4 * img_width * img_height);
-    rgbafp_outptr = (float*)malloc(sizeof(float) * 4 * img_width * img_height);
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT8;
-    streams[0] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-    streams[1] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT16;
-    streams[2] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-    streams[3] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_FLOAT;
-    streams[4] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-    streams[5] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-
-    for (i=0; i<3; i++)
+    for (size_t index = 0; index < image_formats_count; ++index)
     {
-        void    *p, *outp;
-        int        x, y, delta_w = img_width/8, delta_h = img_height/16;
+        void *ptr = nullptr;
+        if (src_image_flags & CL_MEM_USE_HOST_PTR
+            || src_image_flags & CL_MEM_COPY_HOST_PTR)
+
+        {
+            switch (index)
+            {
+                case 0: ptr = rgba8_inptr.get(); break;
+                case 1: ptr = rgba16_inptr.get(); break;
+                case 2: ptr = rgbafp_inptr.get(); break;
+                default: break;
+            }
+        }
+        streams[index * 2] =
+            create_image_2d(context, src_image_flags, &image_formats[index],
+                            img_width, img_height, 0, ptr, &err);
+        test_error(err, "create_image_2d failed");
+
+        streams[index * 2 + 1] =
+            create_image_2d(context, CL_MEM_READ_WRITE, &image_formats[index],
+                            img_width, img_height, 0, nullptr, &err);
+        test_error(err, "create_image_2d failed");
+    }
+
+    for (i = 0; i < 3; i++)
+    {
+        void *p, *outp;
+        int x, y, delta_w = img_width / 8, delta_h = img_height / 16;
 
         switch (i)
         {
             case 0:
-                p = (void *)rgba8_inptr;
-                outp = (void *)rgba8_outptr;
-        log_info("Testing CL_RGBA CL_UNORM_INT8\n");
+                p = rgba8_inptr.get();
+                outp = rgba8_outptr.get();
+                log_info("Testing CL_RGBA CL_UNORM_INT8\n");
                 break;
             case 1:
-                p = (void *)rgba16_inptr;
-                outp = (void *)rgba16_outptr;
-        log_info("Testing CL_RGBA CL_UNORM_INT16\n");
+                p = rgba16_inptr.get();
+                outp = rgba16_outptr.get();
+                log_info("Testing CL_RGBA CL_UNORM_INT16\n");
                 break;
             case 2:
-                p = (void *)rgbafp_inptr;
-                outp = (void *)rgbafp_outptr;
-        log_info("Testing CL_RGBA CL_FLOAT\n");
+                p = rgbafp_inptr.get();
+                outp = rgbafp_outptr.get();
+                log_info("Testing CL_RGBA CL_FLOAT\n");
                 break;
         }
 
-        size_t origin[3] = {0,0,0}, region[3] = {img_width, img_height, 1};
-        err = clEnqueueWriteImage(queue, streams[i*2], CL_TRUE, origin, region, 0, 0, p, 0, NULL, NULL);
-        test_error(err, "create_image_2d failed");
+        size_t origin[3] = { 0, 0, 0 },
+               region[3] = { img_width, img_height, 1 };
+        if (!(src_image_flags & CL_MEM_USE_HOST_PTR
+              || src_image_flags & CL_MEM_COPY_HOST_PTR))
+        {
+            err = clEnqueueWriteImage(queue, streams[i * 2], CL_TRUE, origin,
+                                      region, 0, 0, p, 0, nullptr, nullptr);
+            test_error(err, "create_image_2d failed");
+        }
 
         int copy_number = 0;
-        for (y=0; y<img_height; y+=delta_h)
+        for (y = 0; y < img_height; y += delta_h)
         {
-            for (x=0; x<img_width; x+=delta_w)
+            for (x = 0; x < img_width; x += delta_w)
             {
-        copy_number++;
-        size_t copy_origin[3] = {x,y,0}, copy_region[3]={delta_w, delta_h, 1};
-        err = clEnqueueCopyImage(queue, streams[i*2], streams[i*2+1],
-                                 copy_origin, copy_origin, copy_region,
-                                 0, NULL, NULL);
-        if (err) {
-          log_error("Copy %d (origin [%d, %d], size [%d, %d], image size [%d x %d]) Failed\n", copy_number, x, y, delta_w, delta_h, img_width, img_height);
-        }
-        test_error(err, "clEnqueueCopyImage failed");
+                copy_number++;
+                size_t copy_origin[3] = { x, y, 0 },
+                       copy_region[3] = { delta_w, delta_h, 1 };
+                err = clEnqueueCopyImage(
+                    queue, streams[i * 2], streams[i * 2 + 1], copy_origin,
+                    copy_origin, copy_region, 0, NULL, NULL);
+                if (err)
+                {
+                    log_error("Copy %d (origin [%d, %d], size [%d, %d], image "
+                              "size [%d x %d]) Failed\n",
+                              copy_number, x, y, delta_w, delta_h, img_width,
+                              img_height);
+                }
+                test_error(err, "clEnqueueCopyImage failed");
             }
         }
 
-        err = clEnqueueReadImage(queue, streams[i*2+1], CL_TRUE, origin, region, 0, 0, outp, 0, NULL, NULL);
+        err = clEnqueueReadImage(queue, streams[i * 2 + 1], CL_TRUE, origin,
+                                 region, 0, 0, outp, 0, NULL, NULL);
         test_error(err, "clEnqueueReadImage failed");
 
         switch (i)
         {
             case 0:
-                err = verify_rgba8_image(rgba8_inptr, rgba8_outptr, img_width, img_height);
+                err = verify_rgba8_image(rgba8_inptr.get(), rgba8_outptr.get(),
+                                         img_width, img_height);
                 break;
             case 1:
-                err = verify_rgba16_image(rgba16_inptr, rgba16_outptr, img_width, img_height);
+                err =
+                    verify_rgba16_image(rgba16_inptr.get(), rgba16_outptr.get(),
+                                        img_width, img_height);
                 break;
             case 2:
-                err = verify_rgbafp_image(rgbafp_inptr, rgbafp_outptr, img_width, img_height);
+                err =
+                    verify_rgbafp_image(rgbafp_inptr.get(), rgbafp_outptr.get(),
+                                        img_width, img_height);
                 break;
         }
 
-        if (err)
-            break;
+        if (err) break;
     }
-
-  free(rgba8_inptr);
-  free(rgba16_inptr);
-  free(rgbafp_inptr);
-  free(rgba8_outptr);
-  free(rgba16_outptr);
-  free(rgbafp_outptr);
 
     if (err)
         log_error("IMAGE copy test failed\n");
@@ -233,4 +237,12 @@ REGISTER_TEST(imagecopy)
         log_info("IMAGE copy test passed\n");
 
     return err;
+}
+
+REGISTER_TEST(imagecopy)
+{
+    PASSIVE_REQUIRE_IMAGE_SUPPORT(device);
+
+    return test_imagecopy_impl(device, context, queue, num_elements,
+                               CL_MEM_READ_WRITE);
 }

--- a/test_conformance/basic/test_imagecopy3d.cpp
+++ b/test_conformance/basic/test_imagecopy3d.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,212 +20,226 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <memory>
 
 #include "testBase.h"
 
-static unsigned char *
+static std::unique_ptr<unsigned char[]>
 generate_uint8_image(unsigned num_elements, MTdata d)
 {
-    unsigned char *ptr = (unsigned char*)malloc(num_elements);
-    unsigned i;
+    std::unique_ptr<unsigned char[]> ptr{ new unsigned char[num_elements] };
 
-    for (i=0; i<num_elements; i++)
+    for (unsigned i = 0; i < num_elements; i++)
         ptr[i] = (unsigned char)genrand_int32(d);
 
     return ptr;
 }
 
-static int
-verify_uint8_image(unsigned char *image, unsigned char *outptr, unsigned num_elements)
+static int verify_uint8_image(const unsigned char *image,
+                              const unsigned char *outptr,
+                              unsigned num_elements)
 {
     unsigned i;
 
-    for (i=0; i<num_elements; i++)
+    for (i = 0; i < num_elements; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
 
-static unsigned short *
+static std::unique_ptr<unsigned short[]>
 generate_uint16_image(unsigned num_elements, MTdata d)
 {
-    unsigned short    *ptr = (unsigned short *)malloc(num_elements * sizeof(unsigned short));
-    unsigned i;
+    std::unique_ptr<unsigned short[]> ptr{ new unsigned short[num_elements] };
 
-    for (i=0; i<num_elements; i++)
+    for (unsigned i = 0; i < num_elements; i++)
         ptr[i] = (unsigned short)genrand_int32(d);
 
     return ptr;
 }
 
-static int
-verify_uint16_image(unsigned short *image, unsigned short *outptr, unsigned num_elements)
+static int verify_uint16_image(const unsigned short *image,
+                               const unsigned short *outptr,
+                               unsigned num_elements)
 {
     unsigned i;
 
-    for (i=0; i<num_elements; i++)
+    for (i = 0; i < num_elements; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
 
-static float *
-generate_float_image(unsigned num_elements, MTdata d)
+static std::unique_ptr<float[]> generate_float_image(unsigned num_elements,
+                                                     MTdata d)
 {
-    float   *ptr = (float*)malloc(num_elements * sizeof(float));
-    unsigned i;
+    std::unique_ptr<float[]> ptr{ new float[num_elements] };
 
-    for (i=0; i<num_elements; i++)
+    for (unsigned i = 0; i < num_elements; i++)
         ptr[i] = get_random_float(-0x40000000, 0x40000000, d);
 
     return ptr;
 }
 
-static int
-verify_float_image(float *image, float *outptr, unsigned num_elements)
+static int verify_float_image(const float *image, const float *outptr,
+                              unsigned num_elements)
 {
     unsigned i;
 
-    for (i=0; i<num_elements; i++)
+    for (i = 0; i < num_elements; i++)
     {
-        if (outptr[i] != image[i])
-            return -1;
+        if (outptr[i] != image[i]) return -1;
     }
 
     return 0;
 }
 
+static constexpr cl_image_format image_formats[] = { { CL_RGBA, CL_UNORM_INT8 },
+                                                     { CL_RGBA,
+                                                       CL_UNORM_INT16 },
+                                                     { CL_RGBA, CL_FLOAT } };
 
-REGISTER_TEST(imagecopy3d)
+static int test_imagecopy3d_impl(cl_device_id device, cl_context context,
+                                 cl_command_queue queue,
+                                 int num_elements_ignored,
+                                 cl_mem_flags src_image_flags)
 {
-    cl_image_format    img_format;
-    unsigned char    *rgba8_inptr, *rgba8_outptr;
-    unsigned short *rgba16_inptr, *rgba16_outptr;
-    float *rgbafp_inptr, *rgbafp_outptr;
+    constexpr size_t image_formats_count = ARRAY_SIZE(image_formats);
+    std::unique_ptr<unsigned char[]> rgba8_inptr, rgba8_outptr;
+    std::unique_ptr<unsigned short[]> rgba16_inptr, rgba16_outptr;
+    std::unique_ptr<float[]> rgbafp_inptr, rgbafp_outptr;
     clMemWrapper streams[6];
     int img_width = 128;
     int img_height = 128;
     int img_depth = 64;
     int i;
-    cl_int        err;
-    unsigned num_elems = img_width * img_height * img_depth * 4;
-    MTdata      d;
+    cl_int err;
+    unsigned num_elements = img_width * img_height * img_depth * 4;
+    MTdataHolder d(gRandomSeed);
 
-    PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( device )
+    rgba8_inptr = generate_uint8_image(num_elements, d);
+    rgba16_inptr = generate_uint16_image(num_elements, d);
+    rgbafp_inptr = generate_float_image(num_elements, d);
 
-    d = init_genrand( gRandomSeed );
-    rgba8_inptr = (unsigned char *)generate_uint8_image(num_elems, d);
-    rgba16_inptr = (unsigned short *)generate_uint16_image(num_elems, d);
-    rgbafp_inptr = (float *)generate_float_image(num_elems, d);
-    free_mtdata(d); d = NULL;
+    rgba8_outptr.reset(new unsigned char[num_elements]);
+    rgba16_outptr.reset(new unsigned short[num_elements]);
+    rgbafp_outptr.reset(new float[num_elements]);
 
-    rgba8_outptr = (unsigned char *)malloc(sizeof(unsigned char) * num_elems);
-    rgba16_outptr =
-        (unsigned short *)malloc(sizeof(unsigned short) * num_elems);
-    rgbafp_outptr = (float *)malloc(sizeof(float) * num_elems);
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT8;
-    streams[0] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-    streams[1] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT16;
-    streams[2] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-    streams[3] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_FLOAT;
-    streams[4] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-    streams[5] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-
-    for (i=0; i<3; i++)
+    for (size_t index = 0; index < image_formats_count; ++index)
     {
-        void    *p, *outp;
-        int        x, y, z, delta_w = img_width/8, delta_h = img_height/16, delta_d = img_depth/4;
+        void *ptr = nullptr;
+        if (src_image_flags & CL_MEM_USE_HOST_PTR
+            || src_image_flags & CL_MEM_COPY_HOST_PTR)
+        {
+            switch (index)
+            {
+                case 0: ptr = rgba8_inptr.get(); break;
+                case 1: ptr = rgba16_inptr.get(); break;
+                case 2: ptr = rgbafp_inptr.get(); break;
+                default: break;
+            }
+        }
+        streams[index * 2] =
+            create_image_3d(context, src_image_flags, &image_formats[index],
+                            img_width, img_height, img_depth, 0, 0, ptr, &err);
+        test_error(err, "create_image_3d failed");
+
+        streams[index * 2 + 1] = create_image_3d(
+            context, CL_MEM_READ_ONLY, &image_formats[index], img_width,
+            img_height, img_depth, 0, 0, nullptr, &err);
+        test_error(err, "create_image_3d failed");
+    }
+
+    for (i = 0; i < image_formats_count; i++)
+    {
+        void *p, *outp;
+        int x, y, z, delta_w = img_width / 8, delta_h = img_height / 16,
+                     delta_d = img_depth / 4;
 
         switch (i)
         {
             case 0:
-                p = (void *)rgba8_inptr;
-                outp = (void *)rgba8_outptr;
+                p = rgba8_inptr.get();
+                outp = rgba8_outptr.get();
                 break;
             case 1:
-                p = (void *)rgba16_inptr;
-                outp = (void *)rgba16_outptr;
+                p = rgba16_inptr.get();
+                outp = rgba16_outptr.get();
                 break;
             case 2:
-                p = (void *)rgbafp_inptr;
-                outp = (void *)rgbafp_outptr;
+                p = rgbafp_inptr.get();
+                outp = rgbafp_outptr.get();
                 break;
         }
 
-        size_t origin[3]={0,0,0}, region[3]={img_width, img_height, img_depth};
-        err = clEnqueueWriteImage(queue, streams[i*2], CL_TRUE, origin, region, 0, 0, p, 0, NULL, NULL);
-        test_error(err, "clEnqueueWriteImage failed");
-
-        for (z=0; z<img_depth; z+=delta_d)
+        size_t origin[3] = { 0, 0, 0 },
+               region[3] = { img_width, img_height, img_depth };
+        if (!(src_image_flags & CL_MEM_USE_HOST_PTR
+              || src_image_flags & CL_MEM_COPY_HOST_PTR))
         {
-            for (y=0; y<img_height; y+=delta_h)
-            {
-                for (x=0; x<img_width; x+=delta_w)
-                {
-                  origin[0] = x; origin[1] = y; origin[2] = z;
-                  region[0] = delta_w; region[1] = delta_h; region[2] = delta_d;
+            err = clEnqueueWriteImage(queue, streams[i * 2], CL_TRUE, origin,
+                                      region, 0, 0, p, 0, nullptr, nullptr);
+            test_error(err, "clEnqueueWriteImage failed");
+        }
 
-                  err = clEnqueueCopyImage(queue, streams[i*2], streams[i*2+1], origin, origin, region, 0, NULL, NULL);
-                  test_error(err, "clEnqueueCopyImage failed");
+        for (z = 0; z < img_depth; z += delta_d)
+        {
+            for (y = 0; y < img_height; y += delta_h)
+            {
+                for (x = 0; x < img_width; x += delta_w)
+                {
+                    origin[0] = x;
+                    origin[1] = y;
+                    origin[2] = z;
+                    region[0] = delta_w;
+                    region[1] = delta_h;
+                    region[2] = delta_d;
+
+                    err = clEnqueueCopyImage(queue, streams[i * 2],
+                                             streams[i * 2 + 1], origin, origin,
+                                             region, 0, NULL, NULL);
+                    test_error(err, "clEnqueueCopyImage failed");
                 }
             }
         }
 
-        origin[0] = 0; origin[1] = 0; origin[2] = 0;
-        region[0] = img_width; region[1] = img_height; region[2] = img_depth;
-        err = clEnqueueReadImage(queue, streams[i*2+1], CL_TRUE, origin, region, 0, 0, outp, 0, NULL, NULL);
+        origin[0] = 0;
+        origin[1] = 0;
+        origin[2] = 0;
+        region[0] = img_width;
+        region[1] = img_height;
+        region[2] = img_depth;
+        err = clEnqueueReadImage(queue, streams[i * 2 + 1], CL_TRUE, origin,
+                                 region, 0, 0, outp, 0, NULL, NULL);
         test_error(err, "clEnqueueReadImage failed");
 
         switch (i)
         {
             case 0:
-                err = verify_uint8_image(rgba8_inptr, rgba8_outptr, num_elems);
+                err = verify_uint8_image(rgba8_inptr.get(), rgba8_outptr.get(),
+                                         num_elements);
                 if (err) log_error("Failed uint8\n");
                 break;
             case 1:
-                err =
-                    verify_uint16_image(rgba16_inptr, rgba16_outptr, num_elems);
+                err = verify_uint16_image(rgba16_inptr.get(),
+                                          rgba16_outptr.get(), num_elements);
                 if (err) log_error("Failed uint16\n");
                 break;
             case 2:
-                err =
-                    verify_float_image(rgbafp_inptr, rgbafp_outptr, num_elems);
+                err = verify_float_image(rgbafp_inptr.get(),
+                                         rgbafp_outptr.get(), num_elements);
                 if (err) log_error("Failed float\n");
                 break;
         }
 
-        if (err)
-            break;
+        if (err) break;
     }
-
-  free(rgba8_inptr);
-  free(rgba16_inptr);
-  free(rgbafp_inptr);
-  free(rgba8_outptr);
-  free(rgba16_outptr);
-  free(rgbafp_outptr);
 
     if (err)
         log_error("IMAGE3D copy test failed\n");
@@ -233,4 +247,12 @@ REGISTER_TEST(imagecopy3d)
         log_info("IMAGE3D copy test passed\n");
 
     return err;
+}
+
+REGISTER_TEST(imagecopy3d)
+{
+    PASSIVE_REQUIRE_3D_IMAGE_SUPPORT(device);
+
+    return test_imagecopy3d_impl(device, context, queue, num_elements,
+                                 CL_MEM_READ_WRITE);
 }

--- a/test_conformance/basic/test_imagereadwrite.cpp
+++ b/test_conformance/basic/test_imagereadwrite.cpp
@@ -15,6 +15,7 @@
 //
 #include "harness/compat.h"
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,16 +24,15 @@
 
 #include "testBase.h"
 
-static unsigned char *
-generate_rgba8_image(int w, int h, MTdata d)
+static std::unique_ptr<unsigned char[]> generate_rgba8_image(int w, int h,
+                                                             MTdata d)
 {
-  unsigned char   *ptr = (unsigned char*)malloc(w * h * 4);
-  int             i;
+    std::unique_ptr<unsigned char[]> ptr{ new unsigned char[w * h * 4] };
 
-  for (i=0; i<w*h*4; i++)
-    ptr[i] = (unsigned char)genrand_int32(d);
+    for (int i = 0; i < w * h * 4; i++)
+        ptr[i] = (unsigned char)genrand_int32(d);
 
-  return ptr;
+    return ptr;
 }
 
 static void
@@ -73,8 +73,8 @@ update_image_from_image(void *out, void *in, int x, int y, int w, int h, int img
     }
 }
 
-static int
-verify_rgba8_image(unsigned char *image, unsigned char *outptr, int w, int h)
+static int verify_rgba8_image(const unsigned char *image,
+                              const unsigned char *outptr, int w, int h)
 {
   int     i;
 
@@ -91,16 +91,15 @@ verify_rgba8_image(unsigned char *image, unsigned char *outptr, int w, int h)
 }
 
 
-static unsigned short *
-generate_rgba16_image(int w, int h, MTdata d)
+static std::unique_ptr<unsigned short[]> generate_rgba16_image(int w, int h,
+                                                               MTdata d)
 {
-  unsigned short    *ptr = (unsigned short*)malloc(w * h * 4 * sizeof(unsigned short));
-  int             i;
+    std::unique_ptr<unsigned short[]> ptr{ new unsigned short[w * h * 4] };
 
-  for (i=0; i<w*h*4; i++)
-    ptr[i] = (unsigned short)genrand_int32(d);
+    for (int i = 0; i < w * h * 4; i++)
+        ptr[i] = (unsigned short)genrand_int32(d);
 
-  return ptr;
+    return ptr;
 }
 
 static void
@@ -121,8 +120,8 @@ update_rgba16_image(unsigned short *p, int x, int y, int w, int h, int img_width
     }
 }
 
-static int
-verify_rgba16_image(unsigned short *image, unsigned short *outptr, int w, int h)
+static int verify_rgba16_image(const unsigned short *image,
+                               const unsigned short *outptr, int w, int h)
 {
   int     i;
 
@@ -139,16 +138,14 @@ verify_rgba16_image(unsigned short *image, unsigned short *outptr, int w, int h)
 }
 
 
-static float *
-generate_rgbafp_image(int w, int h, MTdata d)
+static std::unique_ptr<float[]> generate_rgbafp_image(int w, int h, MTdata d)
 {
-  float   *ptr = (float*)malloc(w * h * 4 * sizeof(float));
-  int     i;
+    std::unique_ptr<float[]> ptr{ new float[w * h * 4] };
 
-  for (i=0; i<w*h*4; i++)
-    ptr[i] = get_random_float(-0x40000000, 0x40000000, d);
+    for (int i = 0; i < w * h * 4; i++)
+        ptr[i] = get_random_float(-0x40000000, 0x40000000, d);
 
-  return ptr;
+    return ptr;
 }
 
 static void
@@ -169,8 +166,8 @@ update_rgbafp_image(float *p, int x, int y, int w, int h, int img_width, MTdata 
     }
 }
 
-static int
-verify_rgbafp_image(float *image, float *outptr, int w, int h)
+static int verify_rgbafp_image(const float *image, const float *outptr, int w,
+                               int h)
 {
   int     i;
 
@@ -186,59 +183,52 @@ verify_rgbafp_image(float *image, float *outptr, int w, int h)
   return 0;
 }
 
+static constexpr cl_image_format image_formats[] = { { CL_RGBA, CL_UNORM_INT8 },
+                                                     { CL_RGBA,
+                                                       CL_UNORM_INT16 },
+                                                     { CL_RGBA, CL_FLOAT } };
 
 REGISTER_TEST(imagereadwrite)
 {
-    cl_image_format    img_format;
-    unsigned char    *rgba8_inptr, *rgba8_outptr;
-    unsigned short    *rgba16_inptr, *rgba16_outptr;
-    float            *rgbafp_inptr, *rgbafp_outptr;
+    constexpr size_t image_formats_count = ARRAY_SIZE(image_formats);
+    std::unique_ptr<unsigned char[]> rgba8_inptr, rgba8_outptr;
+    std::unique_ptr<unsigned short[]> rgba16_inptr, rgba16_outptr;
+    std::unique_ptr<float[]> rgbafp_inptr, rgbafp_outptr;
     clMemWrapper            streams[3];
     int                img_width = 512;
     int                img_height = 512;
     int                num_tries = 200;
     int                i, j, err;
-    MTdata          d;
+    MTdataHolder d(gRandomSeed);
 
     PASSIVE_REQUIRE_IMAGE_SUPPORT( device )
 
-    d = init_genrand( gRandomSeed );
-    rgba8_inptr = (unsigned char *)generate_rgba8_image(img_width, img_height, d);
-    rgba16_inptr = (unsigned short *)generate_rgba16_image(img_width, img_height, d);
-    rgbafp_inptr = (float *)generate_rgbafp_image(img_width, img_height, d);
+    rgba8_inptr = generate_rgba8_image(img_width, img_height, d);
+    rgba16_inptr = generate_rgba16_image(img_width, img_height, d);
+    rgbafp_inptr = generate_rgbafp_image(img_width, img_height, d);
 
-    rgba8_outptr = (unsigned char*)malloc(sizeof(unsigned char) * 4 * img_width * img_height);
-    rgba16_outptr = (unsigned short*)malloc(sizeof(unsigned short) * 4 * img_width * img_height);
-    rgbafp_outptr = (float*)malloc(sizeof(float) * 4 * img_width * img_height);
+    rgba8_outptr.reset(new unsigned char[4 * img_width * img_height]);
+    rgba16_outptr.reset(new unsigned short[4 * img_width * img_height]);
+    rgbafp_outptr.reset(new float[4 * img_width * img_height]);
 
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT8;
-    streams[0] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT16;
-    streams[1] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_FLOAT;
-    streams[2] = create_image_2d(context, CL_MEM_READ_WRITE, &img_format,
-                                 img_width, img_height, 0, NULL, &err);
-    test_error(err, "create_image_2d failed");
+    for (size_t index = 0; index < image_formats_count; ++index)
+    {
+        streams[index] =
+            create_image_2d(context, CL_MEM_READ_WRITE, &image_formats[index],
+                            img_width, img_height, 0, NULL, &err);
+        test_error(err, "create_image_2d failed");
+    }
 
     for (i=0; i<3; i++)
     {
         void    *p;
 
         if (i == 0)
-            p = (void *)rgba8_inptr;
+            p = rgba8_inptr.get();
         else if (i == 1)
-            p = (void *)rgba16_inptr;
+            p = rgba16_inptr.get();
         else
-            p = (void *)rgbafp_inptr;
+            p = rgbafp_inptr.get();
         size_t origin[3] = {0,0,0}, region[3] = {img_width, img_height, 1};
         err = clEnqueueWriteImage(queue, streams[i], CL_TRUE,
                               origin, region, 0, 0,
@@ -250,7 +240,7 @@ REGISTER_TEST(imagereadwrite)
         }
     }
 
-    for (i=0,j=0; i<num_tries*3; i++,j++)
+    for (i = 0, j = 0; i < num_tries * image_formats_count; i++, j++)
     {
         int        x = (int)get_random_float(0, img_width, d);
         int        y = (int)get_random_float(0, img_height, d);
@@ -260,10 +250,12 @@ REGISTER_TEST(imagereadwrite)
         int     set_input_pitch = (int)(genrand_int32(d) & 0x01);
         int     packed_update = (int)(genrand_int32(d) & 0x01);
         void    *p, *outp;
+        std::unique_ptr<unsigned char[]> p_rgba8;
+        std::unique_ptr<unsigned short[]> p_rgba16;
+        std::unique_ptr<float[]> p_rgbaf;
         int        elem_size;
 
-        if (j == 3)
-            j = 0;
+        if (j == image_formats_count) j = 0;
 
         switch (j)
         {
@@ -272,45 +264,57 @@ REGISTER_TEST(imagereadwrite)
                 elem_size = 4;
                 if(packed_update)
                 {
-                    p = generate_rgba8_image(w, h, d);
-                    update_image_from_image(rgba8_inptr, p, x, y, w, h, img_width, elem_size);
+                    p_rgba8 = generate_rgba8_image(w, h, d);
+                    p = p_rgba8.get();
+                    update_image_from_image(rgba8_inptr.get(), p, x, y, w, h,
+                                            img_width, elem_size);
                 }
                 else
                 {
-                    update_rgba8_image(rgba8_inptr, x, y, w, h, img_width, d);
-                    p = (void *)(rgba8_inptr + ((y * img_width + x) * 4));
+                    update_rgba8_image(rgba8_inptr.get(), x, y, w, h, img_width,
+                                       d);
+                    p = static_cast<void *>(rgba8_inptr.get()
+                                            + ((y * img_width + x) * 4));
                 }
-                outp = (void *)rgba8_outptr;
+                outp = static_cast<void *>(rgba8_outptr.get());
                 break;
             case 1:
                 //if ((w<=8) || (h<=8)) continue;
                 elem_size = 2*4;
                 if(packed_update)
                 {
-                    p = generate_rgba16_image(w, h, d);
-                    update_image_from_image(rgba16_inptr, p, x, y, w, h, img_width, elem_size);
+                    p_rgba16 = generate_rgba16_image(w, h, d);
+                    p = p_rgba16.get();
+                    update_image_from_image(rgba16_inptr.get(), p, x, y, w, h,
+                                            img_width, elem_size);
                 }
                 else
                 {
-                    update_rgba16_image(rgba16_inptr, x, y, w, h, img_width, d);
-                    p = (void *)(rgba16_inptr + ((y * img_width + x) * 4));
+                    update_rgba16_image(rgba16_inptr.get(), x, y, w, h,
+                                        img_width, d);
+                    p = static_cast<void *>(rgba16_inptr.get()
+                                            + ((y * img_width + x) * 4));
                 }
-                outp = (void *)rgba16_outptr;
+                outp = static_cast<void *>(rgba16_outptr.get());
                 break;
             case 2:
                 //if ((w<=8) || (h<=8)) continue;
                 elem_size = 4*4;
                 if(packed_update)
                 {
-                    p = generate_rgbafp_image(w, h, d);
-                    update_image_from_image(rgbafp_inptr, p, x, y, w, h, img_width, elem_size);
+                    p_rgbaf = generate_rgbafp_image(w, h, d);
+                    p = p_rgbaf.get();
+                    update_image_from_image(rgbafp_inptr.get(), p, x, y, w, h,
+                                            img_width, elem_size);
                 }
                 else
                 {
-                    update_rgbafp_image(rgbafp_inptr, x, y, w, h, img_width, d);
-                    p = (void *)(rgbafp_inptr + ((y * img_width + x) * 4));
+                    update_rgbafp_image(rgbafp_inptr.get(), x, y, w, h,
+                                        img_width, d);
+                    p = static_cast<void *>(rgbafp_inptr.get()
+                                            + ((y * img_width + x) * 4));
                 }
-                outp = (void *)rgbafp_outptr;
+                outp = static_cast<void *>(rgbafp_outptr.get());
                 break;
             default:
                 log_error("ERROR Invalid j = %d\n", j);
@@ -358,8 +362,7 @@ REGISTER_TEST(imagereadwrite)
 
         if(packed_update)
         {
-            free(p);
-            p = NULL;
+            p = nullptr;
         }
 
         memset(outp, 0x7, img_width*img_height*elem_size);
@@ -379,7 +382,8 @@ REGISTER_TEST(imagereadwrite)
         switch (j)
         {
             case 0:
-                err = verify_rgba8_image(rgba8_inptr, rgba8_outptr, img_width, img_height);
+                err = verify_rgba8_image(rgba8_inptr.get(), rgba8_outptr.get(),
+                                         img_width, img_height);
                 if (err)
                 {
                     log_error("x=%d y=%d w=%d h=%d, pitch=%d, try=%d\n", x, y, w, h, (int)input_pitch, (int)i);
@@ -387,7 +391,9 @@ REGISTER_TEST(imagereadwrite)
                 }
                 break;
             case 1:
-                err = verify_rgba16_image(rgba16_inptr, rgba16_outptr, img_width, img_height);
+                err =
+                    verify_rgba16_image(rgba16_inptr.get(), rgba16_outptr.get(),
+                                        img_width, img_height);
                 if (err)
                 {
                     log_error("x=%d y=%d w=%d h=%d, pitch=%d, try=%d\n", x, y, w, h, (int)input_pitch, (int)i);
@@ -395,7 +401,9 @@ REGISTER_TEST(imagereadwrite)
                 }
                 break;
             case 2:
-                err = verify_rgbafp_image(rgbafp_inptr, rgbafp_outptr, img_width, img_height);
+                err =
+                    verify_rgbafp_image(rgbafp_inptr.get(), rgbafp_outptr.get(),
+                                        img_width, img_height);
                 if (err)
                 {
                     log_error("x=%d y=%d w=%d h=%d, pitch=%d, try=%d\n", x, y, w, h, (int)input_pitch, (int)i);
@@ -406,14 +414,6 @@ REGISTER_TEST(imagereadwrite)
 
         if (err) break;
     }
-
-    free_mtdata(d);
-    free(rgba8_inptr);
-    free(rgba16_inptr);
-    free(rgbafp_inptr);
-    free(rgba8_outptr);
-    free(rgba16_outptr);
-    free(rgbafp_outptr);
 
     if (!err)
         log_info("IMAGE read, write test passed\n");

--- a/test_conformance/basic/test_imagereadwrite3d.cpp
+++ b/test_conformance/basic/test_imagereadwrite3d.cpp
@@ -15,6 +15,7 @@
 //
 #include "harness/compat.h"
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,14 +24,13 @@
 
 #include "testBase.h"
 
-static unsigned char *
+static std::unique_ptr<unsigned char[]>
 generate_rgba8_image(int w, int h, int d, MTdata mtData)
 {
-    unsigned char   *ptr = (unsigned char*)malloc(w * h * d *4);
-    int             i;
+    std::unique_ptr<unsigned char[]> ptr{ new unsigned char[w * h * d * 4] };
 
-    for (i=0; i<w*h*d*4; i++)
-            ptr[i] = (unsigned char)genrand_int32(mtData);
+    for (int i = 0; i < w * h * d * 4; i++)
+        ptr[i] = (unsigned char)genrand_int32(mtData);
 
     return ptr;
 }
@@ -77,8 +77,8 @@ update_image_from_image(void *out, void *in, int x, int y, int z, int w, int h, 
         }
 }
 
-static int
-verify_rgba8_image(unsigned char *image, unsigned char *outptr, int w, int h, int d)
+static int verify_rgba8_image(const unsigned char *image,
+                              const unsigned char *outptr, int w, int h, int d)
 {
     int     i;
 
@@ -95,14 +95,13 @@ verify_rgba8_image(unsigned char *image, unsigned char *outptr, int w, int h, in
 }
 
 
-static unsigned short *
+static std::unique_ptr<unsigned short[]>
 generate_rgba16_image(int w, int h, int d, MTdata mtData)
 {
-    unsigned short    *ptr = (unsigned short*)malloc(w * h * d * 4 * sizeof(unsigned short));
-    int             i;
+    std::unique_ptr<unsigned short[]> ptr{ new unsigned short[w * h * d * 4] };
 
-    for (i=0; i<w*h*d*4; i++)
-            ptr[i] = (unsigned short)genrand_int32(mtData);
+    for (int i = 0; i < w * h * d * 4; i++)
+        ptr[i] = (unsigned short)genrand_int32(mtData);
 
     return ptr;
 }
@@ -127,8 +126,9 @@ update_rgba16_image(unsigned short *p, int x, int y, int z, int w, int h, int d,
     }
 }
 
-static int
-verify_rgba16_image(unsigned short *image, unsigned short *outptr, int w, int h, int d)
+static int verify_rgba16_image(const unsigned short *image,
+                               const unsigned short *outptr, int w, int h,
+                               int d)
 {
     int     i;
 
@@ -145,14 +145,13 @@ verify_rgba16_image(unsigned short *image, unsigned short *outptr, int w, int h,
 }
 
 
-static float *
-generate_rgbafp_image(int w, int h, int d, MTdata mtData)
+static std::unique_ptr<float[]> generate_rgbafp_image(int w, int h, int d,
+                                                      MTdata mtData)
 {
-    float   *ptr = (float*)malloc(w * h * d *4 * sizeof(float));
-    int     i;
+    std::unique_ptr<float[]> ptr{ new float[w * h * d * 4] };
 
-    for (i=0; i<w*h*d*4; i++)
-            ptr[i] = get_random_float(-0x40000000, 0x40000000, mtData);
+    for (int i = 0; i < w * h * d * 4; i++)
+        ptr[i] = get_random_float(-0x40000000, 0x40000000, mtData);
 
     return ptr;
 }
@@ -177,8 +176,8 @@ update_rgbafp_image(float *p, int x, int y, int z, int w, int h, int d, int img_
         }
 }
 
-static int
-verify_rgbafp_image(float *image, float *outptr, int w, int h, int d)
+static int verify_rgbafp_image(const float *image, const float *outptr, int w,
+                               int h, int d)
 {
     int     i;
 
@@ -194,13 +193,17 @@ verify_rgbafp_image(float *image, float *outptr, int w, int h, int d)
     return 0;
 }
 
+static constexpr cl_image_format image_formats[] = { { CL_RGBA, CL_UNORM_INT8 },
+                                                     { CL_RGBA,
+                                                       CL_UNORM_INT16 },
+                                                     { CL_RGBA, CL_FLOAT } };
 
 REGISTER_TEST(imagereadwrite3d)
 {
-    cl_image_format    img_format;
-    unsigned char    *rgba8_inptr, *rgba8_outptr;
-    unsigned short *rgba16_inptr, *rgba16_outptr;
-    float            *rgbafp_inptr, *rgbafp_outptr;
+    constexpr size_t image_formats_count = ARRAY_SIZE(image_formats);
+    std::unique_ptr<unsigned char[]> rgba8_inptr, rgba8_outptr;
+    std::unique_ptr<unsigned short[]> rgba16_inptr, rgba16_outptr;
+    std::unique_ptr<float[]> rgbafp_inptr, rgbafp_outptr;
     clMemWrapper    streams[3];
     int       img_width = 64;
     int       img_height = 64;
@@ -208,44 +211,41 @@ REGISTER_TEST(imagereadwrite3d)
     int       img_slice = img_width * img_height;
     int       num_tries = 30;
     int       i, j, err;
-    MTdata      mtData;
+    MTdataHolder mtData(gRandomSeed);
 
     PASSIVE_REQUIRE_3D_IMAGE_SUPPORT( device )
 
-    mtData = init_genrand( gRandomSeed );
-    rgba8_inptr = (unsigned char *)generate_rgba8_image(img_width, img_height, img_depth, mtData);
-    rgba16_inptr = (unsigned short *)generate_rgba16_image(img_width, img_height, img_depth, mtData);
-    rgbafp_inptr = (float *)generate_rgbafp_image(img_width, img_height, img_depth, mtData);
+    rgba8_inptr =
+        generate_rgba8_image(img_width, img_height, img_depth, mtData);
+    rgba16_inptr =
+        generate_rgba16_image(img_width, img_height, img_depth, mtData);
+    rgbafp_inptr =
+        generate_rgbafp_image(img_width, img_height, img_depth, mtData);
 
-    rgba8_outptr = (unsigned char*)malloc(sizeof(unsigned char) * 4 * img_width * img_height * img_depth);
-    rgba16_outptr = (unsigned short*)malloc(sizeof(unsigned short) * 4 * img_width * img_height * img_depth);
-    rgbafp_outptr = (float*)malloc(sizeof(float) * 4 * img_width * img_height * img_depth);
+    rgba8_outptr.reset(
+        new unsigned char[4 * img_width * img_height * img_depth]);
+    rgba16_outptr.reset(
+        new unsigned short[4 * img_width * img_height * img_depth]);
+    rgbafp_outptr.reset(new float[4 * img_width * img_height * img_depth]);
 
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT8;
-    streams[0] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
+    for (size_t index = 0; index < image_formats_count; ++index)
+    {
+        streams[index] = create_image_3d(
+            context, CL_MEM_READ_ONLY, &image_formats[index], img_width,
+            img_height, img_depth, 0, 0, nullptr, &err);
+        test_error(err, "create_image_3d failed");
+    }
 
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_UNORM_INT16;
-    streams[1] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-
-    img_format.image_channel_order = CL_RGBA;
-    img_format.image_channel_data_type = CL_FLOAT;
-    streams[2] = create_image_3d(context, CL_MEM_READ_ONLY, &img_format, img_width, img_height, img_depth, 0, 0, NULL, &err);
-    test_error(err, "create_image_3d failed");
-
-    for (i=0; i<3; i++)
+    for (i = 0; i < image_formats_count; i++)
     {
         void    *p;
 
         if (i == 0)
-            p = (void *)rgba8_inptr;
+            p = rgba8_inptr.get();
         else if (i == 1)
-            p = (void *)rgba16_inptr;
+            p = rgba16_inptr.get();
         else
-            p = (void *)rgbafp_inptr;
+            p = rgbafp_inptr.get();
 
         size_t origin[3] = {0,0,0}, region[3] = {img_width, img_height, img_depth};
         err = clEnqueueWriteImage(queue, streams[i], CL_TRUE,
@@ -255,7 +255,7 @@ REGISTER_TEST(imagereadwrite3d)
         test_error(err, "clEnqueueWriteImage failed");
     }
 
-    for (i=0,j=0; i<num_tries*3; i++,j++)
+    for (i = 0, j = 0; i < num_tries * image_formats_count; i++, j++)
     {
         int        x = (int)get_random_float(0, (float)img_width - 1, mtData);
         int        y = (int)get_random_float(0, (float)img_height - 1, mtData);
@@ -267,10 +267,12 @@ REGISTER_TEST(imagereadwrite3d)
         int     set_input_pitch = (int)(genrand_int32(mtData) & 0x01);
         int     packed_update = (int)(genrand_int32(mtData) & 0x01);
         void    *p, *outp;
+        std::unique_ptr<unsigned char[]> p_rgba8;
+        std::unique_ptr<unsigned short[]> p_rgba16;
+        std::unique_ptr<float[]> p_rgbaf;
         int        elem_size;
 
-        if (j == 3)
-            j = 0;
+        if (j == image_formats_count) j = 0;
 
         // packed: the source image for the write is a whole image                                                                                                                                                                                                                                                      .
         // unpacked: the source image for the write is a subset within a larger image
@@ -280,43 +282,64 @@ REGISTER_TEST(imagereadwrite3d)
                 elem_size = 4;
                 if(packed_update)
                 {
-                    p = generate_rgba8_image(w, h, d, mtData);
-                    update_image_from_image(rgba8_inptr, p, x, y, z, w, h, d, img_width, img_height, img_depth, elem_size);
+                    p_rgba8 = generate_rgba8_image(w, h, d, mtData);
+                    p = p_rgba8.get();
+                    update_image_from_image(rgba8_inptr.get(), p, x, y, z, w, h,
+                                            d, img_width, img_height, img_depth,
+                                            elem_size);
                 }
                 else
                 {
-                    update_rgba8_image(rgba8_inptr, x, y, z, w, h, d, img_width, img_height, img_depth, mtData);
-                    p = (void *)(rgba8_inptr + ((z * img_slice + y * img_width + x) * 4));
+                    update_rgba8_image(rgba8_inptr.get(), x, y, z, w, h, d,
+                                       img_width, img_height, img_depth,
+                                       mtData);
+                    p = static_cast<void *>(
+                        rgba8_inptr.get()
+                        + ((z * img_slice + y * img_width + x) * 4));
                 }
-                outp = (void *)rgba8_outptr;
+                outp = static_cast<void *>(rgba8_outptr.get());
                 break;
             case 1:
                 elem_size = 2*4;
                 if(packed_update)
                 {
-                    p = generate_rgba16_image(w, h, d, mtData);
-                    update_image_from_image(rgba16_inptr, p, x, y, z, w, h, d, img_width, img_height, img_depth, elem_size);
+                    p_rgba16 = generate_rgba16_image(w, h, d, mtData);
+                    p = p_rgba16.get();
+                    update_image_from_image(rgba16_inptr.get(), p, x, y, z, w,
+                                            h, d, img_width, img_height,
+                                            img_depth, elem_size);
                 }
                 else
                 {
-                    update_rgba16_image(rgba16_inptr, x, y, z, w, h, d, img_width, img_height, img_depth, mtData);
-                    p = (void *)(rgba16_inptr + ((z * img_slice + y * img_width + x) * 4));
+                    update_rgba16_image(rgba16_inptr.get(), x, y, z, w, h, d,
+                                        img_width, img_height, img_depth,
+                                        mtData);
+                    p = static_cast<void *>(
+                        rgba16_inptr.get()
+                        + ((z * img_slice + y * img_width + x) * 4));
                 }
-                outp = (void *)rgba16_outptr;
+                outp = static_cast<void *>(rgba16_outptr.get());
                 break;
             case 2:
                 elem_size = 4*4;
                 if(packed_update)
                 {
-                    p = generate_rgbafp_image(w, h, d, mtData);
-                    update_image_from_image(rgbafp_inptr, p, x, y, z, w, h, d, img_width, img_height, img_depth, elem_size);
+                    p_rgbaf = generate_rgbafp_image(w, h, d, mtData);
+                    p = p_rgbaf.get();
+                    update_image_from_image(rgbafp_inptr.get(), p, x, y, z, w,
+                                            h, d, img_width, img_height,
+                                            img_depth, elem_size);
                 }
                 else
                 {
-                    update_rgbafp_image(rgbafp_inptr, x, y, z, w, h, d, img_width, img_height, img_depth, mtData);
-                    p = (void *)(rgbafp_inptr + ((z * img_slice + y * img_width + x) * 4));
+                    update_rgbafp_image(rgbafp_inptr.get(), x, y, z, w, h, d,
+                                        img_width, img_height, img_depth,
+                                        mtData);
+                    p = static_cast<void *>(
+                        rgbafp_inptr.get()
+                        + ((z * img_slice + y * img_width + x) * 4));
                 }
-                outp = (void *)rgbafp_outptr;
+                outp = static_cast<void *>(rgbafp_outptr.get());
                 break;
             default:
                 log_error("ERROR Invalid j = %d\n", j);
@@ -360,8 +383,7 @@ REGISTER_TEST(imagereadwrite3d)
 
         if(packed_update)
         {
-            free(p);
-            p = NULL;
+            p = nullptr;
         }
 
         memset(outp, 0x7, img_width*img_height*img_depth*elem_size);
@@ -375,7 +397,8 @@ REGISTER_TEST(imagereadwrite3d)
         switch (j)
         {
             case 0:
-                err = verify_rgba8_image(rgba8_inptr, rgba8_outptr, img_width, img_height, img_depth);
+                err = verify_rgba8_image(rgba8_inptr.get(), rgba8_outptr.get(),
+                                         img_width, img_height, img_depth);
                 if (err)
                 {
                     log_error("x=%d y=%d z=%d w=%d h=%d d=%d pitch=%d, slice_pitch=%d, try=%d\n", x, y, z, w, h, d, (int)input_pitch, (int)input_slice_pitch, (int)i);
@@ -383,7 +406,9 @@ REGISTER_TEST(imagereadwrite3d)
                 }
                 break;
             case 1:
-                err = verify_rgba16_image(rgba16_inptr, rgba16_outptr, img_width, img_height, img_depth);
+                err =
+                    verify_rgba16_image(rgba16_inptr.get(), rgba16_outptr.get(),
+                                        img_width, img_height, img_depth);
                 if (err)
                 {
                     log_error("x=%d y=%d z=%d w=%d h=%d d=%d pitch=%d, slice_pitch=%d, try=%d\n", x, y, z, w, h, d, (int)input_pitch, (int)input_slice_pitch, (int)i);
@@ -391,7 +416,9 @@ REGISTER_TEST(imagereadwrite3d)
                 }
                 break;
             case 2:
-                err = verify_rgbafp_image(rgbafp_inptr, rgbafp_outptr, img_width, img_height, img_depth);
+                err =
+                    verify_rgbafp_image(rgbafp_inptr.get(), rgbafp_outptr.get(),
+                                        img_width, img_height, img_depth);
                 if (err)
                 {
                     log_error("x=%d y=%d z=%d w=%d h=%d d=%d pitch=%d, slice_pitch=%d, try=%d\n", x, y, z, w, h, d, (int)input_pitch, (int)input_slice_pitch, (int)i);
@@ -403,14 +430,6 @@ REGISTER_TEST(imagereadwrite3d)
         if (err)
             break;
     }
-
-    free_mtdata(mtData);
-    free(rgba8_inptr);
-    free(rgba16_inptr);
-    free(rgbafp_inptr);
-    free(rgba8_outptr);
-    free(rgba16_outptr);
-    free(rgbafp_outptr);
 
     if (!err)
         log_info("IMAGE read, write test passed\n");


### PR DESCRIPTION
Refactor the following tests:
1. `test_imagecopy`
2. `test_imagecopy3d`
3. `test_imagereadwrite`
4. `test_imagereadwrite3d`

The change does the following:
1. Use RAII to manage allocated resources
2. For `imagecopy` and `imagecopy3d`, the change allows for a custom src image memory flags and adjusts how the source image is created according to the input flags.