### PR TITLE
Add AHardwareBufferWrapper

### DIFF
--- a/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.cpp
@@ -191,3 +191,14 @@ std::string ahardwareBufferFormatToString(AHardwareBuffer_Format format)
     }
     return result;
 }
+AHardwareBuffer *create_AHB(AHardwareBuffer_Desc *desc)
+{
+    AHardwareBuffer *buffer_ptr = nullptr;
+    int err = AHardwareBuffer_allocate(desc, &buffer_ptr);
+    if (err != 0)
+    {
+        throw std::runtime_error("AHardwareBuffer_allocate failed with code: "
+                                 + std::to_string(err) + "\n");
+    }
+    return buffer_ptr;
+}

--- a/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.h
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/debug_ahb.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <numeric>
+#include <CL/cl.h>
 
 #define CHECK_AHARDWARE_BUFFER_SUPPORT(ahardwareBuffer_Desc, format)           \
     if (!AHardwareBuffer_isSupported(&ahardwareBuffer_Desc))                   \
@@ -40,3 +41,89 @@ std::string ahardwareBufferFormatToString(AHardwareBuffer_Format format);
 std::string ahardwareBufferUsageFlagToString(AHardwareBuffer_UsageFlags flag);
 std::string
 ahardwareBufferDecodeUsageFlagsToString(AHardwareBuffer_UsageFlags flags);
+
+AHardwareBuffer* create_AHB(AHardwareBuffer_Desc* desc);
+
+struct AHardwareBufferWrapper
+{
+    AHardwareBuffer* m_ahb;
+
+    AHardwareBufferWrapper(): m_ahb(nullptr) {}
+
+    AHardwareBufferWrapper(AHardwareBuffer* ahb) { m_ahb = ahb; }
+
+    AHardwareBufferWrapper(AHardwareBuffer_Desc* desc)
+    {
+        m_ahb = create_AHB(desc);
+    }
+
+    AHardwareBufferWrapper& operator=(AHardwareBuffer* rhs)
+    {
+        release();
+        m_ahb = rhs;
+
+        return *this;
+    }
+
+    ~AHardwareBufferWrapper() { release(); }
+
+    // Copy constructor
+    AHardwareBufferWrapper(AHardwareBufferWrapper const& ahbw)
+        : m_ahb(ahbw.m_ahb)
+    {
+        retain();
+    }
+
+    // Copy assignment operator
+    AHardwareBufferWrapper& operator=(AHardwareBufferWrapper const& rhs)
+    {
+        release();
+
+        m_ahb = rhs.m_ahb;
+        retain();
+
+        return *this;
+    }
+
+    // Move constructor
+    AHardwareBufferWrapper(AHardwareBufferWrapper&& ahbw)
+    {
+        m_ahb = ahbw.m_ahb;
+        ahbw.m_ahb = nullptr;
+    }
+
+    // Move assignment operator
+    AHardwareBufferWrapper& operator=(AHardwareBufferWrapper&& rhs)
+    {
+        if (this != &rhs)
+        {
+            release(); // Giving up current reference
+            m_ahb = rhs.m_ahb;
+            rhs.m_ahb = nullptr;
+        }
+        return *this;
+    }
+
+    void retain()
+    {
+        if (nullptr != m_ahb)
+        {
+            AHardwareBuffer_acquire(m_ahb);
+        }
+    }
+
+    void release()
+    {
+        if (nullptr != m_ahb)
+        {
+            AHardwareBuffer_release(m_ahb);
+        }
+    }
+
+    // Usage operators
+    operator AHardwareBuffer*() { return m_ahb; }
+    cl_mem_properties get_props()
+    {
+        return reinterpret_cast<cl_mem_properties>(m_ahb);
+    }
+};

--- a/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
@@ -134,19 +134,15 @@ REGISTER_TEST(test_images)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
-                const cl_mem_properties props[] = {
+                cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 cl_mem image = clCreateImageWithProperties(
@@ -181,8 +177,6 @@ REGISTER_TEST(test_images)
 
                 test_error(clReleaseMemObject(image),
                            "Failed to release image");
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
             }
         }
     }
@@ -238,15 +232,11 @@ REGISTER_TEST(test_images_read)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -279,7 +269,7 @@ REGISTER_TEST(test_images_read)
                 generate_random_image_data(&imageInfo, srcData, seed);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -301,7 +291,7 @@ REGISTER_TEST(test_images_read)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -482,9 +472,6 @@ REGISTER_TEST(test_images_read)
                         }
                     }
                 }
-
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
             }
         }
     }
@@ -540,15 +527,12 @@ REGISTER_TEST(test_enqueue_read_image)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -581,7 +565,7 @@ REGISTER_TEST(test_enqueue_read_image)
                 generate_random_image_data(&imageInfo, srcData, seed);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -601,9 +585,9 @@ REGISTER_TEST(test_enqueue_read_image)
                     return TEST_FAIL;
                 }
 
-                const cl_mem_properties props[] = {
+                cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -661,9 +645,6 @@ REGISTER_TEST(test_enqueue_read_image)
                     srcData_ptr += imageInfo.rowPitch;
                     out_image_ptr += imageInfo.rowPitch;
                 }
-
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
 
                 if (total_matched == 0)
                 {
@@ -724,15 +705,12 @@ REGISTER_TEST(test_enqueue_copy_image)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -765,7 +743,7 @@ REGISTER_TEST(test_enqueue_copy_image)
                 generate_random_image_data(&imageInfo, srcData, seed);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -787,7 +765,7 @@ REGISTER_TEST(test_enqueue_copy_image)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -975,9 +953,6 @@ REGISTER_TEST(test_enqueue_copy_image)
                         }
                     }
                 }
