### PR TITLE
Rename Version major and minor getters

### DIFF
--- a/test_common/harness/testHarness.h
+++ b/test_common/harness/testHarness.h
@@ -28,8 +28,8 @@ public:
     Version(): m_major(0), m_minor(0) {}
 
     Version(cl_uint major, cl_uint minor): m_major(major), m_minor(minor) {}
-    int version_major() const { return m_major; }
-    int version_minor() const { return m_minor; }
+    int get_major() const { return m_major; }
+    int get_minor() const { return m_minor; }
     bool operator>(const Version &rhs) const
     {
         return to_uint() > rhs.to_uint();

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -248,7 +248,7 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
                 cl_mem_flags buffer_flags = CL_MEM_READ_WRITE;
                 if (enable_pitch)
                 {
-                    if (version.version_major() == 1)
+                    if (version.get_major() == 1)
                     {
                         host_ptr = malloc(imageInfo->rowPitch);
                     }


### PR DESCRIPTION
Both these functions cause a conflict when using an old version of the GNU C Library with the header file sys/sysmacros.h where major() and minor() are defined as a macro