### PR TITLE
Fix size parameters in `cl_ext_buffer_device_address` tests

### DIFF
--- a/test_conformance/extensions/cl_ext_buffer_device_address/buffer_device_address.cpp
+++ b/test_conformance/extensions/cl_ext_buffer_device_address/buffer_device_address.cpp
@@ -310,8 +310,8 @@ private:
             // A basic buffer used to pass the other buffer's address.
             error = clEnqueueWriteBuffer(queue, buffer_in_long,
                                          CL_TRUE, // block
-                                         0, sizeof(cl_long), &DeviceAddrFromAPI,
-                                         0, NULL, NULL);
+                                         0, sizeof(DeviceAddrFromAPI),
+                                         &DeviceAddrFromAPI, 0, NULL, NULL);
         test_error_fail(error,
                         "clEnqueueWriteBuffer of dev_addr_buffer failed\n");
 
@@ -322,9 +322,9 @@ private:
                                &buffer_out_int);
         test_error_fail(error, "clSetKernelArg 1 failed\n");
 
-        error = clSetKernelExecInfo(ind_access_kernel,
-                                    CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT,
-                                    sizeof(void *), &DeviceAddrFromAPI);
+        error = clSetKernelExecInfo(
+            ind_access_kernel, CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT,
+            sizeof(DeviceAddrFromAPI), &DeviceAddrFromAPI);
         test_error_fail(error,
                         "Setting indirect access for "
                         "device ptrs failed!\n");


### PR DESCRIPTION
The `DeviceAddrFromAPI` variable is of type `cl_mem_device_address_ext`. But on 32-bit systems `sizeof(void*) = 4 < 8 = sizeof(cl_mem_device_address_ext)`. Pass `sizeof(DeviceAddrFromAPI)` instead.