### PR TITLE
include algorithm for std::min(list)

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp
@@ -20,6 +20,7 @@
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 
+#include <algorithm>
 #include <vector>
 
 namespace {


### PR DESCRIPTION
std::min(list) is defined in algorithm. Some setup might work without it, but other require it to find the proper definition.

Otherwise it can lead to compilation error:
```
OpenCL-CTS/test_conformance/extensions/cl_khr_command_buffer/cl_khr_command_buffer_mutable_dispatch/mutable_command_full_dispatch.cpp:141:22: error: no matching function for call to 'min'
  141 |         group_size = std::min(
      |                      ^~~~~~~~
/usr/include/c++/14/bits/stl_algobase.h:233:5: note: candidate function template not viable: requires 2 arguments, but 1 was provided
  233 |     min(const _Tp& __a, const _Tp& __b)
      |     ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/stl_algobase.h:281:5: note: candidate function template not viable: requires 3 arguments, but 1 was provided
  281 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```