### PR TITLE
Test image formats of cl_ext_image_unsigned_10x6_12x4_14x2

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -213,6 +213,12 @@ const char *GetChannelTypeName(cl_channel_type type)
         case CL_UNORM_INT24: return "CL_UNORM_INT24";
         case CL_UNSIGNED_INT_RAW10_EXT: return "CL_UNSIGNED_INT_RAW10_EXT";
         case CL_UNSIGNED_INT_RAW12_EXT: return "CL_UNSIGNED_INT_RAW12_EXT";
+        case CL_UNSIGNED_INT10X6_EXT: return "CL_UNSIGNED_INT10X6_EXT";
+        case CL_UNSIGNED_INT12X4_EXT: return "CL_UNSIGNED_INT12X4_EXT";
+        case CL_UNSIGNED_INT14X2_EXT: return "CL_UNSIGNED_INT14X2_EXT";
+        case CL_UNORM_INT10X6_EXT: return "CL_UNORM_INT10X6_EXT";
+        case CL_UNORM_INT12X4_EXT: return "CL_UNORM_INT12X4_EXT";
+        case CL_UNORM_INT14X2_EXT: return "CL_UNORM_INT14X2_EXT";
         default: return NULL;
     }
 }
@@ -238,10 +244,16 @@ int IsChannelTypeSupported(cl_channel_type type)
         case CL_UNSIGNED_INT16:
         case CL_UNSIGNED_INT32:
         case CL_HALF_FLOAT:
-        case CL_FLOAT: return 1;
+        case CL_FLOAT:
 #ifdef CL_SFIXED14_APPLE
-        case CL_SFIXED14_APPLE: return 1;
+        case CL_SFIXED14_APPLE:
 #endif
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT: return 1;
         default: return 0;
     }
 }

--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -97,7 +97,13 @@ uint32_t get_channel_data_type_size(cl_channel_type channelType)
         case CL_UNSIGNED_INT32: return sizeof(cl_int);
 
         case CL_UNORM_SHORT_565:
-        case CL_UNORM_SHORT_555: return 2;
+        case CL_UNORM_SHORT_555:
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT: return 2;
 
         case CL_UNORM_INT_101010:
         case CL_UNORM_INT_101010_2:
@@ -186,6 +192,12 @@ cl_channel_type get_channel_type_from_name(const char *name)
 #ifdef CL_SFIXED14_APPLE
         { CL_SFIXED14_APPLE, "CL_SFIXED14_APPLE" }
 #endif
+        { CL_UNSIGNED_INT10X6_EXT, "CL_UNSIGNED_INT10X6_EXT" },
+        { CL_UNSIGNED_INT12X4_EXT, "CL_UNSIGNED_INT12X4_EXT" },
+        { CL_UNSIGNED_INT14X2_EXT, "CL_UNSIGNED_INT14X2_EXT" },
+        { CL_UNORM_INT10X6_EXT, "CL_UNORM_INT10X6_EXT" },
+        { CL_UNORM_INT12X4_EXT, "CL_UNORM_INT12X4_EXT" },
+        { CL_UNORM_INT14X2_EXT, "CL_UNORM_INT14X2_EXT" },
     };
     for (size_t i = 0; i < sizeof(typeNames) / sizeof(typeNames[0]); i++)
     {
@@ -278,6 +290,12 @@ uint32_t get_pixel_size(const cl_image_format *format)
 #ifdef CL_SFIXED14_APPLE
         case CL_SFIXED14_APPLE:
 #endif
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT:
             return get_format_channel_count(format) * sizeof(cl_ushort);
 
         case CL_SIGNED_INT32:
@@ -940,6 +958,9 @@ float get_max_absolute_error(const cl_image_format *format,
 #endif
         case CL_UNORM_SHORT_555:
         case CL_UNORM_SHORT_565: return 1.0f / 31.0f;
+        case CL_UNORM_INT10X6_EXT: return 1.0f / 1023.0f;
+        case CL_UNORM_INT12X4_EXT: return 1.0f / 4095.0f;
+        case CL_UNORM_INT14X2_EXT: return 1.0f / 16383.0f;
         default: return 0.0f;
     }
 }
