### PR TITLE
allow specifying CL_DEVICE_TYPE_ALL as the harness device type

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -197,7 +197,10 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
     if (env_mode != NULL)
     {
         based_on_env_var = 1;
-        if (strcmp(env_mode, "gpu") == 0
+        if (strcmp(env_mode, "all") == 0
+            || strcmp(env_mode, "CL_DEVICE_TYPE_ALL") == 0)
+            device_type = CL_DEVICE_TYPE_ALL;
+        else if (strcmp(env_mode, "gpu") == 0
             || strcmp(env_mode, "CL_DEVICE_TYPE_GPU") == 0)
             device_type = CL_DEVICE_TYPE_GPU;
         else if (strcmp(env_mode, "cpu") == 0
@@ -271,7 +274,7 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
                  "(default 0).\n");
         log_info("\tid<num>\t\tIndicates device at index <num> should be used "
                  "(default 0).\n");
-        log_info("\t<device_type>\tcpu|gpu|accelerator|<CL_DEVICE_TYPE_*> "
+        log_info("\t<device_type>\tall|cpu|gpu|accelerator|<CL_DEVICE_TYPE_*> "
                  "(default CL_DEVICE_TYPE_DEFAULT)\n");
         log_info("\n");
         log_info("\tNOTE: You may pass environment variable "
@@ -320,8 +323,14 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
     /* Do we have a CPU/GPU specification? */
     if (argc > 1)
     {
-        if (strcmp(argv[argc - 1], "gpu") == 0
-            || strcmp(argv[argc - 1], "CL_DEVICE_TYPE_GPU") == 0)
+        if (strcmp(argv[argc - 1], "all") == 0
+            || strcmp(argv[argc - 1], "CL_DEVICE_TYPE_ALL") == 0)
+        {
+            device_type = CL_DEVICE_TYPE_ALL;
+            argc--;
+        }
+        else if (strcmp(argv[argc - 1], "gpu") == 0
+                 || strcmp(argv[argc - 1], "CL_DEVICE_TYPE_GPU") == 0)
         {
             device_type = CL_DEVICE_TYPE_GPU;
             argc--;
@@ -376,6 +385,7 @@ int runTestHarnessWithCheck(int argc, const char *argv[], int testNum,
 
     switch (device_type)
     {
+        case CL_DEVICE_TYPE_ALL: log_info("Requesting any device "); break;
         case CL_DEVICE_TYPE_GPU: log_info("Requesting GPU device "); break;
         case CL_DEVICE_TYPE_CPU: log_info("Requesting CPU device "); break;
         case CL_DEVICE_TYPE_ACCELERATOR:


### PR DESCRIPTION
Currently, selecting a different device in a platform to test is rather cumbersome, for two reasons:

1. The default device type tested is the "default" device and there is at most one default device in a platform.  This means that, by itself, choosing any non-zero device index is by definition out-of-range:

```sh
$ CL_PLATFORM_INDEX=1 CL_DEVICE_INDEX=1 ./test_conformance/basic/test_basic 
 Initializing random seed to 0.
Requesting Default device based on command line for platform index 1 and device index 1
device index out of range -- choosen_device_index (1) >= num_devices (1)
```

2. To choose a non-default device type you therefore need to explicitly specify another device type also, but "all" is not a valid device type in the harness.  This means that you need to know both the device type and the index of the device within that device type to choose the device to test.

```sh
$ CL_DEVICE_TYPE=all CL_PLATFORM_INDEX=1 CL_DEVICE_INDEX=1 ./test_conformance/basic/test_basic 
Unknown CL_DEVICE_TYPE env variable setting: all.
Aborting...
Aborted (core dumped)
```

This PR aims to fix (2), by allowing "all" as a device type.  In the future, we could consider making the default device type "all" vs. "default", which would fix (1) also, but that will likely need more discussion and should be done in a separate PR.

