### PR TITLE
Enable -Wnarrowing in non_uniform_work_group test suite.

### DIFF
--- a/test_conformance/non_uniform_work_group/CMakeLists.txt
+++ b/test_conformance/non_uniform_work_group/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(MODULE_NAME NON_UNIFORM_WORK_GROUP)
 
-if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-    add_cxx_flag_if_supported(-Wno-narrowing)
-endif()
-
 set(${MODULE_NAME}_SOURCES
     main.cpp
     test_advanced_2d.cpp
@@ -15,5 +11,3 @@ set(${MODULE_NAME}_SOURCES
 )
 
 include(../CMakeCommon.txt)
-
-# end of file #

--- a/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
@@ -39,11 +39,13 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_prime_number_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber, maxWgSize};
     size_t localSize[] = {maxWgSize/2, 2};
 
@@ -52,25 +54,31 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_two_prime_numbers_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1759;
-    size_t globalSize[] = {primeNumber2, primeNumber};
-    size_t localSize[] = {16, maxWgSize/16};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1759;
+      size_t globalSize[] = { primeNumber2, primeNumber };
+      size_t localSize[] = { 16, maxWgSize / 16 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_2d_prime_number_basic_2
   {
-    size_t primeNumber = 1327;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t localSize[] = {maxWgSize/32, 32};
+      size_t primeNumber = 1327;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t localSize[] = { maxWgSize / 32, 32 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_2d_combination_of_max_wg_size_basic
@@ -83,56 +91,69 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1669;
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1669;
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_2d_prime_number_and_ls_null_basic
   {
-    size_t primeNumber = 1249;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 1249;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_2d_four_prime_numbers_basic
   {
-    size_t primeNumber = 1951;
-    size_t primeNumber2 = 911;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
+      size_t primeNumber = 1951;
+      size_t primeNumber2 = 911;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
 
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t localSize[] =  {fit2dResult.Val1, fit2dResult.Val2};
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_2d_three_prime_numbers_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   return exec.status();
@@ -160,11 +181,13 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_prime_number_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber, maxWgSize};
     size_t localSize[] = {maxWgSize/2, 2};
 
@@ -173,25 +196,31 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_two_prime_numbers_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1759;
-    size_t globalSize[] = {primeNumber2, primeNumber};
-    size_t localSize[] = {16, maxWgSize/16};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1759;
+      size_t globalSize[] = { primeNumber2, primeNumber };
+      size_t localSize[] = { 16, maxWgSize / 16 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_2d_prime_number_atomics_2
   {
-    size_t primeNumber = 1327;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t localSize[] = {maxWgSize/32, 32};
+      size_t primeNumber = 1327;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t localSize[] = { maxWgSize / 32, 32 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_2d_combination_of_max_wg_size_atomics
@@ -204,56 +233,69 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1669;
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1669;
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_2d_prime_number_and_ls_null_atomics
   {
-    size_t primeNumber = 1249;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 1249;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_2d_four_prime_numbers_atomics
   {
-    size_t primeNumber = 1951;
-    size_t primeNumber2 = 911;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
+      size_t primeNumber = 1951;
+      size_t primeNumber2 = 911;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
 
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t localSize[] = {fit2dResult.Val1, fit2dResult.Val2};
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_2d_three_prime_numbers_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   return exec.status();
@@ -281,11 +323,13 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_prime_number_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber, maxWgSize};
     size_t localSize[] = {maxWgSize/2, 2};
 
@@ -294,25 +338,31 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_two_prime_numbers_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1759;
-    size_t globalSize[] = {primeNumber2, primeNumber};
-    size_t localSize[] = {16, maxWgSize/16};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1759;
+      size_t globalSize[] = { primeNumber2, primeNumber };
+      size_t localSize[] = { 16, maxWgSize / 16 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_2d_prime_number_barriers_2
   {
-    size_t primeNumber = 1327;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t localSize[] = {maxWgSize/32, 32};
+      size_t primeNumber = 1327;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t localSize[] = { maxWgSize / 32, 32 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_2d_combination_of_max_wg_size_barriers
@@ -325,54 +375,67 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 1669;
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 1669;
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_2d_prime_number_and_ls_null_barriers
   {
-    size_t primeNumber = 1249;
-    size_t globalSize[] = {primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 1249;
+      size_t globalSize[] = { primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_2d_four_prime_numbers_barriers
   {
-    size_t primeNumber = 1951;
-    size_t primeNumber2 = 911;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
-    size_t globalSize[] = {primeNumber, primeNumber2};
-    size_t localSize[] = {fit2dResult.Val1, fit2dResult.Val2};
+      size_t primeNumber = 1951;
+      size_t primeNumber2 = 911;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      size_t globalSize[] = { primeNumber, primeNumber2 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_2d_three_prime_numbers_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   return exec.status();

--- a/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
@@ -39,7 +39,7 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_prime_number_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -52,12 +52,12 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_two_prime_numbers_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 1759;
+    size_t primeNumber2 = 1759;
     size_t globalSize[] = {primeNumber2, primeNumber};
     size_t localSize[] = {16, maxWgSize/16};
 
@@ -66,7 +66,7 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_prime_number_basic_2
   {
-    int primeNumber = 1327;
+    size_t primeNumber = 1327;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t localSize[] = {maxWgSize/32, 32};
 
@@ -83,12 +83,12 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 1669;
+    size_t primeNumber2 = 1669;
     size_t globalSize[] = {primeNumber, primeNumber2};
     size_t *localSize = NULL;
 
@@ -97,7 +97,7 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_prime_number_and_ls_null_basic
   {
-    unsigned int primeNumber = 1249;
+    size_t primeNumber = 1249;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -106,10 +106,10 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_four_prime_numbers_basic
   {
-    unsigned int primeNumber = 1951;
-    unsigned int primeNumber2 = 911;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 1951;
+    size_t primeNumber2 = 911;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
 
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
@@ -122,13 +122,13 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_three_prime_numbers_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
 
@@ -160,7 +160,7 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_prime_number_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -173,12 +173,12 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_two_prime_numbers_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 1759;
+    size_t primeNumber2 = 1759;
     size_t globalSize[] = {primeNumber2, primeNumber};
     size_t localSize[] = {16, maxWgSize/16};
 
@@ -187,7 +187,7 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_prime_number_atomics_2
   {
-    int primeNumber = 1327;
+    size_t primeNumber = 1327;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t localSize[] = {maxWgSize/32, 32};
 
@@ -204,12 +204,12 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 1669;
+    size_t primeNumber2 = 1669;
     size_t globalSize[] = {primeNumber, primeNumber2};
     size_t *localSize = NULL;
 
@@ -218,7 +218,7 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_prime_number_and_ls_null_atomics
   {
-    unsigned int primeNumber = 1249;
+    size_t primeNumber = 1249;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -227,10 +227,10 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_four_prime_numbers_atomics
   {
-    unsigned int primeNumber = 1951;
-    unsigned int primeNumber2 = 911;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 1951;
+    size_t primeNumber2 = 911;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
 
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
@@ -243,13 +243,13 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_three_prime_numbers_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
 
@@ -281,7 +281,7 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_prime_number_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -294,12 +294,12 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_two_prime_numbers_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 1759;
+    size_t primeNumber2 = 1759;
     size_t globalSize[] = {primeNumber2, primeNumber};
     size_t localSize[] = {16, maxWgSize/16};
 
@@ -308,7 +308,7 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_prime_number_barriers_2
   {
-    int primeNumber = 1327;
+    size_t primeNumber = 1327;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t localSize[] = {maxWgSize/32, 32};
 
@@ -325,12 +325,12 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_two_prime_numbers_and_ls_null_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 1669;
+    size_t primeNumber2 = 1669;
     size_t globalSize[] = {primeNumber, primeNumber2};
     size_t *localSize = NULL;
 
@@ -339,7 +339,7 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_prime_number_and_ls_null_barriers
   {
-    unsigned int primeNumber = 1249;
+    size_t primeNumber = 1249;
     size_t globalSize[] = {primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -348,10 +348,10 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_four_prime_numbers_barriers
   {
-    unsigned int primeNumber = 1951;
-    unsigned int primeNumber2 = 911;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 1951;
+    size_t primeNumber2 = 911;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
     size_t globalSize[] = {primeNumber, primeNumber2};
@@ -362,13 +362,13 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_three_prime_numbers_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
 

--- a/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
@@ -39,7 +39,7 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_prime_number_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -52,12 +52,12 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_two_prime_numbers_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 13;
+    size_t primeNumber2 = 13;
     size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
     size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
 
@@ -66,7 +66,7 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_prime_number_basic_2
   {
-    int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
 
@@ -75,12 +75,12 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 23;
+    size_t primeNumber2 = 23;
     size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
     size_t *localSize = NULL;
 
@@ -89,7 +89,7 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_prime_number_and_ls_null_basic
   {
-    unsigned int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -98,13 +98,13 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_three_prime_numbers_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 10711;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 10711;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
     size_t localSize[] = {primeNumber, 1, 1};
 
@@ -113,10 +113,10 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_four_prime_numbers_basic
   {
-    unsigned int primeNumber = 541;
-    unsigned int primeNumber2 = 251;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 541;
+    size_t primeNumber2 = 251;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
@@ -128,12 +128,12 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_six_prime_numbers_basic
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4,primeNumber5,primeNumber6,maxWgSize );
 
@@ -168,7 +168,7 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_prime_number_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -181,12 +181,12 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_two_prime_numbers_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 13;
+    size_t primeNumber2 = 13;
     size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
     size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
 
@@ -195,7 +195,7 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_prime_number_atomics_2
   {
-    int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
 
@@ -204,12 +204,12 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 23;
+    size_t primeNumber2 = 23;
     size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
     size_t *localSize = NULL;
 
@@ -218,7 +218,7 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_prime_number_and_ls_null_atomics
   {
-    unsigned int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -227,13 +227,13 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_three_prime_numbers_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 10711;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 10711;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
     size_t localSize[] = {primeNumber, 1, 1};
 
@@ -242,10 +242,10 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_four_prime_numbers_atomics
   {
-    unsigned int primeNumber = 541;
-    unsigned int primeNumber2 = 251;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 541;
+    size_t primeNumber2 = 251;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
@@ -257,12 +257,12 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_six_prime_numbers_atomics
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize);
 
@@ -297,7 +297,7 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_prime_number_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -310,12 +310,12 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_two_prime_numbers_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    int primeNumber2 = 13;
+    size_t primeNumber2 = 13;
     size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
     size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
 
@@ -324,7 +324,7 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_prime_number_barriers_2
   {
-    int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
 
@@ -333,12 +333,12 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 23;
+    size_t primeNumber2 = 23;
     size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
     size_t *localSize = NULL;
 
@@ -347,7 +347,7 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_prime_number_and_ls_null_barriers
   {
-    unsigned int primeNumber = 113;
+    size_t primeNumber = 113;
     size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
     size_t *localSize = NULL;
 
@@ -356,13 +356,13 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_three_prime_numbers_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 10711;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 10711;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
     size_t localSize[] = {primeNumber, 1, 1};
 
@@ -371,10 +371,10 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_four_prime_numbers_barriers
   {
-    unsigned int primeNumber = 541;
-    unsigned int primeNumber2 = 251;
-    unsigned int primeNumber3 = 13;
-    unsigned int primeNumber4 = 17;
+    size_t primeNumber = 541;
+    size_t primeNumber2 = 251;
+    size_t primeNumber3 = 13;
+    size_t primeNumber4 = 17;
     PrimeNumbers::Result2d fit2dResult;
     fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
@@ -387,12 +387,12 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_six_prime_numbers_barriers
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4,primeNumber5,primeNumber6,maxWgSize );
 

--- a/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
@@ -39,11 +39,13 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_prime_number_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {maxWgSize/25, primeNumber, maxWgSize/25};
     size_t localSize[] = {2, std::max<size_t>(maxWgSize/4,1), 2};
 
@@ -52,95 +54,118 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_two_prime_numbers_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 13;
-    size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
-    size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 13;
+      size_t globalSize[] = { primeNumber2, maxWgSize / 8, primeNumber };
+      size_t localSize[] = { 8, 4, std::max<size_t>(maxWgSize / 32, 1) };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_prime_number_basic_2
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t localSize[] = { 8, std::max<size_t>(maxWgSize / 32, 1), 4 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 23;
-    size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 23;
+      size_t globalSize[] = { primeNumber, primeNumber2, maxWgSize / 16 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_prime_number_and_ls_null_basic
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_three_prime_numbers_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 10711;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
-    size_t localSize[] = {primeNumber, 1, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 10711;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_four_prime_numbers_basic
   {
-    size_t primeNumber = 541;
-    size_t primeNumber2 = 251;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      size_t primeNumber = 541;
+      size_t primeNumber2 = 251;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit2dResult.Val1, fit2dResult.Val2, 1};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_3d_six_prime_numbers_basic
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4,primeNumber5,primeNumber6,maxWgSize );
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   return exec.status();
@@ -168,11 +193,13 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_prime_number_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {maxWgSize/25, primeNumber, maxWgSize/25};
     size_t localSize[] = {2, std::max<size_t>(maxWgSize/4,1), 2};
 
@@ -181,95 +208,118 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_two_prime_numbers_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 13;
-    size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
-    size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 13;
+      size_t globalSize[] = { primeNumber2, maxWgSize / 8, primeNumber };
+      size_t localSize[] = { 8, 4, std::max<size_t>(maxWgSize / 32, 1) };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_prime_number_atomics_2
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t localSize[] = { 8, std::max<size_t>(maxWgSize / 32, 1), 4 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 23;
-    size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 23;
+      size_t globalSize[] = { primeNumber, primeNumber2, maxWgSize / 16 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_prime_number_and_ls_null_atomics
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_three_prime_numbers_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 10711;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
-    size_t localSize[] = {primeNumber, 1, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 10711;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_four_prime_numbers_atomics
   {
-    size_t primeNumber = 541;
-    size_t primeNumber2 = 251;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      size_t primeNumber = 541;
+      size_t primeNumber2 = 251;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit2dResult.Val1, fit2dResult.Val2, 1};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_3d_six_prime_numbers_atomics
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize);
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   return exec.status();
@@ -297,11 +347,13 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_prime_number_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {maxWgSize/25, primeNumber, maxWgSize/25};
     size_t localSize[] = {2, std::max<size_t>(maxWgSize/4,1), 2};
 
@@ -310,96 +362,119 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_two_prime_numbers_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 13;
-    size_t globalSize[] = {primeNumber2, maxWgSize/8, primeNumber};
-    size_t localSize[] = {8, 4, std::max<size_t>(maxWgSize/32,1)};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 13;
+      size_t globalSize[] = { primeNumber2, maxWgSize / 8, primeNumber };
+      size_t localSize[] = { 8, 4, std::max<size_t>(maxWgSize / 32, 1) };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_3d_prime_number_barriers_2
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t localSize[] = {8, std::max<size_t>(maxWgSize/32,1), 4};
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t localSize[] = { 8, std::max<size_t>(maxWgSize / 32, 1), 4 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_3d_two_prime_numbers_and_ls_null_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 23;
-    size_t globalSize[] = {primeNumber, primeNumber2, maxWgSize/16};
-    size_t *localSize = NULL;
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 23;
+      size_t globalSize[] = { primeNumber, primeNumber2, maxWgSize / 16 };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_3d_prime_number_and_ls_null_barriers
   {
-    size_t primeNumber = 113;
-    size_t globalSize[] = {primeNumber, primeNumber, primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 113;
+      size_t globalSize[] = { primeNumber, primeNumber, primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_3d_three_prime_numbers_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 10711;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3, primeNumber3};
-    size_t localSize[] = {primeNumber, 1, 1};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 10711;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_3d_four_prime_numbers_barriers
   {
-    size_t primeNumber = 541;
-    size_t primeNumber2 = 251;
-    size_t primeNumber3 = 13;
-    size_t primeNumber4 = 17;
-    PrimeNumbers::Result2d fit2dResult;
-    fit2dResult = PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
+      size_t primeNumber = 541;
+      size_t primeNumber2 = 251;
+      size_t primeNumber3 = 13;
+      size_t primeNumber4 = 17;
+      PrimeNumbers::Result2d fit2dResult;
+      fit2dResult =
+          PrimeNumbers::fitMaxPrime2d(primeNumber3, primeNumber4, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit2dResult.Val1, fit2dResult.Val2, 1};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit2dResult.Val1, fit2dResult.Val2, 1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
 
   // non_uniform_3d_six_prime_numbers_barriers
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4,primeNumber5,primeNumber6,maxWgSize );
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   return exec.status();

--- a/test_conformance/non_uniform_work_group/test_advanced_other.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_other.cpp
@@ -31,73 +31,88 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_1d_two_prime_numbers_offset_basic
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
-    PrimeNumbers::Result1d fit1dResult;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {fit1dResult.Val1};
-    size_t offset[] = {23};
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { fit1dResult.Val1 };
+      size_t offset[] = { 23 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BASIC);
   }
 
   // non_uniform_2d_three_prime_numbers_offset_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
-    size_t offset[] = {23, 17};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
+      size_t offset[] = { 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BASIC);
   }
 
   // non_uniform_3d_six_prime_numbers_offset_basic
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
 
-    PrimeNumbers::Result3d fit3dResult;
+      PrimeNumbers::Result3d fit3dResult;
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t offset[] = {11, 23, 17};
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t offset[] = { 11, 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BASIC);
   }
 
   // non_uniform_3d_six_prime_numbers_rwgs_basic
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t reqdWorkGroupSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t reqdWorkGroupSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                                     fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, NULL, reqdWorkGroupSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          NULL, reqdWorkGroupSize, Range::BASIC);
   }
 
   return exec.status();
@@ -117,71 +132,86 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_1d_two_prime_numbers_offset_atomics
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
-    PrimeNumbers::Result1d fit1dResult;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {fit1dResult.Val1};
-    size_t offset[] = {23};
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { fit1dResult.Val1 };
+      size_t offset[] = { 23 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::ATOMICS);
   }
 
   // non_uniform_2d_three_prime_numbers_offset_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
-    size_t offset[] = {23, 17};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
+      size_t offset[] = { 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::ATOMICS);
   }
 
   // non_uniform_3d_six_prime_numbers_offset_atomics
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t offset[] = {11, 23, 17};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t offset[] = { 11, 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::ATOMICS);
   }
 
   // non_uniform_3d_six_prime_numbers_rwgs_atomics
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t reqdWorkGroupSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t reqdWorkGroupSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                                     fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, NULL, reqdWorkGroupSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          NULL, reqdWorkGroupSize, Range::ATOMICS);
   }
 
   return exec.status();
@@ -201,74 +231,89 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_1d_two_prime_numbers_offset_barriers
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
-    PrimeNumbers::Result1d fit1dResult;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
+      size_t globalSize[] = { primeNumber };
 
-    size_t localSize[] = {fit1dResult.Val1};
-    size_t offset[] = {23};
+      size_t localSize[] = { fit1dResult.Val1 };
+      size_t offset[] = { 23 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BARRIERS);
   }
 
   // non_uniform_2d_three_prime_numbers_offset_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
-    size_t primeNumber2 = 42967;
-    size_t primeNumber3 = 13;
-    size_t globalSize[] = {primeNumber2, primeNumber3};
-    size_t localSize[] = {primeNumber, 1};
-    size_t offset[] = {23, 17};
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
+      size_t primeNumber2 = 42967;
+      size_t primeNumber3 = 13;
+      size_t globalSize[] = { primeNumber2, primeNumber3 };
+      size_t localSize[] = { primeNumber, 1 };
+      size_t offset[] = { 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BARRIERS);
   }
 
   // non_uniform_3d_six_prime_numbers_offset_barriers
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
 
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t offset[] = {11, 23, 17};
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t offset[] = { 11, 23, 17 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, offset, NULL, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          offset, NULL, Range::BARRIERS);
   }
 
   // non_uniform_3d_six_prime_numbers_rwgs_barriers
   {
-    size_t primeNumber = 373;
-    size_t primeNumber2 = 13;
-    size_t primeNumber3 = 279;
-    size_t primeNumber4 = 3;
-    size_t primeNumber5 = 5;
-    size_t primeNumber6 = 7;
-    PrimeNumbers::Result3d fit3dResult;
+      size_t primeNumber = 373;
+      size_t primeNumber2 = 13;
+      size_t primeNumber3 = 279;
+      size_t primeNumber4 = 3;
+      size_t primeNumber5 = 5;
+      size_t primeNumber6 = 7;
+      PrimeNumbers::Result3d fit3dResult;
 
-    fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
+      fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5,
+                                                primeNumber6, maxWgSize);
 
-    size_t globalSize[] = {primeNumber, primeNumber2, primeNumber3};
+      size_t globalSize[] = { primeNumber, primeNumber2, primeNumber3 };
 
-    size_t localSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
-    size_t reqdWorkGroupSize[] = {fit3dResult.Val1, fit3dResult.Val2, fit3dResult.Val3};
+      size_t localSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                             fit3dResult.Val3 };
+      size_t reqdWorkGroupSize[] = { fit3dResult.Val1, fit3dResult.Val2,
+                                     fit3dResult.Val3 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, NULL, reqdWorkGroupSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(
+          sizeof(globalSize) / sizeof(globalSize[0]), globalSize, localSize,
+          NULL, reqdWorkGroupSize, Range::BARRIERS);
   }
 
   return exec.status();

--- a/test_conformance/non_uniform_work_group/test_advanced_other.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_other.cpp
@@ -31,8 +31,8 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_1d_two_prime_numbers_offset_basic
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
     PrimeNumbers::Result1d fit1dResult;
 
     fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
@@ -46,13 +46,13 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_2d_three_prime_numbers_offset_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
     size_t offset[] = {23, 17};
@@ -62,12 +62,12 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_3d_six_prime_numbers_offset_basic
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
 
     PrimeNumbers::Result3d fit3dResult;
 
@@ -83,12 +83,12 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_3d_six_prime_numbers_rwgs_basic
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
 
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
@@ -117,8 +117,8 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_1d_two_prime_numbers_offset_atomics
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
     PrimeNumbers::Result1d fit1dResult;
 
     fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
@@ -132,13 +132,13 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_2d_three_prime_numbers_offset_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
     size_t offset[] = {23, 17};
@@ -148,12 +148,12 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_3d_six_prime_numbers_offset_atomics
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
 
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
@@ -167,12 +167,12 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_3d_six_prime_numbers_rwgs_atomics
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
 
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
@@ -201,8 +201,8 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_1d_two_prime_numbers_offset_barriers
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
     PrimeNumbers::Result1d fit1dResult;
 
     fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
@@ -217,13 +217,13 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_2d_three_prime_numbers_offset_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize/2, maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
     }
-    unsigned int primeNumber2 = 42967;
-    unsigned int primeNumber3 = 13;
+    size_t primeNumber2 = 42967;
+    size_t primeNumber3 = 13;
     size_t globalSize[] = {primeNumber2, primeNumber3};
     size_t localSize[] = {primeNumber, 1};
     size_t offset[] = {23, 17};
@@ -233,12 +233,12 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_3d_six_prime_numbers_offset_barriers
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
 
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );
@@ -253,12 +253,12 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_3d_six_prime_numbers_rwgs_barriers
   {
-    unsigned int primeNumber = 373;
-    unsigned int primeNumber2 = 13;
-    unsigned int primeNumber3 = 279;
-    unsigned int primeNumber4 = 3;
-    unsigned int primeNumber5 = 5;
-    unsigned int primeNumber6 = 7;
+    size_t primeNumber = 373;
+    size_t primeNumber2 = 13;
+    size_t primeNumber3 = 279;
+    size_t primeNumber4 = 3;
+    size_t primeNumber5 = 5;
+    size_t primeNumber6 = 7;
     PrimeNumbers::Result3d fit3dResult;
 
     fit3dResult = PrimeNumbers::fitMaxPrime3d(primeNumber4, primeNumber5, primeNumber6, maxWgSize );

--- a/test_conformance/non_uniform_work_group/test_basic.cpp
+++ b/test_conformance/non_uniform_work_group/test_basic.cpp
@@ -39,7 +39,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -52,7 +52,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_basic
   {
-    int primeNumber = 11;
+    size_t primeNumber = 11;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -61,7 +61,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_basic_2
   {
-    int primeNumber = 53;
+    size_t primeNumber = 53;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -78,7 +78,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic_2
   {
-    unsigned int primeNumber = 20101;
+    size_t primeNumber = 20101;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -87,7 +87,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic_3
   {
-    unsigned int primeNumber = 42967;
+    size_t primeNumber = 42967;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -96,7 +96,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic_4
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -105,7 +105,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_and_ls_null_basic_2
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -118,7 +118,7 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_and_ls_null_basic_3
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -127,8 +127,8 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_two_prime_numbers_basic
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
     PrimeNumbers::Result1d fit1dResult;
 
     fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
@@ -164,7 +164,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -177,7 +177,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_atomics
   {
-    int primeNumber = 11;
+    size_t primeNumber = 11;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -186,7 +186,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_atomics_2
   {
-    int primeNumber = 53;
+    size_t primeNumber = 53;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -203,7 +203,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics_2
   {
-    unsigned int primeNumber = 20101;
+    size_t primeNumber = 20101;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -212,7 +212,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics_3
   {
-    unsigned int primeNumber = 42967;
+    size_t primeNumber = 42967;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -221,7 +221,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics_4
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -230,7 +230,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_and_ls_null_atomics_2
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -243,7 +243,7 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_and_ls_null_atomics_3
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -252,8 +252,8 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_two_prime_numbers_atomics
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
     PrimeNumbers::Result1d fit1dResult;
 
     fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
@@ -289,7 +289,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -302,7 +302,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_barriers
   {
-    int primeNumber = 11;
+    size_t primeNumber = 11;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -311,7 +311,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_barriers_2
   {
-    int primeNumber = 53;
+    size_t primeNumber = 53;
     size_t globalSize[] = {maxWgSize+primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -328,7 +328,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers_2
   {
-    unsigned int primeNumber = 20101;
+    size_t primeNumber = 20101;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -337,7 +337,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers_3
   {
-    unsigned int primeNumber = 42967;
+    size_t primeNumber = 42967;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -346,7 +346,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers_4
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -355,7 +355,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_and_ls_null_barriers_2
   {
-    int primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
+    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
     if (primeNumber < 1) {
       log_error ("Cannot find proper prime number.");
       return -1;
@@ -368,7 +368,7 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_and_ls_null_barriers_3
   {
-    unsigned int primeNumber = 65521;
+    size_t primeNumber = 65521;
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -377,8 +377,8 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_two_prime_numbers_barriers
   {
-    unsigned int primeNumber = 42967;
-    unsigned int primeNumber2 = 113;
+    size_t primeNumber = 42967;
+    size_t primeNumber2 = 113;
 
     PrimeNumbers::Result1d fit1dResult;
 

--- a/test_conformance/non_uniform_work_group/test_basic.cpp
+++ b/test_conformance/non_uniform_work_group/test_basic.cpp
@@ -39,11 +39,13 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -52,20 +54,24 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_basic
   {
-    size_t primeNumber = 11;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 11;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_max_wg_size_plus_prime_number_basic_2
   {
-    size_t primeNumber = 53;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 53;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_2max_wg_size_minus_1_basic
@@ -78,38 +84,46 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_basic_2
   {
-    size_t primeNumber = 20101;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 20101;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_prime_number_basic_3
   {
-    size_t primeNumber = 42967;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 42967;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_prime_number_basic_4
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_prime_number_and_ls_null_basic_2
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -118,25 +132,29 @@ REGISTER_TEST(non_uniform_1d_basic)
 
   // non_uniform_1d_prime_number_and_ls_null_basic_3
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   // non_uniform_1d_two_prime_numbers_basic
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
-    PrimeNumbers::Result1d fit1dResult;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {fit1dResult.Val1};
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { fit1dResult.Val1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BASIC);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BASIC);
   }
 
   return exec.status();
@@ -164,11 +182,13 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -177,20 +197,24 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_atomics
   {
-    size_t primeNumber = 11;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 11;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_max_wg_size_plus_prime_number_atomics_2
   {
-    size_t primeNumber = 53;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 53;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_2max_wg_size_minus_1_atomics
@@ -203,38 +227,46 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_atomics_2
   {
-    size_t primeNumber = 20101;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 20101;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_prime_number_atomics_3
   {
-    size_t primeNumber = 42967;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 42967;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_prime_number_atomics_4
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_prime_number_and_ls_null_atomics_2
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -243,25 +275,29 @@ REGISTER_TEST(non_uniform_1d_atomics)
 
   // non_uniform_1d_prime_number_and_ls_null_atomics_3
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   // non_uniform_1d_two_prime_numbers_atomics
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
-    PrimeNumbers::Result1d fit1dResult;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {fit1dResult.Val1};
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { fit1dResult.Val1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::ATOMICS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::ATOMICS);
   }
 
   return exec.status();
@@ -289,11 +325,13 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t localSize[] = {maxWgSize};
 
@@ -302,20 +340,24 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_max_wg_size_plus_prime_number_barriers
   {
-    size_t primeNumber = 11;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 11;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_max_wg_size_plus_prime_number_barriers_2
   {
-    size_t primeNumber = 53;
-    size_t globalSize[] = {maxWgSize+primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 53;
+      size_t globalSize[] = { maxWgSize + primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_2max_wg_size_minus_1_barriers
@@ -328,38 +370,46 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_barriers_2
   {
-    size_t primeNumber = 20101;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 20101;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_prime_number_barriers_3
   {
-    size_t primeNumber = 42967;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 42967;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_prime_number_barriers_4
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {maxWgSize};
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { maxWgSize };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_prime_number_and_ls_null_barriers_2
   {
-    size_t primeNumber = PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2*maxWgSize);
-    if (primeNumber < 1) {
-      log_error ("Cannot find proper prime number.");
-      return -1;
-    }
+      size_t primeNumber =
+          PrimeNumbers::getPrimeNumberInRange(maxWgSize, 2 * maxWgSize);
+      if (primeNumber < 1)
+      {
+          log_error("Cannot find proper prime number.");
+          return -1;
+      }
     size_t globalSize[] = {primeNumber};
     size_t *localSize = NULL;
 
@@ -368,26 +418,30 @@ REGISTER_TEST(non_uniform_1d_barriers)
 
   // non_uniform_1d_prime_number_and_ls_null_barriers_3
   {
-    size_t primeNumber = 65521;
-    size_t globalSize[] = {primeNumber};
-    size_t *localSize = NULL;
+      size_t primeNumber = 65521;
+      size_t globalSize[] = { primeNumber };
+      size_t *localSize = NULL;
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   // non_uniform_1d_two_prime_numbers_barriers
   {
-    size_t primeNumber = 42967;
-    size_t primeNumber2 = 113;
+      size_t primeNumber = 42967;
+      size_t primeNumber2 = 113;
 
-    PrimeNumbers::Result1d fit1dResult;
+      PrimeNumbers::Result1d fit1dResult;
 
-    fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize );
+      fit1dResult = PrimeNumbers::fitMaxPrime1d(primeNumber2, maxWgSize);
 
-    size_t globalSize[] = {primeNumber};
-    size_t localSize[] = {fit1dResult.Val1};
+      size_t globalSize[] = { primeNumber };
+      size_t localSize[] = { fit1dResult.Val1 };
 
-    exec.runTestNonUniformWorkGroup(sizeof(globalSize)/sizeof(globalSize[0]), globalSize, localSize, Range::BARRIERS);
+      exec.runTestNonUniformWorkGroup(sizeof(globalSize)
+                                          / sizeof(globalSize[0]),
+                                      globalSize, localSize, Range::BARRIERS);
   }
 
   return exec.status();

--- a/test_conformance/non_uniform_work_group/tools.cpp
+++ b/test_conformance/non_uniform_work_group/tools.cpp
@@ -46,28 +46,31 @@ void PrimeNumbers::generatePrimeNumbers (unsigned int maxValue) {
 }
 
 // Returns prime number for specified range
-size_t PrimeNumbers::getPrimeNumberInRange (size_t lowerValue, size_t higherValue) {
-  if(lowerValue >= higherValue)
-    return 0;
+size_t PrimeNumbers::getPrimeNumberInRange(size_t lowerValue,
+                                           size_t higherValue)
+{
+    if (lowerValue >= higherValue) return 0;
 
-  if(primeNumbers.back() < lowerValue)
-    return 0;
+    if (primeNumbers.back() < lowerValue) return 0;
 
-  PrimeNumbersCollection::iterator it = primeNumbers.begin();
+    PrimeNumbersCollection::iterator it = primeNumbers.begin();
 
-  for (; it != primeNumbers.end(); ++it) {
-    if (lowerValue<*it) {
-      if(higherValue>*it)
-        return *it;
-      else
-        return 0;
+    for (; it != primeNumbers.end(); ++it)
+    {
+        if (lowerValue < *it)
+        {
+            if (higherValue > *it)
+                return *it;
+            else
+                return 0;
+        }
     }
-  }
-  return 0;
+    return 0;
 }
 
 
-size_t PrimeNumbers::getNextLowerPrimeNumber(size_t upperValue) {
+size_t PrimeNumbers::getNextLowerPrimeNumber(size_t upperValue)
+{
     size_t retVal = 1;
 
     PrimeNumbersCollection::iterator it = primeNumbers.begin();

--- a/test_conformance/non_uniform_work_group/tools.cpp
+++ b/test_conformance/non_uniform_work_group/tools.cpp
@@ -46,12 +46,12 @@ void PrimeNumbers::generatePrimeNumbers (unsigned int maxValue) {
 }
 
 // Returns prime number for specified range
-int PrimeNumbers::getPrimeNumberInRange (size_t lowerValue, size_t higherValue) {
+size_t PrimeNumbers::getPrimeNumberInRange (size_t lowerValue, size_t higherValue) {
   if(lowerValue >= higherValue)
-    return -1;
+    return 0;
 
   if(primeNumbers.back() < lowerValue)
-    return -2;
+    return 0;
 
   PrimeNumbersCollection::iterator it = primeNumbers.begin();
 
@@ -60,14 +60,14 @@ int PrimeNumbers::getPrimeNumberInRange (size_t lowerValue, size_t higherValue) 
       if(higherValue>*it)
         return *it;
       else
-        return -3;
+        return 0;
     }
   }
-  return -1;
+  return 0;
 }
 
 
-int PrimeNumbers::getNextLowerPrimeNumber(size_t upperValue) {
+size_t PrimeNumbers::getNextLowerPrimeNumber(size_t upperValue) {
     size_t retVal = 1;
 
     PrimeNumbersCollection::iterator it = primeNumbers.begin();

--- a/test_conformance/non_uniform_work_group/tools.h
+++ b/test_conformance/non_uniform_work_group/tools.h
@@ -26,7 +26,6 @@
 typedef std::vector<size_t> PrimeNumbersCollection;
 
 
-
 // Class responsible for distributing prime numbers
 class PrimeNumbers {
 
@@ -47,8 +46,8 @@ public:
   };
 
   static void generatePrimeNumbers (unsigned int maxValue);
-  static size_t getPrimeNumberInRange (size_t lowerValue, size_t higherValue);
-  static size_t getNextLowerPrimeNumber (size_t upperValue);
+  static size_t getPrimeNumberInRange(size_t lowerValue, size_t higherValue);
+  static size_t getNextLowerPrimeNumber(size_t upperValue);
   static Result1d fitMaxPrime1d(size_t Val1, size_t productMax);
   // Return val1 and Val2 which are largest prime numbers who's product is <= productMax
   static Result2d fitMaxPrime2d(size_t Val1, size_t Val2, size_t productMax);

--- a/test_conformance/non_uniform_work_group/tools.h
+++ b/test_conformance/non_uniform_work_group/tools.h
@@ -23,7 +23,7 @@
 #include <map>
 #include <string>
 
-typedef std::vector<unsigned int> PrimeNumbersCollection;
+typedef std::vector<size_t> PrimeNumbersCollection;
 
 
 
@@ -47,8 +47,8 @@ public:
   };
 
   static void generatePrimeNumbers (unsigned int maxValue);
-  static int getPrimeNumberInRange (size_t lowerValue, size_t higherValue);
-  static int getNextLowerPrimeNumber (size_t upperValue);
+  static size_t getPrimeNumberInRange (size_t lowerValue, size_t higherValue);
+  static size_t getNextLowerPrimeNumber (size_t upperValue);
   static Result1d fitMaxPrime1d(size_t Val1, size_t productMax);
   // Return val1 and Val2 which are largest prime numbers who's product is <= productMax
   static Result2d fitMaxPrime2d(size_t Val1, size_t Val2, size_t productMax);


### PR DESCRIPTION
Modify the prime numbers generator function to return `size_t` instead of `int` and use `0` as a sentinal value instead of hardcoded negative ones. `0` is not a prime number, so it is suitable to use to indicate an error.

Fixes #1159