### PR TITLE
fix compiler/options_build_optimizations

### DIFF
--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "kernelHelpers.h"
 #include "testBase.h"
+#include "harness/kernelHelpers.h"
 #include "harness/os_helpers.h"
 #include "harness/testHarness.h"
 


### PR DESCRIPTION
We need to define -cl-std when compiling with option not in 1.0.