### PR TITLE
Update D3D10 and D3D11 interop tests

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ matrix.arch == 'android-arm' || matrix.arch == 'android-aarch64' }}
         shell: bash
         run: |
-          echo "CMAKE_CONFIG_ARGS_ANDROID=-DCMAKE_ANDROID_ARCH_ABI=${ANDROID_ARCH_ABI} -DANDROID_PLATFORM=${ANDROID_PLATFORM}" >> $GITHUB_ENV
+          echo "CMAKE_ADDITIONAL_CONFIG_ARGS=-DCMAKE_ANDROID_ARCH_ABI=${ANDROID_ARCH_ABI} -DANDROID_PLATFORM=${ANDROID_PLATFORM}" >> $GITHUB_ENV
       - name: Fetch and build OpenCL ICD Loader
         shell: bash
         run: |
@@ -120,7 +120,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
                 -DOPENCL_ICD_LOADER_HEADERS_DIR='${{ github.workspace }}'/OpenCL-Headers/ \
-                ${CMAKE_CONFIG_ARGS_ANDROID}
+                ${CMAKE_ADDITIONAL_CONFIG_ARGS}
           cmake --build . --parallel
       - name: Fetch Vulkan Headers
         shell: bash
@@ -150,6 +150,7 @@ jobs:
           cd build
           if [[ ${RUNNER_OS} == "Windows" ]]; then
               CMAKE_OPENCL_LIBRARIES_OPTION="OpenCL"
+              CMAKE_ADDITIONAL_CONFIG_ARGS="-DD3D10_IS_SUPPORTED=ON -DD3D11_IS_SUPPORTED=ON"
           else
               CMAKE_OPENCL_LIBRARIES_OPTION="-lOpenCL"
               if [[ '${{ matrix.arch }}' != android-* ]]; then
@@ -169,7 +170,7 @@ jobs:
                 -DVULKAN_IS_SUPPORTED=ON \
                 -DVULKAN_INCLUDE_DIR='${{ github.workspace }}'/Vulkan-Headers/include/ \
                 -DVULKAN_LIB_DIR='${{ github.workspace }}'/Vulkan-Loader/build/loader/ \
-                ${CMAKE_CONFIG_ARGS_ANDROID}
+                ${CMAKE_ADDITIONAL_CONFIG_ARGS}
           cmake --build . --parallel
   formatcheck:
     name: Check code format

--- a/test_conformance/d3d10/CMakeLists.txt
+++ b/test_conformance/d3d10/CMakeLists.txt
@@ -1,22 +1,4 @@
 if(WIN32)
-
-set(D3D10_INCLUDE_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Include)
-
-if(${ARCH} STREQUAL "i686")
-set(D3D10_LIB_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Lib/x86)
-endif(${ARCH} STREQUAL "i686")
-
-if(${ARCH} STREQUAL "x86_64")
-set(D3D10_LIB_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Lib/x64)
-endif(${ARCH} STREQUAL "x86_64")
-
-list(APPEND CLConform_INCLUDE_DIR ${D3D10_INCLUDE_DIR})
-include_directories (${CLConform_SOURCE_DIR}/test_common/harness
-                     ${CLConform_INCLUDE_DIR} )
-link_directories(${CL_LIB_DIR}, ${D3D10_LIB_DIR})
-
-list(APPEND CLConform_LIBRARIES d3d10 dxgi)
-
 set(MODULE_NAME D3D10)
 
 set(${MODULE_NAME}_SOURCES
@@ -28,10 +10,9 @@ set(${MODULE_NAME}_SOURCES
     harness.cpp
 )
 
-set_source_files_properties(
-    ${MODULE_NAME}_SOURCES
-    PROPERTIES LANGUAGE CXX)
+list(APPEND CLConform_LIBRARIES d3d10 dxgi)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include(../CMakeCommon.txt)
-endif(WIN32)
+else()
+message(STATUS "D3D10 tests are only supported on Windows.")
+endif()

--- a/test_conformance/d3d11/CMakeLists.txt
+++ b/test_conformance/d3d11/CMakeLists.txt
@@ -1,22 +1,4 @@
 if(WIN32)
-
-set(D3D11_INCLUDE_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Include)
-
-if(${ARCH} STREQUAL "i686")
-set(D3D11_LIB_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Lib/x86)
-endif(${ARCH} STREQUAL "i686")
-
-if(${ARCH} STREQUAL "x86_64")
-set(D3D11_LIB_DIR $ENV{NV_TOOLS}/sdk/DirectX_Aug2009/Lib/x64)
-endif(${ARCH} STREQUAL "x86_64")
-
-list(APPEND CLConform_INCLUDE_DIR ${D3D11_INCLUDE_DIR})
-include_directories (${CLConform_SOURCE_DIR}/test_common/harness
-                     ${CLConform_INCLUDE_DIR} )
-link_directories(${CL_LIB_DIR}, ${D3D11_LIB_DIR})
-
-list(APPEND CLConform_LIBRARIES d3d11 dxgi)
-
 set(MODULE_NAME D3D11)
 
 set(${MODULE_NAME}_SOURCES
@@ -28,10 +10,9 @@ set(${MODULE_NAME}_SOURCES
     harness.cpp
 )
 
-set_source_files_properties(
-    ${MODULE_NAME}_SOURCES
-    PROPERTIES LANGUAGE CXX)
+list(APPEND CLConform_LIBRARIES d3d11 dxgi)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include(../CMakeCommon.txt)
-endif(WIN32)
+else()
+message(STATUS "D3D11 tests are only supported on Windows.")
+endif()


### PR DESCRIPTION
Both tests depend on a very old DirectX SDK (August 2009) and expect it to be extracted to an {NV_TOOLS} environment variable. They additionally require definining {ARCH} as a CMake configuration option, which is not needed.

Update both projects to use DirectX libraries provided by the Windows SDK and drop the unneeded configuration options.