### PR TITLE
Update local workgroup size to generate desired input

### DIFF
--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -1609,6 +1609,7 @@ template <typename Ty, typename Fns, size_t TSIZE = 0> struct subgroup_test
 
         // Generate the desired input for the kernel
         test_params.subgroup_size = subgroup_size;
+        test_params.local_workgroup_size = local;
         Fns::gen(idata.data(), mapin.data(), sgmap.data(), test_params);
 
         test_status status = TEST_FAIL;


### PR DESCRIPTION
The `local_workgroup_size` is changed by `get_max_common_work_group_size`. But the input data still use the original `local_workgroup_size`, which will cause the check logic to failed.