### PR TITLE
Fix 'fpclassify: ambiguous call' in MSVC 2022

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -37,11 +37,7 @@ double sRGBmap(float fc)
 {
     double c = (double)fc;
 
-#if !defined(_WIN32)
-    if (std::isnan(c)) c = 0.0;
-#else
-    if (_isnan(c)) c = 0.0;
-#endif
+    if (isnan_fp(c)) c = 0.0;
 
     if (c > 1.0)
         c = 1.0;

--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -17,6 +17,7 @@
 #define _testHarness_h
 
 #include "clImageHelper.h"
+#include <cmath>
 #include <string>
 #include <sstream>
 
@@ -264,5 +265,14 @@ void memset_pattern4(void *, const void *, size_t);
 
 extern void PrintArch(void);
 
+
+template <typename T> inline bool isnan_fp(const T &v) { return std::isnan(v); }
+
+template <> inline bool isnan_fp<cl_half>(const cl_half &v)
+{
+    uint16_t h_exp = (((cl_half)v) >> 10) & 0x1F;
+    uint16_t h_mant = ((cl_half)v) & 0x3FF;
+    return (h_exp == 0x1F && h_mant != 0);
+}
 
 #endif // _testHarness_h

--- a/test_conformance/basic/test_explicit_s2v.cpp
+++ b/test_conformance/basic/test_explicit_s2v.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 #include <cmath>
-using std::isnan;
 #include "harness/compat.h"
 
 #include <stdio.h>
@@ -102,16 +101,6 @@ const char * kernel_explicit_s2v_set[NUM_VEC_TYPES][NUM_VEC_TYPES][5] = {
 
 // clang-format on
 
-bool IsHalfNaN(cl_half v)
-{
-    // Extract FP16 exponent and mantissa
-    uint16_t h_exp = (((cl_half)v) >> (CL_HALF_MANT_DIG - 1)) & 0x1F;
-    uint16_t h_mant = ((cl_half)v) & 0x3FF;
-
-    // NaN test
-    return (h_exp == 0x1F && h_mant != 0);
-}
-
 static int test_explicit_s2v_function(cl_context context,
                                       cl_command_queue queue, cl_kernel kernel,
                                       ExplicitType srcType, unsigned int count,
@@ -183,20 +172,21 @@ static int test_explicit_s2v_function(cl_context context,
             {
                 bool isSrcNaN =
                     (((srcType == kHalf)
-                      && IsHalfNaN(*reinterpret_cast<cl_half *>(inPtr)))
+                      && isnan_fp(*reinterpret_cast<cl_half *>(inPtr)))
                      || ((srcType == kFloat)
-                         && isnan(*reinterpret_cast<cl_float *>(inPtr)))
+                         && isnan_fp(*reinterpret_cast<cl_float *>(inPtr)))
                      || ((srcType == kDouble)
-                         && isnan(*reinterpret_cast<cl_double *>(inPtr))));
-                bool isDestNaN = (((destType == kHalf)
-                                   && IsHalfNaN(*reinterpret_cast<cl_half *>(
-                                       outPtr + destTypeSize * s)))
-                                  || ((destType == kFloat)
-                                      && isnan(*reinterpret_cast<cl_float *>(
-                                          outPtr + destTypeSize * s)))
-                                  || ((destType == kDouble)
-                                      && isnan(*reinterpret_cast<cl_double *>(
-                                          outPtr + destTypeSize * s))));
+                         && isnan_fp(*reinterpret_cast<cl_double *>(inPtr))));
+                bool isDestNaN =
+                    (((destType == kHalf)
+                      && isnan_fp(*reinterpret_cast<cl_half *>(
+                          outPtr + destTypeSize * s)))
+                     || ((destType == kFloat)
+                         && isnan_fp(*reinterpret_cast<cl_float *>(
+                             outPtr + destTypeSize * s)))
+                     || ((destType == kDouble)
+                         && isnan_fp(*reinterpret_cast<cl_double *>(
+                             outPtr + destTypeSize * s))));
 
                 if (isSrcNaN && isDestNaN)
                 {

--- a/test_conformance/basic/test_fpmath.cpp
+++ b/test_conformance/basic/test_fpmath.cpp
@@ -57,16 +57,6 @@ template <typename T> double toDouble(T val)
         return val;
 }
 
-bool isHalfNan(cl_half v)
-{
-    // Extract FP16 exponent and mantissa
-    uint16_t h_exp = (v >> (CL_HALF_MANT_DIG - 1)) & 0x1F;
-    uint16_t h_mant = v & 0x3FF;
-
-    // NaN test
-    return (h_exp == 0x1F && h_mant != 0);
-}
-
 cl_half half_plus(cl_half a, cl_half b)
 {
     return HFF(std::plus<float>()(HTF(a), HTF(b)));
@@ -101,14 +91,7 @@ int verify_fp(std::vector<T> (&input)[2], std::vector<T> &output,
         T r = test.ref(inA[i], inB[i]);
         bool both_nan = false;
 
-        if (std::is_same<T, cl_half>::value)
-        {
-            both_nan = isHalfNan(r) && isHalfNan(output[i]);
-        }
-        else if (std::is_floating_point<T>::value)
-        {
-            both_nan = std::isnan(r) && std::isnan(output[i]);
-        }
+        both_nan = isnan_fp(r) && isnan_fp(output[i]);
 
         // If not both nan, check if the result is the same
         if (!both_nan && (r != output[i]))

--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -943,8 +943,7 @@ static int RunTest( int testNumber )
         float *b = (float*) buf2;
         for( i = 0; i < BUFFER_SIZE / sizeof( float ); i++ )
         {
-            if( isnan(test[i]) && isnan(correct[testNumber][i] ) )
-                continue;
+            if (isnan_fp(test[i]) && isnan_fp(correct[testNumber][i])) continue;
 
             if( skipTest[testNumber][i] )
                 continue;
@@ -1112,7 +1111,7 @@ static int RunTest_Double( int testNumber )
         double *b = (double*) buf2;
         for( i = 0; i < BUFFER_SIZE / sizeof( double ); i++ )
         {
-            if( isnan(test[i]) && isnan(correct_double[testNumber][i] ) )
+            if (isnan_fp(test[i]) && isnan_fp(correct_double[testNumber][i]))
                 continue;
 
             // sign of zero must be correct

--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -955,24 +955,6 @@ void MapResultValuesComplete(const std::unique_ptr<CalcRefValsBase> &info)
     // destroyed automatically soon after we exit.
 }
 
-template <typename T> static bool isnan_fp(const T &v)
-{
-    if (std::is_same<T, cl_half>::value)
-    {
-        uint16_t h_exp = (((cl_half)v) >> (CL_HALF_MANT_DIG - 1)) & 0x1F;
-        uint16_t h_mant = ((cl_half)v) & 0x3FF;
-        return (h_exp == 0x1F && h_mant != 0);
-    }
-    else
-    {
-#if !defined(_WIN32)
-        return std::isnan(v);
-#else
-        return _isnan(v);
-#endif
-    }
-}
-
 template <typename InType>
 void ZeroNanToIntCases(cl_uint count, void *mapped, Type outType, void *input)
 {

--- a/test_conformance/geometrics/test_geometrics_double.cpp
+++ b/test_conformance/geometrics/test_geometrics_double.cpp
@@ -380,8 +380,7 @@ int test_twoToFloat_kernel_double(cl_command_queue queue, cl_context context, co
         double expected = verifyFn( inDataA + i * vecSize, inDataB + i * vecSize, vecSize );
         if( (double) expected != outData[ i ] )
         {
-            if( isnan(expected) && isnan( outData[i] ) )
-                continue;
+            if (isnan_fp(expected) && isnan_fp(outData[i])) continue;
 
             if( ulpLimit < 0 )
             {
@@ -612,8 +611,7 @@ int test_oneToFloat_kernel_double(cl_command_queue queue, cl_context context, co
                 continue;
 
             // We have to special case NAN
-            if( isnan( outData[ i ] ) && isnan( expected ) )
-                continue;
+            if (isnan_fp(outData[i]) && isnan_fp(expected)) continue;
 
             if(! (fabs(ulps) < ulpLimit) )
             {
@@ -817,7 +815,7 @@ int test_oneToOne_kernel_double(cl_command_queue queue, cl_context context, cons
         for( j = 0; j < vecSize; j++ )
         {
             // We have to special case NAN
-            if( isnan( outData[ i * vecSize + j ] ) && isnan( expected[ j ] ) )
+            if (isnan_fp(outData[i * vecSize + j]) && isnan_fp(expected[j]))
                 continue;
 
             if( expected[j] != outData[ i *vecSize+j ] )

--- a/test_conformance/relationals/test_comparisons_fp.cpp
+++ b/test_conformance/relationals/test_comparisons_fp.cpp
@@ -368,9 +368,8 @@ int RelationalsFPTest::test_equiv_kernel(unsigned int vecSize,
                 {
                     if (gInfNanSupport == 0)
                     {
-                        float a = inDataA[i * vecSize + j];
-                        float b = inDataB[i * vecSize + j];
-                        if (isnan(a) || isnan(b))
+                        if (isnan_fp(inDataA[i * vecSize + j])
+                            || isnan_fp(inDataB[i * vecSize + j]))
                             fail = 0;
                         else
                             fail = 1;

--- a/test_conformance/select/util_select.cpp
+++ b/test_conformance/select/util_select.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "harness/errorHelpers.h"
+#include "harness/testHarness.h"
 
 #include <stdio.h>
 #include <cinttypes>
@@ -834,9 +835,9 @@ size_t check_half(const void *const test, const void *const correct,
         // Allow nans to be binary different
         for (i = 0; i < count; i++)
         {
-            float fcorrect = cl_half_to_float(c[i]);
-            float ftest = cl_half_to_float(t[i]);
-            if ((t[i] != c[i]) && !(isnan(fcorrect) && isnan(ftest)))
+            if ((t[i] != c[i])
+                && !(isnan_fp(cl_half_to_float(c[i]))
+                     && isnan_fp(cl_half_to_float(t[i]))))
             {
                 log_error("\n(check_half) Error for vector size %zu found at "
                           "0x%8.8zx (of 0x%8.8zx):  "

--- a/test_conformance/spirv_new/test_decorate.cpp
+++ b/test_conformance/spirv_new/test_decorate.cpp
@@ -231,7 +231,7 @@ static inline
     f = cl_half_to_float(cl_half_from_float(f, half_rounding));
 
     To val = static_cast<To>(std::min<float>(std::max<float>(f, loVal), hiVal));
-    if (isnan(cl_half_to_float(rhs)))
+    if (isnan_fp(rhs))
     {
         val = 0;
     }


### PR DESCRIPTION
Similar to #2219, we see "'fpclassify': ambiguous call" error in test_conformance\basic\test_fpmath.cpp.
This PR fixes the issue by adding utility function isnan_fp in testHarness.h.
Note IsHalfNaN in test_conformance/math_brute_force/utility.h isn't touched, to avoid change to this file.