### PR TITLE
Sanitize flags before passing them into clGetSupportedImageFormats

### DIFF
--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -127,6 +127,9 @@ int get_format_list(cl_context context, cl_mem_object_type imageType,
                     std::vector<cl_image_format> &outFormatList,
                     cl_mem_flags flags)
 {
+    flags &= CL_MEM_READ_WRITE | CL_MEM_READ_ONLY | CL_MEM_WRITE_ONLY
+        | CL_MEM_KERNEL_READ_AND_WRITE | CL_MEM_IMMUTABLE_EXT;
+
     cl_uint formatCount;
     int error = clGetSupportedImageFormats(context, flags, imageType, 0, NULL,
                                            &formatCount);


### PR DESCRIPTION
Some tests call get_format_list with e.g. CL_MEM_USE_HOSTPTR, but this flag isn't valid clGetSupportedImageFormats, but it's not clear if implementations are allowed to accept it.

This appears to be a problem since !2283 as now we get CL_MEM_USE_HOSTPTR passed into get_format_list.