### PR TITLE
Fix validation layer errors in test_buffer_multiImport_sameCtx

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_buffer.cpp
@@ -762,12 +762,12 @@ int run_test_with_multi_import_same_ctx(
     VulkanExternalSemaphoreHandleType vkExternalSemaphoreHandleType)
 {
     size_t global_work_size[1];
-    uint8_t *error_2 = nullptr;
-    cl_mem error_1 = nullptr;
+    uint8_t error_2[1];
+    clMemWrapper error_1;
     int numImports = numBuffers;
     cl_kernel update_buffer_kernel;
-    clExternalImportableSemaphore *clVk2CLExternalSemaphore = nullptr;
-    clExternalExportableSemaphore *clCl2VkExternalSemaphore = nullptr;
+    std::unique_ptr<clExternalImportableSemaphore> clVk2CLExternalSemaphore;
+    std::unique_ptr<clExternalExportableSemaphore> clCl2VkExternalSemaphore;
     int err = CL_SUCCESS;
     int calc_max_iter;
 
@@ -818,11 +818,13 @@ int run_test_with_multi_import_same_ctx(
     }
     else
     {
-        clVk2CLExternalSemaphore = new clExternalImportableSemaphore(
-            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        clVk2CLExternalSemaphore.reset(new clExternalImportableSemaphore(
+            vkVk2CLSemaphore, context, vkExternalSemaphoreHandleType,
+            deviceId));
 
-        clCl2VkExternalSemaphore = new clExternalExportableSemaphore(
-            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType, deviceId);
+        clCl2VkExternalSemaphore.reset(new clExternalExportableSemaphore(
+            vkCl2VkSemaphore, context, vkExternalSemaphoreHandleType,
+            deviceId));
     }
 
     const uint32_t maxIter = innerIterations;
@@ -835,9 +837,8 @@ int run_test_with_multi_import_same_ctx(
         getVulkanMemoryType(vkDevice,
                             VULKAN_MEMORY_TYPE_PROPERTY_HOST_VISIBLE_COHERENT));
     vkParamsDeviceMemory.bindBuffer(vkParamsBuffer);
-    std::vector<VulkanDeviceMemory *> vkBufferListDeviceMemory;
-    std::vector<std::vector<clExternalMemory *>> externalMemory;
-
+    std::vector<std::unique_ptr<VulkanDeviceMemory>> vkBufferListDeviceMemory;
+    std::vector<std::vector<std::unique_ptr<clExternalMemory>>> externalMemory;
 
     for (size_t emhtIdx = 0; emhtIdx < vkExternalMemoryHandleTypeList.size();
          emhtIdx++)
@@ -867,19 +868,21 @@ int run_test_with_multi_import_same_ctx(
 
             for (size_t bIdx = 0; bIdx < numBuffers; bIdx++)
             {
-                vkBufferListDeviceMemory.push_back(new VulkanDeviceMemory(
-                    vkDevice, vkBufferList[bIdx], memoryType,
-                    vkExternalMemoryHandleType));
+                vkBufferListDeviceMemory.emplace_back(
+                    std::make_unique<VulkanDeviceMemory>(
+                        vkDevice, vkBufferList[bIdx], memoryType,
+                        vkExternalMemoryHandleType));
 
-                std::vector<clExternalMemory *> pExternalMemory;
+                std::vector<std::unique_ptr<clExternalMemory>> pExternalMemory;
                 for (int cl_bIdx = 0; cl_bIdx < numImports; cl_bIdx++)
                 {
-                    pExternalMemory.push_back(
-                        new clExternalMemory(vkBufferListDeviceMemory[bIdx],
-                                             vkExternalMemoryHandleType,
-                                             bufferSize, context, deviceId));
+                    pExternalMemory.emplace_back(
+                        std::make_unique<clExternalMemory>(
+                            vkBufferListDeviceMemory[bIdx].get(),
+                            vkExternalMemoryHandleType, bufferSize, context,
+                            deviceId));
                 }
-                externalMemory.push_back(pExternalMemory);
+                externalMemory.emplace_back(std::move(pExternalMemory));
             }
 
             clFinish(cmd_queue1);
@@ -942,9 +945,9 @@ int run_test_with_multi_import_same_ctx(
                 else
                 {
                     err = clVk2CLExternalSemaphore->wait(cmd_queue1);
-                    test_error_and_cleanup(err, CLEANUP,
-                                           "Error: failed to wait on "
-                                           "CL external semaphore\n");
+                    test_error(err,
+                               "Error: failed to wait on "
+                               "CL external semaphore\n");
                 }
 
                 for (uint8_t launchIter = 0; launchIter < numImports;
@@ -960,28 +963,25 @@ int run_test_with_multi_import_same_ctx(
                         err = clEnqueueAcquireExternalMemObjectsKHRptr(
                             cmd_queue1, 1, &buffers[i][launchIter], 0, nullptr,
                             nullptr);
-                        test_error_and_cleanup(err, CLEANUP,
-                                               "Failed to acquire buffers");
+                        test_error(err, "Failed to acquire buffers");
                     }
-                    test_error_and_cleanup(
-                        err, CLEANUP,
-                        "Error: Failed to set arg values for "
-                        "kernel\n ");
+                    test_error(err,
+                               "Error: Failed to set arg values for "
+                               "kernel\n ");
 
                     err = clEnqueueNDRangeKernel(
                         cmd_queue1, update_buffer_kernel, 1, NULL,
                         global_work_size, NULL, 0, NULL, NULL);
-                    test_error_and_cleanup(err, CLEANUP,
-                                           "Error: Failed to launch "
-                                           "update_buffer_kernel, error\n ");
+                    test_error(err,
+                               "Error: Failed to launch "
+                               "update_buffer_kernel, error\n ");
 
                     for (uint32_t i = 0; i < numBuffers; i++)
                     {
                         err = clEnqueueReleaseExternalMemObjectsKHRptr(
                             cmd_queue1, 1, &buffers[i][launchIter], 0, nullptr,
                             nullptr);
-                        test_error_and_cleanup(err, CLEANUP,
-                                               "Failed to release buffers");
+                        test_error(err, "Failed to release buffers");
                     }
                 }
                 if (use_fence)
@@ -990,28 +990,26 @@ int run_test_with_multi_import_same_ctx(
                 }
                 else if (!use_fence && iter != (maxIter - 1))
                 {
+                    // Wait until semaphore is not in-use before re-import
+                    // (VUID-vkImportSemaphoreFdKHR-semaphore-01142)
+                    vkQueue.waitIdle();
+
                     err = clCl2VkExternalSemaphore->signal(cmd_queue1);
-                    test_error_and_cleanup(err, CLEANUP,
-                                           "Failed to signal CL semaphore\n");
+                    test_error(err, "Failed to signal CL semaphore\n");
                 }
             }
 
-            error_2 = (uint8_t *)malloc(sizeof(uint8_t));
-            if (NULL == error_2)
-            {
-                test_fail_and_cleanup(err, CLEANUP,
-                                      "Not able to allocate memory\n");
-            }
+            // Drain queue before per-iteration resource cleanup
+            vkQueue.waitIdle();
 
             error_1 = clCreateBuffer(context, CL_MEM_WRITE_ONLY,
                                      sizeof(uint8_t), NULL, &err);
-            test_error_and_cleanup(err, CLEANUP, "Error: clCreateBuffer \n");
+            test_error(err, "Error: clCreateBuffer \n");
 
             uint8_t val = 0;
             err = clEnqueueWriteBuffer(cmd_queue1, error_1, CL_TRUE, 0,
                                        sizeof(uint8_t), &val, 0, NULL, NULL);
-            test_error_and_cleanup(err, CLEANUP,
-                                   "Error: clEnqueueWriteBuffer \n");
+            test_error(err, "Error: clEnqueueWriteBuffer \n");
 
             calc_max_iter = maxIter * (numImports + 1);
 
@@ -1025,77 +1023,33 @@ int run_test_with_multi_import_same_ctx(
                                       &calc_max_iter);
                 err |= clSetKernelArg(verify_kernel, 3, sizeof(cl_mem),
                                       (void *)&error_1);
-                test_error_and_cleanup(err, CLEANUP,
-                                       "Error: Failed to set arg values for "
-                                       "verify_kernel \n");
+                test_error(err,
+                           "Error: Failed to set arg values for "
+                           "verify_kernel \n");
 
                 err = clEnqueueNDRangeKernel(cmd_queue1, verify_kernel, 1, NULL,
                                              global_work_size, NULL, 0, NULL,
                                              NULL);
-                test_error_and_cleanup(
-                    err, CLEANUP,
-                    "Error: Failed to launch verify_kernel, error\n");
+                test_error(err,
+                           "Error: Failed to launch verify_kernel, error\n");
 
                 err = clEnqueueReadBuffer(cmd_queue1, error_1, CL_TRUE, 0,
                                           sizeof(uint8_t), error_2, 0, NULL,
                                           NULL);
-                test_error_and_cleanup(err, CLEANUP,
-                                       "Error: Failed read output, error \n");
+                test_error(err, "Error: Failed read output, error \n");
 
                 if (*error_2 == 1)
                 {
-                    test_fail_and_cleanup(
-                        err, CLEANUP, " vulkan_opencl_buffer test FAILED\n");
+                    test_error_ret(err, " vulkan_opencl_buffer test FAILED\n",
+                                   TEST_FAIL);
                 }
             }
-            for (size_t i = 0; i < vkBufferList.size(); i++)
-            {
-                for (int j = 0; j < numImports; j++)
-                {
-                    delete externalMemory[i][j];
-                }
-            }
-            for (size_t i = 0; i < vkBufferListDeviceMemory.size(); i++)
-            {
-                delete vkBufferListDeviceMemory[i];
-            }
-            vkBufferListDeviceMemory.erase(vkBufferListDeviceMemory.begin(),
-                                           vkBufferListDeviceMemory.end());
-            for (size_t i = 0; i < externalMemory.size(); i++)
-            {
-                externalMemory[i].erase(externalMemory[i].begin(),
-                                        externalMemory[i].begin() + numBuffers);
-            }
+
+            vkBufferListDeviceMemory.clear();
             externalMemory.clear();
         }
     }
