### PR TITLE
fix(non_uniform_work_group): respect per-dimension work item size lim…

### DIFF
--- a/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_2d.cpp
@@ -139,8 +139,14 @@ REGISTER_TEST(non_uniform_2d_basic)
 
   // non_uniform_2d_three_prime_numbers_basic
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -149,7 +155,7 @@ REGISTER_TEST(non_uniform_2d_basic)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),
@@ -281,8 +287,14 @@ REGISTER_TEST(non_uniform_2d_atomics)
 
   // non_uniform_2d_three_prime_numbers_atomics
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -291,7 +303,7 @@ REGISTER_TEST(non_uniform_2d_atomics)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),
@@ -421,8 +433,14 @@ REGISTER_TEST(non_uniform_2d_barriers)
 
   // non_uniform_2d_three_prime_numbers_barriers
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -431,7 +449,7 @@ REGISTER_TEST(non_uniform_2d_barriers)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),

--- a/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_3d.cpp
@@ -112,8 +112,14 @@ REGISTER_TEST(non_uniform_3d_basic)
 
   // non_uniform_3d_three_prime_numbers_basic
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -122,7 +128,7 @@ REGISTER_TEST(non_uniform_3d_basic)
       size_t primeNumber2 = 10711;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),
@@ -266,8 +272,14 @@ REGISTER_TEST(non_uniform_3d_atomics)
 
   // non_uniform_3d_three_prime_numbers_atomics
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -276,7 +288,7 @@ REGISTER_TEST(non_uniform_3d_atomics)
       size_t primeNumber2 = 10711;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),
@@ -420,8 +432,14 @@ REGISTER_TEST(non_uniform_3d_barriers)
 
   // non_uniform_3d_three_prime_numbers_barriers
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -430,7 +448,7 @@ REGISTER_TEST(non_uniform_3d_barriers)
       size_t primeNumber2 = 10711;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1, 1 };
 
       exec.runTestNonUniformWorkGroup(sizeof(globalSize)
                                           / sizeof(globalSize[0]),

--- a/test_conformance/non_uniform_work_group/test_advanced_other.cpp
+++ b/test_conformance/non_uniform_work_group/test_advanced_other.cpp
@@ -48,8 +48,14 @@ REGISTER_TEST(non_uniform_other_basic)
 
   // non_uniform_2d_three_prime_numbers_offset_basic
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -58,7 +64,7 @@ REGISTER_TEST(non_uniform_other_basic)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
       size_t offset[] = { 23, 17 };
 
       exec.runTestNonUniformWorkGroup(
@@ -149,8 +155,14 @@ REGISTER_TEST(non_uniform_other_atomics)
 
   // non_uniform_2d_three_prime_numbers_offset_atomics
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -159,7 +171,7 @@ REGISTER_TEST(non_uniform_other_atomics)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
       size_t offset[] = { 23, 17 };
 
       exec.runTestNonUniformWorkGroup(
@@ -249,8 +261,14 @@ REGISTER_TEST(non_uniform_other_barriers)
 
   // non_uniform_2d_three_prime_numbers_offset_barriers
   {
+      size_t maxWorkItemSizes[3];
+      clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                      sizeof(maxWorkItemSizes), maxWorkItemSizes, NULL);
+
+      size_t effectiveMax = std::min(maxWgSize, maxWorkItemSizes[0]);
+
       size_t primeNumber =
-          PrimeNumbers::getPrimeNumberInRange(maxWgSize / 2, maxWgSize);
+          PrimeNumbers::getPrimeNumberInRange(effectiveMax / 2, effectiveMax);
       if (primeNumber < 1)
       {
           log_error("Cannot find proper prime number.");
@@ -259,7 +277,7 @@ REGISTER_TEST(non_uniform_other_barriers)
       size_t primeNumber2 = 42967;
       size_t primeNumber3 = 13;
       size_t globalSize[] = { primeNumber2, primeNumber3 };
-      size_t localSize[] = { primeNumber, 1 };
+      size_t localSize[] = { (size_t)primeNumber, 1 };
       size_t offset[] = { 23, 17 };
 
       exec.runTestNonUniformWorkGroup(


### PR DESCRIPTION
…its when selecting localSize

Problem:
Test cases selected localSize based only on CL_KERNEL_WORK_GROUP_SIZE, without considering CL_DEVICE_MAX_WORK_ITEM_SIZES per-dimension limits.

This caused issues because:
1. Constructor rounds globalSize based on the original localSize
2. prepareDevice() later trims _enqueuedLocalSize to device limits
3. Result: globalSize was rounded with wrong localSize, causing mismatch

For example, with maxWorkItemSizes=[256,256,64] and localSize={512,1}:
- globalSize rounded assuming localSize[0]=512
- prepareDevice() limits localSize[0] to 256
- globalSize and localSize no longer match

Fix:
Query CL_DEVICE_MAX_WORK_ITEM_SIZES in test cases and compute:
  effectiveMax = min(maxWgSize, maxWorkItemSizes[dim])
before selecting localSize for each dimension.

This ensures localSize is valid before rounding, so globalSize and localSize remain consistent throughout the test.

Affected files:
- test_advanced_2d.cpp
- test_advanced_3d.cpp
- test_advanced_other.cpp
- test_basic.cpp