### PR TITLE
Add missing coverage to api::zero_sized_enqueue

### DIFF
--- a/test_conformance/api/test_zero_sized_enqueue.cpp
+++ b/test_conformance/api/test_zero_sized_enqueue.cpp
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2017 The Khronos Group Inc.
-// 
+// Copyright (c) 2017-2025 The Khronos Group Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,18 +14,14 @@
 // limitations under the License.
 //
 #include "testBase.h"
-#include "harness/typeWrappers.h"
-#include "harness/conversions.h"
 
-const char* zero_sized_enqueue_test_kernel[] = {
-    "__kernel void foo_kernel(__global int *dst)\n"
-    "{\n"
-    "    int  tid = get_global_id(0);\n"
-    "\n"
-    "    dst[tid] = 1;\n"
-    "\n"
-    "}\n"
-};
+const char* zero_sized_enqueue_test_kernel = R"(
+__kernel void foo_kernel(__global int *dst)
+{
+    int  tid = get_global_id(0);
+    dst[tid] = 1;
+}
+)";
 
 const int bufSize = 128;
 
@@ -81,15 +77,20 @@ int test_zero_sized_enqueue_helper(cl_device_id device, cl_context context,
     output_stream =
         clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
                        bufSize * sizeof(int), NULL, &error);
+    test_error(error, "clCreateBuffer failed.");
 
     // Initialise output buffer.
     int output_buffer_data = 0;
     error = clEnqueueFillBuffer(queue, output_stream, &output_buffer_data,
                                 sizeof(int), 0, sizeof(int) * bufSize, 0, NULL,
                                 NULL);
+    test_error(error, "clEnqueueFillBuffer failed.");
 
     /* Create a kernel to test with */
-    if( create_single_kernel_helper( context, &program, &kernel, 1, zero_sized_enqueue_test_kernel, "foo_kernel" ) != 0 )
+    if (create_single_kernel_helper(context, &program, &kernel, 1,
+                                    &zero_sized_enqueue_test_kernel,
+                                    "foo_kernel")
+        != 0)
     {
         return -1;
     }
@@ -98,6 +99,16 @@ int test_zero_sized_enqueue_helper(cl_device_id device, cl_context context,
     test_error( error, "clSetKernelArg failed." );
 
     // Simple API return code tests for 1D, 2D and 3D zero sized ND range.
+    error = test_zero_sized_enqueue_and_test_output_buffer(
+        queue, kernel, output_stream, 1, nullptr);
+    test_error(error, "1D null sized kernel enqueue failed.");
+    error = test_zero_sized_enqueue_and_test_output_buffer(
+        queue, kernel, output_stream, 2, nullptr);
+    test_error(error, "2D null sized kernel enqueue failed.");
+    error = test_zero_sized_enqueue_and_test_output_buffer(
+        queue, kernel, output_stream, 3, nullptr);
+    test_error(error, "3D null sized kernel enqueue failed.");
+
     error = test_zero_sized_enqueue_and_test_output_buffer(
         queue, kernel, output_stream, 1, &ndrange1);
     test_error( error, "1D zero sized kernel enqueue failed." );
@@ -153,6 +164,17 @@ int test_zero_sized_enqueue_helper(cl_device_id device, cl_context context,
     if (ev == NULL)
     {
         log_error( "ERROR: failed to create an event object\n" );
+        return -1;
+    }
+
+    cl_command_type cmdtype;
+    error = clGetEventInfo(ev, CL_EVENT_COMMAND_TYPE, sizeof(cmdtype), &cmdtype,
+                           NULL);
+    test_error(error, "Failed to get event command type.");
+    if (cmdtype != CL_COMMAND_NDRANGE_KERNEL)
+    {
+        log_error(
+            "ERROR: incorrect zero sized kernel enqueue event command type.\n");
         return -1;
     }
 


### PR DESCRIPTION
- Cases with a NULL global_work_size were not tested
- The specification states that zero-sized enqueues behave similarly to marker commands. Test that events for NDRange kernel commands have the correct CL_COMMAND_NDRANGE_KERNEL command type to guard against implementations naively using a marker command.
- Tidy up the code a bit and add missing error checking.