### PR TITLE
remove checks for the command-buffer pending state

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_get_command_buffer_info.cpp
@@ -250,9 +250,6 @@ struct CommandBufferGetCommandBufferInfo : public BasicCommandBufferTest
                                           &trigger_event, &execute_event);
         test_error(error, "clEnqueueCommandBufferKHR failed");
 
-        // verify pending state
-        error = verify_state(CL_COMMAND_BUFFER_STATE_PENDING_KHR);
-
         // execute command buffer
         cl_int signal_error = clSetUserEventStatus(trigger_event, CL_COMPLETE);
 

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
@@ -124,8 +124,6 @@ struct EnqueueCommandBufferWithoutSimultaneousUseNotInPendingState
 
         error = EnqueueCommandBuffer();
         test_error(error, "EnqueueCommandBuffer failed");
-        error = verify_state(CL_COMMAND_BUFFER_STATE_PENDING_KHR);
-        test_error(error, "State is not Pending");
 
         return CL_SUCCESS;
     }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_finalize.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_finalize.cpp
@@ -89,8 +89,6 @@ struct FinalizeCommandBufferNotRecordingState : public BasicCommandBufferTest
 
         error = EnqueueCommandBuffer();
         test_error(error, "EnqueueCommandBuffer failed");
-        error = verify_state(CL_COMMAND_BUFFER_STATE_PENDING_KHR);
-        test_error(error, "State is not Pending");
 
         error = clFinalizeCommandBufferKHR(command_buffer);
         test_failure_error_ret(error, CL_INVALID_OPERATION,


### PR DESCRIPTION
This is a very small subset of the changes in #2477 to get things building again, since the command-buffer pending state is no longer in the spec or headers.