### PR TITLE
spirv_new: don't use Physical64 in spvasm32 files

### DIFF
--- a/test_conformance/spirv_new/spirv_asm/spv1.4/image_operand_signextend.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/spv1.4/image_operand_signextend.spvasm32
@@ -8,7 +8,7 @@
                OpCapability Kernel
                OpCapability ImageBasic
                OpCapability LiteralSampler
-               OpMemoryModel Physical64 OpenCL
+               OpMemoryModel Physical32 OpenCL
                OpEntryPoint Kernel %read_image_test "read_image_test"
                OpSource OpenCL_C 102000
        %uint = OpTypeInt 32 0

--- a/test_conformance/spirv_new/spirv_asm/spv1.4/image_operand_zeroextend.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/spv1.4/image_operand_zeroextend.spvasm32
@@ -8,7 +8,7 @@
                OpCapability Kernel
                OpCapability ImageBasic
                OpCapability LiteralSampler
-               OpMemoryModel Physical64 OpenCL
+               OpMemoryModel Physical32 OpenCL
                OpEntryPoint Kernel %read_image_test "read_image_test"
                OpSource OpenCL_C 102000
        %uint = OpTypeInt 32 0


### PR DESCRIPTION
spirv14_image_operand_signextend and spirv14_image_operand_zeroextend accidentally used the `Physical64` memory model for the 32-bit variants.