### PR TITLE
Fix ccache in CI

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -158,7 +158,8 @@ jobs:
           fi
           cmake .. -G Ninja \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -DCMAKE_CACHE_OPTIONS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" \
+                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                 -DCL_INCLUDE_DIR='${{ github.workspace }}'/OpenCL-Headers \
                 -DCL_LIB_DIR='${{ github.workspace }}'/OpenCL-ICD-Loader/build \
                 -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \


### PR DESCRIPTION
sccache emits a warning message after every build that it has failed to save a build cache. Additionally the stats are all zeroes, no cache hits (or misses). The "Caches" tab under "Actions" does not have any cached build artifacts which confirms that nothing is being saved.

Fix by passing the correct launcher options directly to CMake instead of wrapping them in `CMAKE_CACHE_OPTIONS`.