### PR TITLE
Tighten AHB buffer row pitch in test_cl_khr_external_memory_ahb test

### DIFF
--- a/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
+++ b/test_conformance/extensions/cl_khr_external_memory_ahb/test_ahb.cpp
@@ -1239,8 +1239,8 @@ REGISTER_TEST(enqueue_copy_buffer_to_image)
                 imageInfo.type = format.clMemObjectType;
                 imageInfo.width = resolution.width;
                 imageInfo.height = resolution.height;
-                imageInfo.rowPitch = resolution.width * resolution.height
-                    * pixelSize; // data is tightly packed in buffer
+                // data is tightly packed in buffer
+                imageInfo.rowPitch = resolution.width * pixelSize;
                 test_assert_error(imageInfo.rowPitch
                                       >= pixelSize * imageInfo.width,
                                   "Row pitch is smaller than width");
@@ -1446,8 +1446,8 @@ REGISTER_TEST(enqueue_write_image)
                 imageInfo.type = format.clMemObjectType;
                 imageInfo.width = resolution.width;
                 imageInfo.height = resolution.height;
-                imageInfo.rowPitch = resolution.width * resolution.height
-                    * pixelSize; // Data is tightly packed
+                // Data is tightly packed
+                imageInfo.rowPitch = resolution.width * pixelSize;
                 test_assert_error(imageInfo.rowPitch
                                       >= pixelSize * imageInfo.width,
                                   "Row pitch is smaller than width");
@@ -1637,8 +1637,8 @@ REGISTER_TEST(enqueue_fill_image)
                 imageInfo.type = format.clMemObjectType;
                 imageInfo.width = resolution.width;
                 imageInfo.height = resolution.height;
-                imageInfo.rowPitch = resolution.width * resolution.height
-                    * pixelSize; // Data is tightly packed
+                imageInfo.rowPitch = resolution.width * pixelSize;
+                // Data is tightly packed
                 test_assert_error(imageInfo.rowPitch
                                       >= pixelSize * imageInfo.width,
                                   "Row pitch is smaller than width");


### PR DESCRIPTION
What was wrong:
enqueue_copy_buffer_to_image (and the related write/fill tests) mis-set imageInfo.rowPitch to width*height*pixelSize. Because get_image_size multiplies row pitch by height, this wrongly calculates the intended buffer size.

How it’s fixed: set rowPitch to the true per-line pitch (width*pixelSize) for all buffer-backed image cases so the calculated sizes match the actual data layout and stay within the expected memory footprint.