### PR TITLE
Remove overwrite of CMAKE_CXX_FLAGS from cl_khr_external_semaphore test

### DIFF
--- a/test_conformance/extensions/cl_khr_external_semaphore/CMakeLists.txt
+++ b/test_conformance/extensions/cl_khr_external_semaphore/CMakeLists.txt
@@ -18,7 +18,6 @@ include_directories (${CLConform_INCLUDE_DIR})
 
 list(APPEND CLConform_LIBRARIES vulkan_wrapper)
 set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
-set(CMAKE_CXX_FLAGS "-fpermissive")
 
 include_directories("../../common/vulkan_wrapper")
 


### PR DESCRIPTION
Fixes #2430