### PR TITLE
Fix invalid alignment value for _aligned_malloc in Windows

### DIFF
--- a/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
+++ b/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
@@ -211,7 +211,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
                                PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR
                                    | CL_SVM_CAPABILITY_HOST_READ_KHR
                                    | CL_SVM_CAPABILITY_HOST_WRITE_KHR,
-                               0, nullptr, nullptr, nullptr, nullptr));
+                               1, nullptr, nullptr, nullptr, nullptr));
     }
 
     bool caps_compatibility_check(cl_uint srcTypeIndex, cl_uint dstTypeIndex)

--- a/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
+++ b/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
@@ -211,7 +211,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
                                PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR
                                    | CL_SVM_CAPABILITY_HOST_READ_KHR
                                    | CL_SVM_CAPABILITY_HOST_WRITE_KHR,
-                               1, nullptr, nullptr, nullptr, nullptr));
+                               0, nullptr, nullptr, nullptr, nullptr));
     }
 
     bool caps_compatibility_check(cl_uint srcTypeIndex, cl_uint dstTypeIndex)

--- a/test_conformance/SVM/unified_svm_fixture.h
+++ b/test_conformance/SVM/unified_svm_fixture.h
@@ -94,8 +94,9 @@ public:
             else
             {
                 // For now, just unconditionally align to the device maximum
+                const auto alignment = deviceMaxAlignment ? deviceMaxAlignment : 1;
                 data = static_cast<T*>(
-                    align_malloc(count * sizeof(T), deviceMaxAlignment));
+                    align_malloc(count * sizeof(T), alignment));
                 test_assert_error_ret(data != nullptr,
                                       "Failed to allocate memory",
                                       CL_OUT_OF_RESOURCES);

--- a/test_conformance/SVM/unified_svm_fixture.h
+++ b/test_conformance/SVM/unified_svm_fixture.h
@@ -94,9 +94,10 @@ public:
             else
             {
                 // For now, just unconditionally align to the device maximum
-                const auto alignment = deviceMaxAlignment ? deviceMaxAlignment : 1;
-                data = static_cast<T*>(
-                    align_malloc(count * sizeof(T), alignment));
+                const auto alignment =
+                    deviceMaxAlignment ? deviceMaxAlignment : 1;
+                data =
+                    static_cast<T*>(align_malloc(count * sizeof(T), alignment));
                 test_assert_error_ret(data != nullptr,
                                       "Failed to allocate memory",
                                       CL_OUT_OF_RESOURCES);


### PR DESCRIPTION
The Device Maximum Alignment is set up to zero when using the USM wrapper to allocate a System type allocation. 
This value is used for the `alignment` param in the `_aligned_malloc` function if the test is run on Windows. In this case, `alignment` must be a power of 2 [_aligned_malloc](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=msvc-170) :

> If alignment isn't a power of 2 or size is zero, this function invokes the invalid parameter handler, as described in [Parameter validation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/parameter-validation?view=msvc-170).