@@ -968,6 +989,9 @@ float get_max_relative_error(const cl_image_format *format,
         case CL_UNORM_INT_101010:
         case CL_UNORM_INT_101010_2:
         case CL_UNORM_INT_2_101010_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT:
             // Maximum sampling error for round to zero normalization based on
             // multiplication by reciprocal (using reciprocal generated in
             // round to +inf mode, so that 1.0 matches spec)
@@ -1053,7 +1077,15 @@ size_t get_format_max_int(const cl_image_format *format)
 
         case CL_UNORM_INT_101010:
         case CL_UNORM_INT_101010_2:
-        case CL_UNORM_INT_2_101010_EXT: return 1023;
+        case CL_UNORM_INT_2_101010_EXT:
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNORM_INT10X6_EXT: return 1023;
+
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNORM_INT12X4_EXT: return 4095;
+
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT14X2_EXT: return 16383;
 
         case CL_HALF_FLOAT: return 1 << 10;
 
@@ -1087,7 +1119,13 @@ int get_format_min_int(const cl_image_format *format)
         case CL_UNORM_SHORT_555:
         case CL_UNORM_INT_101010:
         case CL_UNORM_INT_101010_2:
-        case CL_UNORM_INT_2_101010_EXT: return 0;
+        case CL_UNORM_INT_2_101010_EXT:
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT: return 0;
 
         case CL_HALF_FLOAT: return -(1 << 10);
 
@@ -1518,6 +1556,30 @@ void read_image_pixel_float(void *imageData, image_descriptor *imageInfo, int x,
             tempData[1] = (float)((dPtr[0] >> 20) & 0x3ff) / (float)1023;
             tempData[2] = (float)(dPtr[0] >> 10 & 0x3ff) / (float)1023;
             tempData[3] = (float)(dPtr[0] >> 0 & 0x3ff) / (float)1023;
+            break;
+        }
+
+        case CL_UNORM_INT10X6_EXT: {
+            cl_ushort *dPtr = (cl_ushort *)ptr;
+            for (i = 0; i < channelCount; i++)
+                tempData[i] =
+                    CLAMP_FLOAT((float)((dPtr[i] >> 6) & 0x3ff) / 1023.0f);
+            break;
+        }
+
+        case CL_UNORM_INT12X4_EXT: {
+            cl_ushort *dPtr = (cl_ushort *)ptr;
+            for (i = 0; i < channelCount; i++)
+                tempData[i] =
+                    CLAMP_FLOAT((float)((dPtr[i] >> 4) & 0xfff) / 4095.0f);
+            break;
+        }
+
+        case CL_UNORM_INT14X2_EXT: {
+            cl_ushort *dPtr = (cl_ushort *)ptr;
+            for (i = 0; i < channelCount; i++)
+                tempData[i] =
+                    CLAMP_FLOAT((float)((dPtr[i] >> 2) & 0x3fff) / 16383.0f);
             break;
         }
 
@@ -2634,6 +2696,24 @@ void pack_image_pixel(unsigned int *srcVector,
                 ptr[i] = (unsigned int)srcVector[i];
             break;
         }
+        case CL_UNSIGNED_INT10X6_EXT: {
+            unsigned short *ptr = (unsigned short *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = (unsigned short)SATURATE(srcVector[i], 0, 1023) << 6;
+            break;
+        }
+        case CL_UNSIGNED_INT12X4_EXT: {
+            unsigned short *ptr = (unsigned short *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = (unsigned short)SATURATE(srcVector[i], 0, 4095) << 4;
+            break;
+        }
+        case CL_UNSIGNED_INT14X2_EXT: {
+            unsigned short *ptr = (unsigned short *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = (unsigned short)SATURATE(srcVector[i], 0, 16383) << 2;
+            break;
+        }
         default: break;
     }
 }
@@ -2809,6 +2889,27 @@ void pack_image_pixel(float *srcVector, const cl_image_format *imageFormat,
                 | (((unsigned int)NORMALIZE(srcVector[3], 1023.f) & 1023) << 0);
             break;
         }
+        case CL_UNORM_INT10X6_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 1023.f) & 1023)
+                    << 6;
+            break;
+        }
+        case CL_UNORM_INT12X4_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 4095.f) & 4095)
+                    << 4;
+            break;
+        }
+        case CL_UNORM_INT14X2_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 16383.f) & 16383)
+                    << 2;
+            break;
+        }
         case CL_SIGNED_INT8: {
             cl_char *ptr = (cl_char *)outData;
             for (unsigned int i = 0; i < channelCount; i++)
@@ -2850,6 +2951,27 @@ void pack_image_pixel(float *srcVector, const cl_image_format *imageFormat,
                     srcVector[i],
                     MAKE_HEX_FLOAT(0x1.fffffep31f, 0x1fffffe, 31 - 23),
                     CL_UINT_MAX);
+            break;
+        }
+        case CL_UNSIGNED_INT10X6_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 1023.f) & 1023)
+                    << 6;
+            break;
+        }
+        case CL_UNSIGNED_INT12X4_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 4095.f) & 4095)
+                    << 4;
+            break;
+        }
+        case CL_UNSIGNED_INT14X2_EXT: {
+            cl_ushort *ptr = (cl_ushort *)outData;
+            for (unsigned int i = 0; i < channelCount; i++)
+                ptr[i] = ((cl_ushort)NORMALIZE(srcVector[i], 16383.f) & 16383)
+                    << 2;
             break;
         }
 #ifdef CL_SFIXED14_APPLE
