### PR TITLE
Fix in contractions - use -cl-denorms-are-zero when gForceFTZ

### DIFF
--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -384,8 +384,10 @@ static void PrintUsage( void )
 {
     vlog( "%s [-z]: <optional: test names>\n", appName );
     vlog( "\tOptions:\n" );
-    vlog( "\t\t-z\tToggle FTZ mode (Section 6.5.3) for all functions. (Set by device capabilities by default.)\n" );
-    vlog( "\t\t-sNUMBER set random seed.\n");
+    vlog("\t\t-z\tToggle FTZ mode (Section 6.5.3) for all functions. Caution: "
+         "the results are valid only if the implementation flushes denormals "
+         "to zero when -cl-denorms-are-zero is enabled.\n");
+    vlog("\t\t-s\tNUMBER set random seed.\n");
     vlog( "\n" );
     vlog( "\tTest names:\n" );
     for (size_t i = 0; i < test_registry::getInstance().num_tests(); i++)
@@ -515,6 +517,8 @@ test_status InitCL( cl_device_id device )
         "}\n"
         "\n" };
 
+    const char *buildOptions = gForceFTZ ? "-cl-denorms-are-zero" : "";
+
     for (i = 0; i < sizeof(sizeNames) / sizeof(sizeNames[0]); i++)
     {
         size_t strCount = sizeof(kernels) / sizeof(kernels[0]);
@@ -522,7 +526,8 @@ test_status InitCL( cl_device_id device )
 
         for (j = 2; j < strCount; j += 2) kernels[j] = sizeNames[i];
         error = create_single_kernel_helper(gContext, &gProgram[i], nullptr,
-                                            strCount, kernels, nullptr);
+                                            strCount, kernels, nullptr,
+                                            buildOptions);
         if (CL_SUCCESS != error || nullptr == gProgram[i])
         {
             log_error("Error: Unable to create test program! (%s) (in %s:%d)\n",
@@ -542,7 +547,7 @@ test_status InitCL( cl_device_id device )
             for (j = 2; j < strCount; j += 2) kernels[j] = sizeNames_double[i];
             error = create_single_kernel_helper(gContext, &gProgram_double[i],
                                                 nullptr, strCount, kernels,
-                                                nullptr);
+                                                nullptr, buildOptions);
             if (CL_SUCCESS != error || nullptr == gProgram_double[i])
             {
                 log_error(

--- a/test_conformance/contractions/contractions.cpp
+++ b/test_conformance/contractions/contractions.cpp
@@ -273,8 +273,10 @@ static test_status ParseArgs(int &argc, const char *argv[],
     argList.push_back(argv[0]);
 
     help =
-        R"(        -z       Toggle FTZ mode (Section 6.5.3) for all functions. (Set by
-                 device capabilities by default.)
+        R"(        -z       Toggle FTZ mode (Section 6.5.3) for all functions.
+                 Caution: the results are valid only if the implementation
+                 flushes denormals to zero when -cl-denorms-are-zero is enabled.
+                 (Set by device capabilities by default.)
         -sNUMBER Set random seed.
 )";
 
@@ -446,6 +448,8 @@ test_status InitCL( cl_device_id device )
         "}\n"
         "\n" };
 
+    const char *buildOptions = gForceFTZ ? "-cl-denorms-are-zero" : "";
+
     for (i = 0; i < sizeof(sizeNames) / sizeof(sizeNames[0]); i++)
     {
         size_t strCount = sizeof(kernels) / sizeof(kernels[0]);
@@ -453,7 +457,8 @@ test_status InitCL( cl_device_id device )
 
         for (j = 2; j < strCount; j += 2) kernels[j] = sizeNames[i];
         error = create_single_kernel_helper(gContext, &gProgram[i], nullptr,
-                                            strCount, kernels, nullptr);
+                                            strCount, kernels, nullptr,
+                                            buildOptions);
         if (CL_SUCCESS != error || nullptr == gProgram[i])
         {
             log_error("Error: Unable to create test program! (%s) (in %s:%d)\n",
@@ -473,7 +478,7 @@ test_status InitCL( cl_device_id device )
             for (j = 2; j < strCount; j += 2) kernels[j] = sizeNames_double[i];
             error = create_single_kernel_helper(gContext, &gProgram_double[i],
                                                 nullptr, strCount, kernels,
-                                                nullptr);
+                                                nullptr, buildOptions);
             if (CL_SUCCESS != error || nullptr == gProgram_double[i])
             {
                 log_error(


### PR DESCRIPTION
To fix issue when user option -z (toogle gForceFTZ) is used:

        Testing with FTZ mode ON? YES
        Testing Doubles? NO
        Random Number seed: 0xe848515f


contractions_float_0...
4) Error for float kernel1: -0.000000 * 0.000000 + 0.000000 =  *0.000000 vs. -0.000000
contractions_float_0 FAILED