### PR TITLE
mutable_command_info: remove unnecessary Skip function

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_info.cpp
@@ -116,26 +116,6 @@ struct PropertiesArray : public InfoMutableCommandBufferTest
         : InfoMutableCommandBufferTest(device, context, queue)
     {}
 
-    virtual bool Skip() override
-    {
-        Version device_version = get_device_cl_version(device);
-        if ((device_version >= Version(3, 0))
-            || is_extension_available(device, "cl_khr_extended_versioning"))
-        {
-
-            cl_version extension_version = get_extension_version(
-                device, "cl_khr_command_buffer_mutable_dispatch");
-
-            if (extension_version != CL_MAKE_VERSION(0, 9, 3))
-            {
-                log_info("cl_khr_command_buffer_mutable_dispatch version 0.9.3 "
-                         "is required to run the test, skipping.\n ");
-                return true;
-            }
-        }
-        return InfoMutableCommandBufferTest::Skip();
-    }
-
     cl_int Run() override
     {
         cl_command_properties_khr props[] = {


### PR DESCRIPTION
The check implementated by that Skip function is already implemented in 'InfoMutableCommandBufferTest::Skip()'.

Also this is trying to get the extension_version before checking whether the extension is supported, leading to false negative for device not supporting the extension.