### PR TITLE
Fix c11_atomics fetch min/max

### DIFF
--- a/test_conformance/c11_atomics/common.h
+++ b/test_conformance/c11_atomics/common.h
@@ -926,7 +926,14 @@ CBasicTest<HostAtomicType, HostDataType>::ProgramHeader(cl_uint maxNumDestItems)
 
         if constexpr (std::is_same_v<HostDataType, HOST_FLOAT>)
         {
-            ss << std::setprecision(10) << _startValue;
+            ss << std::setprecision(std::numeric_limits<cl_float>::max_digits10)
+               << _startValue;
+        }
+        else if constexpr (std::is_same_v<HostDataType, HOST_DOUBLE>)
+        {
+            ss << std::setprecision(
+                std::numeric_limits<cl_double>::max_digits10)
+               << _startValue;
         }
         else if constexpr (std::is_same_v<HostDataType, HOST_HALF>)
         {


### PR DESCRIPTION
@shajder This fix is related to #2386 I see failures on Intel GPU without this fix (tests atomic_fetch_min atomic_fetch_max). Similar to half and float setting precision should be defined for double data type.