### PR TITLE
Fix test_vulkan_api_consistency validation errors for missing vkFreeMemory

### DIFF
--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <assert.h>
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <string.h>
@@ -79,9 +80,9 @@ struct ConsistencyExternalBufferTest : public VulkanTestBase
 
         VulkanBufferList vkBufferList(1, *vkDevice, bufferSize,
                                       vkExternalMemoryHandleType);
-        VulkanDeviceMemory* vkDeviceMem = new VulkanDeviceMemory(
+        std::unique_ptr<VulkanDeviceMemory> vkDeviceMem(new VulkanDeviceMemory(
             *vkDevice, vkBufferList[0], memoryTypeList[0],
-            vkExternalMemoryHandleType);
+            vkExternalMemoryHandleType));
 
         vkDeviceMem->bindBuffer(vkBufferList[0], 0);
 


### PR DESCRIPTION
Fixes vulkan validation layer error:

Vulkan validation layer: Validation Error: [ VUID-vkDestroyDevice-device-05137 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x4872eaa0 | vkCreateDevice(): OBJ ERROR : For VkDevice 0x5555598c2400[], VkDeviceMemory 0xf56c9b0000000004[] has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkDestroyDevice-device-05137)