-CLEANUP:
-    for (size_t i = 0; i < vkBufferListDeviceMemory.size(); i++)
-    {
-        if (vkBufferListDeviceMemory[i])
-        {
-            delete vkBufferListDeviceMemory[i];
-        }
-    }
-    for (size_t i = 0; i < externalMemory.size(); i++)
-    {
-        for (size_t j = 0; j < externalMemory[i].size(); j++)
-        {
-            if (externalMemory[i][j])
-            {
-                delete externalMemory[i][j];
-            }
-        }
-    }
 
-    if (!use_fence)
-    {
-        if (clVk2CLExternalSemaphore) delete clVk2CLExternalSemaphore;
-        if (clCl2VkExternalSemaphore) delete clCl2VkExternalSemaphore;
-    }
-
-    if (error_2) free(error_2);
-    if (error_1) clReleaseMemObject(error_1);
     return err;
 }
 


### PR DESCRIPTION
Related to #2623, additional cleanup corrections applied (replaced regular cl objects with wrappers and smart pointers).

Fixes vulkan validation layer errors:

Vulkan validation layer: Validation Error: [ VUID-vkImportSemaphoreFdKHR-semaphore-01142 ] | MessageID = 0x668a54af | vkImportSemaphoreFdKHR(): pImportSemaphoreFdInfo->semaphore can't be called on VkSemaphore 0xfa21a40000000003[] that is currently in use by VkSemaphore 0xfa21a40000000003[]. The Vulkan spec states: semaphore must not be associated with any queue command that has not yet completed execution on that queue (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkImportSemaphoreFdKHR-semaphore-01142)

