### PR TITLE
math_brute_force: test unary_u_half inputs only once

### DIFF
--- a/test_conformance/math_brute_force/unary_u_half.cpp
+++ b/test_conformance/math_brute_force/unary_u_half.cpp
@@ -65,7 +65,7 @@ int TestFunc_Half_UShort(const Func *f, MTdata d, bool relaxedMode)
         return error;
     }
 
-    for (uint64_t i = 0; i < (1ULL << 32); i += step)
+    for (uint64_t i = 0; i < (1ULL << 16); i += step)
     {
         if (gSkipCorrectnessTesting) break;
 


### PR DESCRIPTION
Avoid testing the same inputs for unary_u_half functions many times. The input domain of such functions only contains 2^16 possible elements.

This only affects the fp16 `nan` built-in functions.