### PR TITLE
Add cl_khr_unified_svm to the list of known extensions in the compiler defines for extension test.

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -95,7 +95,8 @@ const char *known_extensions[] = {
     "cl_khr_command_buffer",
     "cl_khr_command_buffer_mutable_dispatch",
     "cl_khr_command_buffer_multi_device",
-    "cl_khr_external_memory_android_hardware_buffer"
+    "cl_khr_external_memory_android_hardware_buffer",
+    "cl_khr_unified_svm"
 };
 // clang-format on
 


### PR DESCRIPTION
Adds cl_khr_unified_svm to the list of known extensions in the compiler defines for extension test.