### PR TITLE
Add command line flags to override test_compiler include directories

### DIFF
--- a/test_conformance/compiler/main.cpp
+++ b/test_conformance/compiler/main.cpp
@@ -18,9 +18,16 @@
 
 #include "harness/testHarness.h"
 #include "harness/stringHelpers.h"
+#include "harness/os_helpers.h"
 
 std::string spvBinariesPath = "spirv_bin";
+std::string spvIncludeTestDirectory = "includeTestDirectory";
+std::string spvSecondIncludeTestDirectory = "secondIncludeTestDirectory";
+
 const std::string spvBinariesPathArg = "--spirv-binaries-path";
+const std::string spvIncludeTestDirectoryArg = "--include-test-directory";
+const std::string spvSecondIncludeTestDirectoryArg =
+    "--second-include-test-directory";
 
 void printUsage()
 {
@@ -32,6 +39,18 @@ void printUsage()
 
 int main(int argc, const char *argv[])
 {
+    char const *sep = get_dir_sep();
+    char const *exe_dir = get_exe_dir();
+
+    // Set default include directories
+    spvIncludeTestDirectory =
+        std::string(exe_dir) + sep + "includeTestDirectory";
+    spvSecondIncludeTestDirectory =
+        std::string(exe_dir) + sep + "secondIncludeTestDirectory";
+
+    free((void *)sep);
+    free((void *)exe_dir);
+
     bool modifiedSpvBinariesPath = false;
     bool listTests = false;
     for (int i = 0; i < argc; ++i)
@@ -50,6 +69,34 @@ int main(int argc, const char *argv[])
                 spvBinariesPath = std::string(argv[i + 1]);
                 argsRemoveNum += 2;
                 modifiedSpvBinariesPath = true;
+            }
+        }
+        if (argv[i] == spvIncludeTestDirectoryArg)
+        {
+            if (i + 1 == argc)
+            {
+                log_error("Missing value for '%s' argument.\n",
+                          spvIncludeTestDirectoryArg.c_str());
+                return TEST_FAIL;
+            }
+            else
+            {
+                spvIncludeTestDirectory = std::string(argv[i + 1]);
+                argsRemoveNum += 2;
+            }
+        }
+        if (argv[i] == spvSecondIncludeTestDirectoryArg)
+        {
+            if (i + 1 == argc)
+            {
+                log_error("Missing value for '%s' argument.\n",
+                          spvSecondIncludeTestDirectoryArg.c_str());
+                return TEST_FAIL;
+            }
+            else
+            {
+                spvSecondIncludeTestDirectory = std::string(argv[i + 1]);
+                argsRemoveNum += 2;
             }
         }
 

--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -18,6 +18,9 @@
 #include "harness/os_helpers.h"
 #include "harness/testHarness.h"
 
+extern std::string spvIncludeTestDirectory;
+extern std::string spvSecondIncludeTestDirectory;
+
 #include <array>
 
 const char *preprocessor_test_kernel[] = {
@@ -249,8 +252,6 @@ REGISTER_TEST(options_include_directory)
 {
     int error;
 
-    std::string sep  = dir_sep();
-    std::string path = exe_dir();    // Directory where test executable is located.
     std::string include_dir;
 
     clProgramWrapper program;
@@ -265,9 +266,8 @@ REGISTER_TEST(options_include_directory)
     }
 
     /* Build with the include directory defined */
-    include_dir = "-I " + path + sep + "includeTestDirectory";
+    include_dir = "-I " + spvIncludeTestDirectory;
 
-//    log_info("%s\n", include_dir);
     error =
         clBuildProgram(program, 1, &device, include_dir.c_str(), NULL, NULL);
     test_error( error, "Test program did not properly build" );
@@ -295,7 +295,7 @@ REGISTER_TEST(options_include_directory)
     }
 
     // Rebuild with a different include directory
-    include_dir = "-I " + path + sep + "secondIncludeTestDirectory";
+    include_dir = "-I " + spvSecondIncludeTestDirectory;
     error =
         clBuildProgram(program, 1, &device, include_dir.c_str(), NULL, NULL);
     test_error( error, "Test program did not properly rebuild" );

--- a/test_conformance/compiler/test_preprocessor.cpp
+++ b/test_conformance/compiler/test_preprocessor.cpp
@@ -16,6 +16,8 @@
 #include "testBase.h"
 #include "harness/os_helpers.h"
 
+extern std::string spvIncludeTestDirectory;
+
 const char *define_kernel_code[] = {
 " #define VALUE\n"
 "__kernel void define_test(__global int *src, __global int *dstA, __global int *dstB)\n"
@@ -157,18 +159,15 @@ REGISTER_TEST(preprocessor_include)
     cl_int *resultData;
     int i;
 
-    char include_dir[4096] = { 0 };
     char include_kernel[4096] = { 0 };
 
     char const *sep = get_dir_sep();
-    char const *path = get_exe_dir();
 
     /* Build with the include directory defined */
-    sprintf(include_dir, "%s%sincludeTestDirectory%stestIncludeFile.h", path,
-            sep, sep);
-    sprintf(include_kernel, include_kernel_code, include_dir);
+    std::string include_dir =
+        spvIncludeTestDirectory + sep + "testIncludeFile.h";
+    sprintf(include_kernel, include_kernel_code, include_dir.c_str());
     free((void *)sep);
-    free((void *)path);
 
     const char *test_kernel[] = { include_kernel, 0 };
     error = create_single_kernel_helper(context, &program, &kernel, 1,


### PR DESCRIPTION
This adds flags `--include-test-directory` and
`--second-include-test-directory` flags to test_compiler to allow the user to specify their locations rather than relying on the test to infer their location based on the path of the test binary.