### PR TITLE
subgroups: print cl_{,u}char as numbers in error messages

### DIFF
--- a/test_conformance/subgroups/subhelpers.cpp
+++ b/test_conformance/subgroups/subhelpers.cpp
@@ -19,6 +19,19 @@
 #include <algorithm>
 #include <random>
 
+// Override operator<< for cl_char and cl_uchar to print them as numbers.
+std::ostream& operator<<(std::ostream& os, const cl_char& val)
+{
+    os << static_cast<cl_int>(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const cl_uchar& val)
+{
+    os << static_cast<cl_uint>(val);
+    return os;
+}
+
 // Define operator<< for cl_ types, accessing the .s member.
 #define OP_OSTREAM(Ty, VecSize)                                                \
     std::ostream& operator<<(std::ostream& os, const Ty##VecSize& val)         \

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -371,6 +371,10 @@ struct cl_half16
 };
 }
 
+// Override operator<< for cl_char and cl_uchar to print them as numbers.
+std::ostream& operator<<(std::ostream& os, const cl_char& val);
+std::ostream& operator<<(std::ostream& os, const cl_uchar& val);
+
 // Declare operator<< for cl_ types, accessing the .s member.
 #define OP_OSTREAM(Ty, VecSize)                                                \
     std::ostream &operator<<(std::ostream &os, const Ty##VecSize &val);

--- a/test_conformance/subgroups/subhelpers.h
+++ b/test_conformance/subgroups/subhelpers.h
@@ -372,8 +372,8 @@ struct cl_half16
 }
 
 // Override operator<< for cl_char and cl_uchar to print them as numbers.
-std::ostream& operator<<(std::ostream& os, const cl_char& val);
-std::ostream& operator<<(std::ostream& os, const cl_uchar& val);
+std::ostream &operator<<(std::ostream &os, const cl_char &val);
+std::ostream &operator<<(std::ostream &os, const cl_uchar &val);
 
 // Declare operator<< for cl_ types, accessing the .s member.
 #define OP_OSTREAM(Ty, VecSize)                                                \


### PR DESCRIPTION
So the output does not contain invalid UTF-8 values.