### PR TITLE
Use CL_KERNEL_WORK_GROUP_SIZE more often

### DIFF
--- a/test_conformance/api/test_sub_group_dispatch.cpp
+++ b/test_conformance/api/test_sub_group_dispatch.cpp
@@ -108,7 +108,11 @@ REGISTER_TEST_VERSION(sub_group_dispatch, Version(2, 1))
                             nullptr);
     test_error(error, "clGetDeviceInfo failed");
 
-    max_local = max_work_item_sizes[0];
+    error = clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE,
+                                     sizeof(max_local), &max_local, nullptr);
+    test_error(error, "clGetKernelWorkGroupInfo failed");
+
+    max_local = std::min(max_local, max_work_item_sizes[0]);
 
     error = clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform),
                             (void *)&platform, NULL);

--- a/test_conformance/profiling/execute_multipass.cpp
+++ b/test_conformance/profiling/execute_multipass.cpp
@@ -106,28 +106,6 @@ static int run_kernel( cl_device_id device, cl_context context, cl_command_queue
     threads[1] = h;
     threads[2] = d;
 
-    err = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
-                          3 * sizeof(size_t), (size_t *)localThreads, NULL);
-    if (err)
-    {
-        log_error("clGetDeviceInfo(CL_DEVICE_MAX_WORK_ITEM_SIZES) failed\n");
-        return -1;
-    }
-    err = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(size_t),
-                          &maxWorkgroupSize, NULL);
-    if (err)
-    {
-        log_error("clGetDeviceInfo(CL_DEVICE_MAX_WORK_GROUP_SIZE) failed\n");
-        return -1;
-    }
-    localThreads[0] =
-        std::min({ localThreads[0], threads[0], maxWorkgroupSize });
-    localThreads[1] = std::min(
-        { localThreads[1], threads[1], maxWorkgroupSize / localThreads[0] });
-    localThreads[2] =
-        std::min({ localThreads[2], threads[2],
-                   maxWorkgroupSize / (localThreads[0] * localThreads[1]) });
-
     cl_sampler sampler = clCreateSampler( context, CL_FALSE, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_NEAREST, &err );
     if( err ){
         log_error( " clCreateSampler failed.\n" );
@@ -161,6 +139,27 @@ static int run_kernel( cl_device_id device, cl_context context, cl_command_queue
         return -1;
     }
 
+    err = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                          3 * sizeof(size_t), (size_t *)localThreads, NULL);
+    if (err)
+    {
+        log_error("clGetDeviceInfo(CL_DEVICE_MAX_WORK_ITEM_SIZES) failed\n");
+        return -1;
+    }
+    err = clGetKernelWorkGroupInfo(kernel[0], device, CL_KERNEL_WORK_GROUP_SIZE,
+                                   sizeof(size_t), &maxWorkgroupSize, NULL);
+    if (err)
+    {
+        log_error("clGetDeviceInfo(CL_KERNEL_WORK_GROUP_SIZE) failed\n");
+        return -1;
+    }
+    localThreads[0] =
+        std::min({ localThreads[0], threads[0], maxWorkgroupSize });
+    localThreads[1] = std::min(
+        { localThreads[1], threads[1], maxWorkgroupSize / localThreads[0] });
+    localThreads[2] =
+        std::min({ localThreads[2], threads[2],
+                   maxWorkgroupSize / (localThreads[0] * localThreads[1]) });
 
     // create kernel args object and set arg values.
     // set the args values


### PR DESCRIPTION
Drivers _may_ choose to advertise values for `CL_DEVICE_MAX_WORK_GROUP_SIZE` or `CL_DEVICE_MAX_WORK_ITEM_SIZES`  that kernels without a `reqd_work_group_size` are not able to be launched with.

The CTS should therefore make sure that the local_size passed to `clEnqueueNDRangeKernel` does not exceed `CL_KERNEL_WORK_GROUP_SIZE`

This fixes it up in two places I've noticed this not happening.