### PR TITLE
Better support for -cl-uniform-work-group-size

### DIFF
--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -45,13 +45,7 @@ const char *include_test_kernel[] = {
 "\n"
 "}\n" };
 
-const char *options_test_kernel[] = {
-    "__kernel void sample_test(__global float *src, __global int *dst)\n"
-    "{\n"
-    "    size_t tid = get_global_id(0);\n"
-    "    dst[tid] = (int)src[tid];\n"
-    "}\n"
-};
+const char *options_test_kernel[] = { "__kernel void sample_test() {}\n" };
 
 std::array optimization_options{
     std::pair{ "-cl-single-precision-constant", Version(1, 0) },
@@ -429,4 +423,51 @@ REGISTER_TEST(options_denorm_cache)
     }
 
     return 0;
+}
+
+REGISTER_TEST(options_uniform_work_group_size)
+{
+    if (get_device_cl_version(device) < Version(2, 0))
+    {
+        return TEST_SKIPPED_ITSELF;
+    }
+    const char *options = "-cl-uniform-work-group-size";
+    clProgramWrapper program;
+    int error = create_single_kernel_helper_create_program(
+        context, &program, 1, options_test_kernel, options);
+    if (program == NULL || error != CL_SUCCESS)
+    {
+        log_error("Error: Unable to create reference program!\n");
+        return TEST_FAIL;
+    }
+    error = clBuildProgram(program, 1, &device, options, NULL, NULL);
+    test_error(error, "Test program did not properly build");
+
+    clKernelWrapper kernel = clCreateKernel(program, "sample_test", &error);
+    test_error(error, "Unable to create kernel");
+
+    size_t global_work_size = 4;
+    size_t uniform_local_work_size = 2;
+    error = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_work_size,
+                                   &uniform_local_work_size, 0, NULL, NULL);
+    test_error(error,
+               "Unable to enqueue NDRange kernel with uniform work group size");
+    error = clFinish(queue);
+    test_error(error, "Unable to finish");
+
+    size_t non_uniform_local_work_size = 3;
+    error = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_work_size,
+                                   &non_uniform_local_work_size, 0, NULL, NULL);
+
+    if (error != CL_INVALID_WORK_GROUP_SIZE)
+    {
+        log_error(
+            "Error: expected error 'CL_INVALID_WORK_GROUP_SIZE' (got '%s') "
+            "trying to enqueue kernel compiled with '%s' with non-uniform work "
+            "group size\n",
+            IGetErrorString(error), options);
+        return TEST_FAIL;
+    }
+
+    return TEST_PASS;
 }


### PR DESCRIPTION
Add support for build options available only after a certain version:
- -cl-uniform-work-group-size after 2.0
- -cl-no-subgroup-ifp after 2.1

Add specific test for cl-uniform-work-group-size
- Check that test can be executed when work group size is uniform.
- Check that test returns the proper error code when work group size is not uniform.

Ref #2563 