### PR TITLE
samplerlessReads: fix use_pitches test for devices with read_write images supported

### DIFF
--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -89,6 +89,10 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
 
     if(gTestReadWrite)
     {
+        // We need to reset this because gEnablePitch might be true and
+        // specifying a pitch on an image without a parent or host_ptr is
+        // invalid.
+        image_desc.image_row_pitch = 0;
         read_write_image = clCreateImage(context,
                                          CL_MEM_READ_WRITE,
                                          imageInfo->format,

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -91,6 +91,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
 
     if(gTestReadWrite)
     {
+        // We need to reset this because gEnablePitch might be true and
+        // specifying a pitch on an image without a parent or host_ptr is
+        // invalid.
+        image_desc.image_row_pitch = 0;
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
                                         imageInfo->format,

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -91,6 +91,10 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
 
     if(gTestReadWrite)
     {
+        // We need to reset this because gEnablePitch might be true and
+        // specifying a pitch on an image without a parent or host_ptr is
+        // invalid.
+        image_desc.image_row_pitch = 0;
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
                                         imageInfo->format,

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -80,6 +80,11 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
 
     if(gTestReadWrite)
     {
+        // We need to reset this because gEnablePitch might be true and
+        // specifying a pitch on an image without a parent or host_ptr is
+        // invalid.
+        image_desc.image_row_pitch = 0;
+        image_desc.image_slice_pitch = 0;
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
                                         imageInfo->format,

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -79,6 +79,11 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
 
     if(gTestReadWrite)
     {
+        // We need to reset this because gEnablePitch might be true and
+        // specifying a pitch on an image without a parent or host_ptr is
+        // invalid.
+        image_desc.image_row_pitch = 0;
+        image_desc.image_slice_pitch = 0;
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
                                         imageInfo->format,


### PR DESCRIPTION
The test specified a image_row_pitch on the read_write image without a host_ptr or parent buffer.

The read_write image doesn't get inialized like the read_only does, so it's fine to just reset image_row_pitch back to 0 for its creation.