### PR TITLE
Fix sub_group_inverse_ballot testing

### DIFF
--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -339,92 +339,6 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_EXTRACT
     }
 };
 
-template <typename Ty, BallotOp operation> struct BALLOT_INVERSE
-{
-    static void log_test(const WorkGroupParams &test_params,
-                         const char *extra_text)
-    {
-        log_info("  sub_group_inverse_ballot...%s\n", extra_text);
-    }
-
-    static void gen(Ty *x, Ty *t, cl_int *m, const WorkGroupParams &test_params)
-    {
-        // no work here
-    }
-
-    static test_status chk(Ty *x, Ty *y, Ty *mx, Ty *my, cl_int *m,
-                           const WorkGroupParams &test_params)
-    {
-        int wi_id, wg_id, sb_id;
-        int gws = test_params.global_workgroup_size;
-        int lws = test_params.local_workgroup_size;
-        int sbs = test_params.subgroup_size;
-        int sb_number = (lws + sbs - 1) / sbs;
-        cl_uint4 expected_result, device_result;
-        int non_uniform_size = gws % lws;
-        int wg_number = gws / lws;
-        int last_subgroup_size = 0;
-        int current_sbs = 0;
-        if (non_uniform_size) wg_number++;
-
-        for (wg_id = 0; wg_id < wg_number; ++wg_id)
-        { // for each work_group
-            if (non_uniform_size && wg_id == wg_number - 1)
-            {
-                set_last_workgroup_params(non_uniform_size, sb_number, sbs, lws,
-                                          last_subgroup_size);
-            }
-            // Map to array indexed to array indexed by local ID and sub group
-            for (wi_id = 0; wi_id < lws; ++wi_id)
-            { // inside the work_group
-                mx[wi_id] = x[wi_id]; // read host inputs for work_group
-                my[wi_id] = y[wi_id]; // read device outputs for work_group
-            }
-
-            for (sb_id = 0; sb_id < sb_number; ++sb_id)
-            { // for each subgroup
-                int wg_offset = sb_id * sbs;
-                if (last_subgroup_size && sb_id == sb_number - 1)
-                {
-                    current_sbs = last_subgroup_size;
-                }
-                else
-                {
-                    current_sbs = wg_offset + sbs > lws ? lws - wg_offset : sbs;
-                }
-                // take subgroup local id of this work_item
-                // Check result
-                for (wi_id = 0; wi_id < current_sbs; ++wi_id)
-                { // for each subgroup work item
-
-                    wi_id & 1 ? expected_result = { { 1, 0, 0, 1 } }
-                              : expected_result = { { 1, 0, 0, 2 } };
-
-                    device_result = my[wg_offset + wi_id];
-                    if (!compare(device_result, expected_result))
-                    {
-                        log_error(
-                            "ERROR: sub_group_%s mismatch for local id %d in "
-                            "sub group %d in group %d obtained {%d, %d, %d, "
-                            "%d}, expected {%d, %d, %d, %d}\n",
-                            operation_names(operation), wi_id, sb_id, wg_id,
-                            device_result.s0, device_result.s1,
-                            device_result.s2, device_result.s3,
-                            expected_result.s0, expected_result.s1,
-                            expected_result.s2, expected_result.s3);
-                        return TEST_FAIL;
-                    }
-                }
-            }
-            x += lws;
-            y += lws;
-            m += 4 * lws;
-        }
-
-        return TEST_PASS;
-    }
-};
-
 // Used for static_asserts below
 template <auto...> inline constexpr bool always_false_v = false;
 
@@ -474,7 +388,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                 }
                 if constexpr (operation == BallotOp::ballot_bit_count
                               || operation == BallotOp::ballot_inclusive_scan
-                              || operation == BallotOp::ballot_exclusive_scan)
+                              || operation == BallotOp::ballot_exclusive_scan
+                              || operation == BallotOp::inverse_ballot)
                 {
                     set_randomdata_for_subgroup<Ty>(t, wg_offset, current_sbs);
                 }
