### PR TITLE
Properly handle NaN when comparing images in Vulkan interop testing

### DIFF
--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.cpp
@@ -863,7 +863,7 @@ clExternalMemoryImage::clExternalMemoryImage(
     size_t clImageFormatSize;
     cl_image_desc image_desc;
     memset(&image_desc, 0x0, sizeof(cl_image_desc));
-    cl_image_format img_format = { 0 };
+    img_format = { 0 };
     const VkImageCreateInfo VulkanImageCreateInfo =
         image2D.getVkImageCreateInfo();
 

--- a/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/opencl_vulkan_wrapper.hpp
@@ -106,6 +106,7 @@ protected:
     cl_mem m_externalMemory;
     int fd;
     void *handle;
+    cl_image_format img_format;
     clExternalMemoryImage();
 
 public:
@@ -117,6 +118,7 @@ public:
         cl_device_id deviceId);
     virtual ~clExternalMemoryImage();
     cl_mem getExternalMemoryImage();
+    cl_image_format getImageFormat() { return img_format; };
 };
 
 class clExternalSemaphore {


### PR DESCRIPTION
I was considering reusing other code where NaN gets taken into account, but all the other places are a mess. The kernel read write tests are just doing it within loops. Other places only compare raw values as outside of kernel functions it seems to be fine to expect NaN to not mess up results.

However the vulkan interop testing does run kernels and does operate on NaN float values, so we need to special case this there.