### PR TITLE
[NFC] math_brute_force: use common TestInfoBase base

### DIFF
--- a/test_conformance/math_brute_force/binary_double.cpp
+++ b/test_conformance/math_brute_force/binary_double.cpp
@@ -56,11 +56,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -70,19 +67,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isFDim;
-    int skipNanInf;
-    int isNextafter;
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/binary_float.cpp
+++ b/test_conformance/math_brute_force/binary_float.cpp
@@ -56,11 +56,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -70,19 +67,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isFDim;
-    int skipNanInf;
-    int isNextafter;
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/binary_i_double.cpp
+++ b/test_conformance/math_brute_force/binary_i_double.cpp
@@ -55,11 +55,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -69,15 +66,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 
     // no special values
 };

--- a/test_conformance/math_brute_force/binary_i_float.cpp
+++ b/test_conformance/math_brute_force/binary_i_float.cpp
@@ -55,11 +55,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -70,14 +67,6 @@ struct TestInfo
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
 
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
     // no special values
 };
 

--- a/test_conformance/math_brute_force/binary_operator_double.cpp
+++ b/test_conformance/math_brute_force/binary_operator_double.cpp
@@ -54,11 +54,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -68,17 +65,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if the test is being run in relaxed mode, false
-                      // otherwise.
-
-    // no special fields
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/binary_operator_float.cpp
+++ b/test_conformance/math_brute_force/binary_operator_float.cpp
@@ -54,11 +54,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -68,17 +65,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if the test is being run in relaxed mode, false
-                      // otherwise.
-
-    // no special fields
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/binary_operator_half.cpp
+++ b/test_conformance/math_brute_force/binary_operator_half.cpp
@@ -55,11 +55,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -69,15 +66,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    // no special fields
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/macro_binary_double.cpp
+++ b/test_conformance/math_brute_force/macro_binary_double.cpp
@@ -50,11 +50,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -64,14 +61,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/macro_binary_float.cpp
+++ b/test_conformance/math_brute_force/macro_binary_float.cpp
@@ -49,11 +49,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -63,14 +60,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 // A table of more difficult cases to get right

--- a/test_conformance/math_brute_force/macro_unary_double.cpp
+++ b/test_conformance/math_brute_force/macro_unary_double.cpp
@@ -46,11 +46,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -60,14 +57,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)

--- a/test_conformance/math_brute_force/macro_unary_float.cpp
+++ b/test_conformance/math_brute_force/macro_unary_float.cpp
@@ -45,11 +45,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -59,14 +56,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    int ftz; // non-zero if running in flush to zero mode
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)

--- a/test_conformance/math_brute_force/unary_double.cpp
+++ b/test_conformance/math_brute_force/unary_double.cpp
@@ -54,11 +54,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -68,19 +65,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isRangeLimited; // 1 if the function is only to be evaluated over a
-                        // range
-    float half_sin_cos_tan_limit;
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)

--- a/test_conformance/math_brute_force/unary_float.cpp
+++ b/test_conformance/math_brute_force/unary_float.cpp
@@ -53,11 +53,8 @@ struct ThreadInfo
     clCommandQueueWrapper tQueue;
 };
 
-struct TestInfo
+struct TestInfo : public TestInfoBase
 {
-    size_t subBufferSize; // Size of the sub-buffer in elements
-    const Func *f; // A pointer to the function info
-
     // Programs for various vector sizes.
     Programs programs;
 
@@ -67,20 +64,6 @@ struct TestInfo
 
     // Array of thread specific information
     std::vector<ThreadInfo> tinfo;
-
-    cl_uint threadCount; // Number of worker threads
-    cl_uint jobCount; // Number of jobs
-    cl_uint step; // step between each chunk and the next.
-    cl_uint scale; // stride between individual test values
-    float ulps; // max_allowed ulps
-    int ftz; // non-zero if running in flush to zero mode
-
-    int isRangeLimited; // 1 if the function is only to be evaluated over a
-                        // range
-    float half_sin_cos_tan_limit;
-
-    bool relaxedMode; // True if test is running in relaxed mode, false
-                      // otherwise.
 };
 
 cl_int Test(cl_uint job_id, cl_uint thread_id, void *data)


### PR DESCRIPTION
Use `TestInfoBase` as the base for all `TestInfo` classes in math_brute_force, so that individual files do not have to declare common fields.  This reduces code duplication.