### PR TITLE
image_from_small_buffer_negative expecting incorrect error code

### DIFF
--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_from_buffer.cpp
@@ -629,7 +629,7 @@ int image_from_small_buffer_negative(cl_device_id device, cl_context context,
 
                 clCreateImage(context, flag, &format, &image_desc, nullptr,
                               &err);
-                test_failure_error(err, CL_INVALID_MEM_OBJECT,
+                test_failure_error(err, CL_INVALID_IMAGE_SIZE,
                                    "Unexpected clCreateImage return");
 
                 err = clReleaseMemObject(buffer);


### PR DESCRIPTION
CL_INVALID_MEM_OBJECT is not a valid error return from clCreateImage.

Result should either be CL_INVALID_IMAGE_SIZE or CL_INVALID_IMAGE_FORMAT_DESCRIPTOR.

[CL_INVALID_IMAGE_FORMAT_DESCRIPTOR](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_INVALID_IMAGE_FORMAT_DESCRIPTOR)
if image_format is NULL
if values specified in image_format are not valid
if properties includes an AHardwareBuffer external memory handle and image_format is not NULL
if an image is created from a buffer and the row pitch, or slice pitch, if the [cl_ext_image_from_buffer](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_ext_image_from_buffer) extension is supported, or base address alignment do not follow the rules described for creating an image from a buffer

[CL_INVALID_IMAGE_DESCRIPTOR](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_INVALID_IMAGE_DESCRIPTOR)
if properties includes an AHardwareBuffer external memory handle and image_desc is not NULL

[CL_INVALID_IMAGE_SIZE](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_INVALID_IMAGE_SIZE)
if the image dimensions specified in image_desc are not valid or exceed the maximum image dimensions described in the [Device Queries](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#device-queries-table) table for all devices in context
if the [cl_ext_image_from_buffer](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_ext_image_from_buffer) extension is supported and an image is created from a buffer and the buffer passed in mem_object is too small to be used as a data store for the image, e.g. if its size is smaller than the value returned for [CL_IMAGE_REQUIREMENTS_SIZE_EXT](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_IMAGE_REQUIREMENTS_SIZE_EXT) for the parameters used to create the image