### PR TITLE
Fix release call in AHB image read test

### DIFF
--- a/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
@@ -394,7 +394,7 @@ REGISTER_TEST(test_images_read)
                 test_error(err, "clEnqueueNDRangeKernel failed");
 
                 err = clEnqueueReleaseExternalMemObjectsKHR(
-                    queue, 1, &opencl_image, 0, nullptr, nullptr);
+                    queue, 1, &imported_image, 0, nullptr, nullptr);
                 test_error(err, "clEnqueueReleaseExternalMemObjectsKHR failed");
 
                 // Read buffer and verify


### PR DESCRIPTION
Ensure clEnqueueReleaseExternalMemObjectsKHR targets imported_image instead of the non-external opencl_image, matching the prior acquire call.