@@ -514,9 +429,11 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                                   cl_uint sub_group_size)
     {
         bs128 mask;
-        if constexpr (operation == BallotOp::ballot_bit_count
-                      || operation == BallotOp::ballot_find_lsb
-                      || operation == BallotOp::ballot_find_msb)
+        if constexpr (operation == BallotOp::inverse_ballot)
+            mask.set(sub_group_local_id);
+        else if constexpr (operation == BallotOp::ballot_bit_count
+                           || operation == BallotOp::ballot_find_lsb
+                           || operation == BallotOp::ballot_find_msb)
         {
             for (cl_uint i = 0; i < sub_group_size; ++i) mask.set(i);
         }
@@ -599,6 +516,21 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                                       "expected %d\n",
                                       operation_names(operation), wi_id, sb_id,
                                       wg_id, device_result, expected_result);
+                            return TEST_FAIL;
+                        }
+                    }
+                    else if constexpr (operation == BallotOp::inverse_ballot)
+                    {
+                        expected_result = bs.any() ? 1u : 0u;
+                        if (!compare(device_result ? 1u : 0u, expected_result))
+                        {
+                            log_error("ERROR: sub_group_%s "
+                                      "mismatch for local id %d in sub group "
+                                      "%d in group %d obtained %d, "
+                                      "expected %s\n",
+                                      operation_names(operation), wi_id, sb_id,
+                                      wg_id, device_result,
+                                      expected_result ? "non-zero" : "zero");
                             return TEST_FAIL;
                         }
                     }
@@ -839,30 +771,6 @@ __kernel void test_sub_group_ballot(const __global Type *in, __global int4 *xy, 
     out[gid] = value;
 }
 )";
