### PR TITLE
Fix incompatiable pointer type warning for device_execution test

### DIFF
--- a/test_conformance/device_execution/enqueue_block.cpp
+++ b/test_conformance/device_execution/enqueue_block.cpp
@@ -340,7 +340,7 @@ static const char* enqueue_block_capture_event_profiling_info_before_execution[]
 
         set_user_event_status(user_evt, CL_COMPLETE);
 
-        void (^checkBlock) (void)  = ^{ check_res(tid, &value, res);      };
+        void (^checkBlock) (void)  = ^{ check_res(tid, value, res);      };
 
         enq_res = enqueue_kernel(def_q, CLK_ENQUEUE_FLAGS_NO_WAIT, ndrange, 1, &block_evt1, &block_evt2, checkBlock);
         if (enq_res != CLK_SUCCESS) { res[tid] = -3; return; }

--- a/test_conformance/device_execution/enqueue_ndrange.cpp
+++ b/test_conformance/device_execution/enqueue_ndrange.cpp
@@ -129,8 +129,8 @@ static const char *helper_ndrange_2d_glo[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_2d_glo(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,
@@ -156,8 +156,8 @@ static const char *helper_ndrange_2d_loc[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_2d_loc(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,
@@ -193,8 +193,8 @@ static const char *helper_ndrange_2d_ofs[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_2d_ofs(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,
@@ -233,8 +233,8 @@ static const char *helper_ndrange_3d_glo[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_3d_glo(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,
@@ -266,8 +266,8 @@ static const char *helper_ndrange_3d_loc[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_3d_loc(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,
@@ -306,8 +306,8 @@ static const char *helper_ndrange_3d_ofs[] = {
     "}" NL,
     "" NL,
     "kernel void helper_ndrange_3d_ofs(__global int* res, uint n, uint len, "
-    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global int* "
-    "val,  __global uint* ofs_arr)" NL,
+    "__global uint* glob_size_arr, __global uint* loc_size_arr, __global "
+    "atomic_uint* val,  __global uint* ofs_arr)" NL,
     "{" NL,
     "  size_t tid = get_global_id(0);" NL,
     "  void (^kernelBlock)(void) = ^{ block_fn(len, val); };" NL,


### PR DESCRIPTION
There are multiple incompatiable pointer types warnings when compiling the device_execution test with clang. There was an upstream llvm patch that will turn these warnings into an error https://github.com/llvm/llvm-project/pull/157364.

To not encounter this issue in the future, fix these warnings by changing the parameter types.

```
warning: incompatible pointer types passing '__global ulong (*)[512]' (aka '__global unsigned long (*)[512]') to parameter of type 'const __generic ulong *' (aka 'const __generic unsigned long *') [-Wincompatible-pointer-types]
   37 |         void (^checkBlock) (void) = ^{ check_res(tid, &value, res); };
      |                                                       ^~~~~~
note: passing argument to parameter 'value' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
--
warning: incompatible pointer types passing '__global int *const __private' to parameter of type '__global atomic_uint *' (aka '__global _Atomic(unsigned int) *') [-Wincompatible-pointer-types]
   10 |   void (^kernelBlock)(void) = ^{ block_fn(len, val); };
      |                                                ^~~
note: passing argument to parameter 'val' here
```