### PR TITLE
Added support for cl_ext_float_atomics in CBasicTestFetchSub with atomic_float

### DIFF
--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+#include "harness/kernelHelpers.h"
 #include <iostream>
 #include <string>
 
@@ -28,6 +30,8 @@ int gInternalIterations = 10000; // internal test iterations for atomic operatio
 int gMaxDeviceThreads = 1024; // maximum number of threads executed on OCL device
 cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+bool gFloatAtomicsSupported = false;
+cl_device_fp_atomic_capabilities_ext gFloatAtomicCaps = 0;
 
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
@@ -121,6 +125,16 @@ test_status InitCL(cl_device_id device) {
             | CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM
             | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE
             | CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES;
+    }
+
+    if (is_extension_available(device, "cl_ext_float_atomics"))
+    {
+        gFloatAtomicsSupported = true;
+
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT,
+            sizeof(gFloatAtomicCaps), &gFloatAtomicCaps, nullptr);
+        test_error_ret(error, "clGetDeviceInfo failed!", TEST_FAIL);
     }
 
     return TEST_PASS;

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -16,10 +16,13 @@
 #include "harness/testHarness.h"
 #include "harness/kernelHelpers.h"
 #include "harness/typeWrappers.h"
+#include "harness/conversions.h"
 
 #include "common.h"
 #include "host_atomics.h"
 
+#include <algorithm>
+#include <numeric>
 #include <sstream>
 #include <vector>
 
@@ -1178,45 +1181,202 @@ REGISTER_TEST(svm_atomic_fetch_add)
 template <typename HostAtomicType, typename HostDataType>
 class CBasicTestFetchSub
     : public CBasicTestMemOrderScope<HostAtomicType, HostDataType> {
+
+    double min_range;
+    double max_range;
+    double max_error_fp32;
+    std::vector<HostDataType> ref_vals_fp32;
+
 public:
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::MemoryOrder;
     using CBasicTestMemOrderScope<HostAtomicType,
                                   HostDataType>::MemoryOrderScopeStr;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::StartValue;
     using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::DataType;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::LocalMemory;
     CBasicTestFetchSub(TExplicitAtomicType dataType, bool useSVM)
         : CBasicTestMemOrderScope<HostAtomicType, HostDataType>(dataType,
-                                                                useSVM)
-    {}
-    virtual std::string ProgramCore()
+                                                                useSVM),
+          min_range(-999.0), max_range(999.0), max_error_fp32(0.0)
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            StartValue(0.f);
+            CBasicTestMemOrderScope<HostAtomicType,
+                                    HostDataType>::OldValueCheck(false);
+        }
+    }
+    bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
+                      MTdata d) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (threadCount > ref_vals_fp32.size())
+            {
+                ref_vals_fp32.resize(threadCount);
+
+                for (cl_uint i = 0; i < threadCount; i++)
+                    ref_vals_fp32[i] =
+                        get_random_float(min_range, max_range, d);
+
+                memcpy(startRefValues, ref_vals_fp32.data(),
+                       sizeof(HostDataType) * ref_vals_fp32.size());
+
+                // Estimate highest possible summation error for given set.
+                std::vector<HostDataType> sums;
+                std::sort(ref_vals_fp32.begin(), ref_vals_fp32.end());
+
+                sums.push_back(std::accumulate(ref_vals_fp32.begin(),
+                                               ref_vals_fp32.end(), 0.f));
+
+                sums.push_back(std::accumulate(ref_vals_fp32.rbegin(),
+                                               ref_vals_fp32.rend(), 0.f));
+
+                std::sort(
+                    ref_vals_fp32.begin(), ref_vals_fp32.end(),
+                    [](float a, float b) { return std::abs(a) < std::abs(b); });
+
+                double precise = 0.0;
+                for (auto elem : ref_vals_fp32) precise += double(elem);
+                sums.push_back(precise);
+
+                sums.push_back(std::accumulate(ref_vals_fp32.begin(),
+                                               ref_vals_fp32.end(), 0.f));
+
+                sums.push_back(std::accumulate(ref_vals_fp32.rbegin(),
+                                               ref_vals_fp32.rend(), 0.f));
+
+                std::sort(sums.begin(), sums.end());
+                max_error_fp32 =
+                    std::abs((HOST_ATOMIC_FLOAT)sums.front() - sums.back());
+
+                // restore unsorted order
+                memcpy(ref_vals_fp32.data(), startRefValues,
+                       sizeof(HostDataType) * ref_vals_fp32.size());
+            }
+            else
+            {
+                memcpy(startRefValues, ref_vals_fp32.data(),
+                       sizeof(HostDataType) * threadCount);
+            }
+            return true;
+        }
+        return false;
+    }
+    std::string ProgramCore() override
+
     {
         std::string memoryOrderScope = MemoryOrderScopeStr();
         std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
-        return "  oldValues[tid] = atomic_fetch_sub" + postfix
-            + "(&destMemory[0], tid + 3 +((("
-            + DataType().AddSubOperandTypeName() + ")tid + 3) << (sizeof("
-            + DataType().AddSubOperandTypeName() + ")-1)*8)" + memoryOrderScope
-            + ");\n";
+
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            return "  atomic_fetch_sub" + postfix + "(&destMemory[0], ("
+                + DataType().AddSubOperandTypeName() + ")oldValues[tid]"
+                + memoryOrderScope + ");\n"
+                + "  oldValues[tid] = atomic_fetch_sub" + postfix
+                + "(&destMemory[tid], (" + DataType().AddSubOperandTypeName()
+                + ")0" + memoryOrderScope + ");\n";
+        }
+        else
+        {
+            return "  oldValues[tid] = atomic_fetch_sub" + postfix
+                + "(&destMemory[0], tid + 3 +((("
+                + DataType().AddSubOperandTypeName() + ")tid + 3) << (sizeof("
+                + DataType().AddSubOperandTypeName() + ")-1)*8)"
+                + memoryOrderScope + ");\n";
+        }
     }