-
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
             }
         }
     }
@@ -1033,15 +1008,12 @@ REGISTER_TEST(test_enqueue_copy_image_to_buffer)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -1074,7 +1046,7 @@ REGISTER_TEST(test_enqueue_copy_image_to_buffer)
                 generate_random_image_data(&imageInfo, srcData, seed);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -1096,7 +1068,7 @@ REGISTER_TEST(test_enqueue_copy_image_to_buffer)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -1165,9 +1137,6 @@ REGISTER_TEST(test_enqueue_copy_image_to_buffer)
                     out_buffer_ptr += scanlineSize;
                 }
 
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
-
                 if (total_matched == 0)
                 {
                     test_fail("Zero bytes matched");
@@ -1227,15 +1196,12 @@ REGISTER_TEST(test_enqueue_copy_buffer_to_image)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -1275,7 +1241,7 @@ REGISTER_TEST(test_enqueue_copy_buffer_to_image)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -1307,7 +1273,7 @@ REGISTER_TEST(test_enqueue_copy_buffer_to_image)
                                          &hardware_buffer_desc);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -1365,9 +1331,6 @@ REGISTER_TEST(test_enqueue_copy_buffer_to_image)
                               ahb_result);
                     return TEST_FAIL;
                 }
-
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
 
                 if (total_matched == 0)
                 {
@@ -1428,15 +1391,12 @@ REGISTER_TEST(test_enqueue_write_image)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -1453,7 +1413,7 @@ REGISTER_TEST(test_enqueue_write_image)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -1503,7 +1463,7 @@ REGISTER_TEST(test_enqueue_write_image)
                                          &hardware_buffer_desc);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -1564,9 +1524,6 @@ REGISTER_TEST(test_enqueue_write_image)
                     return TEST_FAIL;
                 }
 
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
-
                 if (total_matched == 0)
                 {
                     test_fail("Zero bytes matched");
@@ -1626,15 +1583,12 @@ REGISTER_TEST(test_enqueue_fill_image)
 
                 CHECK_AHARDWARE_BUFFER_SUPPORT(aHardwareBufferDesc, format);
 
-                AHardwareBuffer *aHardwareBuffer = nullptr;
-                int ahb_result = AHardwareBuffer_allocate(&aHardwareBufferDesc,
-                                                          &aHardwareBuffer);
-                if (ahb_result != 0)
-                {
-                    log_error("AHardwareBuffer_allocate failed with code %d\n",
-                              ahb_result);
-                    return TEST_FAIL;
-                }
+                AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+                log_info(
+                    "Testing %s\n",
+                    ahardwareBufferFormatToString(format.aHardwareBufferFormat)
+                        .c_str());
 
                 // Determine AHB memory layout
                 AHardwareBuffer_Desc hardware_buffer_desc = {};
@@ -1650,7 +1604,7 @@ REGISTER_TEST(test_enqueue_fill_image)
 
                 cl_mem_properties props[] = {
                     CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-                    reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+                    aHardwareBuffer.get_props(), 0
                 };
 
                 clMemWrapper imported_image = clCreateImageWithProperties(
@@ -1739,7 +1693,7 @@ REGISTER_TEST(test_enqueue_fill_image)
                                          &hardware_buffer_desc);
 
                 void *hardware_buffer_data = nullptr;
-                ahb_result = AHardwareBuffer_lock(
+                int ahb_result = AHardwareBuffer_lock(
                     aHardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1,
                     nullptr, &hardware_buffer_data);
                 if (ahb_result != 0)
@@ -1819,8 +1773,6 @@ REGISTER_TEST(test_enqueue_fill_image)
                     return TEST_FAIL;
                 }
 
-                AHardwareBuffer_release(aHardwareBuffer);
-                aHardwareBuffer = nullptr;
                 free(verificationLine);
 
                 if (total_matched == 0)
@@ -1883,19 +1835,17 @@ REGISTER_TEST(test_blob)
             continue;
         }
 
-        AHardwareBuffer *aHardwareBuffer = nullptr;
-        int ahb_result =
-            AHardwareBuffer_allocate(&aHardwareBufferDesc, &aHardwareBuffer);
-        if (ahb_result != 0)
-        {
-            log_error("AHardwareBuffer_allocate failed with code %d\n",
-                      ahb_result);
-            return TEST_FAIL;
-        }
+        AHardwareBufferWrapper aHardwareBuffer(&aHardwareBufferDesc);
+
+        log_info(
+            "Testing %s\n",
+            ahardwareBufferFormatToString(
+                static_cast<AHardwareBuffer_Format>(aHardwareBufferDesc.format))
+                .c_str());
 
         cl_mem_properties props[] = {
             CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
-            reinterpret_cast<cl_mem_properties>(aHardwareBuffer), 0
+            aHardwareBuffer.get_props(), 0
         };
 
         cl_mem buffer = clCreateBufferWithProperties(
@@ -1903,8 +1853,6 @@ REGISTER_TEST(test_blob)
         test_error(err, "Failed to create CL buffer from AHardwareBuffer");
 
         test_error(clReleaseMemObject(buffer), "Failed to release buffer");
-        AHardwareBuffer_release(aHardwareBuffer);
-        aHardwareBuffer = nullptr;
     }
 
     return TEST_PASS;


### PR DESCRIPTION
Add a wrapper around AHB for proper resource deallocation and refactor existing tests to use the wrapper.