### PR TITLE
Fix test_consistency_external_for_1dimage and 3dimage validation errors for missing vkFreeMemory

### DIFF
--- a/test_conformance/vulkan/test_vulkan_api_consistency_for_1dimages.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency_for_1dimages.cpp
@@ -97,9 +97,9 @@ struct ConsistencyExternalImage1DTest : public VulkanTestBase
                  memoryTypeList[0].getMemoryTypeProperty());
         log_info("Image size : %" PRIu64 "\n", vkImage1D.getSize());
 
-        VulkanDeviceMemory* vkDeviceMem =
+        std::unique_ptr<VulkanDeviceMemory> vkDeviceMem(
             new VulkanDeviceMemory(*vkDevice, vkImage1D, memoryTypeList[0],
-                                   vkExternalMemoryHandleType);
+                                   vkExternalMemoryHandleType));
         vkDeviceMem->bindImage(vkImage1D, 0);
 
         [[maybe_unused]] void* handle = NULL;

--- a/test_conformance/vulkan/test_vulkan_api_consistency_for_3dimages.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency_for_3dimages.cpp
@@ -99,9 +99,9 @@ struct ConsistencyExternalImage3DTest : public VulkanTestBase
                  memoryTypeList[0].getMemoryTypeProperty());
         log_info("Image size : %" PRIu64 "\n", vkImage3D.getSize());
 
-        VulkanDeviceMemory* vkDeviceMem =
+        std::unique_ptr<VulkanDeviceMemory> vkDeviceMem(
             new VulkanDeviceMemory(*vkDevice, vkImage3D, memoryTypeList[0],
-                                   vkExternalMemoryHandleType);
+                                   vkExternalMemoryHandleType));
         vkDeviceMem->bindImage(vkImage3D, 0);
 
         [[maybe_unused]] void* handle = NULL;


### PR DESCRIPTION
Related to https://github.com/KhronosGroup/OpenCL-CTS/issues/2623

Fixes vulkan validation layer error:

Vulkan validation layer: Validation Error: [ VUID-vkDestroyDevice-device-05137 ] Object 0: handle = 0xfa21a40000000003, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x4872eaa0 | vkCreateDevice():  OBJ ERROR : For VkDevice 0x5cbfef8c9530[], VkDeviceMemory 0xfa21a40000000003[] has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkDestroyDevice-device-05137)