### PR TITLE
fix(images/kernel_read_write): align mem flags between format query a…

### DIFF
--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -145,6 +145,23 @@ int get_format_list(cl_context context, cl_mem_object_type imageType,
     return 0;
 }
 
+bool is_image_format_supported(cl_context context, cl_mem_object_type imageType,
+                               cl_mem_flags flags,
+                               const cl_image_format *format)
+{
+    std::vector<cl_image_format> formatList;
+    if (get_format_list(context, imageType, formatList, flags)) return false;
+
+    for (unsigned int i = 0; i < formatList.size(); i++)
+    {
+        if (formatList[i].image_channel_order == format->image_channel_order
+            && formatList[i].image_channel_data_type
+                == format->image_channel_data_type)
+            return true;
+    }
+    return false;
+}
+
 size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d)
 {
     if (rangeB < rangeA) rangeA = rangeB;

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -50,6 +50,9 @@ int filter_formats(const std::vector<cl_image_format> &formatList,
 int get_format_list(cl_context context, cl_mem_object_type imageType,
                     std::vector<cl_image_format> &outFormatList,
                     cl_mem_flags flags);
+bool is_image_format_supported(cl_context context, cl_mem_object_type imageType,
+                               cl_mem_flags flags,
+                               const cl_image_format *format);
 size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d);
 
 clMemWrapper create_image(cl_context context, cl_command_queue queue,

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "test_common.h"
 
 #if !defined(_WIN32)
@@ -71,6 +72,15 @@ int test_write_image_1D(cl_device_id device, cl_context context,
     }
     for( size_t mem_flag_index = 0; mem_flag_index < num_flags; mem_flag_index++ )
     {
+        if (!is_image_format_supported(context, imageInfo->type,
+                                       mem_flag_types[mem_flag_index],
+                                       imageInfo->format))
+        {
+            log_info("Format not supported for %s, skipping...\n",
+                     mem_flag_names[mem_flag_index]);
+            continue;
+        }
+
         int error;
         size_t threads[2];
         bool verifyRounding = false;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "test_common.h"
 
 #if !defined(_WIN32)
@@ -82,6 +83,15 @@ int test_write_image_1D_array(cl_device_id device, cl_context context,
 
     for( size_t mem_flag_index = 0; mem_flag_index < num_flags; mem_flag_index++ )
     {
+        if (!is_image_format_supported(context, imageInfo->type,
+                                       mem_flag_types[mem_flag_index],
+                                       imageInfo->format))
+        {
+            log_info("Format not supported for %s, skipping...\n",
+                     mem_flag_names[mem_flag_index]);
+            continue;
+        }
+
         int error;
         size_t threads[2];
         bool verifyRounding = false;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "test_common.h"
 
 #if !defined(_WIN32)
@@ -109,6 +110,15 @@ int test_write_image_2D_array(cl_device_id device, cl_context context,
 
     for( size_t mem_flag_index = 0; mem_flag_index < num_flags; mem_flag_index++ )
     {
+        if (!is_image_format_supported(context, imageInfo->type,
+                                       mem_flag_types[mem_flag_index],
+                                       imageInfo->format))
+        {
+            log_info("Format not supported for %s, skipping...\n",
+                     mem_flag_names[mem_flag_index]);
+            continue;
+        }
+
         int error;
         size_t threads[3];
         bool verifyRounding = false;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "test_common.h"
 
 #if !defined(_WIN32)
@@ -111,6 +112,15 @@ int test_write_image_3D(cl_device_id device, cl_context context,
 
     for( size_t mem_flag_index = 0; mem_flag_index < num_flags; mem_flag_index++ )
     {
+        if (!is_image_format_supported(context, imageInfo->type,
+                                       mem_flag_types[mem_flag_index],
+                                       imageInfo->format))
+        {
+            log_info("Format not supported for %s, skipping...\n",
+                     mem_flag_names[mem_flag_index]);
+            continue;
+        }
+
         int error;
         size_t threads[3];
         bool verifyRounding = false;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "../testBase.h"
+#include "../common.h"
 #include "test_common.h"
 
 #if !defined(_WIN32)
@@ -105,6 +106,15 @@ int test_write_image(cl_device_id device, cl_context context,
 
     for( size_t mem_flag_index = 0; mem_flag_index < num_flags; mem_flag_index++ )
     {
+        if (!is_image_format_supported(context, imageInfo->type,
+                                       mem_flag_types[mem_flag_index],
+                                       imageInfo->format))
+        {
+            log_info("Format not supported for %s, skipping...\n",
+                     mem_flag_names[mem_flag_index]);
+            continue;
+        }
+
         int error;
         size_t threads[2];
         bool verifyRounding = false;


### PR DESCRIPTION
…nd image creation

The format query in test_loops.cpp uses CL_MEM_WRITE_ONLY, but test_write_*.cpp creates images with both CL_MEM_WRITE_ONLY and CL_MEM_READ_WRITE flags. This causes test failures for formats that are only supported with WRITE_ONLY flag (e.g., CL_RGB + CL_SIGNED_INT8).

Solution:
- Change write_only_mem_flag_types array from 2 elements to 1 element
- Only test CL_MEM_WRITE_ONLY flag for kWriteTests
- CL_MEM_READ_WRITE is already covered by kReadWriteTests which uses read_write kernel and queries formats with CL_MEM_KERNEL_READ_AND_WRITE