### PR TITLE
Added test to verify API consistency when linker or compiler unavailable

### DIFF
--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -921,7 +921,6 @@ REGISTER_TEST_VERSION(consistency_il_programs, Version(3, 0))
                           "support cl_khr_il_program");
 
         // Test setup:
-
         error = create_single_kernel_helper(context, &program, &kernel, 1,
                                             &test_kernel, "test");
         test_error(error, "Unable to create test kernel");
@@ -961,6 +960,127 @@ REGISTER_TEST_VERSION(consistency_il_programs, Version(3, 0))
                            "clSetProgramSpecializationConstant did not return "
                            "CL_INVALID_OPERATION");
     }
+    else
+    {
+        cl_bool compilerAvail;
+        cl_int err =
+            clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
+                            sizeof(compilerAvail), &compilerAvail, nullptr);
+        test_error_fail(err, "clGetDeviceInfo failed");
+
+        if (!compilerAvail)
+        {
+            cl_uint specConst = 42;
+            error = clSetProgramSpecializationConstant(
+                program, 0, sizeof(specConst), &specConst);
+            test_failure_error(
+                error, CL_COMPILER_NOT_AVAILABLE,
+                "No compiler available for device but "
+                "clSetProgramSpecializationConstant did not return "
+                "CL_COMPILER_NOT_AVAILABLE");
+        }
+    }
+
+    return TEST_PASS;
+}
+
+REGISTER_TEST(consistency_missing_compiler)
+{
+    cl_bool compilerAvail = true;
+    cl_int err =
+        clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
+                        sizeof(compilerAvail), &compilerAvail, nullptr);
+    test_error_fail(err, "clGetDeviceInfo failed");
+
+    if (compilerAvail)
+    {
+        log_info("Can't perform compiler consistency check\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    const char* sample_kernel = R"(
+        __kernel void sample_test_C(__global float *src, __global int *dst)
+        {
+            size_t tid = get_global_id(0);
+            dst[tid] = (int)src[tid];
+        }
+    )";
+
+    size_t line_length = strlen(sample_kernel);
+
+    /* New OpenCL API only has one entry point, so go ahead and just try it */
+    clProgramWrapper program = clCreateProgramWithSource(
+        context, 1, &sample_kernel, &line_length, &err);
+    test_error(err, "Unable to create reference program");
+
+    /* clCompileProgram consistency check */
+    err = clCompileProgram(program, 1, &device, nullptr, 0, nullptr, nullptr,
+                           nullptr, nullptr);
+    test_failure_error_ret(err, CL_COMPILER_NOT_AVAILABLE,
+                           "clCompileProgram should return "
+                           "CL_COMPILER_NOT_AVAILABLE",
+                           TEST_FAIL);
+
+    /* clBuildProgram consistency check */
+    err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
+    test_failure_error_ret(err, CL_COMPILER_NOT_AVAILABLE,
+                           "clBuildProgram should return "
+                           "CL_COMPILER_NOT_AVAILABLE",
+                           TEST_FAIL);
+
+    return TEST_PASS;
+}
+
+REGISTER_TEST(consistency_missing_linker)
+{
+    cl_bool compilerAvail = true;
+    cl_int err =
+        clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
+                        sizeof(compilerAvail), &compilerAvail, nullptr);
+    test_error_fail(err, "clGetDeviceInfo failed");
+
+    cl_bool linkerAvail = true;
+    err = clGetDeviceInfo(device, CL_DEVICE_LINKER_AVAILABLE,
+                          sizeof(linkerAvail), &linkerAvail, nullptr);
+    test_error_fail(err, "clGetDeviceInfo failed");
+
+    if (linkerAvail || !compilerAvail)
+    {
+        log_info("Can't perform linker consistency check\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    const char* sample_kernel = R"(
+        __kernel void sample_test_C(__global float *src, __global int *dst)
+        {
+            size_t tid = get_global_id(0);
+            dst[tid] = (int)src[tid];
+        }
+    )";
+
+    size_t line_length = strlen(sample_kernel);
+    clProgramWrapper program = clCreateProgramWithSource(
+        context, 1, &sample_kernel, &line_length, &err);
+    test_error(err, "Unable to create reference program");
+
+    /* clCompileProgram consistency check */
+    err = clCompileProgram(program, 1, &device, nullptr, 0, nullptr, nullptr,
+                           nullptr, nullptr);
+    test_error(err, "clCompileProgram failed");
+
+    clProgramWrapper linked =
+        clLinkProgram(context, 1, &device, "", 1, &program, 0, 0, &err);
+    test_failure_error_ret(err, CL_LINKER_NOT_AVAILABLE,
+                           "clLinkProgram should return "
+                           "CL_LINKER_NOT_AVAILABLE",
+                           TEST_FAIL);
+
+    /* clBuildProgram consistency check */
+    err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
+    test_failure_error_ret(err, CL_COMPILER_NOT_AVAILABLE,
+                           "clBuildProgram should return "
+                           "CL_COMPILER_NOT_AVAILABLE",
+                           TEST_FAIL);
 
     return TEST_PASS;
 }

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -960,33 +960,13 @@ REGISTER_TEST_VERSION(consistency_il_programs, Version(3, 0))
                            "clSetProgramSpecializationConstant did not return "
                            "CL_INVALID_OPERATION");
     }
