### PR TITLE
Modified kernel code to correspond to the Image declared format (CL_UNSIGNED_INT8) 

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
@@ -429,9 +429,6 @@ struct EnqueueCommandBufferEventWaitListNullOrEventsNull
                                "CL_INVALID_EVENT_WAIT_LIST",
                                TEST_FAIL);
 
-        error = clSetUserEventStatus(event, CL_COMPLETE);
-        test_error(error, "Unable to set user event to complete");
-
         return CL_SUCCESS;
     }
 };


### PR DESCRIPTION
**For mutable_dispatch_image_1d_arguments & mutable_dispatch_image_2d_arguments:**
As the images are created using CL_UNSIGNED_INT8, the kernel does not use correct instructions, as they are designed for signed variable. This fix consists of modifying the kernel code to use unsigned instructions and auxiliary variables .
