### PR TITLE
Fix D3D11 log buffering on redirection

### DIFF
--- a/test_conformance/d3d11/main.cpp
+++ b/test_conformance/d3d11/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, const char* argv[])
     cl_platform_id platform = NULL;
     cl_uint num_devices_tested = 0;
 
+    setvbuf(stdout, nullptr, _IONBF, 0);
+    setvbuf(stderr, nullptr, _IONBF, 0);
+
     argc = parseCustomParam(argc, argv);
 
     // get the platforms to test


### PR DESCRIPTION
When the test log is redirected to a file, the `stdout` and `stderr` is buffered and therefore the complete log is not written to a file.
This tells the program to not use buffers.