-    else
-    {
-        cl_bool compilerAvail;
-        cl_int err =
-            clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
-                            sizeof(compilerAvail), &compilerAvail, nullptr);
-        test_error_fail(err, "clGetDeviceInfo failed");
-
-        if (!compilerAvail)
-        {
-            cl_uint specConst = 42;
-            error = clSetProgramSpecializationConstant(
-                program, 0, sizeof(specConst), &specConst);
-            test_failure_error(
-                error, CL_COMPILER_NOT_AVAILABLE,
-                "No compiler available for device but "
-                "clSetProgramSpecializationConstant did not return "
-                "CL_COMPILER_NOT_AVAILABLE");
-        }
-    }
 
     return TEST_PASS;
 }
 
 REGISTER_TEST(consistency_missing_compiler)
 {
-    cl_bool compilerAvail = true;
+    cl_bool compilerAvail = CL_TRUE;
     cl_int err =
         clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
                         sizeof(compilerAvail), &compilerAvail, nullptr);
@@ -1006,11 +986,8 @@ REGISTER_TEST(consistency_missing_compiler)
         }
     )";
 
-    size_t line_length = strlen(sample_kernel);
-
-    /* New OpenCL API only has one entry point, so go ahead and just try it */
-    clProgramWrapper program = clCreateProgramWithSource(
-        context, 1, &sample_kernel, &line_length, &err);
+    clProgramWrapper program =
+        clCreateProgramWithSource(context, 1, &sample_kernel, nullptr, &err);
     test_error(err, "Unable to create reference program");
 
     /* clCompileProgram consistency check */
@@ -1033,18 +1010,12 @@ REGISTER_TEST(consistency_missing_compiler)
 
 REGISTER_TEST(consistency_missing_linker)
 {
-    cl_bool compilerAvail = true;
-    cl_int err =
-        clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
-                        sizeof(compilerAvail), &compilerAvail, nullptr);
+    cl_bool linkerAvail = CL_TRUE;
+    cl_int err = clGetDeviceInfo(device, CL_DEVICE_LINKER_AVAILABLE,
+                                 sizeof(linkerAvail), &linkerAvail, nullptr);
     test_error_fail(err, "clGetDeviceInfo failed");
 
-    cl_bool linkerAvail = true;
-    err = clGetDeviceInfo(device, CL_DEVICE_LINKER_AVAILABLE,
-                          sizeof(linkerAvail), &linkerAvail, nullptr);
-    test_error_fail(err, "clGetDeviceInfo failed");
-
-    if (linkerAvail || !compilerAvail)
+    if (linkerAvail)
     {
         log_info("Can't perform linker consistency check\n");
         return TEST_SKIPPED_ITSELF;
@@ -1058,9 +1029,8 @@ REGISTER_TEST(consistency_missing_linker)
         }
     )";
 
-    size_t line_length = strlen(sample_kernel);
-    clProgramWrapper program = clCreateProgramWithSource(
-        context, 1, &sample_kernel, &line_length, &err);
+    clProgramWrapper program =
+        clCreateProgramWithSource(context, 1, &sample_kernel, nullptr, &err);
     test_error(err, "Unable to create reference program");
 
     /* clCompileProgram consistency check */

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -1021,6 +1021,13 @@ REGISTER_TEST(consistency_missing_linker)
         return TEST_SKIPPED_ITSELF;
     }
 
+    if (!gIsEmbedded)
+    {
+        log_error("CL_DEVICE_LINKER_AVAILABLE must be CL_TRUE for devices "
+                  "supporting the full profile.\n");
+        return TEST_FAIL;
+    }
+
     cl_bool compilerAvail = CL_TRUE;
     err = clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
                           sizeof(compilerAvail), &compilerAvail, nullptr);
