### PR TITLE
math_brute_force: fix tgamma fp32 reference host-dependence

### DIFF
--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -2354,9 +2354,33 @@ smallarg:
 
 double reference_tgamma(double x)
 {
+    // This function is only used for fp32 reference calculations.
+    const float fx = x;
+
+    // Once |fx| >= 128, tgammaf has already overflowed or underflowed, so avoid
+    // host-dependent olm_tgammal behavior.
+    if (isfinite(fx) && fabsf(fx) >= 128.0f)
+    {
+        // Negative integer inputs are invalid for tgamma, so return NaN.
+        if (fx < 0.0f && fx == std::floor(fx))
+        {
+            return cl_make_nan();
+        }
+
+        if (fx < 0.0f)
+        {
+            // Negative non-integer large values underflow to zero; preserve the
+            // sign, which alternates between consecutive negative integers.
+            const long n = (long)std::floor(-fx);
+            const bool negative = (n % 2 == 0);
+            return negative ? -0.0 : 0.0;
+        }
+
+        return INFINITY;
+    }
+
     if (x < 0.0f)
     {
-        float fx = x;
         if (fx == std::floor(fx))
         {
             return std::numeric_limits<double>::signaling_NaN();


### PR DESCRIPTION
Avoid calling the `long double` tgamma helper for larger fp32 inputs that knowingly result in overflow or underflow.  long-double precision is ABI dependent and can produce different results for large values.

An example case I observed was for input `0x1.62e6p+9` (`709.796875f`) which must yield infinity as it is far beyond the fp32 overflow threshold for tgamma.  The host reference computation wrongly resulted in `NaN` on some platforms.

Fix by avoiding host long-double math when deciding a result that is already known from fp32 semantics.  Use `|x| >= 128` as a conservative cut-off point.  It is well past any finite fp32 tgamma result for both positive and negative inputs.