### PR TITLE
Added initialization of buffer once imported in OpenCL for test_buffer_single_queue_fence test

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -577,6 +577,25 @@ int run_test_with_one_queue(
             // bufferSizeList[i]
             global_work_size[0] = bufferSize;
 
+            err = clEnqueueAcquireExternalMemObjectsKHRptr(
+                cmd_queue1, vkBufferList.size(), buffers, 0, nullptr, nullptr);
+            test_error_and_cleanup(err, CLEANUP, "Failed to acquire buffers");
+
+            uint8_t pattern = 0;
+
+            for (int i = 0; i < vkBufferList.size(); i++)
+            {
+                err = clEnqueueFillBuffer(
+                    cmd_queue1, buffers[i], &pattern, sizeof(pattern), 0,
+                    sizeof(uint8_t) * bufferSize, 0, NULL, NULL);
+            }
+
+            err = clEnqueueReleaseExternalMemObjectsKHRptr(
+                cmd_queue1, vkBufferList.size(), buffers, 0, nullptr, nullptr);
+            test_error_and_cleanup(err, CLEANUP, "Failed to release buffers");
+
+            clFinish(cmd_queue1);
+
             for (uint32_t iter = 0; iter < maxIter; iter++)
             {
                 if (use_fence)


### PR DESCRIPTION
For testing the interoperability between Vulkan and OpenCL, the test exports a Vulkan buffer and then OpenCL imports it. After importing, OpenCL applies a kernel that adds a constant value to the initial buffer (which is not initialized) and afterwards it expects that all the elements in the buffer to have that specific constant value (thus the test fails).

I added an initialization of the buffer, once it is imported into OpenCL.