### PR TITLE
Fix channel count for RGBx

### DIFF
--- a/test_common/harness/imageHelpers.cpp
+++ b/test_common/harness/imageHelpers.cpp
@@ -137,10 +137,10 @@ uint32_t get_channel_order_channel_count(cl_channel_order order)
         case CL_RGx: return 2;
 
         case CL_RGB:
-        case CL_sRGB:
-        case CL_sRGBx: return 3;
+        case CL_sRGB: return 3;
 
         case CL_RGBx:
+        case CL_sRGBx:
         case CL_RGBA:
         case CL_ARGB:
         case CL_BGRA:


### PR DESCRIPTION
RGBx is defined as a 4 channel format where the 4th channel is ignored (5.3.1.1)