### PR TITLE
Fix new lines in error logging

### DIFF
--- a/test_conformance/api/test_spirv_queries.cpp
+++ b/test_conformance/api/test_spirv_queries.cpp
@@ -757,7 +757,7 @@ REGISTER_TEST(spirv_query_dependencies)
         }
         for (const auto& extension_dep : it->second.extensions)
         {
-            log_error("Checked for SPIR-V extension %s.n",
+            log_error("Checked for SPIR-V extension %s.\n",
                       extension_dep.c_str());
         }
         return TEST_FAIL;


### PR DESCRIPTION
This is a small patch to fix a new line when logging an error.