@@ -1030,13 +1037,6 @@ REGISTER_TEST(consistency_missing_linker)
     {
         log_error("CL_DEVICE_LINKER_AVAILABLE must be CL_TRUE if "
                   "CL_DEVICE_COMPILER_AVAILABLE is CL_TRUE.\n");
-        return TEST_FAIL;
-    }
-
-    if (!gIsEmbedded)
-    {
-        log_error("CL_DEVICE_LINKER_AVAILABLE must be CL_TRUE for devices "
-                  "supporting the full profile.\n");
         return TEST_FAIL;
     }
 

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -1040,6 +1040,27 @@ REGISTER_TEST(consistency_missing_linker)
         return TEST_FAIL;
     }
 
+    const char* sample_kernel = R"(
+        __kernel void sample_test_C(__global float *src, __global int *dst)
+        {
+            size_t tid = get_global_id(0);
+            dst[tid] = (int)src[tid];
+        }
+    )";
+
+    clProgramWrapper program =
+        clCreateProgramWithSource(context, 1, &sample_kernel, nullptr, &err);
+    test_error(err, "Unable to create reference program");
+
+    clProgramWrapper linked =
+        clLinkProgram(context, 1, &device, "", 1, &program, 0, 0, &err);
+    if (err != CL_LINKER_NOT_AVAILABLE && err != CL_INVALID_OPERATION)
+    {
+        log_error("clLinkProgram should return CL_LINKER_NOT_AVAILABLE or "
+                  "CL_INVALID_OPERATION\n");
+        return TEST_FAIL;
+    }
+
     return TEST_PASS;
 }
 

--- a/test_conformance/api/test_api_consistency.cpp
+++ b/test_conformance/api/test_api_consistency.cpp
@@ -1021,36 +1021,24 @@ REGISTER_TEST(consistency_missing_linker)
         return TEST_SKIPPED_ITSELF;
     }
 
-    const char* sample_kernel = R"(
-        __kernel void sample_test_C(__global float *src, __global int *dst)
-        {
-            size_t tid = get_global_id(0);
-            dst[tid] = (int)src[tid];
-        }
-    )";
+    cl_bool compilerAvail = CL_TRUE;
+    err = clGetDeviceInfo(device, CL_DEVICE_COMPILER_AVAILABLE,
+                          sizeof(compilerAvail), &compilerAvail, nullptr);
+    test_error_fail(err, "clGetDeviceInfo failed");
 
-    clProgramWrapper program =
-        clCreateProgramWithSource(context, 1, &sample_kernel, nullptr, &err);
-    test_error(err, "Unable to create reference program");
+    if (compilerAvail)
+    {
+        log_error("CL_DEVICE_LINKER_AVAILABLE must be CL_TRUE if "
+                  "CL_DEVICE_COMPILER_AVAILABLE is CL_TRUE.\n");
+        return TEST_FAIL;
+    }
 
-    /* clCompileProgram consistency check */
-    err = clCompileProgram(program, 1, &device, nullptr, 0, nullptr, nullptr,
-                           nullptr, nullptr);
-    test_error(err, "clCompileProgram failed");
-
-    clProgramWrapper linked =
-        clLinkProgram(context, 1, &device, "", 1, &program, 0, 0, &err);
-    test_failure_error_ret(err, CL_LINKER_NOT_AVAILABLE,
-                           "clLinkProgram should return "
-                           "CL_LINKER_NOT_AVAILABLE",
-                           TEST_FAIL);
-
-    /* clBuildProgram consistency check */
-    err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
-    test_failure_error_ret(err, CL_COMPILER_NOT_AVAILABLE,
-                           "clBuildProgram should return "
-                           "CL_COMPILER_NOT_AVAILABLE",
-                           TEST_FAIL);
+    if (!gIsEmbedded)
+    {
+        log_error("CL_DEVICE_LINKER_AVAILABLE must be CL_TRUE for devices "
+                  "supporting the full profile.\n");
+        return TEST_FAIL;
+    }
 
     return TEST_PASS;
 }


### PR DESCRIPTION
Fixes #955

@kpet @bashbaug I've noticed procedure `clBuildProgram` does not return `CL_LINKER_NOT_AVAILABLE`, only `CL_COMPILER_NOT_AVAILABLE`. Is this intentional ? What if compiler is available but linker isn't ? Should it still return `CL_COMPILER_NOT_AVAILABLE` ? Thanks