### PR TITLE
Fix CTS api sub test failure for negative_get_command_queue_info

### DIFF
--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -435,7 +435,7 @@ REGISTER_TEST(negative_get_command_queue_info)
     if (device_supports_on_device_queue(device))
     {
         const cl_queue_properties properties[] = {
-            CL_QUEUE_PROPERTIES, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0
+            CL_QUEUE_ON_DEVICE, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0
         };
         cl_int err = CL_INVALID_VALUE;
         clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -438,10 +438,10 @@ REGISTER_TEST(negative_get_command_queue_info)
         err = clGetCommandQueueInfo(queue, CL_QUEUE_SIZE,
                                     sizeof(queue_size), &queue_size, nullptr);
         test_failure_error_ret(err, CL_INVALID_COMMAND_QUEUE,
-                                "clGetCommandQueueInfo should return "
-                                "CL_INVALID_COMMAND_QUEUE when: \"command_queue "
-                                "is not a valid command-queue for param_name\"",
-                                TEST_FAIL);
+                               "clGetCommandQueueInfo should return "
+                               "CL_INVALID_COMMAND_QUEUE when: \"command_queue "
+                               "is not a valid command-queue for param_name\"",
+                               TEST_FAIL);
     }
 
     constexpr cl_command_queue_info invalid_param = -1;

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -438,7 +438,7 @@ REGISTER_TEST(negative_get_command_queue_info)
             CL_QUEUE_PROPERTIES,
             CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
             0
-            };
+        };
         cl_int err = CL_INVALID_VALUE;
         clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(
             context, device, properties, &err);

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -434,22 +434,14 @@ REGISTER_TEST(negative_get_command_queue_info)
 
     if (device_supports_on_device_queue(device))
     {
-        const cl_queue_properties properties[] = {
-            CL_QUEUE_PROPERTIES,
-            CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0
-        };
-        cl_int err = CL_INVALID_VALUE;
-        clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(
-            context, device, properties, &err);
-        test_error(err, "clCreateCommandQueueWithProperties");
         cl_uint queue_size = -1;
-        err = clGetCommandQueueInfo(cmd_queue, CL_QUEUE_SIZE,
+        err = clGetCommandQueueInfo(queue, CL_QUEUE_SIZE,
                                     sizeof(queue_size), &queue_size, nullptr);
         test_failure_error_ret(err, CL_INVALID_COMMAND_QUEUE,
-                               "clGetCommandQueueInfo should return "
-                               "CL_INVALID_COMMAND_QUEUE when: \"command_queue "
-                               "is not a valid command-queue for param_name\"",
-                               TEST_FAIL);
+                                "clGetCommandQueueInfo should return "
+                                "CL_INVALID_COMMAND_QUEUE when: \"command_queue "
+                                "is not a valid command-queue for param_name\"",
+                                TEST_FAIL);
     }
 
     constexpr cl_command_queue_info invalid_param = -1;

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -435,7 +435,9 @@ REGISTER_TEST(negative_get_command_queue_info)
     if (device_supports_on_device_queue(device))
     {
         const cl_queue_properties properties[] = {
-            CL_QUEUE_ON_DEVICE, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0
+        CL_QUEUE_PROPERTIES,
+        CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+        0
         };
         cl_int err = CL_INVALID_VALUE;
         clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -436,8 +436,7 @@ REGISTER_TEST(negative_get_command_queue_info)
     {
         const cl_queue_properties properties[] = {
             CL_QUEUE_PROPERTIES,
-            CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
-            0
+            CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0
         };
         cl_int err = CL_INVALID_VALUE;
         clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -435,10 +435,10 @@ REGISTER_TEST(negative_get_command_queue_info)
     if (device_supports_on_device_queue(device))
     {
         const cl_queue_properties properties[] = {
-        CL_QUEUE_PROPERTIES,
-        CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
-        0
-        };
+            CL_QUEUE_PROPERTIES,
+            CL_QUEUE_ON_DEVICE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+            0
+            };
         cl_int err = CL_INVALID_VALUE;
         clCommandQueueWrapper cmd_queue = clCreateCommandQueueWithProperties(
             context, device, properties, &err);

--- a/test_conformance/api/negative_queue.cpp
+++ b/test_conformance/api/negative_queue.cpp
@@ -435,8 +435,8 @@ REGISTER_TEST(negative_get_command_queue_info)
     if (device_supports_on_device_queue(device))
     {
         cl_uint queue_size = -1;
-        err = clGetCommandQueueInfo(queue, CL_QUEUE_SIZE,
-                                    sizeof(queue_size), &queue_size, nullptr);
+        err = clGetCommandQueueInfo(queue, CL_QUEUE_SIZE, sizeof(queue_size),
+                                    &queue_size, nullptr);
         test_failure_error_ret(err, CL_INVALID_COMMAND_QUEUE,
                                "clGetCommandQueueInfo should return "
                                "CL_INVALID_COMMAND_QUEUE when: \"command_queue "


### PR DESCRIPTION
To fix a test failure in api sub-test "negative_get_command_queue_info".
The test code gets clGetDeviceInfo for the property CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES, when it create command queue for the device, "CL_QUEUE_ON_DEVICE" should be the correct input, instead of CL_QUEUE_PROPERTIES.