### PR TITLE
add cl_khr_spirv_queries to list of known extensions

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -96,7 +96,8 @@ const char *known_extensions[] = {
     "cl_khr_command_buffer_mutable_dispatch",
     "cl_khr_command_buffer_multi_device",
     "cl_khr_external_memory_android_hardware_buffer",
-    "cl_khr_unified_svm"
+    "cl_khr_unified_svm",
+    "cl_khr_spirv_queries"
 };
 // clang-format on
 


### PR DESCRIPTION
While #2409 is under review, could we please add "cl_khr_spirv_queries" to the list of known extensions?  This will prevent test "failures" for implementations that support the extension.