### PR TITLE
math_brute_force: do not create signaling NaNs for tgamma

### DIFF
--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -2359,7 +2359,7 @@ double reference_tgamma(double x)
         float fx = x;
         if (fx == std::floor(fx))
         {
-            return std::numeric_limits<double>::signaling_NaN();
+            return cl_make_nan();
         }
 
         // The gamma function satisfies the reflection formula:
@@ -6087,7 +6087,7 @@ long double reference_tgammal(long double x)
     {
         if (x == std::floor(x))
         {
-            return std::numeric_limits<long double>::signaling_NaN();
+            return cl_make_nan();
         }
 
         // The gamma function satisfies the reflection formula:


### PR DESCRIPTION
Since this is a reference implementation, we only need the NaN result and are not interested in signaling-NaN behavior, so a quiet NaN is preferred.  Use the same NaN helper that the other reference functions use.