### PR TITLE
Fix test_spir not checking for the required extension

### DIFF
--- a/test_conformance/spir/main.cpp
+++ b/test_conformance/spir/main.cpp
@@ -6911,12 +6911,13 @@ int main (int argc, const char* argv[])
         cl_device_id device = get_platform_device(device_type, choosen_device_index, choosen_platform_index);
         printDeviceHeader(device);
 
+        REQUIRE_EXTENSION("cl_khr_spir");
+
         std::vector<Version> versions;
         get_spir_version(device, versions);
 
-        if (!is_extension_available(device, "cl_khr_spir")
-            || (std::find(versions.begin(), versions.end(), Version{ 1, 2 })
-                == versions.end()))
+        if (std::find(versions.begin(), versions.end(), Version{ 1, 2 })
+            == versions.end())
         {
             log_info("Spir extension version 1.2 is not supported by the device\n");
             return 0;


### PR DESCRIPTION
`clGetDeviceInfo` should fail with `CL_INVALID_VALUE` when queried for `CL_DEVICE_SPIR_VERSIONS` on devices that do not claim to support the extension that provides it, `cl_khr_spir`.

Following this change, the test is skipped instead of failing on devices that do not support `cl_khr_spir`.