### PR TITLE
switch to the upstream headers for unified SVM CI testing

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           git clone https://github.com/KhronosGroup/OpenCL-Headers.git
           cd OpenCL-Headers
-          git checkout cl_khr_unified_svm
           ln -s CL OpenCL # For OSX builds
           cd ..
       - name: Fetch SPIR-V Headers


### PR DESCRIPTION
Since we have added support for unified SVM in the upstream headers, we no longer need to build CI from the unified SVM header branch.