### PR TITLE
Added support for cl_ext_float_atomics in CBasicTestFetchAddSpecialFloats with atomic_float

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -22,6 +22,8 @@
 
 #include "host_atomics.h"
 
+#include <iomanip>
+#include <limits>
 #include <vector>
 #include <sstream>
 
@@ -71,6 +73,9 @@ extern int
     gMaxDeviceThreads; // maximum number of threads executed on OCL device
 extern cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+extern bool gFloatAtomicsSupported;
+extern cl_device_fp_atomic_capabilities_ext gFloatAtomicCaps;
+extern cl_device_fp_config gFloatCaps;
 
 extern const char *
 get_memory_order_type_name(TExplicitMemoryOrderType orderType);
@@ -168,6 +173,13 @@ public:
     {
         return false;
     }
+    virtual bool VerifyExpected(const HostDataType &expected,
+                                const HostAtomicType *const testValue,
+                                cl_uint whichDestValue)
+    {
+        if (testValue != nullptr) return expected != testValue[whichDestValue];
+        return true;
+    }
     virtual bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
                               MTdata d)
     {
@@ -240,13 +252,13 @@ public:
         int error = 0;
         if (_maxDeviceThreads > 0 && !UseSVM())
         {
-            LocalMemory(true);
+            SetLocalMemory(true);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
         if (_maxDeviceThreads + MaxHostThreads() > 0)
         {
-            LocalMemory(false);
+            SetLocalMemory(false);
             EXECUTE_TEST(
                 error, ExecuteForEachDeclarationType(deviceID, context, queue));
         }
@@ -401,7 +413,7 @@ public:
     bool UseSVM() { return _useSVM; }
     void StartValue(HostDataType startValue) { _startValue = startValue; }
     HostDataType StartValue() { return _startValue; }
-    void LocalMemory(bool local) { _localMemory = local; }
+    void SetLocalMemory(bool local) { _localMemory = local; }
     bool LocalMemory() { return _localMemory; }
     void DeclaredInProgram(bool declaredInProgram)
     {
@@ -875,7 +887,21 @@ CBasicTest<HostAtomicType, HostDataType>::ProgramHeader(cl_uint maxNumDestItems)
         header += std::string("__global volatile ") + aTypeName + " destMemory["
             + ss.str() + "] = {\n";
         ss.str("");
-        ss << _startValue;
+
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (std::isinf(_startValue))
+                ss << (_startValue < 0 ? "-" : "") << "INFINITY";
+            else if (std::isnan(_startValue))
+                ss << "0.0f / 0.0f";
+            else
+                ss << std::setprecision(
+                    std::numeric_limits<HostDataType>::max_digits10)
+                   << _startValue;
+        }
+        else
+            ss << _startValue;
+
         for (cl_uint i = 0; i < maxNumDestItems; i++)
         {
             if (aTypeName == "atomic_flag")
@@ -1434,7 +1460,7 @@ int CBasicTest<HostAtomicType, HostDataType>::ExecuteSingleTest(
                            startRefValues.size() ? &startRefValues[0] : 0, i))
             break; // no expected value function provided
 
-        if (expected != destItems[i])
+        if (VerifyExpected(expected, destItems.data(), i))
         {
             std::stringstream logLine;
             logLine << "ERROR: Result " << i

--- a/test_conformance/c11_atomics/host_atomics.h
+++ b/test_conformance/c11_atomics/host_atomics.h
@@ -17,6 +17,7 @@
 #define HOST_ATOMICS_H_
 
 #include "harness/testHarness.h"
+#include <mutex>
 
 #ifdef WIN32
 #include "Windows.h"
@@ -91,14 +92,39 @@ template <typename AtomicType, typename CorrespondingType>
 CorrespondingType host_atomic_fetch_add(volatile AtomicType *a, CorrespondingType c,
                                         TExplicitMemoryOrderType order)
 {
+    if (std::is_same<AtomicType, HOST_ATOMIC_FLOAT>::value)
+    {
+        static std::mutex mx;
+        std::lock_guard<std::mutex> lock(mx);
+        CorrespondingType old_value = *a;
+        *a += c;
+        return old_value;
+    }
+    else
+    {
 #if defined( _MSC_VER ) || (defined( __INTEL_COMPILER ) && defined(WIN32))
-  return InterlockedExchangeAdd(a, c);
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value)
+            return InterlockedExchangeAdd((volatile cl_uint *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            return InterlockedExchangeAdd((volatile cl_uint *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value)
+            return InterlockedExchangeAdd64((volatile cl_long *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            return InterlockedExchangeAdd64((volatile cl_long *)a, c);
 #elif defined(__GNUC__)
-  return __sync_fetch_and_add(a, c);
+        if (std::is_same<AtomicType, HOST_ATOMIC_INT>::value)
+            return __sync_fetch_and_add((volatile cl_int *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_UINT>::value)
+            return __sync_fetch_and_add((volatile cl_uint *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_LONG>::value)
+            return __sync_fetch_and_add((volatile cl_long *)a, c);
+        else if (std::is_same<AtomicType, HOST_ATOMIC_ULONG>::value)
+            return __sync_fetch_and_add((volatile cl_ulong *)a, c);
 #else
-  log_info("Host function not implemented: atomic_fetch_add\n");
-  return 0;
+        log_info("Host function not implemented: atomic_fetch_add\n");
+        return 0;
 #endif
+    }
 }
 
 template <typename AtomicType, typename CorrespondingType>

--- a/test_conformance/c11_atomics/main.cpp
+++ b/test_conformance/c11_atomics/main.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include "harness/testHarness.h"
+#include "harness/deviceInfo.h"
+#include "harness/kernelHelpers.h"
 #include <iostream>
 #include <string>
 
@@ -28,6 +30,9 @@ int gInternalIterations = 10000; // internal test iterations for atomic operatio
 int gMaxDeviceThreads = 1024; // maximum number of threads executed on OCL device
 cl_device_atomic_capabilities gAtomicMemCap,
     gAtomicFenceCap; // atomic memory and fence capabilities for this device
+bool gFloatAtomicsSupported = false;
+cl_device_fp_atomic_capabilities_ext gFloatAtomicCaps = 0;
+cl_device_fp_config gFloatCaps = 0;
 
 test_status InitCL(cl_device_id device) {
     auto version = get_device_cl_version(device);
@@ -121,6 +126,23 @@ test_status InitCL(cl_device_id device) {
             | CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM
             | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE
             | CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES;
+    }
+
+    if (is_extension_available(device, "cl_ext_float_atomics"))
+    {
+        gFloatAtomicsSupported = true;
+
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT,
+            sizeof(gFloatAtomicCaps), &gFloatAtomicCaps, nullptr);
+        test_error_ret(error, "clGetDeviceInfo failed!", TEST_FAIL);
+
+        error = clGetDeviceInfo(device, CL_DEVICE_SINGLE_FP_CONFIG,
+                                sizeof(gFloatCaps), &gFloatCaps, NULL);
+        test_error_ret(
+            error,
+            "Unable to run INFINITY/NAN tests (unable to get FP_CONFIG bits)",
+            TEST_FAIL);
     }
 
     return TEST_PASS;

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -1094,6 +1094,181 @@ public:
     }
 };
 
+template <typename HostAtomicType, typename HostDataType>
+class CBasicTestFetchAddSpecialFloats
+    : public CBasicTestMemOrderScope<HostAtomicType, HostDataType> {
+
+    std::vector<HostDataType> ref_vals;
+
+public:
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::MemoryOrder;
+    using CBasicTestMemOrderScope<HostAtomicType,
+                                  HostDataType>::MemoryOrderScopeStr;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::StartValue;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::DataType;
+    using CBasicTestMemOrderScope<HostAtomicType, HostDataType>::LocalMemory;
+    CBasicTestFetchAddSpecialFloats(TExplicitAtomicType dataType,
+                                    const HostDataType &special, bool useSVM)
+        : CBasicTestMemOrderScope<HostAtomicType, HostDataType>(dataType,
+                                                                useSVM)
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            StartValue(special);
+            CBasicTestMemOrderScope<HostAtomicType,
+                                    HostDataType>::OldValueCheck(false);
+        }
+    }
+
+    static std::vector<HostDataType> &GetSpecialValues()
+    {
+        const float test_value_zero = 0.0f;
+        const float test_value_minus_zero = -0.0f;
+        const float test_value_without_fraction = 2.0f;
+        const float test_value_with_fraction = 2.2f;
+
+        static std::vector<HostDataType> special_values;
+
+        if (special_values.empty())
+        {
+            special_values = {
+                static_cast<HostDataType>(test_value_minus_zero),
+                static_cast<HostDataType>(test_value_zero),
+                static_cast<HostDataType>(test_value_without_fraction),
+                static_cast<HostDataType>(test_value_with_fraction),
+                std::numeric_limits<HostDataType>::infinity(),
+                std::numeric_limits<HostDataType>::quiet_NaN(),
+                std::numeric_limits<HostDataType>::signaling_NaN(),
+                -std::numeric_limits<HostDataType>::infinity(),
+                -std::numeric_limits<HostDataType>::quiet_NaN(),
+                -std::numeric_limits<HostDataType>::signaling_NaN(),
+                std::numeric_limits<HostDataType>::lowest(),
+                std::numeric_limits<HostDataType>::min(),
+                std::numeric_limits<HostDataType>::max(),
+            };
+
+            if (0 != (CL_FP_DENORM & gFloatCaps))
+            {
+                special_values.push_back(
+                    std::numeric_limits<HostDataType>::denorm_min());
+            }
+        }
+
+        return special_values;
+    }
+
+    bool GenerateRefs(cl_uint threadCount, HostDataType *startRefValues,
+                      MTdata d) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (threadCount > ref_vals.size())
+            {
+                ref_vals.assign(threadCount, 0);
+                auto spec_vals = GetSpecialValues();
+
+                memcpy(ref_vals.data(), spec_vals.data(),
+                       sizeof(HostDataType)
+                           * (ref_vals.data() < spec_vals.data()
+                                  ? threadCount
+                                  : spec_vals.size()));
+            }
+
+            memcpy(startRefValues, ref_vals.data(),
+                   sizeof(HostDataType) * threadCount);
+
+            return true;
+        }
+        return false;
+    }
+    std::string ProgramCore() override
+    {
+        std::string memoryOrderScope = MemoryOrderScopeStr();
+        std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
+
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            return "  atomic_fetch_add" + postfix + "(&destMemory[tid], ("
+                + DataType().AddSubOperandTypeName() + ")oldValues[tid]"
+                + memoryOrderScope + ");\n";
+        }
+    }
+    void HostFunction(cl_uint tid, cl_uint threadCount,
+                      volatile HostAtomicType *destMemory,
+                      HostDataType *oldValues) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            host_atomic_fetch_add(&destMemory[tid],
+                                  (HostDataType)oldValues[tid], MemoryOrder());
+        }
+    }
+    bool ExpectedValue(HostDataType &expected, cl_uint threadCount,
+                       HostDataType *startRefValues,
+                       cl_uint whichDestValue) override
+    {
+        expected = StartValue();
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            expected += startRefValues[whichDestValue];
+        }
+
+        return true;
+    }
+    bool VerifyExpected(const HostDataType &expected,
+                        const HostAtomicType *const testValue,
+                        cl_uint whichDestValue) override
+    {
+        if (testValue != nullptr)
+        {
+
+            if (std::isnan(testValue[whichDestValue]) && std::isnan(expected))
+                return false;
+            else
+                return expected != testValue[whichDestValue];
+        }
+
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::VerifyExpected(expected, testValue,
+                                                          whichDestValue);
+    }
+    int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
+                          cl_command_queue queue) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            if (LocalMemory()
+                && (gFloatAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0; // skip test - not applicable
+
+            if (!LocalMemory()
+                && (gFloatAtomicCaps & CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT) == 0)
+                return 0;
+
+            if (!CBasicTestMemOrderScope<HostAtomicType,
+                                         HostDataType>::LocalMemory()
+                && CBasicTestMemOrderScope<HostAtomicType,
+                                           HostDataType>::DeclaredInProgram())
+            {
+                if ((gFloatCaps & CL_FP_INF_NAN) == 0) return 0;
+            }
+        }
+        return CBasicTestMemOrderScope<
+            HostAtomicType, HostDataType>::ExecuteSingleTest(deviceID, context,
+                                                             queue);
+    }
+    cl_uint NumResults(cl_uint threadCount, cl_device_id deviceID) override
+    {
+        if (std::is_same<HostDataType, HOST_ATOMIC_FLOAT>::value)
+        {
+            return threadCount;
+        }
+        return CBasicTestMemOrderScope<HostAtomicType,
+                                       HostDataType>::NumResults(threadCount,
+                                                                 deviceID);
+    }
+};
+
 static int test_atomic_fetch_add_generic(cl_device_id deviceID,
                                          cl_context context,
                                          cl_command_queue queue,
@@ -1116,6 +1291,23 @@ static int test_atomic_fetch_add_generic(cl_device_id deviceID,
         TYPE_ATOMIC_ULONG, useSVM);
     EXECUTE_TEST(error,
                  test_ulong.Execute(deviceID, context, queue, num_elements));
+
+    if (gFloatAtomicsSupported)
+    {
+        auto spec_vals =
+            CBasicTestFetchAddSpecialFloats<HOST_ATOMIC_FLOAT,
+                                            HOST_FLOAT>::GetSpecialValues();
+
+        for (auto &elem : spec_vals)
+        {
+            CBasicTestFetchAddSpecialFloats<HOST_ATOMIC_FLOAT, HOST_FLOAT>
+                test_float(TYPE_ATOMIC_FLOAT, elem, useSVM);
+            EXECUTE_TEST(
+                error,
+                test_float.Execute(deviceID, context, queue, num_elements));
+        }
+    }
+
     if (AtomicTypeInfo(TYPE_ATOMIC_SIZE_T).Size(deviceID) == 4)
     {
         CBasicTestFetchAdd<HOST_ATOMIC_INTPTR_T32, HOST_INTPTR_T32>


### PR DESCRIPTION
Related to #2142, according to the work plan, extending CBasicTestFetchAddSpecialFloats with support for atomic_double.