### PR TITLE
Add cl_khr_cooperative_matrix to known extensions list

### DIFF
--- a/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
+++ b/test_conformance/compiler/test_compiler_defines_for_extensions.cpp
@@ -99,7 +99,8 @@ const char *known_extensions[] = {
     "cl_khr_command_buffer_multi_device",
     "cl_khr_external_memory_android_hardware_buffer",
     "cl_khr_unified_svm",
-    "cl_khr_spirv_queries"
+    "cl_khr_spirv_queries",
+    "cl_khr_cooperative_matrix",
 };
 // clang-format on
 


### PR DESCRIPTION
Avoid spurious failures for the new extension while the extension tests themselves are still under review in #2655 .