-std::string sub_group_inverse_ballot_source = R"(
-__kernel void test_sub_group_inverse_ballot(const __global Type *in, __global int4 *xy, __global Type *out) {
-    int gid = get_global_id(0);
-    XY(xy,gid);
-    Type x = in[gid];
-    uint4 value = (uint4)(10,0,0,0);
-    if (get_sub_group_local_id() & 1) {
-        uint4 partial_ballot_mask = (uint4)(0xAAAAAAAA,0xAAAAAAAA,0xAAAAAAAA,0xAAAAAAAA);
-        if (sub_group_inverse_ballot(partial_ballot_mask)) {
-            value = (uint4)(1,0,0,1);
-        } else {
-            value = (uint4)(0,0,0,1);
-        }
-    } else {
-        uint4 partial_ballot_mask = (uint4)(0x55555555,0x55555555,0x55555555,0x55555555);
-        if (sub_group_inverse_ballot(partial_ballot_mask)) {
-            value = (uint4)(1,0,0,2);
-        } else {
-            value = (uint4)(0,0,0,2);
-        }
-    }
-    out[gid] = value;
-}
-)";
 std::string sub_group_ballot_bit_extract_source = R"(
  __kernel void test_sub_group_ballot_bit_extract(const __global Type *in, __global int4 *xy, __global Type *out) {
     int gid = get_global_id(0);
@@ -1067,14 +975,12 @@ REGISTER_TEST(subgroup_functions_ballot)
     // ballot bit-op functions
     WorkGroupParams test_params_bit_ops(global_work_size, local_work_size);
     test_params_bit_ops.save_kernel_source(sub_group_ballot_bit_ops_source);
-    test_params_bit_ops.save_kernel_source(sub_group_inverse_ballot_source,
-                                           "sub_group_inverse_ballot");
     test_params_bit_ops.save_kernel_source(sub_group_ballot_bit_extract_source,
                                            "sub_group_ballot_bit_extract");
     RunTestForType rft_bit_ops(device, context, queue, num_elements,
                                test_params_bit_ops);
     error |= rft_bit_ops.run_impl<
-        cl_uint4, BALLOT_INVERSE<cl_uint4, BallotOp::inverse_ballot>>(
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::inverse_ballot>>(
         "sub_group_inverse_ballot");
     error |= rft_bit_ops.run_impl<
         cl_uint4, BALLOT_BIT_EXTRACT<cl_uint4, BallotOp::ballot_bit_extract>>(

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -425,6 +425,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_INVERSE
     }
 };
 
+// Used for static_asserts below
+template <auto...> inline constexpr bool always_false_v = false;
 
 // Test for bit count/inclusive and exclusive scan/ find lsb msb ballot function
 template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
@@ -470,18 +472,18 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                 {
                     current_sbs = wg_offset + sbs > lws ? lws - wg_offset : sbs;
                 }
-                if (operation == BallotOp::ballot_bit_count
-                    || operation == BallotOp::ballot_inclusive_scan
-                    || operation == BallotOp::ballot_exclusive_scan)
+                if constexpr (operation == BallotOp::ballot_bit_count
+                              || operation == BallotOp::ballot_inclusive_scan
+                              || operation == BallotOp::ballot_exclusive_scan)
                 {
                     set_randomdata_for_subgroup<Ty>(t, wg_offset, current_sbs);
                 }
-                else if (operation == BallotOp::ballot_find_lsb
-                         || operation == BallotOp::ballot_find_msb)
+                else if constexpr (operation == BallotOp::ballot_find_lsb
+                                   || operation == BallotOp::ballot_find_msb)
                 {
-                    // Regarding to the spec, find lsb and find msb result is
-                    // undefined behavior if input value is zero, so generate
-                    // only non-zero values.
+                    // Regarding to the spec, find lsb and find msb result
+                    // is undefined behavior if input value is zero, so
+                    // generate only non-zero values.
                     for (wi_id = 0; wi_id < current_sbs; ++wi_id)
                     {
                         char x = (genrand_int32(gMTdata)) & 0xff;
@@ -492,7 +494,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                 }
                 else
                 {
-                    log_error("Unknown operation...\n");
+                    static_assert(always_false_v<operation>,
+                                  "Unknown BallotOp in BALLOT_BIT_OPS::gen");
                 }
             }
 
@@ -511,18 +514,24 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                                   cl_uint sub_group_size)
     {
         bs128 mask;
-        if (operation == BallotOp::ballot_bit_count
-            || operation == BallotOp::ballot_find_lsb
-            || operation == BallotOp::ballot_find_msb)
+        if constexpr (operation == BallotOp::ballot_bit_count
+                      || operation == BallotOp::ballot_find_lsb
+                      || operation == BallotOp::ballot_find_msb)
         {
             for (cl_uint i = 0; i < sub_group_size; ++i) mask.set(i);
         }
-        else if (operation == BallotOp::ballot_inclusive_scan
-                 || operation == BallotOp::ballot_exclusive_scan)
+        else if constexpr (operation == BallotOp::ballot_inclusive_scan
+                           || operation == BallotOp::ballot_exclusive_scan)
         {
             for (cl_uint i = 0; i < sub_group_local_id; ++i) mask.set(i);
             if (operation == BallotOp::ballot_inclusive_scan)
                 mask.set(sub_group_local_id);
+        }
+        else
+        {
+            static_assert(
+                always_false_v<operation>,
+                "Unknown BallotOp in BALLOT_BIT_OPS::getImportantBits");
         }
         return mask;
     }
@@ -576,9 +585,10 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                     bs128 bs = cl_uint4_to_bs128(mx[wg_offset + wi_id])
                         & getImportantBits(wi_id, sbs);
                     device_result = my[wg_offset + wi_id].s0;
