### PR TITLE
Fix file paths in test_compiler

### DIFF
--- a/test_conformance/compiler/main.cpp
+++ b/test_conformance/compiler/main.cpp
@@ -13,10 +13,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#include <string>
+#include <filesystem>
+
 #include "harness/testHarness.h"
+
+std::string spvBinariesPath =
+    (std::filesystem::path("compiler") / "spirv_bin").u8string();
+const std::string spvBinariesPathArg = "--spirv-binaries-path";
+
+void printUsage()
+{
+    log_info("Reading SPIR-V files from default '%s' path.\n",
+             spvBinariesPath.c_str());
+    log_info("In case you want to set other directory use '%s' argument.\n",
+             spvBinariesPathArg.c_str());
+}
 
 int main(int argc, const char *argv[])
 {
+    bool modifiedSpvBinariesPath = false;
+    bool listTests = false;
+    for (int i = 0; i < argc; ++i)
+    {
+        int argsRemoveNum = 0;
+        if (argv[i] == spvBinariesPathArg)
+        {
+            if (i + 1 == argc)
+            {
+                log_error("Missing value for '%s' argument.\n",
+                          spvBinariesPathArg.c_str());
+                return TEST_FAIL;
+            }
+            else
+            {
+                spvBinariesPath = std::string(argv[i + 1]);
+                argsRemoveNum += 2;
+                modifiedSpvBinariesPath = true;
+            }
+        }
+
+        if (argsRemoveNum > 0)
+        {
+            for (int j = i; j < (argc - argsRemoveNum); ++j)
+                argv[j] = argv[j + argsRemoveNum];
+
+            argc -= argsRemoveNum;
+            --i;
+        }
+        listTests |= (argv[i] == std::string("--list")
+                      || argv[i] == std::string("-list"));
+    }
+    if (modifiedSpvBinariesPath == false && !listTests)
+    {
+        printUsage();
+    }
+
     return runTestHarness(argc, argv, test_registry::getInstance().num_tests(),
                           test_registry::getInstance().definitions(), false, 0);
 }

--- a/test_conformance/compiler/test_unload_platform_compiler.cpp
+++ b/test_conformance/compiler/test_unload_platform_compiler.cpp
@@ -32,8 +32,6 @@ const std::string slash = "\\";
 #else
 const std::string slash = "/";
 #endif
-std::string compilerSpvBinaries = "test_conformance" + slash + "compiler"
-    + slash + "spirv_bin" + slash + "write_kernel.spv";
 
 const std::string spvExt = ".spv";
 
@@ -338,8 +336,8 @@ public:
 
         std::vector<unsigned char> kernel_buffer;
 
-        std::string file_name =
-            compilerSpvBinaries + std::to_string(address_bits);
+        std::string file_name = spvBinariesPath + slash + "write_kernel.spv"
+            + std::to_string(address_bits);
         m_spirv_binary = readBinary(file_name.c_str());
         m_spirv_size = m_spirv_binary.size();
     }

--- a/test_conformance/compiler/test_unload_platform_compiler_resources.hpp
+++ b/test_conformance/compiler/test_unload_platform_compiler_resources.hpp
@@ -1,4 +1,6 @@
-#include <array>
+#include <string>
+
+extern std::string spvBinariesPath;
 
 static const char write_kernel_source[] = R"(
 	kernel void write_kernel(global unsigned int *p) {


### PR DESCRIPTION
Add a command line argument to override the SPIR-V file paths if needed, similar to `test_spirv_new`. Set the default path to the one required by `run_conformance.py`, which assumes the current working directory to be `<build_dir>/test_conformance`.