### PR TITLE
c11_atomics: fix fp16 capability guard for atomic_exchange

### DIFF
--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -532,7 +532,7 @@ public:
     virtual int ExecuteSingleTest(cl_device_id deviceID, cl_context context,
                                   cl_command_queue queue)
     {
-        if constexpr (std::is_same_v<HostDataType, HOST_ATOMIC_HALF>)
+        if constexpr (std::is_same_v<HostDataType, HOST_HALF>)
         {
             if (LocalMemory()
                 && (gHalfAtomicCaps & CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT)


### PR DESCRIPTION
The `CBasicTestExchange` class is never instantiated with `HostDataType` set to `HOST_ATOMIC_HALF`, so the condition was always false.

As a result, the atomic_exchange fp16 tests could run even when the required fp16 atomic load/store capabilities were not reported by the implementation.