### PR TITLE
add missing image support checks to a few SPIR-V tests

### DIFF
--- a/test_conformance/spirv_new/test_spirv_14.cpp
+++ b/test_conformance/spirv_new/test_spirv_14.cpp
@@ -97,6 +97,7 @@ REGISTER_TEST(spirv14_image_operand_signextend)
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
+    PASSIVE_REQUIRE_IMAGE_SUPPORT(device);
     return test_image_operand_helper(device, context, queue, true);
 }
 
@@ -107,6 +108,7 @@ REGISTER_TEST(spirv14_image_operand_zeroextend)
         log_info("SPIR-V 1.4 not supported; skipping tests.\n");
         return TEST_SKIPPED_ITSELF;
     }
+    PASSIVE_REQUIRE_IMAGE_SUPPORT(device);
     return test_image_operand_helper(device, context, queue, false);
 }
 

--- a/test_conformance/spirv_new/test_spirv_16.cpp
+++ b/test_conformance/spirv_new/test_spirv_16.cpp
@@ -29,6 +29,8 @@ REGISTER_TEST(spirv16_image_operand_nontemporal)
         return TEST_SKIPPED_ITSELF;
     }
 
+    PASSIVE_REQUIRE_IMAGE_SUPPORT(device);
+
     cl_int error = CL_SUCCESS;
 
     clProgramWrapper prog;


### PR DESCRIPTION
The tests for new image operands should not run on devices that do not support images.