### PR TITLE
fix api/negative_create_command_queue

### DIFF
--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -47,7 +47,7 @@ REGISTER_TEST(negative_create_command_queue)
     }
 
     cl_queue_properties invalid_property{ static_cast<cl_queue_properties>(
-        -1) };
+        ~CL_QUEUE_ALL_PROPERTIES) };
     clCreateCommandQueue(context, device, invalid_property, &err);
     test_failure_error_ret(
         err, CL_INVALID_VALUE,


### PR DESCRIPTION
When trying to trigger CL_INVALID_VALUE by passing invalid properties, we are using `-1` right now. But properties is a bitfield. Thus `-1` represent everything.
On devices not supporting a valid
property (`CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE` example), `clCreateCommandQueue` can return the error code
`CL_INVALID_QUEUE_PROPERTIES`.