### PR TITLE
Fix test_vulkan_interop_buffer/image validation errors for illegal memory type selection on AMD/RADV

### DIFF
--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -728,6 +728,30 @@ VulkanDevice::VulkanDevice(
         vkCreateDevice(physicalDevice, &vkDeviceCreateInfo, NULL, &m_vkDevice);
     }
 
+    VkPhysicalDeviceCoherentMemoryFeaturesAMD coherentFeatures = {};
+    coherentFeatures.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD;
+
+    VkPhysicalDeviceFeatures2 enabledFeatures = {};
+    enabledFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    enabledFeatures.pNext = &coherentFeatures;
+
+    vkGetPhysicalDeviceFeatures2(physicalDevice, &enabledFeatures);
+
+    // Build device-level memory type list with only legally usable types
+    auto &memTypeList = physicalDevice.getMemoryTypeList();
+    for (size_t i = 0; i < memTypeList.size(); i++)
+    {
+        const VulkanMemoryType &mt = memTypeList[i];
+        VulkanMemoryTypeProperty flags = mt.getMemoryTypeProperty();
+        if ((flags & VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD)
+            && !coherentFeatures.deviceCoherentMemory)
+        {
+            continue; // feature not enabled, skip
+        }
+        m_memoryTypeList.add(mt);
+    }
+
     for (uint32_t qfIdx = 0;
          qfIdx < (uint32_t)m_physicalDevice.getQueueFamilyList().size();
          qfIdx++)
@@ -775,6 +799,11 @@ VulkanQueue &VulkanDevice::getQueue(const VulkanQueueFamily &queueFamily,
 }
 
 VulkanDevice::operator VkDevice() const { return m_vkDevice; }
+
+const VulkanMemoryTypeList &VulkanDevice::getMemoryTypeList() const
+{
+    return m_memoryTypeList;
+}
 
 ////////////////////////////////
 // VulkanFence implementation //
@@ -1810,8 +1839,7 @@ VulkanBuffer::VulkanBuffer(
 
     m_size = vkMemoryRequirements.memoryRequirements.size;
     m_alignment = vkMemoryRequirements.memoryRequirements.alignment;
-    const VulkanMemoryTypeList &memoryTypeList =
-        m_device.getPhysicalDevice().getMemoryTypeList();
+    const VulkanMemoryTypeList &memoryTypeList = m_device.getMemoryTypeList();
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];
@@ -1920,8 +1948,7 @@ VulkanImage::VulkanImage(
     m_alignment = vkMemoryRequirements.memoryRequirements.alignment;
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
 
-    const VulkanMemoryTypeList &memoryTypeList =
-        m_device.getPhysicalDevice().getMemoryTypeList();
+    const VulkanMemoryTypeList &memoryTypeList = m_device.getMemoryTypeList();
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];

--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.hpp
@@ -137,10 +137,13 @@ public:
 };
 
 class VulkanDevice {
+    friend class VulkanMemoryTypeList;
+
 protected:
     const VulkanPhysicalDevice &m_physicalDevice;
     VkDevice m_vkDevice;
     VulkanQueueFamilyToQueueListMap m_queueFamilyIndexToQueueListMap;
+    VulkanMemoryTypeList m_memoryTypeList;
 
     VulkanDevice(const VulkanDevice &device);
 
@@ -155,6 +158,7 @@ public:
     VulkanQueue &
     getQueue(const VulkanQueueFamily &queueFamily /* = getVulkanQueueFamily()*/,
              uint32_t queueIndex = 0);
+    const VulkanMemoryTypeList &getMemoryTypeList() const;
     operator VkDevice() const;
 };
 


### PR DESCRIPTION
Fixes #2491

@karolherbst I don't have an AMD device to test with, I would appreciate extra caution on this one, thanks!

VulkanDevice now builds its own memory type list from the physical device's list, excluding types whose required features were  not enabled at device creation time.

related to error message:

Validation Error: [ VUID-vkAllocateMemory-deviceCoherentMemory-02790 ] | MessageID = 0x8830dc95 vkAllocateMemory(): pAllocateInfo->memoryTypeIndex 7 includes the VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD memory property, but the deviceCoherentMemory feature is not enabled. The Vulkan spec states: If the deviceCoherentMemory feature is not enabled, pAllocateInfo->memoryTypeIndex must not identify a memory type supporting VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD