### PR TITLE
Registration for the profiling_timebase test has been changed: version 2.1 is now required.

### DIFF
--- a/test_conformance/profiling/profiling_timebase.cpp
+++ b/test_conformance/profiling/profiling_timebase.cpp
@@ -18,7 +18,7 @@
 
 const char *kernelCode = "__kernel void kernel_empty(){}";
 
-REGISTER_TEST(profiling_timebase)
+REGISTER_TEST_VERSION(profiling_timebase, Version(2, 1))
 {
     Version version = get_device_cl_version(device);
     cl_platform_id platform = getPlatformFromDevice(device);


### PR DESCRIPTION
This fix is necessary to install the minimum version of OpenCL in the profiling_timebase test. This test uses clGetDeviceAndHostTimer, available only since version 2.1.
fix #2582