### PR TITLE
Fix warnings treated as errors in Vulkan tests.

### DIFF
--- a/test_conformance/vulkan/main.cpp
+++ b/test_conformance/vulkan/main.cpp
@@ -50,7 +50,7 @@ static void printUsage(const char *execName)
 
     log_info("Usage: %s [test_names] [options]\n", execName);
     log_info("Test names:\n");
-    for (int i = 0; i < test_registry::getInstance().num_tests(); i++)
+    for (unsigned int i = 0; i < test_registry::getInstance().num_tests(); i++)
     {
         log_info("\t%s\n", test_registry::getInstance().definitions()[i].name);
     }

--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -84,8 +84,8 @@ struct ConsistencyExternalBufferTest : public VulkanTestBase
 
         vkDeviceMem->bindBuffer(vkBufferList[0], 0);
 
-        void* handle = NULL;
-        int fd;
+        [[maybe_unused]] void* handle = NULL;
+        [[maybe_unused]] int fd;
 
         std::vector<cl_mem_properties> extMemProperties{
             (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
@@ -243,8 +243,8 @@ struct ConsistencyExternalImageTest : public VulkanTestBase
                                    vkExternalMemoryHandleType);
         vkDeviceMem->bindImage(vkImage2D, 0);
 
-        void* handle = NULL;
-        int fd;
+        [[maybe_unused]] void* handle = NULL;
+        [[maybe_unused]] int fd;
         std::vector<cl_mem_properties> extMemProperties{
             (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
             (cl_mem_properties)device,
@@ -386,9 +386,9 @@ struct ConsistencyExternalSemaphoreTest : public VulkanTestBase
             VulkanSemaphore vkCl2Vksemaphore(*vkDevice, semaphoreHandleType);
             cl_semaphore_khr clCl2Vksemaphore;
             cl_semaphore_khr clVk2Clsemaphore;
-            void* handle1 = NULL;
-            void* handle2 = NULL;
-            int fd1, fd2;
+            [[maybe_unused]] void* handle1 = NULL;
+            [[maybe_unused]] void* handle2 = NULL;
+            [[maybe_unused]] int fd1, fd2;
             std::vector<cl_semaphore_properties_khr> sema_props1{
                 (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR,
                 (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,

--- a/test_conformance/vulkan/test_vulkan_api_consistency_for_1dimages.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency_for_1dimages.cpp
@@ -101,8 +101,8 @@ struct ConsistencyExternalImage1DTest : public VulkanTestBase
                                    vkExternalMemoryHandleType);
         vkDeviceMem->bindImage(vkImage1D, 0);
 
-        void* handle = NULL;
-        int fd;
+        [[maybe_unused]] void* handle = NULL;
+        [[maybe_unused]] int fd;
         std::vector<cl_mem_properties> extMemProperties{
             (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
             (cl_mem_properties)device,

--- a/test_conformance/vulkan/test_vulkan_api_consistency_for_3dimages.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency_for_3dimages.cpp
@@ -103,8 +103,8 @@ struct ConsistencyExternalImage3DTest : public VulkanTestBase
                                    vkExternalMemoryHandleType);
         vkDeviceMem->bindImage(vkImage3D, 0);
 
-        void* handle = NULL;
-        int fd;
+        [[maybe_unused]] void* handle = NULL;
+        [[maybe_unused]] int fd;
         std::vector<cl_mem_properties> extMemProperties{
             (cl_mem_properties)CL_MEM_DEVICE_HANDLE_LIST_KHR,
             (cl_mem_properties)device,

--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -272,7 +272,7 @@ int run_test_with_two_queue(
                 err |= clSetKernelArg(kernel_cq, 1, sizeof(cl_mem),
                                       (void *)&(buffers[0]));
 
-                for (int i = 0; i < vkBufferList.size() - 1; i++)
+                for (size_t i = 0; i < vkBufferList.size() - 1; i++)
                 {
                     err |=
                         clSetKernelArg(update_buffer_kernel, i + 1,
@@ -352,7 +352,7 @@ int run_test_with_two_queue(
                                    "Error: Failed read output, error\n");
 
             int calc_max_iter;
-            for (int i = 0; i < vkBufferList.size(); i++)
+            for (size_t i = 0; i < vkBufferList.size(); i++)
             {
                 if (i == 0)
                     calc_max_iter = (maxIter * 3);
@@ -602,7 +602,7 @@ int run_test_with_one_queue(
 
                 err = clSetKernelArg(update_buffer_kernel, 0, sizeof(uint32_t),
                                      (void *)&bufferSize);
-                for (int i = 0; i < vkBufferList.size(); i++)
+                for (size_t i = 0; i < vkBufferList.size(); i++)
                 {
                     err |=
                         clSetKernelArg(update_buffer_kernel, i + 1,
@@ -662,7 +662,7 @@ int run_test_with_one_queue(
                                    "Error: clEnqueueWriteBuffer \n");
 
             int calc_max_iter = (maxIter * 2);
-            for (int i = 0; i < vkBufferList.size(); i++)
+            for (size_t i = 0; i < vkBufferList.size(); i++)
             {
                 err = clSetKernelArg(verify_kernel, 0, sizeof(cl_mem),
                                      (void *)&(buffers[i]));
@@ -836,7 +836,7 @@ int run_test_with_multi_import_same_ctx(
                     vkExternalMemoryHandleType));
 
                 std::vector<clExternalMemory *> pExternalMemory;
-                for (size_t cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
+                for (int cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
                 {
                     pExternalMemory.push_back(
                         new clExternalMemory(vkBufferListDeviceMemory[bIdx],
@@ -857,7 +857,7 @@ int run_test_with_multi_import_same_ctx(
             {
                 vkBufferListDeviceMemory[bIdx]->bindBuffer(vkBufferList[bIdx],
                                                            0);
-                for (size_t cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
+                for (int cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
                 {
                     buffers[bIdx][cl_bIdx] = externalMemory[bIdx][cl_bIdx]
                                                  ->getExternalMemoryBuffer();
@@ -916,7 +916,7 @@ int run_test_with_multi_import_same_ctx(
                 {
                     err = clSetKernelArg(update_buffer_kernel, 0,
                                          sizeof(uint32_t), (void *)&bufferSize);
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err |= clSetKernelArg(
                             update_buffer_kernel, i + 1, sizeof(cl_mem),
@@ -939,7 +939,7 @@ int run_test_with_multi_import_same_ctx(
                                            "Error: Failed to launch "
                                            "update_buffer_kernel, error\n ");
 
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clEnqueueReleaseExternalMemObjectsKHRptr(
                             cmd_queue1, 1, &buffers[i][launchIter], 0, nullptr,
@@ -979,7 +979,7 @@ int run_test_with_multi_import_same_ctx(
 
             calc_max_iter = maxIter * (numImports + 1);
 
-            for (int i = 0; i < vkBufferList.size(); i++)
+            for (size_t i = 0; i < vkBufferList.size(); i++)
             {
                 err = clSetKernelArg(verify_kernel, 0, sizeof(cl_mem),
                                      (void *)&(buffers[i][0]));
@@ -1014,7 +1014,7 @@ int run_test_with_multi_import_same_ctx(
             }
             for (size_t i = 0; i < vkBufferList.size(); i++)
             {
-                for (size_t j = 0; j < numImports; j++)
+                for (int j = 0; j < numImports; j++)
                 {
                     delete externalMemory[i][j];
                 }
@@ -1184,7 +1184,7 @@ int run_test_with_multi_import_diff_ctx(
                     vkExternalMemoryHandleType));
                 std::vector<clExternalMemory *> pExternalMemory1;
                 std::vector<clExternalMemory *> pExternalMemory2;
-                for (size_t cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
+                for (int cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
                 {
                     pExternalMemory1.push_back(
                         new clExternalMemory(vkBufferListDeviceMemory[bIdx],
@@ -1209,7 +1209,7 @@ int run_test_with_multi_import_diff_ctx(
             {
                 vkBufferListDeviceMemory[bIdx]->bindBuffer(vkBufferList[bIdx],
                                                            0);
-                for (size_t cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
+                for (int cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
                 {
                     buffers1[bIdx][cl_bIdx] = externalMemory1[bIdx][cl_bIdx]
                                                   ->getExternalMemoryBuffer();
@@ -1226,7 +1226,7 @@ int run_test_with_multi_import_diff_ctx(
             vkCommandBuffer.dispatch(512, 1, 1);
             vkCommandBuffer.end();
 
-            for (int i = 0; i < numImports; i++)
+            for (uint32_t i = 0; i < numImports; i++)
             {
                 update_buffer_kernel1[i] = (numBuffers == 1)
                     ? kernel1[0]
@@ -1282,7 +1282,7 @@ int run_test_with_multi_import_diff_ctx(
                     test_error_and_cleanup(err, CLEANUP,
                                            "Failed to set kernel arg");
 
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clSetKernelArg(
                             update_buffer_kernel1[launchIter], i + 1,
@@ -1307,7 +1307,7 @@ int run_test_with_multi_import_diff_ctx(
                     test_error_and_cleanup(err, CLEANUP,
                                            "Error: Failed to launch "
                                            "update_buffer_kernel, error\n");
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clEnqueueReleaseExternalMemObjectsKHRptr(
                             cmd_queue1, 1, &buffers1[i][launchIter], 0, nullptr,
@@ -1369,7 +1369,7 @@ int run_test_with_multi_import_diff_ctx(
                     test_error_and_cleanup(err, CLEANUP,
                                            "Failed to set kernel arg");
 
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clSetKernelArg(
                             update_buffer_kernel2[launchIter], i + 1,
@@ -1394,7 +1394,7 @@ int run_test_with_multi_import_diff_ctx(
                     test_error_and_cleanup(err, CLEANUP,
                                            "Error: Failed to launch "
                                            "update_buffer_kernel, error\n ");
-                    for (int i = 0; i < numBuffers; i++)
+                    for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clEnqueueReleaseExternalMemObjectsKHRptr(
                             cmd_queue2, 1, &buffers2[i][launchIter], 0, nullptr,
@@ -1442,7 +1442,7 @@ int run_test_with_multi_import_diff_ctx(
                                    "Error: Failed read output, error  \n");
 
             calc_max_iter = maxIter * 2 * (numBuffers + 1);
-            for (int i = 0; i < numBuffers; i++)
+            for (uint32_t i = 0; i < numBuffers; i++)
             {
                 err = clSetKernelArg(verify_kernel, 0, sizeof(cl_mem),
                                      (void *)&(buffers1[i][0]));
@@ -1477,7 +1477,7 @@ int run_test_with_multi_import_diff_ctx(
                 }
             }
             *error_3 = 0;
-            for (int i = 0; i < vkBufferList.size(); i++)
+            for (size_t i = 0; i < vkBufferList.size(); i++)
             {
                 err = clSetKernelArg(verify_kernel2, 0, sizeof(cl_mem),
                                      (void *)&(buffers2[i][0]));
@@ -1513,7 +1513,7 @@ int run_test_with_multi_import_diff_ctx(
             }
             for (size_t i = 0; i < vkBufferList.size(); i++)
             {
-                for (size_t j = 0; j < numImports; j++)
+                for (int j = 0; j < numImports; j++)
                 {
                     delete externalMemory1[i][j];
                     delete externalMemory2[i][j];

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -463,7 +463,7 @@ int run_test_with_two_queue(
 
                             cl_mem external_mem_image1[5];
                             cl_mem external_mem_image2[5];
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 external_mem_image1[i] =
                                     externalMemory1[i]
@@ -631,7 +631,8 @@ int run_test_with_two_queue(
                                 err |= clSetKernelArg(updateKernelCQ2, 7,
                                                       sizeof(unsigned int),
                                                       &numMipLevels);
-                                for (int i = 0; i < num2DImages - 1; i++, ++j)
+                                for (uint32_t i = 0; i < num2DImages - 1;
+                                     i++, ++j)
                                 {
                                     err = clSetKernelArg(
                                         updateKernelCQ1, j, sizeof(cl_mem),
@@ -732,7 +733,7 @@ int run_test_with_two_queue(
                             }
 
                             clFinish(cmd_queue2);
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 err = clEnqueueReadImage(
                                     cmd_queue1, external_mem_image2[i], CL_TRUE,
@@ -772,7 +773,7 @@ int run_test_with_two_queue(
                                     break;
                                 }
                             }
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 delete vkImage2DListDeviceMemory1[i];
                                 delete vkImage2DListDeviceMemory2[i];
@@ -1083,7 +1084,7 @@ int run_test_with_one_queue(
 
                             cl_mem external_mem_image1[4];
                             cl_mem external_mem_image2[4];
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 external_mem_image1[i] =
                                     externalMemory1[i]
@@ -1218,7 +1219,7 @@ int run_test_with_one_queue(
                                         break;
                                 }
                                 int j = 0;
-                                for (int i = 0; i < num2DImages; i++, ++j)
+                                for (uint32_t i = 0; i < num2DImages; i++, ++j)
                                 {
                                     err = clSetKernelArg(
                                         updateKernelCQ1, j, sizeof(cl_mem),
@@ -1284,7 +1285,7 @@ int run_test_with_one_queue(
                                     "Failed to signal CL semaphore\n");
                             }
 
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 err = clEnqueueReadImage(
                                     cmd_queue1, external_mem_image2[i], CL_TRUE,
@@ -1324,7 +1325,7 @@ int run_test_with_one_queue(
                                     break;
                                 }
                             }
-                            for (int i = 0; i < num2DImages; i++)
+                            for (uint32_t i = 0; i < num2DImages; i++)
                             {
                                 delete vkImage2DListDeviceMemory1[i];
                                 delete vkImage2DListDeviceMemory2[i];
@@ -1423,7 +1424,7 @@ struct ImageCommonTest : public VulkanTestBase
 
         log_info("clCreateCommandQueue2 successful \n");
 
-        for (int i = 0; i < num_kernels; i++)
+        for (uint32_t i = 0; i < num_kernels; i++)
         {
             switch (i)
             {
@@ -1474,7 +1475,7 @@ struct ImageCommonTest : public VulkanTestBase
             }
             const char *sourceTexts[num_kernel_types] = { source_1, source_2,
                                                           source_3 };
-            for (int k = 0; k < num_kernel_types; k++)
+            for (uint32_t k = 0; k < num_kernel_types; k++)
             {
                 program_source_length = strlen(sourceTexts[k]);
                 program[k] = clCreateProgramWithSource(


### PR DESCRIPTION
Unused variables and mismatched sign comparisons.