-                    if (operation == BallotOp::ballot_inclusive_scan
-                        || operation == BallotOp::ballot_exclusive_scan
-                        || operation == BallotOp::ballot_bit_count)
+                    if constexpr (operation == BallotOp::ballot_inclusive_scan
+                                  || operation
+                                      == BallotOp::ballot_exclusive_scan
+                                  || operation == BallotOp::ballot_bit_count)
                     {
                         expected_result = bs.count();
                         if (!compare(device_result, expected_result))
@@ -592,7 +602,7 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                             return TEST_FAIL;
                         }
                     }
-                    else if (operation == BallotOp::ballot_find_lsb)
+                    else if constexpr (operation == BallotOp::ballot_find_lsb)
                     {
                         if (bs.none())
                         {
@@ -619,7 +629,7 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                             return TEST_FAIL;
                         }
                     }
-                    else if (operation == BallotOp::ballot_find_msb)
+                    else if constexpr (operation == BallotOp::ballot_find_msb)
                     {
                         if (bs.none())
                         {
@@ -645,6 +655,12 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                                       expected_result);
                             return TEST_FAIL;
                         }
+                    }
+                    else
+                    {
+                        static_assert(
+                            always_false_v<operation>,
+                            "Unknown BallotOp in BALLOT_BIT_OPS::chk");
                     }
                 }
             }

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -427,7 +427,7 @@ template <typename Ty, BallotOp operation> struct BALLOT_INVERSE
 
 
 // Test for bit count/inclusive and exclusive scan/ find lsb msb ballot function
-template <typename Ty, BallotOp operation> struct BALLOT_COUNT_SCAN_FIND
+template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
 {
     static void log_test(const WorkGroupParams &test_params,
                          const char *extra_text)
@@ -785,7 +785,7 @@ __kernel void test_sub_group_broadcast_first(const __global Type *in, __global i
     }
 }
 )";
