### PR TITLE
Add `cl_ext_immutable_memory_objects` tests writing to and from buffer

### DIFF
--- a/test_conformance/basic/test_arrayimagecopy.cpp
+++ b/test_conformance/basic/test_arrayimagecopy.cpp
@@ -188,9 +188,17 @@ REGISTER_TEST(arrayimagecopy)
 {
     PASSIVE_REQUIRE_IMAGE_SUPPORT(device)
 
-    return test_arrayimagecommon(device, context, queue, CL_MEM_READ_WRITE,
-                                 CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE2D,
-                                 test_arrayimagecopy_single_format);
+    int error = test_arrayimagecommon(device, context, queue, CL_MEM_READ_WRITE,
+                                      CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE2D,
+                                      test_arrayimagecopy_single_format);
+    if (is_extension_available(device, "cl_ext_immutable_memory_objects"))
+    {
+        error |= test_arrayimagecommon(
+            device, context, queue, CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR,
+            CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE2D,
+            test_arrayimagecopy_single_format);
+    }
+    return error;
 }
 
 
@@ -198,7 +206,15 @@ REGISTER_TEST(arrayimagecopy3d)
 {
     PASSIVE_REQUIRE_3D_IMAGE_SUPPORT(device)
 
-    return test_arrayimagecommon(device, context, queue, CL_MEM_READ_WRITE,
-                                 CL_MEM_READ_ONLY, CL_MEM_OBJECT_IMAGE3D,
-                                 test_arrayimagecopy_single_format);
+    int error = test_arrayimagecommon(device, context, queue, CL_MEM_READ_WRITE,
+                                      CL_MEM_READ_ONLY, CL_MEM_OBJECT_IMAGE3D,
+                                      test_arrayimagecopy_single_format);
+    if (is_extension_available(device, "cl_ext_immutable_memory_objects"))
+    {
+        error |= test_arrayimagecommon(
+            device, context, queue, CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR,
+            CL_MEM_READ_WRITE, CL_MEM_OBJECT_IMAGE3D,
+            test_arrayimagecopy_single_format);
+    }
+    return error;
 }

--- a/test_conformance/buffers/main.cpp
+++ b/test_conformance/buffers/main.cpp
@@ -19,19 +19,24 @@
 
 #include "testBase.h"
 
-const cl_mem_flags flag_set[] = {
-    CL_MEM_ALLOC_HOST_PTR,
-    CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
-    CL_MEM_USE_HOST_PTR,
-    CL_MEM_COPY_HOST_PTR,
-    0
-};
+const cl_mem_flags flag_set[] = { CL_MEM_ALLOC_HOST_PTR,
+                                  CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR,
+                                  CL_MEM_USE_HOST_PTR,
+                                  CL_MEM_COPY_HOST_PTR,
+                                  0,
+                                  CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR,
+                                  CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR,
+                                  CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR
+                                      | CL_MEM_ALLOC_HOST_PTR };
 const char* flag_set_names[] = {
     "CL_MEM_ALLOC_HOST_PTR",
     "CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR",
     "CL_MEM_USE_HOST_PTR",
     "CL_MEM_COPY_HOST_PTR",
-    "0"
+    "0",
+    "CL_MEM_IMMUTABLE_EXT | CL_MEM_USE_HOST_PTR",
+    "CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR",
+    "CL_MEM_IMMUTABLE_EXT | CL_MEM_COPY_HOST_PTR | CL_MEM_ALLOC_HOST_PTR",
 };
 
 int main( int argc, const char *argv[] )

--- a/test_conformance/buffers/testBase.h
+++ b/test_conformance/buffers/testBase.h
@@ -25,6 +25,6 @@
 extern const cl_mem_flags flag_set[];
 extern const char* flag_set_names[];
 
-#define NUM_FLAGS 5
+#define NUM_FLAGS 8
 
 #endif // _testBase_h

--- a/test_conformance/buffers/test_buffer_fill.cpp
+++ b/test_conformance/buffers/test_buffer_fill.cpp
@@ -598,6 +598,12 @@ static int test_buffer_fill(cl_device_id deviceID, cl_context context,
 
         for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
         {
+            // Skip immutable memory flags
+            if (flag_set[src_flag_id] & CL_MEM_IMMUTABLE_EXT)
+            {
+                continue;
+            }
+
             clEventWrapper event[2];
             clMemWrapper buffers[2];
             if ((flag_set[src_flag_id] & CL_MEM_USE_HOST_PTR) || (flag_set[src_flag_id] & CL_MEM_COPY_HOST_PTR))
@@ -721,6 +727,12 @@ REGISTER_TEST(buffer_fill_struct)
 
     for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
     {
+        // Skip immutable memory flags
+        if (flag_set[src_flag_id] & CL_MEM_IMMUTABLE_EXT)
+        {
+            continue;
+        }
+
         clProgramWrapper program;
         clKernelWrapper kernel;
         log_info("Testing with cl_mem_flags: %s\n",

--- a/test_conformance/buffers/test_buffer_read.cpp
+++ b/test_conformance/buffers/test_buffer_read.cpp
@@ -666,6 +666,12 @@ static int test_buffer_read(cl_device_id deviceID, cl_context context,
 
         for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
         {
+            // Skip immutable memory flags
+            if (flag_set[src_flag_id] & CL_MEM_IMMUTABLE_EXT)
+            {
+                continue;
+            }
+
             clMemWrapper buffer;
             outptr[i] = align_malloc( ptrSizes[i] * num_elements, min_alignment);
             if ( ! outptr[i] ){
@@ -809,6 +815,12 @@ static int test_buffer_read_async(cl_device_id deviceID, cl_context context,
 
         for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
         {
+            // Skip immutable memory flags
+            if (flag_set[src_flag_id] & CL_MEM_IMMUTABLE_EXT)
+            {
+                continue;
+            }
+
             clMemWrapper buffer;
             clEventWrapper event;
             outptr[i] = align_malloc(ptrSizes[i] * num_elements, min_alignment);
@@ -946,6 +958,12 @@ static int test_buffer_read_array_barrier(
 
         for (src_flag_id = 0; src_flag_id < NUM_FLAGS; src_flag_id++)
         {
+            // Skip immutable memory flags
+            if (flag_set[src_flag_id] & CL_MEM_IMMUTABLE_EXT)
+            {
+                continue;
+            }
+
             clMemWrapper buffer;
             clEventWrapper event;
             outptr[i] = align_malloc(ptrSizes[i] * num_elements, min_alignment);


### PR DESCRIPTION
This change extends the test coverage for https://github.com/KhronosGroup/OpenCL-Docs/pull/1280

The change tests:
1. Writing to immutable buffers.
2. Writing to buffer/image from immutable buffers.
3. Reading from immutable buffers.

This change adds the following tests:
1. `test_negative_imagearraycopy`
2. `test_negative_imagearraycopy3d`
3. `test_immutable_bufferreadwriterect`
4. `test_immutable_arrayreadwrite`
5. `test_write_from_immutable_buffer_to_buffer`
6. `test_immutable_buffer_map_*`

and extends the following tests:
1. `test_arrayimagecopy3d`
2. `test_arrayimagecopy`
3. `test_imagearraycopy3d`
4. `test_imagearraycopy`
5. `test_buffer_copy`
6. `test_buffer_partial_copy`