### PR TITLE
Fix path to spv file in test_compiler.

### DIFF
--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -32,8 +32,8 @@ const std::string slash = "\\";
 #else
 const std::string slash = "/";
 #endif
-std::string compilerSpvBinaries = "test_conformance" + slash + "compiler"
-    + slash + "spirv_bin" + slash + "write_kernel.spv";
+std::string compilerSpvBinaries =
+    "compiler" + slash + "spirv_bin" + slash + "write_kernel.spv";
 
 const std::string spvExt = ".spv";
 


### PR DESCRIPTION
In #1220, test_compiler was changed to load write_kernel.spv* from a file using a relative path
test_conformance/compiler/spirv_bin/write_kernel.spv*. This works when test_compiler is run from the build directory, but does not work when it is run from the test_conformance directory, which is how run_conformance.py expects to run it. Adjust the path accordingly.