-std::string sub_group_ballot_bit_scan_find_source = R"(
+std::string sub_group_ballot_bit_ops_source = R"(
 __kernel void test_%s(const __global Type *in, __global int4 *xy, __global Type *out) {
     int gid = get_global_id(0);
     XY(xy,gid);
@@ -1053,38 +1053,35 @@ REGISTER_TEST(subgroup_functions_ballot)
     error |=
         rft_ballot.run_impl<cl_uint4, BALLOT<cl_uint4>>("sub_group_ballot");
 
-    // ballot arithmetic functions
-    WorkGroupParams test_params_arith(global_work_size, local_work_size);
-    test_params_arith.save_kernel_source(sub_group_ballot_bit_scan_find_source);
-    test_params_arith.save_kernel_source(sub_group_inverse_ballot_source,
-                                         "sub_group_inverse_ballot");
-    test_params_arith.save_kernel_source(sub_group_ballot_bit_extract_source,
-                                         "sub_group_ballot_bit_extract");
-    RunTestForType rft_arith(device, context, queue, num_elements,
-                             test_params_arith);
-    error |=
-        rft_arith.run_impl<cl_uint4,
-                           BALLOT_INVERSE<cl_uint4, BallotOp::inverse_ballot>>(
-            "sub_group_inverse_ballot");
-    error |= rft_arith.run_impl<
+    // ballot bit-op functions
+    WorkGroupParams test_params_bit_ops(global_work_size, local_work_size);
+    test_params_bit_ops.save_kernel_source(sub_group_ballot_bit_ops_source);
+    test_params_bit_ops.save_kernel_source(sub_group_inverse_ballot_source,
+                                           "sub_group_inverse_ballot");
+    test_params_bit_ops.save_kernel_source(sub_group_ballot_bit_extract_source,
+                                           "sub_group_ballot_bit_extract");
+    RunTestForType rft_bit_ops(device, context, queue, num_elements,
+                               test_params_bit_ops);
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_INVERSE<cl_uint4, BallotOp::inverse_ballot>>(
+        "sub_group_inverse_ballot");
+    error |= rft_bit_ops.run_impl<
         cl_uint4, BALLOT_BIT_EXTRACT<cl_uint4, BallotOp::ballot_bit_extract>>(
         "sub_group_ballot_bit_extract");
-    error |= rft_arith.run_impl<
-        cl_uint4, BALLOT_COUNT_SCAN_FIND<cl_uint4, BallotOp::ballot_bit_count>>(
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::ballot_bit_count>>(
         "sub_group_ballot_bit_count");
-    error |= rft_arith.run_impl<
-        cl_uint4,
-        BALLOT_COUNT_SCAN_FIND<cl_uint4, BallotOp::ballot_inclusive_scan>>(
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::ballot_inclusive_scan>>(
         "sub_group_ballot_inclusive_scan");
-    error |= rft_arith.run_impl<
-        cl_uint4,
-        BALLOT_COUNT_SCAN_FIND<cl_uint4, BallotOp::ballot_exclusive_scan>>(
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::ballot_exclusive_scan>>(
         "sub_group_ballot_exclusive_scan");
-    error |= rft_arith.run_impl<
-        cl_uint4, BALLOT_COUNT_SCAN_FIND<cl_uint4, BallotOp::ballot_find_lsb>>(
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::ballot_find_lsb>>(
         "sub_group_ballot_find_lsb");
-    error |= rft_arith.run_impl<
-        cl_uint4, BALLOT_COUNT_SCAN_FIND<cl_uint4, BallotOp::ballot_find_msb>>(
+    error |= rft_bit_ops.run_impl<
+        cl_uint4, BALLOT_BIT_OPS<cl_uint4, BallotOp::ballot_find_msb>>(
         "sub_group_ballot_find_msb");
 
     return error;

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -340,7 +340,7 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_EXTRACT
 };
 
 // Used for static_asserts below
-template <auto...> inline constexpr bool always_false_v = false;
+template <auto...> [[maybe_unused]] inline constexpr bool always_false_v = false;
 
 // Test for bit count/inclusive and exclusive scan/ find lsb msb ballot function
 template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -340,7 +340,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_EXTRACT
 };
 
 // Used for static_asserts below
-template <auto...> [[maybe_unused]] inline constexpr bool always_false_v = false;
+template <auto...>
+[[maybe_unused]] inline constexpr bool always_false_v = false;
 
 // Test for bit count/inclusive and exclusive scan/ find lsb msb ballot function
 template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS

--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -573,13 +573,8 @@ template <typename Ty, BallotOp operation> struct BALLOT_BIT_OPS
                 expected_result = 0;
                 for (wi_id = 0; wi_id < current_sbs; ++wi_id)
                 { // for subgroup element
-                    bs128 bs;
-                    // convert cl_uint4 input into std::bitset<128>
-                    bs |= bs128(mx[wg_offset + wi_id].s0)
-                        | (bs128(mx[wg_offset + wi_id].s1) << 32)
-                        | (bs128(mx[wg_offset + wi_id].s2) << 64)
-                        | (bs128(mx[wg_offset + wi_id].s3) << 96);
-                    bs &= getImportantBits(wi_id, sbs);
+                    bs128 bs = cl_uint4_to_bs128(mx[wg_offset + wi_id])
+                        & getImportantBits(wi_id, sbs);
                     device_result = my[wg_offset + wi_id].s0;
                     if (operation == BallotOp::ballot_inclusive_scan
                         || operation == BallotOp::ballot_exclusive_scan


### PR DESCRIPTION
The previous test would still pass even if the implementation always
returned true.

Now that we use BALLOT_BIT_OPS for inverse_ballot, we no longer need
sub_group_inverse_ballot_source. We use sub_group_ballot_bit_ops_source
instead.

This change also renames BALLOT_COUNT_SCAN_FIND to BALLOT_BIT_OPS,
along with renaming rft_arith to rft_bit_ops, test_params_arith to
test_params_bit_ops, and sub_group_ballot_bit_scan_find_source to
sub_group_ballot_bit_ops_source.

It also uses cl_uint4_to_bs128 in BALLOT_BIT_OPS::chk and adds
static_asserts for BallotOp values.