### PR TITLE
Add clFinish to compiler multiple_build_program test before building again

### DIFF
--- a/test_conformance/compiler/test_compile.cpp
+++ b/test_conformance/compiler/test_compile.cpp
@@ -3983,6 +3983,9 @@ REGISTER_TEST(multiple_build_program)
         error = clEnqueueNDRangeKernel(queue, kernel0, 1, NULL, &num_threads,
                                        NULL, 0, NULL, NULL);
         test_error(error, "clEnqueueNDRangeKernel failed");
+
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
     }
 
     {
@@ -4001,10 +4004,10 @@ REGISTER_TEST(multiple_build_program)
         error = clEnqueueNDRangeKernel(queue, kernel1, 1, NULL, &num_threads,
                                        NULL, 0, NULL, NULL);
         test_error(error, "clEnqueueNDRangeKernel failed");
-    }
 
-    error = clFinish(queue);
-    test_error(error, "clFinish failed");
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
+    }
 
     std::vector<cl_int> test_values(num_threads, 0);
     error = clEnqueueReadBuffer(queue, out_stream_0, true, 0,


### PR DESCRIPTION
[clBuildProgram](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clBuildProgram) has the next error condition:

> [CL_INVALID_OPERATION](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_INVALID_OPERATION) if there are kernel objects attached to program.

The test needs to wait for the NDRangeKernel to finish in order to build the program again. If not, kernel0 might still have references and therefore still be attached to program.