@@ -2999,6 +3121,33 @@ void pack_image_pixel_error(const float *srcVector,
 
             break;
         }
+        case CL_UNORM_INT10X6_EXT: {
+            const cl_ushort *ptr = (const cl_ushort *)results;
+
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] =
+                    (ptr[i] >> 6) - NORMALIZE_UNROUNDED(srcVector[i], 1023.f);
+
+            break;
+        }
+        case CL_UNORM_INT12X4_EXT: {
+            const cl_ushort *ptr = (const cl_ushort *)results;
+
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] =
+                    (ptr[i] >> 4) - NORMALIZE_UNROUNDED(srcVector[i], 4095.f);
+
+            break;
+        }
+        case CL_UNORM_INT14X2_EXT: {
+            const cl_ushort *ptr = (const cl_ushort *)results;
+
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] =
+                    (ptr[i] >> 2) - NORMALIZE_UNROUNDED(srcVector[i], 16383.f);
+
+            break;
+        }
         case CL_SIGNED_INT8: {
             const cl_char *ptr = (const cl_char *)results;
 
@@ -3048,6 +3197,29 @@ void pack_image_pixel_error(const float *srcVector,
                         srcVector[i],
                         MAKE_HEX_FLOAT(0x1.fffffep31f, 0x1fffffe, 31 - 23),
                         CL_UINT_MAX));
+            break;
+        }
+        case CL_UNSIGNED_INT10X6_EXT: {
+            cl_ushort *ptr = (cl_ushort *)results;
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] = static_cast<float>(
+                    (cl_int)ptr[i] - (*((cl_int *)(&srcVector[i])) & 0xffc0));
+            break;
+        }
+        case CL_UNSIGNED_INT12X4_EXT: {
+            cl_ushort *ptr = (cl_ushort *)results;
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] = static_cast<float>(
+                    (cl_int)ptr[i] - (*((cl_int *)(&srcVector[i])) & 0xfff0));
+            break;
+        }
+        case CL_UNSIGNED_INT14X2_EXT: {
+            cl_ushort *ptr = (cl_ushort *)results;
+            for (unsigned int i = 0; i < channelCount; i++)
+                errors[i] = static_cast<float>(
+                    (cl_int)ptr[i]
+                    - (cl_int)CONVERT_UINT(srcVector[i], 16383.f,
+                                           CL_USHRT_MAX));
             break;
         }
 #ifdef CL_SFIXED14_APPLE

--- a/test_common/harness/imageHelpers.h
+++ b/test_common/harness/imageHelpers.h
@@ -448,6 +448,27 @@ void read_image_pixel(void *imageData, image_descriptor *imageInfo, int x,
             tempData[0] = (T)(hi_val | lo_val);
             break;
         }
