### PR TITLE
add test for a NULL local work size and a required work-group size

### DIFF
--- a/test_conformance/api/test_kernel_attributes.cpp
+++ b/test_conformance/api/test_kernel_attributes.cpp
@@ -440,6 +440,7 @@ REGISTER_TEST(null_required_work_group_size)
                          device_max_work_item_sizes[1],
                          device_max_work_item_sizes[2],
                          device_max_work_group_size);
+                continue;
             }
 
             const cl_int zero = 0;


### PR DESCRIPTION
see #2501 

This tests the following scenarios:

1. Execute a kernel with a required work-group size, passing `NULL` as the local work size.
2. Query the suggested work-group size for a kernel with a required work-group size.