### PR TITLE
Test releasing a command-buffer after submission but before execution has finished

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -128,6 +128,15 @@ struct InterleavedEnqueueTest : public BasicCommandBufferTest
     bool Skip() override;
 };
 
+// Test releasing a command-buffer after it has been submitted for execution,
+// but before the user has waited on completion of the enqueue.
+struct EnqueueAndReleaseTest : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    cl_int Run() override;
+};
+
 template <class T>
 int MakeAndRunTest(cl_device_id device, cl_context context,
                    cl_command_queue queue, int num_elements)

--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer_tests.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer_tests.cpp
@@ -44,3 +44,9 @@ REGISTER_TEST(explicit_flush)
     return MakeAndRunTest<ExplicitFlushTest>(device, context, queue,
                                              num_elements);
 }
+
+REGISTER_TEST(enqueue_and_release)
+{
+    return MakeAndRunTest<EnqueueAndReleaseTest>(device, context, queue,
+                                                 num_elements);
+}


### PR DESCRIPTION
Add cl_khr_command_buffer test that is it valid to release a command-buffer after it has been enqueued but before execution is finished.

This stresses the semantics from [clReleaseCommandBufferKHR](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clReleaseCommandBufferKHR.html#_description) that: "After the command_buffer reference count becomes zero **and has finished execution**, the command-buffer is deleted"