Vulkan validation layer: Validation Error: [ VUID-vkFreeMemory-memory-00677 ] | MessageID = 0x485c8ea2 | vkFreeMemory(): can't be called on VkDeviceMemory 0xe7e6d0000000000f[] that is currently in use by VkBuffer 0x967dd1000000000e[]. The Vulkan spec states: All submitted commands that refer to memory (via images or buffers) must have completed execution (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkFreeMemory-memory-00677)

Vulkan validation layer: Validation Error: [ VUID-vkFreeCommandBuffers-pCommandBuffers-00047 ] Object 0: handle = 0x5ef05db4a000, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xcfef35000000000a, type = VK_OBJECT_TYPE_COMMAND_POOL; | MessageID = 0x1ab902fc | vkFreeCommandBuffers(): pCommandBuffers[0] (VkCommandBuffer 0x5ef05db4a000[]) is in use. The Vulkan spec states: All elements of pCommandBuffers must not be in the pending state (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkFreeCommandBuffers-pCommandBuffers-00047)

Vulkan validation layer: Validation Error: [ VUID-vkDestroySemaphore-semaphore-05149 ] | MessageID = 0x93e24db1 | vkDestroySemaphore(): semaphore can't be called on VkSemaphore 0xfa21a40000000003[] that is currently in use by VkSemaphore 0xfa21a40000000003[]. The Vulkan spec states: All submitted batches that refer to semaphore must have completed execution (https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/1.3-extensions/vkspec.html#VUID-vkDestroySemaphore-semaphore-05149)
