### PR TITLE
conversions: remove timing functionality

### DIFF
--- a/test_conformance/conversions/basic_test_conversions.h
+++ b/test_conformance/conversions/basic_test_conversions.h
@@ -86,8 +86,6 @@ extern int gSkipTesting;
 extern int gMinVectorSize;
 extern int gMaxVectorSize;
 extern int gForceFTZ;
-extern int gTimeResults;
-extern int gReportAverageTimes;
 extern int gStartTestNumber;
 extern int gEndTestNumber;
 extern int gIsRTZ;

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -226,8 +226,6 @@ static int ParseArgs(int argc, const char **argv)
                         gForceFTZ ^= 1;
                         gForceHalfFTZ ^= 1;
                         break;
-                    case 't': gTimeResults ^= 1; break;
-                    case 'a': gReportAverageTimes ^= 1; break;
                     case '1':
                         if (arg[1] == '6')
                         {


### PR DESCRIPTION
Remove the test timing functionality from the conversions test, because it

 - is not advertised in the help,

 - is not supported on all platforms, triggering warnings during the build,

 - goes beyond the core purpose of the conformance test suite.