### PR TITLE
Fix compilation errors cl_khr_external_memory_ahb

### DIFF
--- a/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.cpp
@@ -173,6 +173,9 @@ std::string ahardwareBufferFormatToString(AHardwareBuffer_Format format)
         case AHARDWAREBUFFER_FORMAT_YCbCr_P010:
             result = "AHARDWAREBUFFER_FORMAT_YCbCr_P010";
             break;
+        case AHARDWAREBUFFER_FORMAT_YCbCr_P210:
+            result = "AHARDWAREBUFFER_FORMAT_YCbCr_P210";
+            break;
         case AHARDWAREBUFFER_FORMAT_R8_UNORM:
             result = "AHARDWAREBUFFER_FORMAT_R8_UNORM";
             break;

--- a/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
@@ -145,7 +145,7 @@ REGISTER_TEST(test_images)
                 }
 
                 const cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -300,7 +300,7 @@ REGISTER_TEST(test_images_read)
                 }
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -602,7 +602,7 @@ REGISTER_TEST(test_enqueue_read_image)
                 }
 
                 const cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -786,7 +786,7 @@ REGISTER_TEST(test_enqueue_copy_image)
                 }
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -1095,7 +1095,7 @@ REGISTER_TEST(test_enqueue_copy_image_to_buffer)
                 }
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -1274,7 +1274,7 @@ REGISTER_TEST(test_enqueue_copy_buffer_to_image)
                 test_error(err, "Failed to create CL buffer");
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -1452,7 +1452,7 @@ REGISTER_TEST(test_enqueue_write_image)
 
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -1649,7 +1649,7 @@ REGISTER_TEST(test_enqueue_fill_image)
                                   "AHB has unexpected height");
 
                 cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
                     reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
                 };
 
@@ -1894,7 +1894,7 @@ REGISTER_TEST(test_blob)
         }
 
         cl_mem_properties props[] = {
-            CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+            CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
             reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
         };
 

--- a/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb_negative.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb_negative.cpp
@@ -77,7 +77,7 @@ REGISTER_TEST(test_buffer_format_negative)
                  .c_str());
 
     cl_mem_properties props[] = {
-        CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+        CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
         reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
     };
 
@@ -155,7 +155,7 @@ REGISTER_TEST(test_buffer_size_negative)
                  .c_str());
 
     cl_mem_properties props[] = {
-        CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+        CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
         reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
     };
 
@@ -215,7 +215,7 @@ REGISTER_TEST(test_images_negative)
     }
 
     const cl_mem_properties props[] = {
-        CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR,
+        CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
         reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
     };
 


### PR DESCRIPTION
Update the test to use
`CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR` instead of `CL_EXTERNAL_MEMORY_HANDLE_AHB_KHR` to match the headers.

Handle missing format in switch statement.