### PR TITLE
One last file path fix for test_compiler.

### DIFF
--- a/test_conformance/compiler/main.cpp
+++ b/test_conformance/compiler/main.cpp
@@ -18,8 +18,7 @@
 
 #include "harness/testHarness.h"
 
-std::string spvBinariesPath =
-    (std::filesystem::path("compiler") / "spirv_bin").u8string();
+std::string spvBinariesPath = "spirv_bin";
 const std::string spvBinariesPathArg = "--spirv-binaries-path";
 
 void printUsage()


### PR DESCRIPTION
Although run_conformance.py runs from test_conformance, it will change the current working directory before launching each individual test. Adjust the path accordingly.