### PR TITLE
Fix left shift operator undefined behavior in integer_ops

### DIFF
--- a/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
+++ b/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
@@ -35,12 +35,12 @@ cpu_bit_insert(T tbase, T tinsert, cl_uint offset, cl_uint count)
     cl_ulong base = static_cast<cl_ulong>(tbase);
     cl_ulong insert = static_cast<cl_ulong>(tinsert);
 
-    cl_ulong mask = 0;
+    cl_ulong result = base;
     if (offset < 64)
-        mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
-    cl_ulong shifted = 0;
-    if (offset < 64) shifted = (insert << offset);
-    cl_ulong result = (shifted & mask) | (base & ~mask);
+    {
+        cl_ulong mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
+        result = ((insert << offset) & mask) | (base & ~mask);
+    }
 
     return static_cast<typename std::make_unsigned<T>::type>(result);
 }

--- a/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
+++ b/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
@@ -36,9 +36,10 @@ cpu_bit_insert(T tbase, T tinsert, cl_uint offset, cl_uint count)
     cl_ulong insert = static_cast<cl_ulong>(tinsert);
 
     cl_ulong mask = 0;
-    if(offset < 64 )  mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
+    if (offset < 64)
+        mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
     cl_ulong shifted = 0;
-    if(offset < 64 )  shifted = (insert << offset);
+    if (offset < 64) shifted = (insert << offset);
     cl_ulong result = (shifted & mask) | (base & ~mask);
 
     return static_cast<typename std::make_unsigned<T>::type>(result);

--- a/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
+++ b/test_conformance/integer_ops/test_extended_bit_ops_insert.cpp
@@ -35,8 +35,11 @@ cpu_bit_insert(T tbase, T tinsert, cl_uint offset, cl_uint count)
     cl_ulong base = static_cast<cl_ulong>(tbase);
     cl_ulong insert = static_cast<cl_ulong>(tinsert);
 
-    cl_ulong mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
-    cl_ulong result = ((insert << offset) & mask) | (base & ~mask);
+    cl_ulong mask = 0;
+    if(offset < 64 )  mask = (count < 64) ? ((1ULL << count) - 1) << offset : ~0ULL;
+    cl_ulong shifted = 0;
+    if(offset < 64 )  shifted = (insert << offset);
+    cl_ulong result = (shifted & mask) | (base & ~mask);
 
     return static_cast<typename std::make_unsigned<T>::type>(result);
 }


### PR DESCRIPTION
As per the C++ Programming Reference page n0: 151, section: 7.6.7 Shift operators 
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/n5001.pdf

> The operands shall be prvalues of integral or unscoped enumeration type and integral promotions are performed. The type of the result is that of the promoted left operand. The behavior is undefined if the right operand is negative, or greater than or equal to the width of the promoted left operand.