-    virtual void HostFunction(cl_uint tid, cl_uint threadCount,
-                              volatile HostAtomicType *destMemory,
-                              HostDataType *oldValues)
+    void HostFunction(cl_uint tid, cl_uint threadCount,
+                      volatile HostAtomicType *destMemory,
+                      HostDataType *oldValues) override
     {
-        oldValues[tid] = host_atomic_fetch_sub(
-            &destMemory[0],
-            (HostDataType)tid + 3
-                + (((HostDataType)tid + 3) << (sizeof(HostDataType) - 1) * 8),
-            MemoryOrder());
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            host_atomic_fetch_sub(&destMemory[0], (HostDataType)oldValues[tid],
+                                  MemoryOrder());
+            oldValues[tid] = host_atomic_fetch_sub(
+                &destMemory[0], (HostDataType)0, MemoryOrder());
+        }
+        else
+        {
+            oldValues[tid] = host_atomic_fetch_sub(
+                &destMemory[0],
+                (HostDataType)tid + 3 + GetTypeDependentAddition(tid),
+                MemoryOrder());
+        }
     }
-    virtual bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
-                               HostDataType *startRefValues,
-                               cl_uint whichDestValue)
+    bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
+                       HostDataType *startRefValues,
+                       cl_uint whichDestValue) override
     {
         expected = StartValue();
-        for (cl_uint i = 0; i < threadCount; i++)
-            expected -= (HostDataType)i + 3
-                + (((HostDataType)i + 3) << (sizeof(HostDataType) - 1) * 8);
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (whichDestValue == 0)
+                for (cl_uint i = 0; i < threadCount; i++)
+                    expected -= startRefValues[i];
+        }
+        else
+        {
+            for (cl_uint i = 0; i < threadCount; i++)
+                expected -= (HostDataType)i + 3 + GetTypeDependentAddition(i);
+        }
         return true;
+    }
+    HostDataType GetTypeDependentAddition(cl_uint id)
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_INT>::value)
+            return (((cl_int)id + 3) << (sizeof(cl_int) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_UINT>::value)
+            return (((cl_uint)id + 3) << (sizeof(cl_uint) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_LONG>::value)
+            return (((cl_long)id + 3) << (sizeof(cl_long) - 1) * 8);
+        else if (std::is_same<HostDataType, HOST_ATOMIC_ULONG>::value)
+            return (((cl_ulong)id + 3) << (sizeof(cl_ulong) - 1) * 8);
+        return (HostDataType)0;
+    }
+    bool VerifyExpected(const HostDataType &expected,
+                        const HostAtomicType *const testValue,
+                        cl_uint whichDestValue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (whichDestValue == 0 && testValue != nullptr)
+                return std::abs((HOST_ATOMIC_FLOAT)expected
+                                - testValue[whichDestValue])
+                    > max_error_fp32;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::VerifyExpected(expected, testValue,
+                                                          whichDestValue);
+    }
+    int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (LocalMemory()
+                && (gFloatAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0; // skip test - not applicable
+
+            if (!LocalMemory()
+                && (gFloatAtomicCaps & CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0;
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::ExecuteSingleTest(deviceID, context,
+                                                             queue);
+    }
+    cl_uint NumResults(cl_uint threadCount, cl_device_id deviceID) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            return threadCount;
+        }
+        return CBasicTestMemOrderScope<HostAtomicType,
+                                       HostDataType>::NumResults(threadCount,
+                                                                 deviceID);
     }
 };
 
@@ -1242,6 +1402,15 @@ static int test_atomic_fetch_sub_generic(cl_device_id deviceID,
         TYPE_ATOMIC_ULONG, useSVM);
     EXECUTE_TEST(error,
                  test_ulong.Execute(deviceID, context, queue, num_elements));
+
+    if (gFloatAtomicsSupported)
+    {
+        CBasicTestFetchSub<HOST_ATOMIC_FLOAT, HOST_FLOAT> test_float(
+            TYPE_ATOMIC_FLOAT, useSVM);
+        EXECUTE_TEST(
+            error, test_float.Execute(deviceID, context, queue, num_elements));
+    }
+
     if (AtomicTypeInfo(TYPE_ATOMIC_SIZE_T).Size(deviceID) == 4)
     {
         CBasicTestFetchSub<HOST_ATOMIC_INTPTR_T32, HOST_INTPTR_T32>


### PR DESCRIPTION
Related to #2142, according to the work plan, extending CBasicTestFetchSub with support for atomic_float.