+        case CL_UNSIGNED_INT10X6_EXT: {
+            cl_short *dPtr = (cl_short *)ptr;
+            const size_t channelCount = get_format_channel_count(format);
+            for (i = 0; i < channelCount; i++)
+                tempData[i] = (dPtr[i] >> 6) & 0x3ff;
+            break;
+        }
+        case CL_UNSIGNED_INT12X4_EXT: {
+            cl_short *dPtr = (cl_short *)ptr;
+            const size_t channelCount = get_format_channel_count(format);
+            for (i = 0; i < channelCount; i++)
+                tempData[i] = (dPtr[i] >> 4) & 0xfff;
+            break;
+        }
+        case CL_UNSIGNED_INT14X2_EXT: {
+            cl_short *dPtr = (cl_short *)ptr;
+            const size_t channelCount = get_format_channel_count(format);
+            for (i = 0; i < channelCount; i++)
+                tempData[i] = (dPtr[i] >> 2) & 0x3fff;
+            break;
+        }
     }
 
 

--- a/test_common/harness/kernelHelpers.cpp
+++ b/test_common/harness/kernelHelpers.cpp
@@ -1328,6 +1328,12 @@ size_t get_pixel_bytes(const cl_image_format *fmt)
         case CL_SIGNED_INT8:
         case CL_UNSIGNED_INT8: return chanCount;
 
+        case CL_UNSIGNED_INT10X6_EXT:
+        case CL_UNSIGNED_INT12X4_EXT:
+        case CL_UNSIGNED_INT14X2_EXT:
+        case CL_UNORM_INT10X6_EXT:
+        case CL_UNORM_INT12X4_EXT:
+        case CL_UNORM_INT14X2_EXT:
         case CL_SNORM_INT16:
         case CL_UNORM_INT16:
         case CL_HALF_FLOAT:

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -30,6 +30,9 @@ cl_channel_type floatFormats[] = {
     CL_SNORM_INT16,
     CL_FLOAT,
     CL_HALF_FLOAT,
+    CL_UNORM_INT10X6_EXT,
+    CL_UNORM_INT12X4_EXT,
+    CL_UNORM_INT14X2_EXT,
     (cl_channel_type)-1,
 };
 
@@ -41,9 +44,8 @@ cl_channel_type intFormats[] = {
 };
 
 cl_channel_type uintFormats[] = {
-    CL_UNSIGNED_INT8,
-    CL_UNSIGNED_INT16,
-    CL_UNSIGNED_INT32,
+    CL_UNSIGNED_INT8,        CL_UNSIGNED_INT16,       CL_UNSIGNED_INT32,
+    CL_UNSIGNED_INT10X6_EXT, CL_UNSIGNED_INT12X4_EXT, CL_UNSIGNED_INT14X2_EXT,
     (cl_channel_type)-1,
 };
 

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -2152,8 +2152,13 @@ int filter_rounding_errors(int forceCorrectlyRoundedWrites,
             || imageInfo->format->image_channel_data_type == CL_SNORM_INT8
             || imageInfo->format->image_channel_data_type == CL_SNORM_INT16
             || imageInfo->format->image_channel_data_type == CL_UNORM_SHORT_555
+            || imageInfo->format->image_channel_data_type == CL_UNORM_SHORT_565
             || imageInfo->format->image_channel_data_type
-                == CL_UNORM_SHORT_565))
+                == CL_UNORM_INT10X6_EXT
+            || imageInfo->format->image_channel_data_type
+                == CL_UNORM_INT12X4_EXT
+            || imageInfo->format->image_channel_data_type
+                == CL_UNORM_INT14X2_EXT))
     {
         if (!(fabsf(errors[0]) > 0.6f) && !(fabsf(errors[1]) > 0.6f)
             && !(fabsf(errors[2]) > 0.6f) && !(fabsf(errors[3]) > 0.6f))


### PR DESCRIPTION
This change add the following image formats to the supported image formats:
1. CL_UNSIGNED_INT10X6_EXT
2. CL_UNSIGNED_INT12X4_EXT
3. CL_UNSIGNED_INT14X2_EXT
4. CL_UNORM_INT10X6_EXT
5. CL_UNORM_INT12X4_EXT
6. CL_UNORM_INT14X2_EXT

For reference, the specification for `cl_ext_image_unsigned_10x6_12x4_14x2` can be found here: https://github.com/KhronosGroup/OpenCL-Docs/pull/1352