### PR TITLE
Add cl_khr_external_memory_android_hardware_buffer to the list of known compiler test extensions

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -94,7 +94,8 @@ const char *known_extensions[] = {
     "cl_khr_external_memory_dma_buf",
     "cl_khr_command_buffer",
     "cl_khr_command_buffer_mutable_dispatch",
-    "cl_khr_command_buffer_multi_device"
+    "cl_khr_command_buffer_multi_device",
+    "cl_khr_external_memory_android_hardware_buffer"
 };
 // clang-format on
 


### PR DESCRIPTION
Fixes compiler_defines_for_extensions failure when the extension is supported.