### PR TITLE
Limit work group size by the max item size in mutable_command_full_dispatch

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -126,7 +126,20 @@ struct MutableCommandFullDispatch : InfoMutableCommandBufferTest
             &workgroupinfo_size, NULL);
         test_error(error, "clGetKernelWorkGroupInfo failed");
 
-        group_size = std::min(num_elements, workgroupinfo_size);
+        cl_uint max_work_dimension = 0;
+        error = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,
+                                sizeof(max_work_dimension), &max_work_dimension,
+                                NULL);
+        test_error(error, "clGetDeviceInfo failed");
+
+        std::vector<size_t> max_work_item_sizes(max_work_dimension, 0);
+        error = clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                                sizeof(size_t) * max_work_item_sizes.size(),
+                                max_work_item_sizes.data(), NULL);
+        test_error(error, "clGetDeviceInfo failed");
+
+        group_size = std::min(
+            { num_elements, workgroupinfo_size, max_work_item_sizes[0] });
         const size_t size_to_allocate_src = group_size * sizeof(cl_int);
 
         // create and initialize source buffer


### PR DESCRIPTION
The maximum value for the workgroup size in a specific dimension can be lower than the overall maximum workgroup size. This patch queries for the maximum work item size in the first dimension and limits the group_size by that value as well.