### PR TITLE
Fix test_consistency_external_image validation errors for missing vkFreeMemory

### DIFF
--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -240,9 +240,9 @@ struct ConsistencyExternalImageTest : public VulkanTestBase
                  memoryTypeList[0].getMemoryTypeProperty());
         log_info("Image size : %" PRIu64 "\n", vkImage2D.getSize());
 
-        VulkanDeviceMemory* vkDeviceMem =
+        std::unique_ptr<VulkanDeviceMemory> vkDeviceMem(
             new VulkanDeviceMemory(*vkDevice, vkImage2D, memoryTypeList[0],
-                                   vkExternalMemoryHandleType);
+                                   vkExternalMemoryHandleType));
         vkDeviceMem->bindImage(vkImage2D, 0);
 
         [[maybe_unused]] void* handle = NULL;


### PR DESCRIPTION
Related to #2623

Fixes vulkan validation layer error:

Vulkan validation layer: Validation Error: [ VUID-vkDestroyDevice-device-05137 ] Object 0: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x4872eaa0 | vkCreateDevice():  OBJ ERROR : For VkDevice 0x5573db5a6f10[], VkDeviceMemory 0xf443490000000006[] has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkDestroyDevice-device-05137)