### PR TITLE
images: Remove global variables to allow for parallel execution

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -132,6 +132,9 @@
         }
     },
     "test_image_streams": {
+        "--num-worker-threads 2 CL_A CL_FILTER_NEAREST": {
+            "1D": "pass"
+        },
         "--num-worker-threads 2 CL_FILTER_NEAREST CL_R": {
             "1D": "fail"
         }

--- a/test_conformance/images/clCopyImage/main.cpp
+++ b/test_conformance/images/clCopyImage/main.cpp
@@ -20,63 +20,59 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-bool gDebugTrace;
-bool gTestSmallImages;
-bool gTestMaxImages;
-bool gEnablePitch;
-bool gTestMipmaps;
-int gTypesToTest;
-cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
+static context_t ctx;
 
-extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod );
+extern int test_image_set(cl_device_id device, cl_context context,
+                          cl_command_queue queue, MethodsToTest testMethod,
+                          const context_t &ctx);
 
-REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D); }
-REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D); }
-REGISTER_TEST(3D) { return test_image_set(device, context, queue, k3D); }
+REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D, ctx); }
+REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D, ctx); }
+REGISTER_TEST(3D) { return test_image_set(device, context, queue, k3D, ctx); }
+
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, queue, k1DBuffer);
+    return test_image_set(device, context, queue, k1DBuffer, ctx);
 }
 REGISTER_TEST(1DTo1Dbuffer)
 {
-    return test_image_set(device, context, queue, k1DTo1DBuffer);
+    return test_image_set(device, context, queue, k1DTo1DBuffer, ctx);
 }
 REGISTER_TEST(1DbufferTo1D)
 {
-    return test_image_set(device, context, queue, k1DBufferTo1D);
+    return test_image_set(device, context, queue, k1DBufferTo1D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set( device, context, queue, k1DArray );
+    return test_image_set(device, context, queue, k1DArray, ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set( device, context, queue, k2DArray );
+    return test_image_set(device, context, queue, k2DArray, ctx);
 }
 REGISTER_TEST(2Dto3D)
 {
-    return test_image_set( device, context, queue, k2DTo3D );
+    return test_image_set(device, context, queue, k2DTo3D, ctx);
 }
 REGISTER_TEST(3Dto2D)
 {
-    return test_image_set( device, context, queue, k3DTo2D );
+    return test_image_set(device, context, queue, k3DTo2D, ctx);
 }
 REGISTER_TEST(2Darrayto2D)
 {
-    return test_image_set( device, context, queue, k2DArrayTo2D );
+    return test_image_set(device, context, queue, k2DArrayTo2D, ctx);
 }
 REGISTER_TEST(2Dto2Darray)
 {
-    return test_image_set( device, context, queue, k2DTo2DArray );
+    return test_image_set(device, context, queue, k2DTo2DArray, ctx);
 }
 REGISTER_TEST(2Darrayto3D)
 {
-    return test_image_set( device, context, queue, k2DArrayTo3D );
+    return test_image_set(device, context, queue, k2DArrayTo3D, ctx);
 }
 REGISTER_TEST(3Dto2Darray)
 {
-    return test_image_set( device, context, queue, k3DTo2DArray );
+    return test_image_set(device, context, queue, k3DTo2DArray, ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -97,30 +93,32 @@ static test_status parseArgs(int &argc, const char *argv[],
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
 
+    init_context(ctx);
+
     // Parse arguments
     for (int i = 1; i < argc; i++)
     {
         removed_args.push_back(argv[i]);
         if (strcmp(argv[i], "test_mipmaps") == 0)
         {
-            gTestMipmaps = true;
+            ctx.testMipmaps = true;
             // Don't test pitches with mipmaps, at least currently.
-            gEnablePitch = false;
+            ctx.enablePitch = false;
         }
         else if (strcmp(argv[i], "debug_trace") == 0)
-            gDebugTrace = true;
+            ctx.debugTrace = true;
         else if (strcmp(argv[i], "small_images") == 0)
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if (strcmp(argv[i], "max_images") == 0)
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if (strcmp(argv[i], "use_pitches") == 0)
-            gEnablePitch = true;
+            ctx.enablePitch = true;
         else if ((chanType = get_channel_type_from_name(argv[i]))
                  != (cl_channel_type)-1)
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
         else if ((chanOrder = get_channel_order_from_name(argv[i]))
                  != (cl_channel_order)-1)
-            gChannelOrderToUse = chanOrder;
+            ctx.channelOrderToUse = chanOrder;
         else
         {
             removed_args.pop_back();
@@ -128,7 +126,7 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if (gTestSmallImages) log_info("Note: Using small test images\n");
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/clCopyImage/main.cpp
+++ b/test_conformance/images/clCopyImage/main.cpp
@@ -20,11 +20,11 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, MethodsToTest testMethod,
-                          const context_t &ctx);
+                          const image_test_context_t &ctx);
 
 REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D, ctx); }
 REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D, ctx); }
@@ -92,8 +92,6 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-
-    init_context(ctx);
 
     // Parse arguments
     for (int i = 1; i < argc; i++)

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -21,12 +21,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
                             image_descriptor *dstImageInfo, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
   size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
   int ret = 0, retCode;
@@ -123,7 +123,7 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
                            cl_mem_object_type dst_type, cl_image_format *format,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 1D -> 1D images
     size_t maxWidth;

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -80,21 +80,24 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-      if( ctx.testMipmaps )
-      {
-        // Work at a random mip level
-        src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        dst_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
-        src_width_lod = (srcImageInfo->width >> src_lod)
-            ? (srcImageInfo->width >> src_lod)
-            : 1;
-        dst_width_lod = (dstImageInfo->width >> dst_lod)
-            ? (dstImageInfo->width >> dst_lod)
-            : 1;
-        width_lod  = ( src_width_lod > dst_width_lod ) ? dst_width_lod : src_width_lod;
-        sourcePos[ 1 ] = src_lod;
-        destPos[ 1 ] = dst_lod;
-      }
+        if (ctx.testMipmaps)
+        {
+            // Work at a random mip level
+            src_lod = (size_t)random_in_range(
+                0, max_mip_level ? max_mip_level - 1 : 0, d);
+            dst_lod = (size_t)random_in_range(
+                0, max_mip_level ? max_mip_level - 1 : 0, d);
+            src_width_lod = (srcImageInfo->width >> src_lod)
+                ? (srcImageInfo->width >> src_lod)
+                : 1;
+            dst_width_lod = (dstImageInfo->width >> dst_lod)
+                ? (dstImageInfo->width >> dst_lod)
+                : 1;
+            width_lod =
+                (src_width_lod > dst_width_lod) ? dst_width_lod : src_width_lod;
+            sourcePos[1] = src_lod;
+            destPos[1] = dst_lod;
+        }
       // Pick a random size
       regionSize[ 0 ] = ( width_lod > 8 ) ? (size_t)random_in_range( 8, (int)width_lod - 1, d ) : width_lod;
 
@@ -147,38 +150,40 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( ctx.testSmallImages )
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-      size_t rowPadding = ctx.enablePitch ? 48 : 0;
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
-      if (ctx.debugTrace) log_info("   at size %d\n", (int)srcImageInfo.width);
+            if (ctx.debugTrace)
+                log_info("   at size %d\n", (int)srcImageInfo.width);
 
-      dstImageInfo = srcImageInfo;
-      dstImageInfo.mem_flags = dst_flags;
-      int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed, ctx);
-      if (ret) return -1;
+            dstImageInfo = srcImageInfo;
+            dstImageInfo.mem_flags = dst_flags;
+            int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
+                                              &dstImageInfo, seed, ctx);
+            if (ret) return -1;
         }
     }
-    else if( ctx.testMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -189,23 +194,24 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = ctx.enablePitch ? 48 : 0;
-      srcImageInfo.width = sizes[idx][0];
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
+            srcImageInfo.width = sizes[idx][0];
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
             if (ctx.debugTrace)
@@ -260,15 +266,15 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( ctx.debugTrace )
-      {
-          log_info("   at size %d (row pitch %d) out of %d\n",
-                   (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
-                   (int)maxWidth);
-          if (ctx.testMipmaps)
-              log_info("   and %zu mip levels\n",
-                       (size_t)srcImageInfo.num_mip_levels);
-      }
+            if (ctx.debugTrace)
+            {
+                log_info("   at size %d (row pitch %d) out of %d\n",
+                         (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
+                         (int)maxWidth);
+                if (ctx.testMipmaps)
+                    log_info("   and %zu mip levels\n",
+                             (size_t)srcImageInfo.num_mip_levels);
+            }
       dstImageInfo = srcImageInfo;
       dstImageInfo.mem_flags = dst_flags;
       int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -15,12 +15,18 @@
 //
 #include "../testBase.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
-                            image_descriptor *dstImageInfo, MTdata d)
+                            image_descriptor *dstImageInfo, MTdata d,
+                            const context_t &ctx)
 {
   size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
   int ret = 0, retCode;
@@ -29,7 +35,7 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
   size_t width_lod = srcImageInfo->width;
   size_t max_mip_level = 0;
 
-  if (gTestMipmaps)
+  if (ctx.testMipmaps)
   {
       max_mip_level = srcImageInfo->num_mip_levels;
       // Work at a random mip level
@@ -56,7 +62,7 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
     regionSize[ 1 ] = 1;
     regionSize[ 2 ] = 1;
 
-    if(gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         sourcePos[ 1 ] = src_lod;
         destPos[ 1 ] = dst_lod;
@@ -65,7 +71,7 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
 
     retCode =
         test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d);
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
       return retCode;
     else
@@ -74,7 +80,7 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-      if( gTestMipmaps )
+      if( ctx.testMipmaps )
       {
         // Work at a random mip level
         src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
@@ -100,7 +106,7 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
       // Go for it!
       retCode =
           test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                  sourcePos, destPos, regionSize, d);
+                                  sourcePos, destPos, regionSize, d, ctx);
       if( retCode < 0 )
         return retCode;
       else
@@ -113,7 +119,8 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
 int test_copy_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                           cl_mem_object_type dst_type, cl_image_format *format)
+                           cl_mem_object_type dst_type, cl_image_format *format,
+                           const context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 1D -> 1D images
     size_t maxWidth;
@@ -140,19 +147,19 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+      size_t rowPadding = ctx.enablePitch ? 48 : 0;
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -162,16 +169,16 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
           } while ((srcImageInfo.rowPitch % pixelSize) != 0);
       }
 
-      if (gDebugTrace) log_info("   at size %d\n", (int)srcImageInfo.width);
+      if (ctx.debugTrace) log_info("   at size %d\n", (int)srcImageInfo.width);
 
       dstImageInfo = srcImageInfo;
       dstImageInfo.mem_flags = dst_flags;
       int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed);
+                                        &dstImageInfo, seed, ctx);
       if (ret) return -1;
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -182,15 +189,15 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+      size_t rowPadding = ctx.enablePitch ? 48 : 0;
       srcImageInfo.width = sizes[idx][0];
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -201,13 +208,13 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
       }
 
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             if (test_copy_image_size_1D(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed))
+                                        &dstImageInfo, seed, ctx))
                 return -1;
         }
     }
@@ -216,7 +223,7 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong size;
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
@@ -224,7 +231,7 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
                 srcImageInfo.width =
                     (size_t)random_log_in_range(16, (int)maxWidth / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -239,7 +246,7 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         {
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -253,19 +260,19 @@ int test_copy_image_set_1D(cl_device_id device, cl_context context,
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if( ctx.debugTrace )
       {
           log_info("   at size %d (row pitch %d) out of %d\n",
                    (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
                    (int)maxWidth);
-          if (gTestMipmaps)
+          if (ctx.testMipmaps)
               log_info("   and %zu mip levels\n",
                        (size_t)srcImageInfo.num_mip_levels);
       }
       dstImageInfo = srcImageInfo;
       dstImageInfo.mem_flags = dst_flags;
       int ret = test_copy_image_size_1D(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed);
+                                        &dstImageInfo, seed, ctx);
       if (ret) return -1;
         }
     }

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -15,12 +15,18 @@
 //
 #include "../testBase.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
                                   image_descriptor *srcImageInfo,
-                                  image_descriptor *dstImageInfo, MTdata d)
+                                  image_descriptor *dstImageInfo, MTdata d,
+                                  const context_t &ctx)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -29,7 +35,7 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
     size_t width_lod = srcImageInfo->width;
     size_t max_mip_level = 0;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         max_mip_level = srcImageInfo->num_mip_levels;
         // Work at a random mip level
@@ -55,7 +61,7 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
     regionSize[1] = srcImageInfo->arraySize;
     regionSize[ 2 ] = 1;
 
-    if(gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         sourcePos[ 2 ] = src_lod;
         destPos[ 2 ] = dst_lod;
@@ -64,7 +70,7 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
 
     retCode =
         test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d);
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
         return retCode;
     else
@@ -73,7 +79,7 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             // Work at a random mip level
             src_lod = (size_t) ( max_mip_level > 1 )? random_in_range( 0,  max_mip_level - 1 , d ) : 0;
@@ -112,7 +118,7 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
         // Go for it!
         retCode =
             test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d);
+                                    sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else
@@ -127,7 +133,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format)
+                                 cl_image_format *format, const context_t &ctx)
 {
     assert(
         dst_type
@@ -155,20 +161,20 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+      size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -182,19 +188,19 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
       for (srcImageInfo.arraySize = 2; srcImageInfo.arraySize < 9;
            srcImageInfo.arraySize++)
       {
-          if (gDebugTrace)
+          if (ctx.debugTrace)
               log_info("   at size %d,%d\n", (int)srcImageInfo.width,
                        (int)srcImageInfo.arraySize);
 
           dstImageInfo = srcImageInfo;
           dstImageInfo.mem_flags = dst_flags;
           int ret = test_copy_image_size_1D_array(context, queue, &srcImageInfo,
-                                                  &dstImageInfo, seed);
+                                                  &dstImageInfo, seed, ctx);
           if (ret) return -1;
       }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -205,17 +211,17 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+      size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
       srcImageInfo.width = sizes[idx][0];
       srcImageInfo.arraySize = sizes[idx][2];
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -227,14 +233,14 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
 
       srcImageInfo.slicePitch = srcImageInfo.rowPitch;
       log_info("Testing %d x %d\n", (int)sizes[idx][0], (int)sizes[idx][2]);
-      if (gDebugTrace)
+      if (ctx.debugTrace)
           log_info("   at max size %d,%d\n", (int)sizes[idx][0],
                    (int)sizes[idx][2]);
 
       dstImageInfo = srcImageInfo;
       dstImageInfo.mem_flags = dst_flags;
       if (test_copy_image_size_1D_array(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed))
+                                        &dstImageInfo, seed, ctx))
           return -1;
         }
     }
@@ -243,7 +249,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong size;
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
@@ -254,7 +260,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
                     16, (int)maxArraySize / 32, seed);
                 srcImageInfo.height = srcImageInfo.depth = 0;
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -270,7 +276,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         {
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -287,7 +293,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-      if( gDebugTrace )
+      if( ctx.debugTrace )
           log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
                    (int)srcImageInfo.width, (int)srcImageInfo.arraySize,
                    (int)srcImageInfo.rowPitch, (int)maxWidth,
@@ -296,7 +302,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
       dstImageInfo = srcImageInfo;
       dstImageInfo.mem_flags = dst_flags;
       int ret = test_copy_image_size_1D_array(context, queue, &srcImageInfo,
-                                              &dstImageInfo, seed);
+                                              &dstImageInfo, seed, ctx);
       if( ret )
         return -1;
     }

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -166,23 +166,24 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-      size_t rowPadding = ctx.enablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
       srcImageInfo.slicePitch = srcImageInfo.rowPitch;
       for (srcImageInfo.arraySize = 2; srcImageInfo.arraySize < 9;
@@ -211,25 +212,26 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = ctx.enablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
-      srcImageInfo.width = sizes[idx][0];
-      srcImageInfo.arraySize = sizes[idx][2];
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.width = sizes[idx][0];
+            srcImageInfo.arraySize = sizes[idx][2];
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0), seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2, (int)compute_max_mip_levels(srcImageInfo.width, 0, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
       srcImageInfo.slicePitch = srcImageInfo.rowPitch;
       log_info("Testing %d x %d\n", (int)sizes[idx][0], (int)sizes[idx][2]);
@@ -293,18 +295,17 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-      if( ctx.debugTrace )
-          log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
-                   (int)srcImageInfo.width, (int)srcImageInfo.arraySize,
-                   (int)srcImageInfo.rowPitch, (int)maxWidth,
-                   (int)maxArraySize);
+            if (ctx.debugTrace)
+                log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
+                         (int)srcImageInfo.width, (int)srcImageInfo.arraySize,
+                         (int)srcImageInfo.rowPitch, (int)maxWidth,
+                         (int)maxArraySize);
 
-      dstImageInfo = srcImageInfo;
-      dstImageInfo.mem_flags = dst_flags;
-      int ret = test_copy_image_size_1D_array(context, queue, &srcImageInfo,
-                                              &dstImageInfo, seed, ctx);
-      if( ret )
-        return -1;
+            dstImageInfo = srcImageInfo;
+            dstImageInfo.mem_flags = dst_flags;
+            int ret = test_copy_image_size_1D_array(
+                context, queue, &srcImageInfo, &dstImageInfo, seed, ctx);
+            if (ret) return -1;
     }
     }
 

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -133,7 +133,8 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format, const image_test_context_t &ctx)
+                                 cl_image_format *format,
+                                 const image_test_context_t &ctx)
 {
     assert(
         dst_type

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -21,12 +21,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
                                   image_descriptor *srcImageInfo,
                                   image_descriptor *dstImageInfo, MTdata d,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -133,7 +133,7 @@ int test_copy_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format, const context_t &ctx)
+                                 cl_image_format *format, const image_test_context_t &ctx)
 {
     assert(
         dst_type

--- a/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
@@ -20,11 +20,13 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *dstImageInfo,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
-                                   const size_t regionSize[], MTdata d);
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
                                    image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo, MTdata d)
+                                   image_descriptor *dstImageInfo, MTdata d,
+                                   const context_t &ctx)
 {
     size_t sourcePos[3], destPos[3], regionSize[3];
     int ret = 0, retCode;
@@ -39,7 +41,7 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 
     retCode =
         test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d);
+                                sourcePos, destPos, regionSize, d, ctx);
     if (retCode < 0)
         return retCode;
     else
@@ -65,7 +67,7 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
         // Go for it!
         retCode =
             test_copy_image_generic(context, queue, srcImageInfo, srcImageInfo,
-                                    sourcePos, destPos, regionSize, d);
+                                    sourcePos, destPos, regionSize, d, ctx);
         if (retCode < 0)
             return retCode;
         else
@@ -78,7 +80,7 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format)
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
 {
     assert(
         dst_type
@@ -90,7 +92,7 @@ int test_copy_image_set_1D_buffer(
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         // 1D image buffers don't support mipmaps
         // https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image
@@ -118,15 +120,15 @@ int test_copy_image_set_1D_buffer(
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -136,17 +138,17 @@ int test_copy_image_set_1D_buffer(
                 } while ((srcImageInfo.rowPitch % pixelSize) != 0);
             }
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d\n", (int)srcImageInfo.width);
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             int ret = test_copy_image_size_1D_buffer(
-                context, queue, &srcImageInfo, &dstImageInfo, seed);
+                context, queue, &srcImageInfo, &dstImageInfo, seed, ctx);
             if (ret) return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -157,11 +159,11 @@ int test_copy_image_set_1D_buffer(
 
         for (size_t idx = 0; idx < numbeOfSizes; idx++)
         {
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             srcImageInfo.width = sizes[idx][0];
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -172,13 +174,13 @@ int test_copy_image_set_1D_buffer(
             }
 
             log_info("Testing %d\n", (int)sizes[idx][0]);
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at max size %d\n", (int)sizes[idx][0]);
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             if (test_copy_image_size_1D_buffer(context, queue, &srcImageInfo,
-                                               &dstImageInfo, seed))
+                                               &dstImageInfo, seed, ctx))
                 return -1;
         }
     }
@@ -187,7 +189,7 @@ int test_copy_image_set_1D_buffer(
         for (int i = 0; i < NUM_IMAGE_ITERATIONS; i++)
         {
             cl_ulong size;
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             // Loop until we get a size that a) will fit in the max alloc size
             // and b) that an allocation of that image, the result array, plus
             // offset arrays, will fit in the global ram space
@@ -199,7 +201,7 @@ int test_copy_image_set_1D_buffer(
                 srcImageInfo.rowPitch =
                     srcImageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                     do
                     {
@@ -212,7 +214,7 @@ int test_copy_image_set_1D_buffer(
                 size = (size_t)srcImageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
             {
                 log_info("   at size %d (row pitch %d) out of %d\n",
                          (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
@@ -222,7 +224,7 @@ int test_copy_image_set_1D_buffer(
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             int ret = test_copy_image_size_1D_buffer(
-                context, queue, &srcImageInfo, &dstImageInfo, seed);
+                context, queue, &srcImageInfo, &dstImageInfo, seed, ctx);
             if (ret) return -1;
         }
     }
@@ -233,7 +235,7 @@ int test_copy_image_set_1D_buffer(
 int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format)
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -242,7 +244,7 @@ int test_copy_image_set_1D_1D_buffer(
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         // 1D image buffers don't support mipmaps
         // https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image
@@ -270,15 +272,15 @@ int test_copy_image_set_1D_1D_buffer(
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -288,7 +290,7 @@ int test_copy_image_set_1D_1D_buffer(
                 } while ((srcImageInfo.rowPitch % pixelSize) != 0);
             }
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d\n", (int)srcImageInfo.width);
 
             dstImageInfo = srcImageInfo;
@@ -296,11 +298,11 @@ int test_copy_image_set_1D_1D_buffer(
             dstImageInfo.mem_flags = dst_flags;
 
             int ret = test_copy_image_size_1D_buffer(
-                context, queue, &srcImageInfo, &dstImageInfo, seed);
+                context, queue, &srcImageInfo, &dstImageInfo, seed, ctx);
             if (ret) return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -311,11 +313,11 @@ int test_copy_image_set_1D_1D_buffer(
 
         for (size_t idx = 0; idx < numbeOfSizes; idx++)
         {
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             srcImageInfo.width = sizes[idx][0];
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -326,7 +328,7 @@ int test_copy_image_set_1D_1D_buffer(
             }
 
             log_info("Testing %d\n", (int)sizes[idx][0]);
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at max size %d\n", (int)sizes[idx][0]);
 
             dstImageInfo = srcImageInfo;
@@ -334,7 +336,7 @@ int test_copy_image_set_1D_1D_buffer(
             dstImageInfo.mem_flags = dst_flags;
 
             if (test_copy_image_size_1D_buffer(context, queue, &srcImageInfo,
-                                               &dstImageInfo, seed))
+                                               &dstImageInfo, seed, ctx))
                 return -1;
         }
     }
@@ -343,7 +345,7 @@ int test_copy_image_set_1D_1D_buffer(
         for (int i = 0; i < NUM_IMAGE_ITERATIONS; i++)
         {
             cl_ulong size;
-            size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             // Loop until we get a size that a) will fit in the max alloc size
             // and b) that an allocation of that image, the result array, plus
             // offset arrays, will fit in the global ram space
@@ -355,7 +357,7 @@ int test_copy_image_set_1D_1D_buffer(
                 srcImageInfo.rowPitch =
                     srcImageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                     do
                     {
@@ -368,7 +370,7 @@ int test_copy_image_set_1D_1D_buffer(
                 size = (size_t)srcImageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
             {
                 log_info("   at size %d (row pitch %d) out of %d\n",
                          (int)srcImageInfo.width, (int)srcImageInfo.rowPitch,
@@ -380,7 +382,7 @@ int test_copy_image_set_1D_1D_buffer(
             dstImageInfo.mem_flags = dst_flags;
 
             int ret = test_copy_image_size_1D_buffer(
-                context, queue, &srcImageInfo, &dstImageInfo, seed);
+                context, queue, &srcImageInfo, &dstImageInfo, seed, ctx);
             if (ret) return -1;
         }
     }

--- a/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
@@ -21,12 +21,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
                                    image_descriptor *srcImageInfo,
                                    image_descriptor *dstImageInfo, MTdata d,
-                                   const context_t &ctx)
+                                   const image_test_context_t &ctx)
 {
     size_t sourcePos[3], destPos[3], regionSize[3];
     int ret = 0, retCode;
@@ -80,7 +80,7 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
 {
     assert(
         dst_type
@@ -235,7 +235,7 @@ int test_copy_image_set_1D_buffer(
 int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
@@ -80,7 +80,8 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx)
 {
     assert(
         dst_type
@@ -235,7 +236,8 @@ int test_copy_image_set_1D_buffer(
 int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -172,24 +172,24 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
         {
             size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2,
-              (int)compute_max_mip_levels(srcImageInfo.width,
-                                          srcImageInfo.height, 0),
-              seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2,
+                    (int)compute_max_mip_levels(srcImageInfo.width,
+                                                srcImageInfo.height, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
       for (srcImageInfo.height = 1; srcImageInfo.height < 9;
            srcImageInfo.height++)
@@ -217,28 +217,28 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = ctx.enablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
-      srcImageInfo.width = sizes[idx][0];
-      srcImageInfo.height = sizes[idx][1];
-      srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
+            srcImageInfo.width = sizes[idx][0];
+            srcImageInfo.height = sizes[idx][1];
+            srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (ctx.testMipmaps)
-          srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
-              2,
-              (int)compute_max_mip_levels(srcImageInfo.width,
-                                          srcImageInfo.height, 0),
-              seed);
+            if (ctx.testMipmaps)
+                srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                    2,
+                    (int)compute_max_mip_levels(srcImageInfo.width,
+                                                srcImageInfo.height, 0),
+                    seed);
 
-      if (ctx.enablePitch)
-      {
-          do
-          {
-              rowPadding++;
-              srcImageInfo.rowPitch =
-                  srcImageInfo.width * pixelSize + rowPadding;
-          } while ((srcImageInfo.rowPitch % pixelSize) != 0);
-      }
+            if (ctx.enablePitch)
+            {
+                do
+                {
+                    rowPadding++;
+                    srcImageInfo.rowPitch =
+                        srcImageInfo.width * pixelSize + rowPadding;
+                } while ((srcImageInfo.rowPitch % pixelSize) != 0);
+            }
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             if (ctx.debugTrace)

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -21,12 +21,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
                             image_descriptor *dstImageInfo, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -139,7 +139,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
                            cl_mem_object_type dst_type, cl_image_format *format,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 2D -> 2D images
     size_t maxWidth, maxHeight;

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -15,12 +15,18 @@
 //
 #include "../testBase.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
-                            image_descriptor *dstImageInfo, MTdata d)
+                            image_descriptor *dstImageInfo, MTdata d,
+                            const context_t &ctx)
 {
     size_t sourcePos[ 3 ], destPos[ 3 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +37,7 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
     size_t width_lod = srcImageInfo->width, height_lod = srcImageInfo->height;
     size_t max_mip_level = 0;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         max_mip_level = srcImageInfo->num_mip_levels;
         // Work at a random mip level
@@ -64,7 +70,7 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
     regionSize[1] = srcImageInfo->height;
     regionSize[ 2 ] = 1;
 
-    if(gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         sourcePos[ 2 ] = src_lod;
         destPos[ 2 ] = dst_lod;
@@ -74,7 +80,7 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
 
     retCode =
         test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d);
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
         return retCode;
     else
@@ -83,7 +89,7 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             // Work at a random mip level
             src_lod = (size_t)random_in_range( 0, max_mip_level ? max_mip_level - 1 : 0, d );
@@ -119,7 +125,7 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
         // Go for it!
         retCode =
             test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d);
+                                    sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else
@@ -132,7 +138,8 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
 int test_copy_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                           cl_mem_object_type dst_type, cl_image_format *format)
+                           cl_mem_object_type dst_type, cl_image_format *format,
+                           const context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 2D -> 2D images
     size_t maxWidth, maxHeight;
@@ -158,23 +165,23 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2,
               (int)compute_max_mip_levels(srcImageInfo.width,
                                           srcImageInfo.height, 0),
               seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -187,19 +194,19 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
       for (srcImageInfo.height = 1; srcImageInfo.height < 9;
            srcImageInfo.height++)
       {
-          if (gDebugTrace)
+          if (ctx.debugTrace)
               log_info("   at size %d,%d\n", (int)srcImageInfo.width,
                        (int)srcImageInfo.height);
 
           dstImageInfo = srcImageInfo;
           dstImageInfo.mem_flags = dst_flags;
           int ret = test_copy_image_size_2D(context, queue, &srcImageInfo,
-                                            &dstImageInfo, seed);
+                                            &dstImageInfo, seed, ctx);
           if (ret) return -1;
       }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -210,20 +217,20 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+      size_t rowPadding = ctx.enablePitch ? 48 : 0;
 
       srcImageInfo.width = sizes[idx][0];
       srcImageInfo.height = sizes[idx][1];
       srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
           srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
               2,
               (int)compute_max_mip_levels(srcImageInfo.width,
                                           srcImageInfo.height, 0),
               seed);
 
-      if (gEnablePitch)
+      if (ctx.enablePitch)
       {
           do
           {
@@ -234,13 +241,13 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
       }
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             if (test_copy_image_size_2D(context, queue, &srcImageInfo,
-                                        &dstImageInfo, seed))
+                                        &dstImageInfo, seed, ctx))
                 return -1;
         }
     }
@@ -249,7 +256,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong size;
-      size_t rowPadding = gEnablePitch ? 48 : 0;
+            size_t rowPadding = ctx.enablePitch ? 48 : 0;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
@@ -259,7 +266,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
                 srcImageInfo.height =
                     (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -274,7 +281,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
         else
         {
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do
                 {
@@ -289,7 +296,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
         }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d (row pitch %d) out of %d,%d\n",
                          (int)srcImageInfo.width, (int)srcImageInfo.height,
                          (int)srcImageInfo.rowPitch, (int)maxWidth,
@@ -298,7 +305,7 @@ int test_copy_image_set_2D(cl_device_id device, cl_context context,
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             int ret = test_copy_image_size_2D(context, queue, &srcImageInfo,
-                                              &dstImageInfo, seed);
+                                              &dstImageInfo, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -16,10 +16,18 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
-static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t arraySize, size_t rowPadding, size_t slicePadding )
+static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
+                                 size_t height, size_t arraySize,
+                                 size_t rowPadding, size_t slicePadding,
+                                 const context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -28,7 +36,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
     imageInfo->arraySize = arraySize;
     imageInfo->rowPitch = imageInfo->width * pixelSize + rowPadding;
 
-    if (gEnablePitch)
+    if (ctx.enablePitch)
     {
         do {
             rowPadding++;
@@ -47,7 +55,10 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
+                                     image_descriptor *srcImageInfo,
+                                     image_descriptor *dstImageInfo, MTdata d,
+                                     const context_t &ctx)
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -72,7 +83,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
     size_t width_lod, height_lod;
     size_t twoImage_max_mip_level = 0, threeImage_max_mip_level = 0;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         twoImage_max_mip_level = twoImage->num_mip_levels;
         threeImage_max_mip_level = threeImage->num_mip_levels;
@@ -101,7 +112,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
     {
         // 2D to 2D array
         destPos[ 2 ] = (size_t)random_in_range( 0, (int)dstImageInfo->arraySize - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             sourcePos[ 2 ] = twoImage_lod;
             destPos[ 3 ] = threeImage_lod;
@@ -113,7 +124,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
     {
         // 2D array to 2D
         sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)srcImageInfo->arraySize - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             sourcePos[ 3 ] = threeImage_lod;
             destPos[ 2 ] = twoImage_lod;
@@ -122,7 +133,9 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
         }
     }
 
-    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
         return retCode;
     else
@@ -131,7 +144,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             // Work at a random mip level
             twoImage_lod = (size_t)random_in_range( 0, twoImage_max_mip_level ? twoImage_max_mip_level - 1 : 0, d );
@@ -146,7 +159,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
         // Pick a random size
         regionSize[ 0 ] = random_in_ranges( 8, srcImageInfo->width, dstImageInfo->width, d );
         regionSize[ 1 ] = random_in_ranges( 8, srcImageInfo->height, dstImageInfo->height, d );
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             regionSize[ 0 ] = ( width_lod > 8 ) ? random_in_range( 8, width_lod, d ) : width_lod;
             regionSize[ 1 ] = ( height_lod > 8) ? random_in_range( 8, height_lod, d ): height_lod;
@@ -155,8 +168,8 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
         // Now pick positions within valid ranges
         sourcePos[ 0 ] = ( srcImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         sourcePos[ 1 ] = ( srcImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
-        sourcePos[ 2 ] = ( srcImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->arraySize - 1 ), d ) : gTestMipmaps ? twoImage_lod : 0;
-        if (gTestMipmaps)
+        sourcePos[ 2 ] = ( srcImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->arraySize - 1 ), d ) : ctx.testMipmaps ? twoImage_lod : 0;
+        if (ctx.testMipmaps)
         {
             if( srcImageInfo->arraySize > 0 )
             {
@@ -174,8 +187,8 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
 
         destPos[ 0 ] = ( dstImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         destPos[ 1 ] = ( dstImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
-        destPos[ 2 ] = ( dstImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->arraySize - 1 ), d ) : gTestMipmaps ? twoImage_lod : 0;
-        if (gTestMipmaps)
+        destPos[ 2 ] = ( dstImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->arraySize - 1 ), d ) : ctx.testMipmaps ? twoImage_lod : 0;
+        if (ctx.testMipmaps)
         {
             if( dstImageInfo->arraySize > 0 )
             {
@@ -192,7 +205,9 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
         }
 
         // Go for it!
-        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode =
+            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                    sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else
@@ -206,7 +221,7 @@ int test_copy_image_size_2D_2D_array( cl_context context, cl_command_queue queue
 int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format)
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -241,7 +256,7 @@ int test_copy_image_set_2D_2D_array(
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (imageInfo2Darray.width = 4; imageInfo2Darray.width < 17;
              imageInfo2Darray.width++)
@@ -253,18 +268,18 @@ int test_copy_image_set_2D_2D_array(
                      imageInfo2Darray.arraySize < 9;
                      imageInfo2Darray.arraySize++)
                 {
-                    size_t rowPadding = gEnablePitch ? 256 : 0;
-                    size_t slicePadding = gEnablePitch ? 3 : 0;
+                    size_t rowPadding = ctx.enablePitch ? 256 : 0;
+                    size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
                     set_image_dimensions(
                         &imageInfo2Darray, imageInfo2Darray.width,
                         imageInfo2Darray.height, imageInfo2Darray.arraySize,
-                        rowPadding, slicePadding);
+                        rowPadding, slicePadding, ctx);
                     set_image_dimensions(&imageInfo2D, imageInfo2Darray.width,
                                          imageInfo2Darray.height, 0, rowPadding,
-                                         slicePadding);
+                                         slicePadding, ctx);
 
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                     {
                         imageInfo2D.num_mip_levels =
                             (cl_uint)random_log_in_range(
@@ -288,7 +303,7 @@ int test_copy_image_set_2D_2D_array(
                             imageInfo2Darray.rowPitch * imageInfo2Darray.height;
                     }
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                     {
                         if (reverse)
                             log_info("   at size %d,%d,%d to %d,%d\n",
@@ -309,18 +324,18 @@ int test_copy_image_set_2D_2D_array(
                     if( reverse )
                         ret = test_copy_image_size_2D_2D_array(
                             context, queue, &imageInfo2Darray, &imageInfo2D,
-                            seed);
+                            seed, ctx);
                     else
                         ret = test_copy_image_size_2D_2D_array(
                             context, queue, &imageInfo2D, &imageInfo2Darray,
-                            seed);
+                            seed, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numberOfSizes2DArray, numberOfSizes2D;
@@ -338,19 +353,19 @@ int test_copy_image_set_2D_2D_array(
         {
           for( size_t j = 0; j < numberOfSizes2DArray; j++ )
           {
-            size_t rowPadding = gEnablePitch ? 256 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 256 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             set_image_dimensions(&imageInfo2Darray, sizes2DArray[j][0],
                                  sizes2DArray[j][1], sizes2DArray[j][2],
-                                 rowPadding, slicePadding);
+                                 rowPadding, slicePadding, ctx);
             set_image_dimensions(&imageInfo2D, sizes2D[i][0], sizes2D[i][1], 0,
-                                 rowPadding, slicePadding);
+                                 rowPadding, slicePadding, ctx);
 
             cl_ulong dstSize = get_image_size(&imageInfo2Darray);
             cl_ulong srcSize = get_image_size(&imageInfo2D);
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
@@ -388,7 +403,7 @@ int test_copy_image_set_2D_2D_array(
                            (int)imageInfo2Darray.height,
                            (int)imageInfo2Darray.arraySize);
 
-              if( gDebugTrace )
+              if (ctx.debugTrace)
               {
                 if (reverse)
                     log_info("   at max size %d,%d,%d to %d,%d\n",
@@ -406,10 +421,12 @@ int test_copy_image_set_2D_2D_array(
               int ret;
               if( reverse )
                   ret = test_copy_image_size_2D_2D_array(
-                      context, queue, &imageInfo2Darray, &imageInfo2D, seed);
+                      context, queue, &imageInfo2Darray, &imageInfo2D, seed,
+                      ctx);
               else
                   ret = test_copy_image_size_2D_2D_array(
-                      context, queue, &imageInfo2D, &imageInfo2Darray, seed);
+                      context, queue, &imageInfo2D, &imageInfo2Darray, seed,
+                      ctx);
               if( ret )
                 return -1;
             }
@@ -439,8 +456,8 @@ int test_copy_image_set_2D_2D_array(
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong srcSize, dstSize;
-            size_t rowPadding = gEnablePitch ? 256 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 256 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
@@ -456,7 +473,7 @@ int test_copy_image_set_2D_2D_array(
                 imageInfo2D.height =
                     (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -485,11 +502,11 @@ int test_copy_image_set_2D_2D_array(
                 {
                     set_image_dimensions(&imageInfo2D, imageInfo2D.width,
                                          imageInfo2D.height, 0, rowPadding,
-                                         slicePadding);
+                                         slicePadding, ctx);
                     set_image_dimensions(
                         &imageInfo2Darray, imageInfo2Darray.width,
                         imageInfo2Darray.height, imageInfo2Darray.arraySize,
-                        rowPadding, slicePadding);
+                        rowPadding, slicePadding, ctx);
 
                     srcSize = (cl_ulong)imageInfo2D.rowPitch
                         * (cl_ulong)imageInfo2D.height * 4;
@@ -498,7 +515,7 @@ int test_copy_image_set_2D_2D_array(
                 }
             } while( srcSize > maxAllocSize || ( srcSize * 3 ) > memSize || dstSize > maxAllocSize || ( dstSize * 3 ) > memSize);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
             {
                 if (reverse)
                     log_info("   at size %d,%d,%d to %d,%d\n",
@@ -516,10 +533,10 @@ int test_copy_image_set_2D_2D_array(
             int ret;
             if( reverse )
                 ret = test_copy_image_size_2D_2D_array(
-                    context, queue, &imageInfo2Darray, &imageInfo2D, seed);
+                    context, queue, &imageInfo2Darray, &imageInfo2D, seed, ctx);
             else
                 ret = test_copy_image_size_2D_2D_array(
-                    context, queue, &imageInfo2D, &imageInfo2Darray, seed);
+                    context, queue, &imageInfo2D, &imageInfo2Darray, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -22,12 +22,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t arraySize,
                                  size_t rowPadding, size_t slicePadding,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -58,7 +58,7 @@ static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
 int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
                                      image_descriptor *srcImageInfo,
                                      image_descriptor *dstImageInfo, MTdata d,
-                                     const context_t &ctx)
+                                     const image_test_context_t &ctx)
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -227,7 +227,7 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
 int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -168,7 +168,10 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
         // Now pick positions within valid ranges
         sourcePos[ 0 ] = ( srcImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         sourcePos[ 1 ] = ( srcImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
-        sourcePos[ 2 ] = ( srcImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->arraySize - 1 ), d ) : ctx.testMipmaps ? twoImage_lod : 0;
+        sourcePos[2] = (srcImageInfo->arraySize > 0)
+            ? (size_t)random_in_range(0, (int)(srcImageInfo->arraySize - 1), d)
+            : ctx.testMipmaps ? twoImage_lod
+                              : 0;
         if (ctx.testMipmaps)
         {
             if( srcImageInfo->arraySize > 0 )
@@ -187,7 +190,10 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
 
         destPos[ 0 ] = ( dstImageInfo->width > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->width - regionSize[ 0 ] - 1 ), d ) : 0;
         destPos[ 1 ] = ( dstImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
-        destPos[ 2 ] = ( dstImageInfo->arraySize > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->arraySize - 1 ), d ) : ctx.testMipmaps ? twoImage_lod : 0;
+        destPos[2] = (dstImageInfo->arraySize > 0)
+            ? (size_t)random_in_range(0, (int)(dstImageInfo->arraySize - 1), d)
+            : ctx.testMipmaps ? twoImage_lod
+                              : 0;
         if (ctx.testMipmaps)
         {
             if( dstImageInfo->arraySize > 0 )
@@ -353,40 +359,42 @@ int test_copy_image_set_2D_2D_array(
         {
           for( size_t j = 0; j < numberOfSizes2DArray; j++ )
           {
-            size_t rowPadding = ctx.enablePitch ? 256 : 0;
-            size_t slicePadding = ctx.enablePitch ? 3 : 0;
+              size_t rowPadding = ctx.enablePitch ? 256 : 0;
+              size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
-            set_image_dimensions(&imageInfo2Darray, sizes2DArray[j][0],
-                                 sizes2DArray[j][1], sizes2DArray[j][2],
-                                 rowPadding, slicePadding, ctx);
-            set_image_dimensions(&imageInfo2D, sizes2D[i][0], sizes2D[i][1], 0,
-                                 rowPadding, slicePadding, ctx);
+              set_image_dimensions(&imageInfo2Darray, sizes2DArray[j][0],
+                                   sizes2DArray[j][1], sizes2DArray[j][2],
+                                   rowPadding, slicePadding, ctx);
+              set_image_dimensions(&imageInfo2D, sizes2D[i][0], sizes2D[i][1],
+                                   0, rowPadding, slicePadding, ctx);
 
-            cl_ulong dstSize = get_image_size(&imageInfo2Darray);
-            cl_ulong srcSize = get_image_size(&imageInfo2D);
+              cl_ulong dstSize = get_image_size(&imageInfo2Darray);
+              cl_ulong srcSize = get_image_size(&imageInfo2D);
 
-            if (ctx.testMipmaps)
-            {
-                imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
-                    2,
-                    (int)compute_max_mip_levels(imageInfo2D.width,
-                                                imageInfo2D.height, 0),
-                    seed);
-                imageInfo2Darray.num_mip_levels = (cl_uint)random_log_in_range(
-                    2,
-                    (int)compute_max_mip_levels(imageInfo2Darray.width,
-                                                imageInfo2Darray.height, 0),
-                    seed);
-                imageInfo2D.rowPitch =
-                    imageInfo2D.width * get_pixel_size(imageInfo2D.format);
-                imageInfo2D.slicePitch = 0;
-                imageInfo2Darray.rowPitch = imageInfo2Darray.width
-                    * get_pixel_size(imageInfo2Darray.format);
-                imageInfo2Darray.slicePitch =
-                    imageInfo2Darray.rowPitch * imageInfo2Darray.height;
-                dstSize = 4 * compute_mipmapped_image_size(imageInfo2Darray);
-                srcSize = 4 * compute_mipmapped_image_size(imageInfo2D);
-            }
+              if (ctx.testMipmaps)
+              {
+                  imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
+                      2,
+                      (int)compute_max_mip_levels(imageInfo2D.width,
+                                                  imageInfo2D.height, 0),
+                      seed);
+                  imageInfo2Darray.num_mip_levels =
+                      (cl_uint)random_log_in_range(
+                          2,
+                          (int)compute_max_mip_levels(imageInfo2Darray.width,
+                                                      imageInfo2Darray.height,
+                                                      0),
+                          seed);
+                  imageInfo2D.rowPitch =
+                      imageInfo2D.width * get_pixel_size(imageInfo2D.format);
+                  imageInfo2D.slicePitch = 0;
+                  imageInfo2Darray.rowPitch = imageInfo2Darray.width
+                      * get_pixel_size(imageInfo2Darray.format);
+                  imageInfo2Darray.slicePitch =
+                      imageInfo2Darray.rowPitch * imageInfo2Darray.height;
+                  dstSize = 4 * compute_mipmapped_image_size(imageInfo2Darray);
+                  srcSize = 4 * compute_mipmapped_image_size(imageInfo2D);
+              }
 
             if( dstSize < maxAllocSize && dstSize < ( memSize / 3 ) && srcSize < maxAllocSize && srcSize < ( memSize / 3 ) )
             {

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -227,7 +227,8 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
 int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -16,10 +16,17 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
-static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t rowPadding, size_t slicePadding )
+static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
+                                 size_t height, size_t depth, size_t rowPadding,
+                                 size_t slicePadding, const context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -28,7 +35,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
     imageInfo->depth = depth;
     imageInfo->rowPitch = imageInfo->width * pixelSize + rowPadding;
 
-    if (gEnablePitch)
+    if (ctx.enablePitch)
     {
         do {
             rowPadding++;
@@ -41,7 +48,10 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
+                               image_descriptor *srcImageInfo,
+                               image_descriptor *dstImageInfo, MTdata d,
+                               const context_t &ctx)
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -66,7 +76,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
     size_t width_lod, height_lod;
     size_t twoImage_max_mip_level = 0, threeImage_max_mip_level = 0;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         twoImage_max_mip_level = twoImage->num_mip_levels;
         threeImage_max_mip_level = threeImage->num_mip_levels;
@@ -96,7 +106,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
     {
         // 2D to 3D
         destPos[ 2 ] = (size_t)random_in_range( 0, (int)dstImageInfo->depth - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             destPos[ 2 ] = (size_t)random_in_range( 0, (int)depth_lod - 1, d );
             sourcePos[ 2 ] = twoImage_lod;
@@ -109,7 +119,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
     {
         // 3D to 2D
         sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)srcImageInfo->depth - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)depth_lod - 1, d );
             sourcePos[ 3 ] = threeImage_lod;
@@ -119,7 +129,9 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         }
     }
 
-    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
         return retCode;
     else
@@ -128,7 +140,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             // Work at a random mip level
             twoImage_lod = (size_t)random_in_range( 0, twoImage_max_mip_level ? twoImage_max_mip_level - 1 : 0, d );
@@ -144,7 +156,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         // Pick a random size
         regionSize[ 0 ] = random_in_ranges( 8, srcImageInfo->width, dstImageInfo->width, d );
         regionSize[ 1 ] = random_in_ranges( 8, srcImageInfo->height, dstImageInfo->height, d );
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             regionSize[ 0 ] = ( width_lod > 8 ) ? random_in_range( 8, width_lod, d ) : width_lod;
             regionSize[ 1 ] = ( height_lod > 8) ? random_in_range( 8, height_lod, d ): height_lod;
@@ -155,7 +167,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         sourcePos[ 1 ] = ( srcImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         sourcePos[ 2 ] = ( srcImageInfo->depth > 0 ) ? (size_t)random_in_range( 0, (int)( srcImageInfo->depth - 1 ), d ) : 0;
 
-        if (gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             if( srcImageInfo->depth > 0 )
             {
@@ -176,7 +188,7 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         destPos[ 1 ] = ( dstImageInfo->height > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->height - regionSize[ 1 ] - 1 ), d ) : 0;
         destPos[ 2 ] = ( dstImageInfo->depth > 0 ) ? (size_t)random_in_range( 0, (int)( dstImageInfo->depth - 1 ), d ) : 0;
 
-        if (gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             if( dstImageInfo->depth > 0 )
             {
@@ -194,7 +206,9 @@ int test_copy_image_size_2D_3D( cl_context context, cl_command_queue queue, imag
         }
 
         // Go for it!
-        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode =
+            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                    sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else
@@ -210,7 +224,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                               cl_mem_object_type src_type,
                               cl_mem_flags dst_flags,
                               cl_mem_object_type dst_type,
-                              cl_image_format *format)
+                              cl_image_format *format, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, max3DDepth;
     cl_ulong maxAllocSize, memSize;
@@ -247,7 +261,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (imageInfo3D.width = 4; imageInfo3D.width < 17; imageInfo3D.width++)
         {
@@ -257,17 +271,17 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                 for (imageInfo3D.depth = 4; imageInfo3D.depth < 9;
                      imageInfo3D.depth++)
                 {
-                    size_t rowPadding = gEnablePitch ? 256 : 0;
-                    size_t slicePadding = gEnablePitch ? 3 : 0;
+                    size_t rowPadding = ctx.enablePitch ? 256 : 0;
+                    size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
                     set_image_dimensions(&imageInfo3D, imageInfo3D.width,
                                          imageInfo3D.height, imageInfo3D.depth,
-                                         rowPadding, slicePadding);
+                                         rowPadding, slicePadding, ctx);
                     set_image_dimensions(&imageInfo2D, imageInfo3D.width,
                                          imageInfo3D.height, 0, rowPadding,
-                                         slicePadding);
+                                         slicePadding, ctx);
 
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                     {
                         imageInfo2D.num_mip_levels =
                             (cl_uint)random_log_in_range(
@@ -291,7 +305,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                             imageInfo3D.rowPitch * imageInfo3D.height;
                     }
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info(
                             "   at size %d,%d to %d,%d,%d\n",
                             (int)imageInfo2D.width, (int)imageInfo2D.height,
@@ -301,17 +315,19 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                     int ret;
                     if( reverse )
                         ret = test_copy_image_size_2D_3D(
-                            context, queue, &imageInfo3D, &imageInfo2D, seed);
+                            context, queue, &imageInfo3D, &imageInfo2D, seed,
+                            ctx);
                     else
                         ret = test_copy_image_size_2D_3D(
-                            context, queue, &imageInfo2D, &imageInfo3D, seed);
+                            context, queue, &imageInfo2D, &imageInfo3D, seed,
+                            ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numberOfSizes3D, numberOfSizes2D;
@@ -328,17 +344,17 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
         for( size_t i = 0; i < numberOfSizes2D; i++ )
         for( size_t j = 0; j < numberOfSizes3D; j++ )
         {
-            size_t rowPadding = gEnablePitch ? 256 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 256 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             set_image_dimensions(&imageInfo3D, sizes3D[j][0], sizes3D[j][1],
-                                 sizes3D[j][2], rowPadding, slicePadding);
+                                 sizes3D[j][2], rowPadding, slicePadding, ctx);
             set_image_dimensions(&imageInfo2D, sizes2D[i][0], sizes2D[i][1], 0,
-                                 rowPadding, slicePadding);
+                                 rowPadding, slicePadding, ctx);
             cl_ulong dstSize = get_image_size(&imageInfo3D);
             cl_ulong srcSize = get_image_size(&imageInfo2D);
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
@@ -368,7 +384,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                          (int)imageInfo2D.width, (int)imageInfo2D.height,
                          (int)imageInfo3D.width, (int)imageInfo3D.height,
                          (int)imageInfo3D.depth);
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info("   at max size %d,%d to %d,%d,%d\n",
                              (int)imageInfo2D.width, (int)imageInfo2D.height,
                              (int)imageInfo3D.width, (int)imageInfo3D.height,
@@ -376,10 +392,10 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                 int ret;
                 if( reverse )
                     ret = test_copy_image_size_2D_3D(
-                        context, queue, &imageInfo3D, &imageInfo2D, seed);
+                        context, queue, &imageInfo3D, &imageInfo2D, seed, ctx);
                 else
                     ret = test_copy_image_size_2D_3D(
-                        context, queue, &imageInfo2D, &imageInfo3D, seed);
+                        context, queue, &imageInfo2D, &imageInfo3D, seed, ctx);
                 if( ret )
                     return -1;
             }
@@ -399,8 +415,8 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong srcSize, dstSize;
-            size_t rowPadding = gEnablePitch ? 256 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 256 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
@@ -417,7 +433,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                 imageInfo2D.height =
                     (size_t)random_log_in_range(16, (int)maxHeight / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo2D.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -444,10 +460,10 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                 {
                     set_image_dimensions(&imageInfo2D, imageInfo2D.width,
                                          imageInfo2D.height, 0, rowPadding,
-                                         slicePadding);
+                                         slicePadding, ctx);
                     set_image_dimensions(&imageInfo3D, imageInfo3D.width,
                                          imageInfo3D.height, imageInfo3D.depth,
-                                         rowPadding, slicePadding);
+                                         rowPadding, slicePadding, ctx);
 
                     srcSize = (cl_ulong)imageInfo2D.rowPitch
                         * (cl_ulong)imageInfo2D.height * 4;
@@ -456,7 +472,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                 }
             } while( srcSize > maxAllocSize || ( srcSize * 3 ) > memSize || dstSize > maxAllocSize || ( dstSize * 3 ) > memSize);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d to %d,%d,%d\n",
                          (int)imageInfo2D.width, (int)imageInfo2D.height,
                          (int)imageInfo3D.width, (int)imageInfo3D.height,
@@ -464,10 +480,10 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
             int ret;
             if( reverse )
                 ret = test_copy_image_size_2D_3D(context, queue, &imageInfo3D,
-                                                 &imageInfo2D, seed);
+                                                 &imageInfo2D, seed, ctx);
             else
                 ret = test_copy_image_size_2D_3D(context, queue, &imageInfo2D,
-                                                 &imageInfo3D, seed);
+                                                 &imageInfo3D, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -22,11 +22,11 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t depth, size_t rowPadding,
-                                 size_t slicePadding, const context_t &ctx)
+                                 size_t slicePadding, const image_test_context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -51,7 +51,7 @@ static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
 int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
                                image_descriptor *srcImageInfo,
                                image_descriptor *dstImageInfo, MTdata d,
-                               const context_t &ctx)
+                               const image_test_context_t &ctx)
 {
     size_t sourcePos[ 4 ] = { 0 }, destPos[ 4 ] = { 0 }, regionSize[ 3 ];
     int ret = 0, retCode;
@@ -224,7 +224,7 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                               cl_mem_object_type src_type,
                               cl_mem_flags dst_flags,
                               cl_mem_object_type dst_type,
-                              cl_image_format *format, const context_t &ctx)
+                              cl_image_format *format, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, max3DDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -26,7 +26,8 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t depth, size_t rowPadding,
-                                 size_t slicePadding, const image_test_context_t &ctx)
+                                 size_t slicePadding,
+                                 const image_test_context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -224,7 +225,8 @@ int test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
                               cl_mem_object_type src_type,
                               cl_mem_flags dst_flags,
                               cl_mem_object_type dst_type,
-                              cl_image_format *format, const image_test_context_t &ctx)
+                              cl_image_format *format,
+                              const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, max3DDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -16,12 +16,18 @@
 #include "../testBase.h"
 
 // Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *srcImageInfo,
-                             image_descriptor *dstImageInfo, MTdata d)
+                             image_descriptor *dstImageInfo, MTdata d,
+                             const context_t &ctx)
 {
     size_t srcPos[] = { 0, 0, 0, 0}, dstPos[] = {0, 0, 0, 0};
     size_t region[] = { srcImageInfo->width, srcImageInfo->height,
@@ -34,7 +40,7 @@ int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
     size_t width_lod = srcImageInfo->width, height_lod = srcImageInfo->height;
     size_t max_mip_level;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         max_mip_level = srcImageInfo->num_mip_levels;
         // Work at a random mip level
@@ -61,7 +67,7 @@ int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
         dstPos[ 3 ] = dst_lod;
 }
 return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                               srcPos, dstPos, region, d);
+                               srcPos, dstPos, region, d, ctx);
 }
 
 int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
@@ -69,7 +75,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format)
+                                 cl_image_format *format, const context_t &ctx)
 {
     assert(
         dst_type
@@ -98,24 +104,24 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
                     (int)compute_max_mip_levels(srcImageInfo.width,
                                                 srcImageInfo.height, 0),
                     seed);
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do {
                     rowPadding++;
@@ -133,7 +139,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                 for (srcImageInfo.arraySize = 2; srcImageInfo.arraySize < 9;
                      srcImageInfo.arraySize++)
                 {
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info("   at size %d,%d,%d\n",
                                  (int)srcImageInfo.width,
                                  (int)srcImageInfo.height,
@@ -141,15 +147,16 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
 
                     dstImageInfo = srcImageInfo;
                     dstImageInfo.mem_flags = dst_flags;
-                    int ret = test_copy_image_2D_array(
-                        context, queue, &srcImageInfo, &dstImageInfo, seed);
+                    int ret =
+                        test_copy_image_2D_array(context, queue, &srcImageInfo,
+                                                 &dstImageInfo, seed, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -160,22 +167,22 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             srcImageInfo.width = sizes[idx][0];
             srcImageInfo.height = sizes[idx][1];
             srcImageInfo.arraySize = sizes[idx][2];
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
                     (int)compute_max_mip_levels(srcImageInfo.width,
                                                 srcImageInfo.height, 0),
                     seed);
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do {
                     rowPadding++;
@@ -187,13 +194,13 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
             srcImageInfo.slicePitch =
                 srcImageInfo.rowPitch * (srcImageInfo.height + slicePadding);
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             if (test_copy_image_2D_array(context, queue, &srcImageInfo,
-                                         &dstImageInfo, seed))
+                                         &dstImageInfo, seed, ctx))
                 return -1;
         }
     }
@@ -202,8 +209,8 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong size;
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
             do
@@ -215,7 +222,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                 srcImageInfo.arraySize = (size_t)random_log_in_range(
                     16, (int)maxArraySize / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -233,7 +240,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                 {
                     srcImageInfo.rowPitch =
                         srcImageInfo.width * pixelSize + rowPadding;
-                    if (gEnablePitch)
+                    if (ctx.enablePitch)
                     {
                         do
                         {
@@ -251,7 +258,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n",
                          (int)srcImageInfo.width, (int)srcImageInfo.height,
                          (int)srcImageInfo.arraySize,
@@ -262,7 +269,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             int ret = test_copy_image_2D_array(context, queue, &srcImageInfo,
-                                               &dstImageInfo, seed);
+                                               &dstImageInfo, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -75,7 +75,8 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format, const image_test_context_t &ctx)
+                                 cl_image_format *format,
+                                 const image_test_context_t &ctx)
 {
     assert(
         dst_type

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -22,12 +22,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *srcImageInfo,
                              image_descriptor *dstImageInfo, MTdata d,
-                             const context_t &ctx)
+                             const image_test_context_t &ctx)
 {
     size_t srcPos[] = { 0, 0, 0, 0}, dstPos[] = {0, 0, 0, 0};
     size_t region[] = { srcImageInfo->width, srcImageInfo->height,
@@ -75,7 +75,7 @@ int test_copy_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_mem_object_type src_type,
                                  cl_mem_flags dst_flags,
                                  cl_mem_object_type dst_type,
-                                 cl_image_format *format, const context_t &ctx)
+                                 cl_image_format *format, const image_test_context_t &ctx)
 {
     assert(
         dst_type

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -16,18 +16,24 @@
 #include "../testBase.h"
 
 // Defined in test_copy_generic.cpp
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
 int test_copy_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *srcImageInfo,
-                       image_descriptor *dstImageInfo, MTdata d)
+                       image_descriptor *dstImageInfo, MTdata d,
+                       const context_t &ctx)
 {
     size_t origin[] = { 0, 0, 0, 0};
     size_t region[] = { srcImageInfo->width, srcImageInfo->height,
                         srcImageInfo->depth };
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         size_t lod = (srcImageInfo->num_mip_levels > 1)
             ? (size_t)random_in_range(0, srcImageInfo->num_mip_levels - 1, d)
@@ -42,13 +48,14 @@ int test_copy_image_3D(cl_context context, cl_command_queue queue,
     }
 
     return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                   origin, origin, region, d);
+                                   origin, origin, region, d, ctx);
 }
 
 int test_copy_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                           cl_mem_object_type dst_type, cl_image_format *format)
+                           cl_mem_object_type dst_type, cl_image_format *format,
+                           const context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 3D -> 3D images
     size_t maxWidth, maxHeight, maxDepth;
@@ -75,17 +82,17 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (srcImageInfo.width = 1; srcImageInfo.width < 13;
              srcImageInfo.width++)
         {
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
                     (int)compute_max_mip_levels(srcImageInfo.width,
@@ -93,7 +100,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                                                 srcImageInfo.depth),
                     seed);
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do {
                     rowPadding++;
@@ -110,7 +117,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                 for (srcImageInfo.depth = 2; srcImageInfo.depth < 9;
                      srcImageInfo.depth++)
                 {
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info(
                             "   at size %d,%d,%d\n", (int)srcImageInfo.width,
                             (int)srcImageInfo.height, (int)srcImageInfo.depth);
@@ -118,14 +125,14 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                     dstImageInfo = srcImageInfo;
                     dstImageInfo.mem_flags = dst_flags;
                     int ret = test_copy_image_3D(context, queue, &srcImageInfo,
-                                                 &dstImageInfo, seed);
+                                                 &dstImageInfo, seed, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -136,15 +143,15 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
 
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             srcImageInfo.width = sizes[idx][0];
             srcImageInfo.height = sizes[idx][1];
             srcImageInfo.depth = sizes[idx][2];
             srcImageInfo.rowPitch = srcImageInfo.width * pixelSize + rowPadding;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
                     (int)compute_max_mip_levels(srcImageInfo.width,
@@ -152,7 +159,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                                                 srcImageInfo.depth),
                     seed);
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 do {
                     rowPadding++;
@@ -164,13 +171,13 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
             srcImageInfo.slicePitch =
                 srcImageInfo.rowPitch * (srcImageInfo.height + slicePadding);
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
 
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             if (test_copy_image_3D(context, queue, &srcImageInfo, &dstImageInfo,
-                                   seed))
+                                   seed, ctx))
                 return -1;
         }
     }
@@ -179,8 +186,8 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
         {
             cl_ulong size;
-            size_t rowPadding = gEnablePitch ? 80 : 0;
-            size_t slicePadding = gEnablePitch ? 3 : 0;
+            size_t rowPadding = ctx.enablePitch ? 80 : 0;
+            size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
             // image, the result array, plus offset arrays, will fit in the global ram space
@@ -193,7 +200,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                 srcImageInfo.depth =
                     (size_t)random_log_in_range(16, (int)maxDepth / 32, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     srcImageInfo.num_mip_levels = (cl_uint)random_log_in_range(
                         2,
@@ -213,7 +220,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                     srcImageInfo.rowPitch =
                         srcImageInfo.width * pixelSize + rowPadding;
 
-                    if (gEnablePitch)
+                    if (ctx.enablePitch)
                     {
                         do
                         {
@@ -231,7 +238,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n",
                          (int)srcImageInfo.width, (int)srcImageInfo.height,
                          (int)srcImageInfo.depth, (int)srcImageInfo.rowPitch,
@@ -241,7 +248,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
             dstImageInfo = srcImageInfo;
             dstImageInfo.mem_flags = dst_flags;
             int ret = test_copy_image_3D(context, queue, &srcImageInfo,
-                                         &dstImageInfo, seed);
+                                         &dstImageInfo, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -22,12 +22,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 int test_copy_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *srcImageInfo,
                        image_descriptor *dstImageInfo, MTdata d,
-                       const context_t &ctx)
+                       const image_test_context_t &ctx)
 {
     size_t origin[] = { 0, 0, 0, 0};
     size_t region[] = { srcImageInfo->width, srcImageInfo->height,
@@ -55,7 +55,7 @@ int test_copy_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_mem_flags src_flags,
                            cl_mem_object_type src_type, cl_mem_flags dst_flags,
                            cl_mem_object_type dst_type, cl_image_format *format,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     assert(dst_type == src_type); // This test expects to copy 3D -> 3D images
     size_t maxWidth, maxHeight, maxDepth;

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -16,10 +16,18 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d );
+extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *srcImageInfo,
+                                   image_descriptor *dstImageInfo,
+                                   const size_t sourcePos[],
+                                   const size_t destPos[],
+                                   const size_t regionSize[], MTdata d,
+                                   const context_t &ctx);
 
-static void set_image_dimensions( image_descriptor *imageInfo, size_t width, size_t height, size_t depth, size_t arraySize, size_t rowPadding, size_t slicePadding )
+static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
+                                 size_t height, size_t depth, size_t arraySize,
+                                 size_t rowPadding, size_t slicePadding,
+                                 const context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -29,7 +37,7 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
     imageInfo->arraySize = arraySize;
     imageInfo->rowPitch = imageInfo->width * pixelSize + rowPadding;
 
-    if (gEnablePitch)
+    if (ctx.enablePitch)
     {
         do {
             rowPadding++;
@@ -42,7 +50,10 @@ static void set_image_dimensions( image_descriptor *imageInfo, size_t width, siz
 }
 
 
-int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo, MTdata d )
+int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
+                                     image_descriptor *srcImageInfo,
+                                     image_descriptor *dstImageInfo, MTdata d,
+                                     const context_t &ctx)
 {
     size_t sourcePos[ 4 ], destPos[ 4 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -66,7 +77,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
     size_t width_lod = 0, height_lod = 0, depth_lod = 0;
     size_t twoImage_max_mip_level,threeImage_max_mip_level;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         twoImage_max_mip_level = twoImage->num_mip_levels;
         threeImage_max_mip_level = threeImage->num_mip_levels;
@@ -95,7 +106,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         // 3D to 2D array
         sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)srcImageInfo->depth - 1, d );
         destPos[ 2 ] = (size_t)random_in_range( 0, (int)dstImageInfo->arraySize - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             sourcePos[ 2 ] = 0/*(size_t)random_in_range( 0, (int)depth_lod - 1, d )*/;
             destPos[ 2 ] = ( twoImage->arraySize > depth_lod ) ? (size_t)random_in_range( 0, twoImage->arraySize - depth_lod, d) : 0;
@@ -111,7 +122,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         // 2D array to 3D
         sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)srcImageInfo->arraySize - 1, d );
         destPos[ 2 ] = (size_t)random_in_range( 0, (int)dstImageInfo->depth - 1, d );
-        if(gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             destPos[ 2 ] = 0 /*(size_t)random_in_range( 0, (int)depth_lod - 1, d )*/;
             sourcePos[ 2 ] = ( twoImage->arraySize > depth_lod ) ? (size_t)random_in_range( 0, twoImage->arraySize - depth_lod, d) : 0;
@@ -123,7 +134,9 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         }
     }
 
-    retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+    retCode =
+        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                sourcePos, destPos, regionSize, d, ctx);
     if( retCode < 0 )
         return retCode;
     else
@@ -132,7 +145,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
     // Now try a sampling of different random regions
     for( int i = 0; i < 8; i++ )
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             twoImage_max_mip_level = twoImage->num_mip_levels;
             threeImage_max_mip_level = threeImage->num_mip_levels;
@@ -151,7 +164,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         // Pick a random size
         regionSize[ 0 ] = random_in_ranges( 8, srcImageInfo->width, dstImageInfo->width, d );
         regionSize[ 1 ] = random_in_ranges( 8, srcImageInfo->height, dstImageInfo->height, d );
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             regionSize[ 0 ] = random_in_range( 1, width_lod, d );
             regionSize[ 1 ] = random_in_range( 1, height_lod, d );
@@ -165,7 +178,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         if (srcImageInfo->type == CL_MEM_OBJECT_IMAGE3D)
         {
             sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)( srcImageInfo->depth - 1 ), d );
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 sourcePos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
                 sourcePos[ 1 ] = ( threeImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
@@ -176,7 +189,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         else
         {
             sourcePos[ 2 ] = (size_t)random_in_range( 0, (int)( srcImageInfo->arraySize - 1 ), d );
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 sourcePos[ 0 ] = ( twoImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
                 sourcePos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
@@ -190,7 +203,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         if (dstImageInfo->type == CL_MEM_OBJECT_IMAGE3D)
         {
             destPos[ 2 ] = (size_t)random_in_range( 0, (int)( dstImageInfo->depth - 1 ), d );
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 destPos[ 0 ] = ( threeImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
                 destPos[ 1 ] = ( threeImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( threeImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
@@ -201,7 +214,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
         else
         {
             destPos[ 2 ] = (size_t)random_in_range( 0, (int)( dstImageInfo->arraySize - 1 ), d );
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 destPos[ 0 ] = ( twoImage_width_lod > regionSize[ 0 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_width_lod - regionSize[ 0 ] - 1 ), d ) : 0;
                 destPos[ 1 ] = ( twoImage_height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( twoImage_height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
@@ -212,7 +225,9 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
 
 
         // Go for it!
-        retCode = test_copy_image_generic( context, queue, srcImageInfo, dstImageInfo, sourcePos, destPos, regionSize, d );
+        retCode =
+            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                    sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else
@@ -226,7 +241,7 @@ int test_copy_image_size_3D_2D_array( cl_context context, cl_command_queue queue
 int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format)
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, maxDepth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -234,8 +249,8 @@ int test_copy_image_set_3D_2D_array(
     image_descriptor imageInfo3D = { 0 };
     image_descriptor imageInfo2Darray = { 0 };
     RandomSeed  seed( gRandomSeed );
-    size_t rowPadding = gEnablePitch ? 256 : 0;
-    size_t slicePadding = gEnablePitch ? 3 : 0;
+    size_t rowPadding = ctx.enablePitch ? 256 : 0;
+    size_t slicePadding = ctx.enablePitch ? 3 : 0;
 
     imageInfo3D.format = imageInfo2Darray.format = format;
     imageInfo3D.type = CL_MEM_OBJECT_IMAGE3D;
@@ -266,7 +281,7 @@ int test_copy_image_set_3D_2D_array(
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for (imageInfo2Darray.width = 4; imageInfo2Darray.width < 17;
              imageInfo2Darray.width++)
@@ -281,13 +296,13 @@ int test_copy_image_set_3D_2D_array(
                     set_image_dimensions(
                         &imageInfo2Darray, imageInfo2Darray.width,
                         imageInfo2Darray.height, 0, imageInfo2Darray.arraySize,
-                        rowPadding, slicePadding);
+                        rowPadding, slicePadding, ctx);
                     set_image_dimensions(&imageInfo3D, imageInfo2Darray.width,
                                          imageInfo2Darray.height,
                                          imageInfo2Darray.arraySize, 0,
-                                         rowPadding, slicePadding);
+                                         rowPadding, slicePadding, ctx);
 
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                     {
                         imageInfo2Darray.num_mip_levels =
                             (cl_uint)random_log_in_range(
@@ -313,7 +328,7 @@ int test_copy_image_set_3D_2D_array(
                             imageInfo2Darray.rowPitch * imageInfo2Darray.height;
                     }
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                     {
                         if (reverse)
                             log_info("   at size %d,%d,%d to %d,%d,%d\n",
@@ -336,18 +351,18 @@ int test_copy_image_set_3D_2D_array(
                     if( reverse )
                         ret = test_copy_image_size_3D_2D_array(
                             context, queue, &imageInfo2Darray, &imageInfo3D,
-                            seed);
+                            seed, ctx);
                     else
                         ret = test_copy_image_size_3D_2D_array(
                             context, queue, &imageInfo3D, &imageInfo2Darray,
-                            seed);
+                            seed, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -365,17 +380,18 @@ int test_copy_image_set_3D_2D_array(
         for( size_t idx = 0; idx < numbeOfSizes; idx++ )
         {
             set_image_dimensions(&imageInfo3D, sizes3D[idx][0], sizes3D[idx][1],
-                                 sizes3D[idx][2], 0, rowPadding, slicePadding);
+                                 sizes3D[idx][2], 0, rowPadding, slicePadding,
+                                 ctx);
             set_image_dimensions(&imageInfo2Darray, sizes2Darray[idx][0],
                                  sizes2Darray[idx][1], 0, sizes2Darray[idx][2],
-                                 rowPadding, slicePadding);
+                                 rowPadding, slicePadding, ctx);
 
             cl_ulong dstSize = (cl_ulong)imageInfo2Darray.slicePitch
                 * (cl_ulong)imageInfo2Darray.arraySize;
             cl_ulong srcSize =
                 (cl_ulong)imageInfo3D.slicePitch * (cl_ulong)imageInfo3D.depth;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 imageInfo2Darray.num_mip_levels = (cl_uint)random_log_in_range(
                     2,
@@ -418,7 +434,7 @@ int test_copy_image_set_3D_2D_array(
                              (int)imageInfo2Darray.height,
                              (int)imageInfo2Darray.arraySize);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                 {
                     if (reverse)
                         log_info("   at max size %d,%d,%d to %d,%d,%d\n",
@@ -439,10 +455,12 @@ int test_copy_image_set_3D_2D_array(
                 int ret;
                 if( reverse )
                     ret = test_copy_image_size_3D_2D_array(
-                        context, queue, &imageInfo2Darray, &imageInfo3D, seed);
+                        context, queue, &imageInfo2Darray, &imageInfo3D, seed,
+                        ctx);
                 else
                     ret = test_copy_image_size_3D_2D_array(
-                        context, queue, &imageInfo3D, &imageInfo2Darray, seed);
+                        context, queue, &imageInfo3D, &imageInfo2Darray, seed,
+                        ctx);
                 if( ret )
                     return -1;
             }
@@ -490,7 +508,7 @@ int test_copy_image_set_3D_2D_array(
                 imageInfo3D.depth =
                     (size_t)random_log_in_range(16, (int)maxDepth / 128, seed);
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo2Darray.num_mip_levels =
                         (cl_uint)random_log_in_range(
@@ -521,11 +539,11 @@ int test_copy_image_set_3D_2D_array(
                 {
                     set_image_dimensions(&imageInfo3D, imageInfo3D.width,
                                          imageInfo3D.height, imageInfo3D.depth,
-                                         0, rowPadding, slicePadding);
+                                         0, rowPadding, slicePadding, ctx);
                     set_image_dimensions(
                         &imageInfo2Darray, imageInfo2Darray.width,
                         imageInfo2Darray.height, 0, imageInfo2Darray.arraySize,
-                        rowPadding, slicePadding);
+                        rowPadding, slicePadding, ctx);
 
                     srcSize = (cl_ulong)imageInfo3D.slicePitch
                         * (cl_ulong)imageInfo3D.depth * 4;
@@ -534,7 +552,7 @@ int test_copy_image_set_3D_2D_array(
                 }
             } while( srcSize > maxAllocSize || ( srcSize * 3 ) > memSize || dstSize > maxAllocSize || ( dstSize * 3 ) > memSize);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
             {
                 if (reverse)
                     log_info("   at size %d,%d,%d to %d,%d,%d\n",
@@ -554,10 +572,10 @@ int test_copy_image_set_3D_2D_array(
             int ret;
             if( reverse )
                 ret = test_copy_image_size_3D_2D_array(
-                    context, queue, &imageInfo2Darray, &imageInfo3D, seed);
+                    context, queue, &imageInfo2Darray, &imageInfo3D, seed, ctx);
             else
                 ret = test_copy_image_size_3D_2D_array(
-                    context, queue, &imageInfo3D, &imageInfo2Darray, seed);
+                    context, queue, &imageInfo3D, &imageInfo2Darray, seed, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -241,7 +241,8 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
 int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, maxDepth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -22,12 +22,12 @@ extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
                                    const size_t sourcePos[],
                                    const size_t destPos[],
                                    const size_t regionSize[], MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t depth, size_t arraySize,
                                  size_t rowPadding, size_t slicePadding,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t pixelSize = get_pixel_size( imageInfo->format );
 
@@ -53,7 +53,7 @@ static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
 int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
                                      image_descriptor *srcImageInfo,
                                      image_descriptor *dstImageInfo, MTdata d,
-                                     const context_t &ctx)
+                                     const image_test_context_t &ctx)
 {
     size_t sourcePos[ 4 ], destPos[ 4 ], regionSize[ 3 ];
     int ret = 0, retCode;
@@ -241,7 +241,7 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
 int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx)
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, max3DWidth, max3DHeight, maxDepth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -39,8 +39,12 @@ static cl_int cleanup_mapped_image(cl_command_queue queue, cl_mem image,
     return CL_SUCCESS;
 }
 
-int test_copy_image_generic( cl_context context, cl_command_queue queue, image_descriptor *srcImageInfo, image_descriptor *dstImageInfo,
-                            const size_t sourcePos[], const size_t destPos[], const size_t regionSize[], MTdata d )
+int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                            image_descriptor *srcImageInfo,
+                            image_descriptor *dstImageInfo,
+                            const size_t sourcePos[], const size_t destPos[],
+                            const size_t regionSize[], MTdata d,
+                            const context_t &ctx)
 {
     int error;
 
@@ -51,12 +55,11 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     BufferOwningPtr<char> srcHost;
     BufferOwningPtr<char> dstHost;
 
-    if( gDebugTrace )
-        log_info( " ++ Entering inner test loop...\n" );
+    if (ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
 
     // Generate some data to test against
     size_t srcBytes = 0;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         srcBytes = (size_t)compute_mipmapped_image_size( *srcImageInfo );
     }
@@ -67,8 +70,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
 
     if (srcBytes > srcData.getSize())
     {
-        if( gDebugTrace )
-            log_info( " - Resizing random image data...\n" );
+        if (ctx.debugTrace) log_info(" - Resizing random image data...\n");
 
         generate_random_image_data( srcImageInfo, srcData, d  );
 
@@ -83,18 +85,18 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     }
 
     // Construct testing sources
-    if( gDebugTrace )
-        log_info( " - Writing source image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing source image...\n");
 
-    srcImage = create_image(context, queue, srcData, srcImageInfo, gEnablePitch,
-                            gTestMipmaps, &error);
+    srcImage =
+        create_image(context, queue, srcData, srcImageInfo, ctx.enablePitch,
+                     ctx.testMipmaps, ctx.debugTrace, &error);
     if( srcImage == NULL )
         return error;
 
 
     // Initialize the destination to empty
     size_t destImageSize = 0;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         destImageSize = (size_t)compute_mipmapped_image_size( *dstImageInfo );
     }
@@ -105,8 +107,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
 
     if (destImageSize > dstData.getSize())
     {
-        if( gDebugTrace )
-            log_info( " - Resizing destination buffer...\n" );
+        if (ctx.debugTrace) log_info(" - Resizing destination buffer...\n");
         dstData.reset(malloc(destImageSize),NULL,0,destImageSize);
         if (dstData == NULL) {
             log_error("ERROR: Unable to malloc %zu bytes for dstData\n",
@@ -129,11 +130,11 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     memset( dstData, 0xff, destImageSize );
     memset( dstHost, 0xff, destImageSize );
 
-    if( gDebugTrace )
-        log_info( " - Writing destination image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing destination image...\n");
 
-    dstImage = create_image(context, queue, dstData, dstImageInfo, gEnablePitch,
-                            gTestMipmaps, &error);
+    dstImage =
+        create_image(context, queue, dstData, dstImageInfo, ctx.enablePitch,
+                     ctx.testMipmaps, ctx.debugTrace, &error);
     if( dstImage == NULL )
         return error;
 
@@ -141,7 +142,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     size_t dst_lod = 0;
     size_t origin[ 4 ] = { 0, 0, 0, 0 };
 
-    if(gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         switch(dstImageInfo->type)
         {
@@ -163,12 +164,11 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     {
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
         case CL_MEM_OBJECT_IMAGE1D:
-            if( gTestMipmaps )
-                origin[ 1 ] = dst_lod;
+            if (ctx.testMipmaps) origin[1] = dst_lod;
             break;
         case CL_MEM_OBJECT_IMAGE2D:
             dstRegion[ 1 ] = dstImageInfo->height;
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 origin[ 2 ] = dst_lod;
@@ -177,7 +177,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         case CL_MEM_OBJECT_IMAGE3D:
             dstRegion[ 1 ] = dstImageInfo->height;
             dstRegion[ 2 ] = dstImageInfo->depth;
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 dstRegion[ 2 ] = (dstImageInfo->depth >> dst_lod) ?(dstImageInfo->depth >> dst_lod): 1;
@@ -186,13 +186,12 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
             dstRegion[ 1 ] = dstImageInfo->arraySize;
-            if( gTestMipmaps )
-                origin[ 2 ] = dst_lod;
+            if (ctx.testMipmaps) origin[2] = dst_lod;
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
             dstRegion[ 1 ] = dstImageInfo->height;
             dstRegion[ 2 ] = dstImageInfo->arraySize;
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 origin[ 3 ] = dst_lod;
@@ -203,9 +202,9 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     size_t region[ 3 ] = { dstRegion[ 0 ], dstRegion[ 1 ], dstRegion[ 2 ] };
 
     // Now copy a subset to the destination image. This is the meat of what we're testing
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             log_info( " - Copying from %d,%d,%d,%d to %d,%d,%d,%d size %d,%d,%d\n", (int)sourcePos[ 0 ], (int)sourcePos[ 1 ], (int)sourcePos[ 2 ],(int)sourcePos[ 3 ],
                      (int)destPos[ 0 ], (int)destPos[ 1 ], (int)destPos[ 2 ],(int)destPos[ 3 ],
@@ -229,15 +228,13 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     }
 
     // Construct the final dest image values to test against
-    if( gDebugTrace )
-        log_info( " - Host verification copy...\n" );
+    if (ctx.debugTrace) log_info(" - Host verification copy...\n");
 
     copy_image_data( srcImageInfo, dstImageInfo, srcHost, dstHost, sourcePos, destPos, regionSize );
 
     // Map the destination image to verify the results with the host
     // copy. The contents of the entire buffer are compared.
-    if( gDebugTrace )
-        log_info( " - Mapping results...\n" );
+    if (ctx.debugTrace) log_info(" - Mapping results...\n");
 
     size_t mappedRow, mappedSlice;
     void* mapped = (char*)clEnqueueMapImage(queue, dstImage, CL_TRUE, CL_MAP_READ, origin, region, &mappedRow, &mappedSlice, 0, NULL, NULL, &error);
@@ -252,7 +249,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     size_t cur_lod_offset = 0;
     char *destPtr = (char*)mapped;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         cur_lod_offset = compute_mip_level_offset(dstImageInfo, dst_lod);
         sourcePtr += cur_lod_offset;
@@ -262,7 +259,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
     size_t rowPitch = dstImageInfo->rowPitch;
     size_t slicePitch = dstImageInfo->slicePitch;
     size_t dst_height_lod = dstImageInfo->height;
-    if(gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         size_t dst_width_lod = (dstImageInfo->width >> dst_lod)?(dstImageInfo->width >> dst_lod) : 1;
         dst_height_lod = (dstImageInfo->height >> dst_lod)?(dstImageInfo->height >> dst_lod) : 1;
@@ -271,8 +268,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
         slicePitch = rowPitch * dst_height_lod;
     }
 
-    if( gDebugTrace )
-        log_info( " - Scanline verification...\n" );
+    if (ctx.debugTrace) log_info(" - Scanline verification...\n");
 
     size_t thirdDim = 1;
     size_t secondDim = 1;
@@ -309,7 +305,7 @@ int test_copy_image_generic( cl_context context, cl_command_queue queue, image_d
             break;
         }
     }
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         switch (dstImageInfo->type)
         {

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -44,7 +44,7 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
                             image_descriptor *dstImageInfo,
                             const size_t sourcePos[], const size_t destPos[],
                             const size_t regionSize[], MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     int error;
 

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -17,54 +17,51 @@
 #include "../common.h"
 #include <algorithm>
 
-extern int
-test_copy_image_set_1D(cl_device_id device, cl_context context,
-                       cl_command_queue queue, cl_mem_flags src_flags,
-                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                       cl_mem_object_type dst_type, cl_image_format *format);
-extern int
-test_copy_image_set_2D(cl_device_id device, cl_context context,
-                       cl_command_queue queue, cl_mem_flags src_flags,
-                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                       cl_mem_object_type dst_type, cl_image_format *format);
-extern int
-test_copy_image_set_3D(cl_device_id device, cl_context context,
-                       cl_command_queue queue, cl_mem_flags src_flags,
-                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                       cl_mem_object_type dst_type, cl_image_format *format);
+extern int test_copy_image_set_1D(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+extern int test_copy_image_set_2D(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+extern int test_copy_image_set_3D(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_1D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
-extern int
-test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
-                          cl_command_queue queue, cl_mem_flags src_flags,
-                          cl_mem_object_type src_type, cl_mem_flags dst_flags,
-                          cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+extern int test_copy_image_set_2D_3D(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 extern int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format);
+    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
 
 using test_function_t = int (*)(cl_device_id, cl_context, cl_command_queue,
                                 cl_mem_flags, cl_mem_object_type, cl_mem_flags,
-                                cl_mem_object_type, cl_image_format *);
+                                cl_mem_object_type, cl_image_format *,
+                                const context_t &);
 
 struct TestConfigs
 {
@@ -83,11 +80,12 @@ struct TestConfigs
 };
 
 int test_image_type(cl_device_id device, cl_context context,
-                    cl_command_queue queue, MethodsToTest testMethod)
+                    cl_command_queue queue, MethodsToTest testMethod,
+                    const context_t &ctx)
 {
     test_function_t test_fn = nullptr;
 
-    if ( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         if ( 0 == is_extension_available( device, "cl_khr_mipmap_image" ))
         {
@@ -104,111 +102,111 @@ int test_image_type(cl_device_id device, cl_context context,
         case k1D:
             test_configs.emplace_back(
                 "1D -> 1D", CL_MEM_OBJECT_IMAGE1D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE1D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_1D;
             break;
         case k2D:
             test_configs.emplace_back(
                 "2D -> 2D", CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D;
             break;
         case k3D:
             test_configs.emplace_back(
                 "3D -> 3D", CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_3D;
             break;
         case k1DArray:
             test_configs.emplace_back(
                 "1D array -> 1D array", CL_MEM_OBJECT_IMAGE1D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE1D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_1D_array;
             break;
         case k2DArray:
             test_configs.emplace_back(
                 "2D array -> 2D array", CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D_array;
             break;
         case k2DTo3D:
             test_configs.emplace_back(
                 "2D -> 3D", CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D_3D;
             break;
         case k3DTo2D:
             test_configs.emplace_back(
                 "3D -> 2D", CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D_3D;
             break;
         case k2DArrayTo2D:
             test_configs.emplace_back(
                 "2D array -> 2D", CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D_2D_array;
             break;
         case k2DTo2DArray:
             test_configs.emplace_back(
                 "2D -> 2D array", CL_MEM_OBJECT_IMAGE2D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_2D_2D_array;
             break;
         case k2DArrayTo3D:
             test_configs.emplace_back(
                 "2D array -> 3D", CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_3D_2D_array;
             break;
         case k3DTo2DArray:
             test_configs.emplace_back(
                 "3D -> 2D array", CL_MEM_OBJECT_IMAGE3D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE2D_ARRAY,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_3D_2D_array;
             break;
         case k1DBuffer:
@@ -221,8 +219,8 @@ int test_image_type(cl_device_id device, cl_context context,
         case k1DTo1DBuffer:
             test_configs.emplace_back(
                 "1D -> 1D buffer", CL_MEM_OBJECT_IMAGE1D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY,
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY,
                 CL_MEM_OBJECT_IMAGE1D_BUFFER, CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_1D_1D_buffer;
             break;
@@ -230,8 +228,8 @@ int test_image_type(cl_device_id device, cl_context context,
             test_configs.emplace_back(
                 "1D buffer -> 1D", CL_MEM_OBJECT_IMAGE1D_BUFFER,
                 CL_MEM_READ_ONLY, CL_MEM_OBJECT_IMAGE1D,
-                gEnablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
-                             : CL_MEM_READ_ONLY);
+                ctx.enablePitch ? CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY
+                                : CL_MEM_READ_ONLY);
             test_fn = test_copy_image_set_1D_1D_buffer;
             break;
     }
@@ -240,7 +238,7 @@ int test_image_type(cl_device_id device, cl_context context,
     int ret = 0;
     for (const auto &test_config : test_configs)
     {
-        if (gTestMipmaps)
+        if (ctx.testMipmaps)
             log_info("Running mipmapped %s tests...\n", test_config.name);
         else
             log_info("Running %s tests...\n", test_config.name);
@@ -276,7 +274,8 @@ int test_image_type(cl_device_id device, cl_context context,
         }
 
         std::vector<bool> filterFlags(formatList.size(), false);
-        filter_formats(formatList, filterFlags, nullptr);
+        filter_formats(formatList, filterFlags, nullptr, ctx.channelTypeToUse,
+                       ctx.channelOrderToUse);
 
         // Run the format list
         for (unsigned int i = 0; i < formatList.size(); i++)
@@ -293,7 +292,7 @@ int test_image_type(cl_device_id device, cl_context context,
 
             test_return = test_fn(device, context, queue, test_config.src_flags,
                                   test_config.src_type, test_config.dst_flags,
-                                  test_config.dst_type, &formatList[i]);
+                                  test_config.dst_type, &formatList[i], ctx);
 
             if (test_return)
             {
@@ -310,9 +309,11 @@ int test_image_type(cl_device_id device, cl_context context,
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, MethodsToTest testMethod,
+                   const context_t &ctx)
 {
-    return test_image_type(device, context, queue, testMethod);
+    return test_image_type(device, context, queue, testMethod, ctx);
 }
 
 

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -17,46 +17,60 @@
 #include "../common.h"
 #include <algorithm>
 
-extern int test_copy_image_set_1D(
-    cl_device_id device, cl_context context, cl_command_queue queue,
-    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
-extern int test_copy_image_set_2D(
-    cl_device_id device, cl_context context, cl_command_queue queue,
-    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
-extern int test_copy_image_set_3D(
-    cl_device_id device, cl_context context, cl_command_queue queue,
-    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+extern int
+test_copy_image_set_1D(cl_device_id device, cl_context context,
+                       cl_command_queue queue, cl_mem_flags src_flags,
+                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                       cl_mem_object_type dst_type, cl_image_format *format,
+                       const image_test_context_t &ctx);
+extern int
+test_copy_image_set_2D(cl_device_id device, cl_context context,
+                       cl_command_queue queue, cl_mem_flags src_flags,
+                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                       cl_mem_object_type dst_type, cl_image_format *format,
+                       const image_test_context_t &ctx);
+extern int
+test_copy_image_set_3D(cl_device_id device, cl_context context,
+                       cl_command_queue queue, cl_mem_flags src_flags,
+                       cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                       cl_mem_object_type dst_type, cl_image_format *format,
+                       const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
 extern int test_copy_image_set_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
-extern int test_copy_image_set_2D_3D(
-    cl_device_id device, cl_context context, cl_command_queue queue,
-    cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
+extern int
+test_copy_image_set_2D_3D(cl_device_id device, cl_context context,
+                          cl_command_queue queue, cl_mem_flags src_flags,
+                          cl_mem_object_type src_type, cl_mem_flags dst_flags,
+                          cl_mem_object_type dst_type, cl_image_format *format,
+                          const image_test_context_t &ctx);
 extern int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
 extern int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format,
+    const image_test_context_t &ctx);
 
 using test_function_t = int (*)(cl_device_id, cl_context, cl_command_queue,
                                 cl_mem_flags, cl_mem_object_type, cl_mem_flags,

--- a/test_conformance/images/clCopyImage/test_loops.cpp
+++ b/test_conformance/images/clCopyImage/test_loops.cpp
@@ -20,48 +20,48 @@
 extern int test_copy_image_set_1D(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_2D(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_3D(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_2D_3D(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_2D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_3D_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 extern int test_copy_image_set_1D_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     cl_mem_flags src_flags, cl_mem_object_type src_type, cl_mem_flags dst_flags,
-    cl_mem_object_type dst_type, cl_image_format *format, const context_t &ctx);
+    cl_mem_object_type dst_type, cl_image_format *format, const image_test_context_t &ctx);
 
 using test_function_t = int (*)(cl_device_id, cl_context, cl_command_queue,
                                 cl_mem_flags, cl_mem_object_type, cl_mem_flags,
                                 cl_mem_object_type, cl_image_format *,
-                                const context_t &);
+                                const image_test_context_t &);
 
 struct TestConfigs
 {
@@ -81,7 +81,7 @@ struct TestConfigs
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, MethodsToTest testMethod,
-                    const context_t &ctx)
+                    const image_test_context_t &ctx)
 {
     test_function_t test_fn = nullptr;
 
@@ -311,7 +311,7 @@ int test_image_type(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, MethodsToTest testMethod,
-                   const context_t &ctx)
+                   const image_test_context_t &ctx)
 {
     return test_image_type(device, context, queue, testMethod, ctx);
 }

--- a/test_conformance/images/clFillImage/main.cpp
+++ b/test_conformance/images/clFillImage/main.cpp
@@ -20,31 +20,26 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-bool gDebugTrace;
-bool gTestSmallImages;
-bool gTestMaxImages;
-bool gEnablePitch;
-int  gTypesToTest;
-cl_channel_type  gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
+static context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
-                          cl_command_queue queue, MethodsToTest testMethod);
+                          cl_command_queue queue, MethodsToTest testMethod,
+                          const context_t &ctx);
 
-REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D); }
-REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D); }
-REGISTER_TEST(3D) { return test_image_set(device, context, queue, k3D); }
+REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D, ctx); }
+REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D, ctx); }
+REGISTER_TEST(3D) { return test_image_set(device, context, queue, k3D, ctx); }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set(device, context, queue, k1DArray);
+    return test_image_set(device, context, queue, k1DArray, ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set(device, context, queue, k2DArray);
+    return test_image_set(device, context, queue, k2DArray, ctx);
 }
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, queue, k1DBuffer);
+    return test_image_set(device, context, queue, k1DBuffer, ctx);
 }
 static test_status parseArgs(int &argc, const char *argv[],
                              std::vector<std::string> &removed_args,
@@ -71,30 +66,32 @@ static test_status parseArgs(int &argc, const char *argv[],
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
 
+    init_context(ctx);
+
     // Parse arguments
     for (int i = 1; i < argc; i++)
     {
         removed_args.push_back(argv[i]);
         if (strcmp(argv[i], "debug_trace") == 0)
-            gDebugTrace = true;
+            ctx.debugTrace = true;
         else if (strcmp(argv[i], "small_images") == 0)
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if (strcmp(argv[i], "max_images") == 0)
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if (strcmp(argv[i], "use_pitches") == 0)
-            gEnablePitch = true;
+            ctx.enablePitch = true;
         else if (strcmp(argv[i], "int") == 0)
-            gTypesToTest |= kTestInt;
+            ctx.typesToTest |= kTestInt;
         else if (strcmp(argv[i], "uint") == 0)
-            gTypesToTest |= kTestUInt;
+            ctx.typesToTest |= kTestUInt;
         else if (strcmp(argv[i], "float") == 0)
-            gTypesToTest |= kTestFloat;
+            ctx.typesToTest |= kTestFloat;
         else if ((chanType = get_channel_type_from_name(argv[i]))
                  != (cl_channel_type)-1)
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
         else if ((chanOrder = get_channel_order_from_name(argv[i]))
                  != (cl_channel_order)-1)
-            gChannelOrderToUse = chanOrder;
+            ctx.channelOrderToUse = chanOrder;
         else
         {
             removed_args.pop_back();
@@ -102,9 +99,9 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if (gTypesToTest == 0) gTypesToTest = kTestAllTypes;
+    if (ctx.typesToTest == 0) ctx.typesToTest = kTestAllTypes;
 
-    if (gTestSmallImages) log_info("Note: Using small test images\n");
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/clFillImage/main.cpp
+++ b/test_conformance/images/clFillImage/main.cpp
@@ -20,11 +20,11 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, MethodsToTest testMethod,
-                          const context_t &ctx);
+                          const image_test_context_t &ctx);
 
 REGISTER_TEST(1D) { return test_image_set(device, context, queue, k1D, ctx); }
 REGISTER_TEST(2D) { return test_image_set(device, context, queue, k2D, ctx); }
@@ -65,8 +65,6 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-
-    init_context(ctx);
 
     // Parse arguments
     for (int i = 1; i < argc; i++)

--- a/test_conformance/images/clFillImage/test_fill_1D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D.cpp
@@ -16,11 +16,17 @@
 #include "../testBase.h"
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                                    const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
+extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *imageInfo,
+                                   const size_t origin[], const size_t region[],
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
-int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_1D(cl_context context, cl_command_queue queue,
+                            image_descriptor *imageInfo,
+                            ExplicitType outputType, MTdata d,
+                            const context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +37,8 @@ int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_d
     region[ 1 ] = 1;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
+                                      outputType, d, ctx);
     if ( retCode < 0 )
         return retCode;
     else
@@ -47,7 +54,8 @@ int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_d
         origin[ 0 ] = ( imageInfo->width > region[ 0 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->width - region[ 0 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic(context, queue, imageInfo, origin,
+                                          region, outputType, d, ctx);
         if ( retCode < 0 )
             return retCode;
         else
@@ -60,14 +68,15 @@ int test_fill_image_size_1D( cl_context context, cl_command_queue queue, image_d
 
 int test_fill_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags mem_flags, ExplicitType outputType)
+                           cl_mem_flags mem_flags, ExplicitType outputType,
+                           const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     const size_t rowPadding_default = 48;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -86,13 +95,13 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -101,15 +110,16 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
               } while ((imageInfo.rowPitch % pixelSize) != 0);
             }
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-            int ret = test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D(context, queue, &imageInfo,
+                                              outputType, seed, ctx);
             if ( ret )
                 return -1;
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -122,7 +132,7 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -132,9 +142,10 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
             }
 
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ] );
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if ( test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed ) )
+            if (test_fill_image_size_1D(context, queue, &imageInfo, outputType,
+                                        seed, ctx))
                 return -1;
         }
     }
@@ -151,7 +162,7 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                   rowPadding = rowPadding_default;
                   do {
@@ -163,9 +174,10 @@ int test_fill_image_set_1D(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret = test_fill_image_size_1D( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D(context, queue, &imageInfo,
+                                              outputType, seed, ctx);
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_1D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D.cpp
@@ -20,13 +20,13 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 int test_fill_image_size_1D(cl_context context, cl_command_queue queue,
                             image_descriptor *imageInfo,
                             ExplicitType outputType, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -69,7 +69,7 @@ int test_fill_image_size_1D(cl_context context, cl_command_queue queue,
 int test_fill_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
                            cl_mem_flags mem_flags, ExplicitType outputType,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_1D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_array.cpp
@@ -16,11 +16,17 @@
 #include "../testBase.h"
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                                    const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
+extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *imageInfo,
+                                   const size_t origin[], const size_t region[],
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
-int test_fill_image_size_1D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_1D_array(cl_context context, cl_command_queue queue,
+                                  image_descriptor *imageInfo,
+                                  ExplicitType outputType, MTdata d,
+                                  const context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +37,8 @@ int test_fill_image_size_1D_array( cl_context context, cl_command_queue queue, i
     region[ 1 ] = imageInfo->arraySize;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
+                                      outputType, d, ctx);
     if ( retCode < 0 )
         return retCode;
     else
@@ -49,7 +56,8 @@ int test_fill_image_size_1D_array( cl_context context, cl_command_queue queue, i
         origin[ 1 ] = ( imageInfo->arraySize > region[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - region[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic(context, queue, imageInfo, origin,
+                                          region, outputType, d, ctx);
         if ( retCode < 0 )
             return retCode;
         else
@@ -64,14 +72,14 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType)
+                                 ExplicitType outputType, const context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     const size_t rowPadding_default = 48;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -91,13 +99,13 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -109,16 +117,17 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
             for ( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int ret = test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed );
+                int ret = test_fill_image_size_1D_array(
+                    context, queue, &imageInfo, outputType, seed, ctx);
                 if ( ret )
                     return -1;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -132,7 +141,7 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -143,9 +152,10 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
 
             imageInfo.slicePitch = imageInfo.rowPitch;
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if ( test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed ) )
+            if (test_fill_image_size_1D_array(context, queue, &imageInfo,
+                                              outputType, seed, ctx))
                 return -1;
         }
     }
@@ -163,7 +173,7 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                   rowPadding = rowPadding_default;
                   do {
@@ -177,9 +187,10 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.arraySize * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int ret = test_fill_image_size_1D_array( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_1D_array(context, queue, &imageInfo,
+                                                    outputType, seed, ctx);
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_1D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_array.cpp
@@ -72,7 +72,8 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType, const image_test_context_t &ctx)
+                                 ExplicitType outputType,
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_1D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_array.cpp
@@ -20,13 +20,13 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 int test_fill_image_size_1D_array(cl_context context, cl_command_queue queue,
                                   image_descriptor *imageInfo,
                                   ExplicitType outputType, MTdata d,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -72,7 +72,7 @@ int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType, const context_t &ctx)
+                                 ExplicitType outputType, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
@@ -19,12 +19,14 @@
 extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
-                                   ExplicitType outputType, MTdata d);
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
 int test_fill_image_size_1D_buffer(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
-                                   ExplicitType outputType, MTdata d)
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx)
 {
     size_t origin[3], region[3];
     int ret = 0, retCode;
@@ -36,7 +38,7 @@ int test_fill_image_size_1D_buffer(cl_context context, cl_command_queue queue,
     region[2] = 1;
 
     retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
-                                      outputType, d);
+                                      outputType, d, ctx);
     if (retCode < 0)
         return retCode;
     else
@@ -57,7 +59,7 @@ int test_fill_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 
         // Go for it!
         retCode = test_fill_image_generic(context, queue, imageInfo, origin,
-                                          region, outputType, d);
+                                          region, outputType, d, ctx);
         if (retCode < 0)
             return retCode;
         else
@@ -72,14 +74,14 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType)
+                                  ExplicitType outputType, const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     const size_t rowPadding_default = 48;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -102,13 +104,13 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 rowPadding = rowPadding_default;
                 do
@@ -119,16 +121,16 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                 } while ((imageInfo.rowPitch % pixelSize) != 0);
             }
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d\n", (int)imageInfo.width,
                          (int)imageInfo.height);
 
             int ret = test_fill_image_size_1D_buffer(context, queue, &imageInfo,
-                                                     outputType, seed);
+                                                     outputType, seed, ctx);
             if (ret) return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -143,7 +145,7 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
             imageInfo.width = sizes[idx][0];
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
                 rowPadding = rowPadding_default;
                 do
@@ -155,10 +157,10 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
             }
 
             log_info("Testing %d\n", (int)sizes[idx][0]);
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at max size %d\n", (int)sizes[idx][0]);
             if (test_fill_image_size_1D_buffer(context, queue, &imageInfo,
-                                               outputType, seed))
+                                               outputType, seed, ctx))
                 return -1;
         }
     }
@@ -177,7 +179,7 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                     rowPadding = rowPadding_default;
                     do
@@ -191,12 +193,12 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d (row pitch %d) out of %d\n",
                          (int)imageInfo.width, (int)imageInfo.rowPitch,
                          (int)maxWidth);
             int ret = test_fill_image_size_1D_buffer(context, queue, &imageInfo,
-                                                     outputType, seed);
+                                                     outputType, seed, ctx);
             if (ret) return -1;
         }
     }

--- a/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
@@ -20,13 +20,13 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 int test_fill_image_size_1D_buffer(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx)
+                                   const image_test_context_t &ctx)
 {
     size_t origin[3], region[3];
     int ret = 0, retCode;
@@ -74,7 +74,7 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType, const context_t &ctx)
+                                  ExplicitType outputType, const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
+++ b/test_conformance/images/clFillImage/test_fill_1D_buffer.cpp
@@ -74,7 +74,8 @@ int test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType, const image_test_context_t &ctx)
+                                  ExplicitType outputType,
+                                  const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_2D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D.cpp
@@ -16,11 +16,17 @@
 #include "../testBase.h"
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                                    const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
+extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *imageInfo,
+                                   const size_t origin[], const size_t region[],
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
-int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_size_2D(cl_context context, cl_command_queue queue,
+                            image_descriptor *imageInfo,
+                            ExplicitType outputType, MTdata d,
+                            const context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +37,8 @@ int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_d
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = 1;
 
-    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
+                                      outputType, d, ctx);
     if ( retCode < 0 )
         return retCode;
     else
@@ -49,7 +56,8 @@ int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_d
         origin[ 1 ] = ( imageInfo->height > region[ 1 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->height - region[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic(context, queue, imageInfo, origin,
+                                          region, outputType, d, ctx);
         if ( retCode < 0 )
             return retCode;
         else
@@ -62,14 +70,15 @@ int test_fill_image_size_2D( cl_context context, cl_command_queue queue, image_d
 
 int test_fill_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags mem_flags, ExplicitType outputType)
+                           cl_mem_flags mem_flags, ExplicitType outputType,
+                           const context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed(gRandomSeed);
     const size_t rowPadding_default = 48;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -89,13 +98,13 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -106,16 +115,17 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
 
             for ( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret = test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed );
+                int ret = test_fill_image_size_2D(context, queue, &imageInfo,
+                                                  outputType, seed, ctx);
                 if ( ret )
                     return -1;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -129,7 +139,7 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
             imageInfo.height = sizes[ idx ][ 1 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -139,9 +149,10 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
             }
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if ( test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed ) )
+            if (test_fill_image_size_2D(context, queue, &imageInfo, outputType,
+                                        seed, ctx))
                 return -1;
         }
     }
@@ -159,7 +170,7 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                   rowPadding = rowPadding_default;
                   do {
@@ -171,9 +182,10 @@ int test_fill_image_set_2D(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.height * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret = test_fill_image_size_2D( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_size_2D(context, queue, &imageInfo,
+                                              outputType, seed, ctx);
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_2D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D.cpp
@@ -20,13 +20,13 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 int test_fill_image_size_2D(cl_context context, cl_command_queue queue,
                             image_descriptor *imageInfo,
                             ExplicitType outputType, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -71,7 +71,7 @@ int test_fill_image_size_2D(cl_context context, cl_command_queue queue,
 int test_fill_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
                            cl_mem_flags mem_flags, ExplicitType outputType,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_2D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D_array.cpp
@@ -16,11 +16,17 @@
 #include "../testBase.h"
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                                   const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
+extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *imageInfo,
+                                   const size_t origin[], const size_t region[],
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
-static int test_fill_image_2D_array( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+static int test_fill_image_2D_array(cl_context context, cl_command_queue queue,
+                                    image_descriptor *imageInfo,
+                                    ExplicitType outputType, MTdata d,
+                                    const context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +37,8 @@ static int test_fill_image_2D_array( cl_context context, cl_command_queue queue,
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = imageInfo->arraySize;
 
-    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
+                                      outputType, d, ctx);
     if ( retCode < 0 )
         return retCode;
     else
@@ -51,7 +58,8 @@ static int test_fill_image_2D_array( cl_context context, cl_command_queue queue,
         origin[ 2 ] = ( imageInfo->arraySize > region[ 2 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->arraySize - region[ 2 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic(context, queue, imageInfo, origin,
+                                          region, outputType, d, ctx);
         if ( retCode < 0 )
             return retCode;
         else
@@ -66,15 +74,15 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType)
+                                 ExplicitType outputType, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed( gRandomSeed );
     const size_t rowPadding_default = 80;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
-    size_t slicePadding = gEnablePitch ? 3 : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
+    size_t slicePadding = ctx.enablePitch ? 3 : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -95,13 +103,13 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -115,16 +123,17 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * (imageInfo.height + slicePadding);
                 for ( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
                 {
-                    if ( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed );
+                    int ret = test_fill_image_2D_array(
+                        context, queue, &imageInfo, outputType, seed, ctx);
                     if ( ret )
                         return -1;
                 }
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -138,7 +147,7 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -170,7 +179,8 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
 
             log_info( "Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize);
 
-            if ( test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed ) )
+            if (test_fill_image_2D_array(context, queue, &imageInfo, outputType,
+                                         seed, ctx))
                 return -1;
         }
     }
@@ -189,7 +199,7 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                   rowPadding = rowPadding_default;
                   do {
@@ -203,9 +213,10 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.arraySize * 4 * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int ret = test_fill_image_2D_array( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_2D_array(context, queue, &imageInfo,
+                                               outputType, seed, ctx);
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_2D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D_array.cpp
@@ -74,7 +74,8 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType, const image_test_context_t &ctx)
+                                 ExplicitType outputType,
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_2D_array.cpp
+++ b/test_conformance/images/clFillImage/test_fill_2D_array.cpp
@@ -20,13 +20,13 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 static int test_fill_image_2D_array(cl_context context, cl_command_queue queue,
                                     image_descriptor *imageInfo,
                                     ExplicitType outputType, MTdata d,
-                                    const context_t &ctx)
+                                    const image_test_context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -74,7 +74,7 @@ int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format,
                                  cl_mem_flags mem_flags,
-                                 ExplicitType outputType, const context_t &ctx)
+                                 ExplicitType outputType, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_3D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_3D.cpp
@@ -16,11 +16,16 @@
 #include "../testBase.h"
 
 // Defined in test_fill_2D_3D.cpp
-extern int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                                   const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d );
+extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                                   image_descriptor *imageInfo,
+                                   const size_t origin[], const size_t region[],
+                                   ExplicitType outputType, MTdata d,
+                                   const context_t &ctx);
 
 
-int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descriptor *imageInfo, ExplicitType outputType, MTdata d )
+int test_fill_image_3D(cl_context context, cl_command_queue queue,
+                       image_descriptor *imageInfo, ExplicitType outputType,
+                       MTdata d, const context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -31,7 +36,8 @@ int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descri
     region[ 1 ] = imageInfo->height;
     region[ 2 ] = imageInfo->depth;
 
-    retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+    retCode = test_fill_image_generic(context, queue, imageInfo, origin, region,
+                                      outputType, d, ctx);
     if ( retCode < 0 )
         return retCode;
     else
@@ -51,7 +57,8 @@ int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descri
         origin[ 2 ] = ( imageInfo->depth > region[ 2 ] ) ? (size_t)random_in_range( 0, (int)( imageInfo->depth - region[ 2 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_fill_image_generic( context, queue, imageInfo, origin, region, outputType, d );
+        retCode = test_fill_image_generic(context, queue, imageInfo, origin,
+                                          region, outputType, d, ctx);
         if ( retCode < 0 )
             return retCode;
         else
@@ -64,15 +71,16 @@ int test_fill_image_3D( cl_context context, cl_command_queue queue, image_descri
 
 int test_fill_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags mem_flags, ExplicitType outputType)
+                           cl_mem_flags mem_flags, ExplicitType outputType,
+                           const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
     image_descriptor imageInfo = { 0 };
     RandomSeed seed( gRandomSeed );
     const size_t rowPadding_default = 80;
-    size_t rowPadding = gEnablePitch ? rowPadding_default : 0;
-    size_t slicePadding = gEnablePitch ? 3 : 0;
+    size_t rowPadding = ctx.enablePitch ? rowPadding_default : 0;
+    size_t slicePadding = ctx.enablePitch ? 3 : 0;
     size_t pixelSize;
 
     memset(&imageInfo, 0x0, sizeof(image_descriptor));
@@ -93,13 +101,13 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
       maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -113,16 +121,17 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * (imageInfo.height + slicePadding);
                 for ( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
                 {
-                    if ( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_fill_image_3D( context, queue, &imageInfo, outputType, seed );
+                    int ret = test_fill_image_3D(context, queue, &imageInfo,
+                                                 outputType, seed, ctx);
                     if ( ret )
                         return -1;
                 }
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -137,7 +146,7 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
 
             imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-            if (gEnablePitch)
+            if (ctx.enablePitch)
             {
               rowPadding = rowPadding_default;
               do {
@@ -148,9 +157,10 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
 
             imageInfo.slicePitch = imageInfo.rowPitch * (imageInfo.height + slicePadding);
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if ( test_fill_image_3D( context, queue, &imageInfo, outputType, seed ) )
+            if (test_fill_image_3D(context, queue, &imageInfo, outputType, seed,
+                                   ctx))
                 return -1;
         }
     }
@@ -169,7 +179,7 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize + rowPadding;
 
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                   rowPadding = rowPadding_default;
                   do {
@@ -183,9 +193,10 @@ int test_fill_image_set_3D(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.depth * 4 * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret = test_fill_image_3D( context, queue, &imageInfo, outputType, seed );
+            int ret = test_fill_image_3D(context, queue, &imageInfo, outputType,
+                                         seed, ctx);
             if ( ret )
                 return -1;
         }

--- a/test_conformance/images/clFillImage/test_fill_3D.cpp
+++ b/test_conformance/images/clFillImage/test_fill_3D.cpp
@@ -20,12 +20,12 @@ extern int test_fill_image_generic(cl_context context, cl_command_queue queue,
                                    image_descriptor *imageInfo,
                                    const size_t origin[], const size_t region[],
                                    ExplicitType outputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 
 
 int test_fill_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, ExplicitType outputType,
-                       MTdata d, const context_t &ctx)
+                       MTdata d, const image_test_context_t &ctx)
 {
     size_t origin[ 3 ], region[ 3 ];
     int ret = 0, retCode;
@@ -72,7 +72,7 @@ int test_fill_image_3D(cl_context context, cl_command_queue queue,
 int test_fill_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
                            cl_mem_flags mem_flags, ExplicitType outputType,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -49,8 +49,10 @@ static void fill_region_with_value( image_descriptor *imageInfo, void *imageValu
     free(fillColor);
 }
 
-int test_fill_image_generic( cl_context context, cl_command_queue queue, image_descriptor *imageInfo,
-                             const size_t origin[], const size_t region[], ExplicitType outputType, MTdata d )
+int test_fill_image_generic(cl_context context, cl_command_queue queue,
+                            image_descriptor *imageInfo, const size_t origin[],
+                            const size_t region[], ExplicitType outputType,
+                            MTdata d, const context_t &ctx)
 {
     BufferOwningPtr<char> imgData;
     BufferOwningPtr<char> imgHost;
@@ -58,8 +60,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
     int error;
     clMemWrapper image;
 
-    if ( gDebugTrace )
-        log_info( " ++ Entering inner test loop...\n" );
+    if (ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
 
     // Generate some data to test against
     size_t dataBytes = 0;
@@ -88,8 +89,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
 
     if (dataBytes > imgData.getSize())
     {
-        if ( gDebugTrace )
-            log_info( " - Resizing random image data...\n" );
+        if (ctx.debugTrace) log_info(" - Resizing random image data...\n");
 
         generate_random_image_data( imageInfo, imgData, d  );
 
@@ -107,16 +107,15 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
     memcpy(imgHost, imgData, dataBytes);
 
     // Construct testing sources
-    if ( gDebugTrace )
-        log_info( " - Creating image...\n" );
+    if (ctx.debugTrace) log_info(" - Creating image...\n");
 
-    image = create_image(context, queue, imgData, imageInfo, gEnablePitch,
-                         false, &error);
+    image = create_image(context, queue, imgData, imageInfo, ctx.enablePitch,
+                         false, ctx.debugTrace, &error);
     if ( image == NULL )
         return error;
 
     // Now fill the region defined by origin, region with the pixel value found at origin.
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Filling at %d,%d,%d size %d,%d,%d\n", (int)origin[ 0 ], (int)origin[ 1 ], (int)origin[ 2 ],
                  (int)region[ 0 ], (int)region[ 1 ], (int)region[ 2 ] );
 
@@ -129,7 +128,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
     {
         cl_float fillColor[ 4 ];
         read_image_pixel_float( imgHost, imageInfo, origin[ 0 ], origin[ 1 ], origin[ 2 ], fillColor );
-        if ( gDebugTrace )
+        if (ctx.debugTrace)
             log_info( " - with value %g, %g, %g, %g\n", fillColor[ 0 ], fillColor[ 1 ], fillColor[ 2 ], fillColor[ 3 ] );
         error = clEnqueueFillImage ( queue, image, fillColor, origin, region, 0, NULL, NULL );
         if ( error != CL_SUCCESS )
@@ -150,7 +149,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
     {
         cl_int fillColor[ 4 ];
         read_image_pixel<cl_int>( imgHost, imageInfo, origin[ 0 ], origin[ 1 ], origin[ 2 ], fillColor );
-        if ( gDebugTrace )
+        if (ctx.debugTrace)
             log_info( " - with value %d, %d, %d, %d\n", fillColor[ 0 ], fillColor[ 1 ], fillColor[ 2 ], fillColor[ 3 ] );
         error = clEnqueueFillImage ( queue, image, fillColor, origin, region, 0, NULL, NULL );
         if ( error != CL_SUCCESS )
@@ -171,7 +170,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
     {
         cl_uint fillColor[ 4 ];
         read_image_pixel<cl_uint>( imgHost, imageInfo, origin[ 0 ], origin[ 1 ], origin[ 2 ], fillColor );
-        if ( gDebugTrace )
+        if (ctx.debugTrace)
             log_info( " - with value %u, %u, %u, %u\n", fillColor[ 0 ], fillColor[ 1 ], fillColor[ 2 ], fillColor[ 3 ] );
         error = clEnqueueFillImage ( queue, image, fillColor, origin, region, 0, NULL, NULL );
         if ( error != CL_SUCCESS )
@@ -191,8 +190,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
 
     // Map the destination image to verify the results with the host
     // copy. The contents of the entire buffer are compared.
-    if ( gDebugTrace )
-        log_info( " - Mapping results...\n" );
+    if (ctx.debugTrace) log_info(" - Mapping results...\n");
 
     size_t imageOrigin[ 3 ] = { 0, 0, 0 };
     size_t imageRegion[ 3 ] = { imageInfo->width, 1, 1 };
@@ -231,8 +229,7 @@ int test_fill_image_generic( cl_context context, cl_command_queue queue, image_d
 
     size_t scanlineSize = imageInfo->width * get_pixel_size( imageInfo->format );
 
-    if ( gDebugTrace )
-        log_info( " - Scanline verification...\n" );
+    if (ctx.debugTrace) log_info(" - Scanline verification...\n");
 
     size_t thirdDim = 1;
     size_t secondDim = 1;

--- a/test_conformance/images/clFillImage/test_fill_generic.cpp
+++ b/test_conformance/images/clFillImage/test_fill_generic.cpp
@@ -52,7 +52,7 @@ static void fill_region_with_value( image_descriptor *imageInfo, void *imageValu
 int test_fill_image_generic(cl_context context, cl_command_queue queue,
                             image_descriptor *imageInfo, const size_t origin[],
                             const size_t region[], ExplicitType outputType,
-                            MTdata d, const context_t &ctx)
+                            MTdata d, const image_test_context_t &ctx)
 {
     BufferOwningPtr<char> imgData;
     BufferOwningPtr<char> imgHost;

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -22,36 +22,45 @@ extern int test_fill_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_fill_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_fill_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
-                                  ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags mem_flags,
-                                        ExplicitType outputType);
+                                        ExplicitType outputType,
+                                        const context_t &ctx);
 extern int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags mem_flags,
-                                        ExplicitType outputType);
+                                        ExplicitType outputType,
+                                        const context_t &ctx);
 extern int
 test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_image_format *format,
-                              cl_mem_flags mem_flags, ExplicitType outputType);
+                              cl_mem_flags mem_flags, ExplicitType outputType,
+                              const context_t &ctx);
 typedef int (*test_func)(cl_device_id device, cl_context context,
                          cl_command_queue queue, cl_image_format *format,
-                         cl_mem_flags mem_flags, ExplicitType outputType);
+                         cl_mem_flags mem_flags, ExplicitType outputType,
+                         const context_t &ctx);
 
-int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod, cl_mem_flags flags )
+int test_image_type(cl_device_id device, cl_context context,
+                    cl_command_queue queue, MethodsToTest testMethod,
+                    cl_mem_flags flags, const context_t &ctx)
 {
     const char *name;
     cl_mem_object_type imageType;
@@ -102,10 +111,12 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
     for (auto test : imageTestTypes)
     {
-        if (gTypesToTest & test.type)
+        if (ctx.typesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
-            if (filter_formats(formatList, filterFlags, test.channelTypes) == 0)
+            if (filter_formats(formatList, filterFlags, test.channelTypes,
+                               ctx.channelTypeToUse, ctx.channelOrderToUse)
+                == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);
             }
@@ -125,7 +136,7 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
                     int test_return =
                         test_fn(device, context, queue, &formatList[i], flags,
-                                test.explicitType);
+                                test.explicitType, ctx);
                     if (test_return)
                     {
                         gFailCount++;
@@ -144,15 +155,17 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 }
 
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, MethodsToTest testMethod )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, MethodsToTest testMethod,
+                   const context_t &ctx)
 {
     int ret = 0;
     cl_mem_flags flags = CL_MEM_READ_ONLY;
-    if (gEnablePitch && testMethod != k1DBuffer)
+    if (ctx.enablePitch && testMethod != k1DBuffer)
     {
         flags |= CL_MEM_USE_HOST_PTR;
     }
-    ret += test_image_type(device, context, queue, testMethod, flags);
+    ret += test_image_type(device, context, queue, testMethod, flags, ctx);
 
     return ret;
 }

--- a/test_conformance/images/clFillImage/test_loops.cpp
+++ b/test_conformance/images/clFillImage/test_loops.cpp
@@ -23,44 +23,44 @@ extern int test_fill_image_set_1D(cl_device_id device, cl_context context,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_fill_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_fill_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format,
                                   cl_mem_flags mem_flags,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_fill_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags mem_flags,
                                         ExplicitType outputType,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int test_fill_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags mem_flags,
                                         ExplicitType outputType,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int
 test_fill_image_set_1D_buffer(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_image_format *format,
                               cl_mem_flags mem_flags, ExplicitType outputType,
-                              const context_t &ctx);
+                              const image_test_context_t &ctx);
 typedef int (*test_func)(cl_device_id device, cl_context context,
                          cl_command_queue queue, cl_image_format *format,
                          cl_mem_flags mem_flags, ExplicitType outputType,
-                         const context_t &ctx);
+                         const image_test_context_t &ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, MethodsToTest testMethod,
-                    cl_mem_flags flags, const context_t &ctx)
+                    cl_mem_flags flags, const image_test_context_t &ctx)
 {
     const char *name;
     cl_mem_object_type imageType;
@@ -157,7 +157,7 @@ int test_image_type(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, MethodsToTest testMethod,
-                   const context_t &ctx)
+                   const image_test_context_t &ctx)
 {
     int ret = 0;
     cl_mem_flags flags = CL_MEM_READ_ONLY;

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -19,22 +19,18 @@
 #include "../testBase.h"
 #include "../harness/compat.h"
 
-bool gDebugTrace;
-bool gTestSmallImages;
-bool gTestMaxImages;
-cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
+static context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
-                          cl_mem_object_type image_type);
+                          cl_mem_object_type image_type, const context_t &ctx);
 
 REGISTER_TEST(1D)
 {
-    return test_image_set( device, context, CL_MEM_OBJECT_IMAGE1D );
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE1D, ctx);
 }
 REGISTER_TEST(2D)
 {
-    return test_image_set( device, context, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE2D, ctx);
 }
 REGISTER_TEST(3D)
 {
@@ -44,19 +40,19 @@ REGISTER_TEST(3D)
         return 0;
     }
 
-    return test_image_set( device, context, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE3D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set( device, context, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE1D_ARRAY, ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set( device, context, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE2D_ARRAY, ctx);
 }
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE1D_BUFFER);
+    return test_image_set(device, context, CL_MEM_OBJECT_IMAGE1D_BUFFER, ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -76,20 +72,21 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
+    init_context(ctx);
 
     // Parse arguments
     for (int i = 1; i < argc; i++)
     {
         removed_args.push_back(argv[i]);
         if (strcmp(argv[i], "debug_trace") == 0)
-            gDebugTrace = true;
+            ctx.debugTrace = true;
         else if (strcmp(argv[i], "small_images") == 0)
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if (strcmp(argv[i], "max_images") == 0)
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if ((chanType = get_channel_type_from_name(argv[i]))
                  != (cl_channel_type)-1)
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
         else
         {
             removed_args.pop_back();
@@ -97,7 +94,7 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if (gTestSmallImages) log_info("Note: Using small test images\n");
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -22,7 +22,8 @@
 static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
-                          cl_mem_object_type image_type, const image_test_context_t &ctx);
+                          cl_mem_object_type image_type,
+                          const image_test_context_t &ctx);
 
 REGISTER_TEST(1D)
 {

--- a/test_conformance/images/clGetInfo/main.cpp
+++ b/test_conformance/images/clGetInfo/main.cpp
@@ -19,10 +19,10 @@
 #include "../testBase.h"
 #include "../harness/compat.h"
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
-                          cl_mem_object_type image_type, const context_t &ctx);
+                          cl_mem_object_type image_type, const image_test_context_t &ctx);
 
 REGISTER_TEST(1D)
 {
@@ -72,7 +72,6 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-    init_context(ctx);
 
     // Parse arguments
     for (int i = 1; i < argc; i++)

--- a/test_conformance/images/clGetInfo/test_1D.cpp
+++ b/test_conformance/images/clGetInfo/test_1D.cpp
@@ -15,10 +15,15 @@
 //
 #include "../testBase.h"
 
-extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single(cl_context context,
+                                      image_descriptor *imageInfo, MTdata d,
+                                      cl_mem_flags flags, size_t row_pitch,
+                                      size_t slice_pitch, const context_t &ctx);
 
 
-int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_1D(cl_device_id device, cl_context context,
+                           cl_image_format *format, cl_mem_flags flags,
+                           const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -54,25 +59,29 @@ int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_fo
         memSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -87,12 +96,16 @@ int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_fo
             log_info( "Testing %d x 1\n", (int)sizes[ idx ][ 0 ]);
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at max size %d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
                 }
             }
@@ -123,12 +136,16 @@ int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_fo
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d (flags[%u] 0x%x pitch %d) out of %d\n", (int)imageInfo.width, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_1D.cpp
+++ b/test_conformance/images/clGetInfo/test_1D.cpp
@@ -18,7 +18,8 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const image_test_context_t &ctx);
+                                      size_t slice_pitch,
+                                      const image_test_context_t &ctx);
 
 
 int test_get_image_info_1D(cl_device_id device, cl_context context,

--- a/test_conformance/images/clGetInfo/test_1D.cpp
+++ b/test_conformance/images/clGetInfo/test_1D.cpp
@@ -18,12 +18,12 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const context_t &ctx);
+                                      size_t slice_pitch, const image_test_context_t &ctx);
 
 
 int test_get_image_info_1D(cl_device_id device, cl_context context,
                            cl_image_format *format, cl_mem_flags flags,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -18,7 +18,8 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const image_test_context_t &ctx);
+                                      size_t slice_pitch,
+                                      const image_test_context_t &ctx);
 
 int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                  cl_image_format *format, cl_mem_flags flags,

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -18,11 +18,11 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const context_t &ctx);
+                                      size_t slice_pitch, const image_test_context_t &ctx);
 
 int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -169,7 +169,7 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
 
 int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -259,18 +259,25 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-              if( ctx.debugTrace )
-                log_info( "   at max size %d,%d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-              if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0, ctx ) )
-                return -1;
-              if (all_host_ptr_flags[j]
-                  & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
-              { // skip test when host_ptr is NULL
-                  if (test_get_image_info_single(
-                          context, &imageInfo, seed, all_host_ptr_flags[j],
-                          imageInfo.rowPitch, imageInfo.slicePitch, ctx))
-                      return -1;
-              }
+                if (ctx.debugTrace)
+                    log_info(
+                        "   at max size %d,%d,%d (flags[%u] 0x%x pitch %d)\n",
+                        (int)imageInfo.width, (int)imageInfo.height,
+                        (int)imageInfo.arraySize, j,
+                        (unsigned int)all_host_ptr_flags[j],
+                        (int)imageInfo.rowPitch);
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
+                    return -1;
+                if (all_host_ptr_flags[j]
+                    & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
+                { // skip test when host_ptr is NULL
+                    if (test_get_image_info_single(
+                            context, &imageInfo, seed, all_host_ptr_flags[j],
+                            imageInfo.rowPitch, imageInfo.slicePitch, ctx))
+                        return -1;
+                }
             }
         }
     }
@@ -306,9 +313,11 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( ctx.debugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d,%d (flags[%u] 0x%x pitch %d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0, ctx ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j]
                     & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))

--- a/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_2D_array.cpp
@@ -15,9 +15,14 @@
 //
 #include "../testBase.h"
 
-extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single(cl_context context,
+                                      image_descriptor *imageInfo, MTdata d,
+                                      cl_mem_flags flags, size_t row_pitch,
+                                      size_t slice_pitch, const context_t &ctx);
 
-int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_1D_array(cl_device_id device, cl_context context,
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -52,7 +57,7 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
         memSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -62,19 +67,24 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
             {
                 for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
                 {
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j], 0, 0,
+                                                   ctx))
                         return -1;
                     if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                        if (test_get_image_info_single(
+                                context, &imageInfo, seed,
+                                all_host_ptr_flags[j], imageInfo.rowPitch, 0,
+                                ctx))
                             return -1;
                     }
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -93,14 +103,23 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-              if( gDebugTrace )
-                log_info( "   at max size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-              if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
-                return -1;
-              if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
-                  return -1;
-              }
+                if (ctx.debugTrace)
+                    log_info("   at max size %d,%d (flags[%u] 0x%x pitch %d)\n",
+                             (int)imageInfo.width, (int)imageInfo.arraySize, j,
+                             (unsigned int)all_host_ptr_flags[j],
+                             (int)imageInfo.rowPitch);
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
+                    return -1;
+                if (all_host_ptr_flags[j]
+                    & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
+                { // skip test when host_ptr is NULL
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
+                        return -1;
+                }
             }
       }
     }
@@ -128,12 +147,16 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
                 }
             }
@@ -144,7 +167,9 @@ int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_im
 }
 
 
-int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_2D_array(cl_device_id device, cl_context context,
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -182,7 +207,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
         memSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -195,9 +220,11 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
                 {
                     for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
                     {
-                        if( gDebugTrace )
+                        if (ctx.debugTrace)
                             log_info( "   at size %d,%d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                        if (test_get_image_info_single(
+                                context, &imageInfo, seed,
+                                all_host_ptr_flags[j], 0, 0, ctx))
                             return -1;
                         if (all_host_ptr_flags[j]
                             & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
@@ -205,7 +232,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
                             if (test_get_image_info_single(
                                     context, &imageInfo, seed,
                                     all_host_ptr_flags[j], imageInfo.rowPitch,
-                                    imageInfo.slicePitch))
+                                    imageInfo.slicePitch, ctx))
                                 return -1;
                         }
                     }
@@ -213,7 +240,7 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -232,16 +259,16 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-              if( gDebugTrace )
+              if( ctx.debugTrace )
                 log_info( "   at max size %d,%d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-              if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+              if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0, ctx ) )
                 return -1;
               if (all_host_ptr_flags[j]
                   & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
               { // skip test when host_ptr is NULL
                   if (test_get_image_info_single(
                           context, &imageInfo, seed, all_host_ptr_flags[j],
-                          imageInfo.rowPitch, imageInfo.slicePitch))
+                          imageInfo.rowPitch, imageInfo.slicePitch, ctx))
                       return -1;
               }
             }
@@ -279,16 +306,16 @@ int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_im
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if( ctx.debugTrace )
                     log_info( "   at size %d,%d,%d (flags[%u] 0x%x pitch %d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0, ctx ) )
                     return -1;
                 if (all_host_ptr_flags[j]
                     & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR))
                 { // skip test when host_ptr is NULL
                     if (test_get_image_info_single(
                             context, &imageInfo, seed, all_host_ptr_flags[j],
-                            imageInfo.rowPitch, imageInfo.slicePitch))
+                            imageInfo.rowPitch, imageInfo.slicePitch, ctx))
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_1D_buffer.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_buffer.cpp
@@ -19,11 +19,12 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch);
+                                      size_t slice_pitch, const context_t &ctx);
 
 
 int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
-                                  cl_image_format *format, cl_mem_flags flags)
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -50,21 +51,21 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d (flags 0x%x pitch %d)\n",
                          (int)imageInfo.width, (unsigned int)flags,
                          (int)imageInfo.rowPitch);
             if (test_get_image_info_single(context, &imageInfo, seed, flags, 0,
-                                           0))
+                                           0, ctx))
                 return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -79,12 +80,12 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
             imageInfo.width = sizes[idx][0];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             log_info("Testing %d x 1\n", (int)sizes[idx][0]);
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at max size %d (flags 0x%x pitch %d)\n",
                          (int)imageInfo.width, (unsigned int)flags,
                          (int)imageInfo.rowPitch);
             if (test_get_image_info_single(context, &imageInfo, seed, flags, 0,
-                                           0))
+                                           0, ctx))
                 return -1;
         }
     }
@@ -114,12 +115,12 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d (flags 0x%x pitch %d) out of %d\n",
                          (int)imageInfo.width, (unsigned int)flags,
                          (int)imageInfo.rowPitch, (int)maxWidth);
             if (test_get_image_info_single(context, &imageInfo, seed, flags, 0,
-                                           0))
+                                           0, ctx))
                 return -1;
         }
     }

--- a/test_conformance/images/clGetInfo/test_1D_buffer.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_buffer.cpp
@@ -19,12 +19,12 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const context_t &ctx);
+                                      size_t slice_pitch, const image_test_context_t &ctx);
 
 
 int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clGetInfo/test_1D_buffer.cpp
+++ b/test_conformance/images/clGetInfo/test_1D_buffer.cpp
@@ -19,7 +19,8 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const image_test_context_t &ctx);
+                                      size_t slice_pitch,
+                                      const image_test_context_t &ctx);
 
 
 int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,

--- a/test_conformance/images/clGetInfo/test_2D.cpp
+++ b/test_conformance/images/clGetInfo/test_2D.cpp
@@ -15,7 +15,9 @@
 //
 #include "../testBase.h"
 
-int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch )
+int test_get_image_info_single(cl_context context, image_descriptor *imageInfo,
+                               MTdata d, cl_mem_flags flags, size_t row_pitch,
+                               size_t slice_pitch, const context_t &ctx)
 {
     int error;
     clMemWrapper image;
@@ -48,30 +50,30 @@ int test_get_image_info_single( cl_context context, image_descriptor *imageInfo,
     switch (imageInfo->type)
     {
         case CL_MEM_OBJECT_IMAGE1D:
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( " - Creating 1D image %d with flags=0x%lx row_pitch=%d slice_pitch=%d host_ptr=%p...\n", (int)imageInfo->width, (unsigned long)flags, (int)row_pitch, (int)slice_pitch, host_ptr );
             break;
         case CL_MEM_OBJECT_IMAGE2D:
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( " - Creating 2D image %d by %d with flags=0x%lx row_pitch=%d slice_pitch=%d host_ptr=%p...\n", (int)imageInfo->width, (int)imageInfo->height, (unsigned long)flags, (int)row_pitch, (int)slice_pitch, host_ptr );
             break;
         case CL_MEM_OBJECT_IMAGE3D:
             imageInfo->slicePitch = imageInfo->rowPitch * imageInfo->height;
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( " - Creating 3D image %d by %d by %d with flags=0x%lx row_pitch=%d slice_pitch=%d host_ptr=%p...\n", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, (unsigned long)flags, (int)row_pitch, (int)slice_pitch, host_ptr );
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
             imageInfo->slicePitch = imageInfo->rowPitch;
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( " - Creating 1D image array %d by %d with flags=0x%lx row_pitch=%d slice_pitch=%d host_ptr=%p...\n", (int)imageInfo->width, (int)imageInfo->arraySize, (unsigned long)flags, (int)row_pitch, (int)slice_pitch, host_ptr );
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
             imageInfo->slicePitch = imageInfo->rowPitch * imageInfo->height;
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( " - Creating 2D image array %d by %d by %d with flags=0x%lx row_pitch=%d slice_pitch=%d host_ptr=%p...\n", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize, (unsigned long)flags, (int)row_pitch, (int)slice_pitch, host_ptr );
             break;
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info(" - Creating 1D buffer image %d with flags=0x%lx "
                          "row_pitch=%d slice_pitch=%d host_ptr=%p...\n",
                          (int)imageInfo->width, (unsigned long)flags,
@@ -332,7 +334,9 @@ int test_get_image_info_single( cl_context context, image_descriptor *imageInfo,
     return 0;
 }
 
-int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_2D(cl_device_id device, cl_context context,
+                           cl_image_format *format, cl_mem_flags flags,
+                           const context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -369,7 +373,7 @@ int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_fo
         memSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -378,19 +382,24 @@ int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_fo
             {
                 for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
                 {
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j], 0, 0,
+                                                   ctx))
                         return -1;
                     if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                        if (test_get_image_info_single(
+                                context, &imageInfo, seed,
+                                all_host_ptr_flags[j], imageInfo.rowPitch, 0,
+                                ctx))
                             return -1;
                     }
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -406,12 +415,16 @@ int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_fo
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at max size %d,%d (flags[%u] 0x%x pitch %d)\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch );
-                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
         }
             }
@@ -443,12 +456,16 @@ int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_fo
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d (flags[%u] 0x%x pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, j, (unsigned int) all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, 0 ) )
+                    if (test_get_image_info_single(context, &imageInfo, seed,
+                                                   all_host_ptr_flags[j],
+                                                   imageInfo.rowPitch, 0, ctx))
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_2D.cpp
+++ b/test_conformance/images/clGetInfo/test_2D.cpp
@@ -17,7 +17,8 @@
 
 int test_get_image_info_single(cl_context context, image_descriptor *imageInfo,
                                MTdata d, cl_mem_flags flags, size_t row_pitch,
-                               size_t slice_pitch, const image_test_context_t &ctx)
+                               size_t slice_pitch,
+                               const image_test_context_t &ctx)
 {
     int error;
     clMemWrapper image;

--- a/test_conformance/images/clGetInfo/test_2D.cpp
+++ b/test_conformance/images/clGetInfo/test_2D.cpp
@@ -17,7 +17,7 @@
 
 int test_get_image_info_single(cl_context context, image_descriptor *imageInfo,
                                MTdata d, cl_mem_flags flags, size_t row_pitch,
-                               size_t slice_pitch, const context_t &ctx)
+                               size_t slice_pitch, const image_test_context_t &ctx)
 {
     int error;
     clMemWrapper image;
@@ -336,7 +336,7 @@ int test_get_image_info_single(cl_context context, image_descriptor *imageInfo,
 
 int test_get_image_info_2D(cl_device_id device, cl_context context,
                            cl_image_format *format, cl_mem_flags flags,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clGetInfo/test_3D.cpp
+++ b/test_conformance/images/clGetInfo/test_3D.cpp
@@ -15,9 +15,14 @@
 //
 #include "../testBase.h"
 
-extern int test_get_image_info_single( cl_context context, image_descriptor *imageInfo, MTdata d, cl_mem_flags flags, size_t row_pitch, size_t slice_pitch );
+extern int test_get_image_info_single(cl_context context,
+                                      image_descriptor *imageInfo, MTdata d,
+                                      cl_mem_flags flags, size_t row_pitch,
+                                      size_t slice_pitch, const context_t &ctx);
 
-int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags )
+int test_get_image_info_3D(cl_device_id device, cl_context context,
+                           cl_image_format *format, cl_mem_flags flags,
+                           const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -55,7 +60,7 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
         memSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -68,12 +73,17 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
                 {
                     for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
                     {
-                        if( gDebugTrace )
+                        if (ctx.debugTrace)
                             log_info( "   at size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d)\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, j, (unsigned long)all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch );
-                        if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                        if (test_get_image_info_single(
+                                context, &imageInfo, seed,
+                                all_host_ptr_flags[j], 0, 0, ctx))
                             return -1;
                         if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                            if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                            if (test_get_image_info_single(
+                                    context, &imageInfo, seed,
+                                    all_host_ptr_flags[j], imageInfo.rowPitch,
+                                    imageInfo.slicePitch, ctx))
                                 return -1;
                         }
                     }
@@ -81,7 +91,7 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -100,12 +110,16 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at max size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d)\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ], j, (unsigned long)all_host_ptr_flags[j], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch );
-                if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                    if (test_get_image_info_single(
+                            context, &imageInfo, seed, all_host_ptr_flags[j],
+                            imageInfo.rowPitch, imageInfo.slicePitch, ctx))
                         return -1;
                 }
             }
@@ -143,12 +157,16 @@ int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_fo
 
             for (unsigned int j=0; j < sizeof(all_host_ptr_flags)/sizeof(cl_mem_flags); j++)
             {
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d,%d (flags[%u] 0x%lx pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, j, (unsigned long) all_host_ptr_flags[i], (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-                if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], 0, 0 ) )
+                if (test_get_image_info_single(context, &imageInfo, seed,
+                                               all_host_ptr_flags[j], 0, 0,
+                                               ctx))
                     return -1;
                 if (all_host_ptr_flags[j] & (CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR)) { // skip test when host_ptr is NULL
-                    if ( test_get_image_info_single( context, &imageInfo, seed, all_host_ptr_flags[j], imageInfo.rowPitch, imageInfo.slicePitch ) )
+                    if (test_get_image_info_single(
+                            context, &imageInfo, seed, all_host_ptr_flags[j],
+                            imageInfo.rowPitch, imageInfo.slicePitch, ctx))
                         return -1;
                 }
             }

--- a/test_conformance/images/clGetInfo/test_3D.cpp
+++ b/test_conformance/images/clGetInfo/test_3D.cpp
@@ -18,7 +18,8 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const image_test_context_t &ctx);
+                                      size_t slice_pitch,
+                                      const image_test_context_t &ctx);
 
 int test_get_image_info_3D(cl_device_id device, cl_context context,
                            cl_image_format *format, cl_mem_flags flags,

--- a/test_conformance/images/clGetInfo/test_3D.cpp
+++ b/test_conformance/images/clGetInfo/test_3D.cpp
@@ -18,11 +18,11 @@
 extern int test_get_image_info_single(cl_context context,
                                       image_descriptor *imageInfo, MTdata d,
                                       cl_mem_flags flags, size_t row_pitch,
-                                      size_t slice_pitch, const context_t &ctx);
+                                      size_t slice_pitch, const image_test_context_t &ctx);
 
 int test_get_image_info_3D(cl_device_id device, cl_context context,
                            cl_image_format *format, cl_mem_flags flags,
-                           const context_t &ctx)
+                           const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -16,17 +16,32 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int test_get_image_info_1D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_2D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_3D( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_1D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
-extern int test_get_image_info_2D_array( cl_device_id device, cl_context context, cl_image_format *format, cl_mem_flags flags );
+extern int test_get_image_info_1D(cl_device_id device, cl_context context,
+                                  cl_image_format* format, cl_mem_flags flags,
+                                  const context_t& ctx);
+extern int test_get_image_info_2D(cl_device_id device, cl_context context,
+                                  cl_image_format* format, cl_mem_flags flags,
+                                  const context_t& ctx);
+extern int test_get_image_info_3D(cl_device_id device, cl_context context,
+                                  cl_image_format* format, cl_mem_flags flags,
+                                  const context_t& ctx);
+extern int test_get_image_info_1D_array(cl_device_id device, cl_context context,
+                                        cl_image_format* format,
+                                        cl_mem_flags flags,
+                                        const context_t& ctx);
+extern int test_get_image_info_2D_array(cl_device_id device, cl_context context,
+                                        cl_image_format* format,
+                                        cl_mem_flags flags,
+                                        const context_t& ctx);
 extern int test_get_image_info_1D_buffer(cl_device_id device,
                                          cl_context context,
-                                         cl_image_format *format,
-                                         cl_mem_flags flags);
+                                         cl_image_format* format,
+                                         cl_mem_flags flags,
+                                         const context_t& ctx);
 
-int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type image_type, cl_mem_flags flags )
+int test_image_type(cl_device_id device, cl_context context,
+                    cl_mem_object_type image_type, cl_mem_flags flags,
+                    const context_t& ctx)
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(image_type), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -37,7 +52,8 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
     if (get_format_list(context, image_type, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats(formatList, filterFlags, nullptr);
+    filter_formats(formatList, filterFlags, nullptr, ctx.channelTypeToUse,
+                   ctx.channelOrderToUse);
 
     // Run the format list
     for (unsigned int i = 0; i < formatList.size(); i++)
@@ -56,23 +72,28 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
 
         switch (image_type) {
           case CL_MEM_OBJECT_IMAGE1D:
-            test_return = test_get_image_info_1D( device, context, &formatList[ i ], flags );
-            break;
+              test_return = test_get_image_info_1D(device, context,
+                                                   &formatList[i], flags, ctx);
+              break;
           case CL_MEM_OBJECT_IMAGE2D:
-            test_return = test_get_image_info_2D( device, context,&formatList[ i ], flags );
-            break;
+              test_return = test_get_image_info_2D(device, context,
+                                                   &formatList[i], flags, ctx);
+              break;
           case CL_MEM_OBJECT_IMAGE3D:
-            test_return = test_get_image_info_3D( device, context, &formatList[ i ], flags );
-            break;
+              test_return = test_get_image_info_3D(device, context,
+                                                   &formatList[i], flags, ctx);
+              break;
           case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            test_return = test_get_image_info_1D_array( device, context, &formatList[ i ], flags );
-            break;
+              test_return = test_get_image_info_1D_array(
+                  device, context, &formatList[i], flags, ctx);
+              break;
           case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            test_return = test_get_image_info_2D_array( device, context, &formatList[ i ], flags );
-            break;
+              test_return = test_get_image_info_2D_array(
+                  device, context, &formatList[i], flags, ctx);
+              break;
           case CL_MEM_OBJECT_IMAGE1D_BUFFER:
               test_return = test_get_image_info_1D_buffer(
-                  device, context, &formatList[i], flags);
+                  device, context, &formatList[i], flags, ctx);
               break;
         }
 
@@ -89,12 +110,13 @@ int test_image_type( cl_device_id device, cl_context context, cl_mem_object_type
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_context context, cl_mem_object_type image_type )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_mem_object_type image_type, const context_t& ctx)
 {
     int ret = 0;
 
-    ret += test_image_type( device, context, image_type, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, context, image_type, CL_MEM_WRITE_ONLY );
+    ret += test_image_type(device, context, image_type, CL_MEM_READ_ONLY, ctx);
+    ret += test_image_type(device, context, image_type, CL_MEM_WRITE_ONLY, ctx);
 
     return ret;
 }

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -18,30 +18,30 @@
 
 extern int test_get_image_info_1D(cl_device_id device, cl_context context,
                                   cl_image_format* format, cl_mem_flags flags,
-                                  const context_t& ctx);
+                                  const image_test_context_t& ctx);
 extern int test_get_image_info_2D(cl_device_id device, cl_context context,
                                   cl_image_format* format, cl_mem_flags flags,
-                                  const context_t& ctx);
+                                  const image_test_context_t& ctx);
 extern int test_get_image_info_3D(cl_device_id device, cl_context context,
                                   cl_image_format* format, cl_mem_flags flags,
-                                  const context_t& ctx);
+                                  const image_test_context_t& ctx);
 extern int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                         cl_image_format* format,
                                         cl_mem_flags flags,
-                                        const context_t& ctx);
+                                        const image_test_context_t& ctx);
 extern int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                         cl_image_format* format,
                                         cl_mem_flags flags,
-                                        const context_t& ctx);
+                                        const image_test_context_t& ctx);
 extern int test_get_image_info_1D_buffer(cl_device_id device,
                                          cl_context context,
                                          cl_image_format* format,
                                          cl_mem_flags flags,
-                                         const context_t& ctx);
+                                         const image_test_context_t& ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_mem_object_type image_type, cl_mem_flags flags,
-                    const context_t& ctx)
+                    const image_test_context_t& ctx)
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(image_type), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -111,7 +111,7 @@ int test_image_type(cl_device_id device, cl_context context,
 }
 
 int test_image_set(cl_device_id device, cl_context context,
-                   cl_mem_object_type image_type, const context_t& ctx)
+                   cl_mem_object_type image_type, const image_test_context_t& ctx)
 {
     int ret = 0;
 

--- a/test_conformance/images/clGetInfo/test_loops.cpp
+++ b/test_conformance/images/clGetInfo/test_loops.cpp
@@ -111,7 +111,8 @@ int test_image_type(cl_device_id device, cl_context context,
 }
 
 int test_image_set(cl_device_id device, cl_context context,
-                   cl_mem_object_type image_type, const image_test_context_t& ctx)
+                   cl_mem_object_type image_type,
+                   const image_test_context_t& ctx)
 {
     int ret = 0;
 

--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -20,39 +20,38 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-bool gDebugTrace;
-bool gTestSmallImages;
-bool gTestMaxImages;
-bool gTestMipmaps;
-cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-bool            gEnablePitch = false;
+static context_t ctx;
 
-extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type image_type );
+extern int test_image_set(cl_device_id device, cl_context context,
+                          cl_command_queue queue, cl_mem_object_type image_type,
+                          const context_t &ctx);
 
 REGISTER_TEST(1D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D, ctx);
 }
 REGISTER_TEST(2D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D, ctx);
 }
 REGISTER_TEST(3D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE3D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY,
+                          ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY,
+                          ctx);
 }
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER);
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER,
+                          ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -79,24 +78,24 @@ static test_status parseArgs(int &argc, const char *argv[],
         removed_args.push_back(argv[i]);
         if (strcmp(argv[i], "test_mipmaps") == 0)
         {
-            gTestMipmaps = true;
+            ctx.testMipmaps = true;
             // Don't test pitches with mipmaps, at least currently.
-            gEnablePitch = false;
+            ctx.enablePitch = false;
         }
         else if (strcmp(argv[i], "debug_trace") == 0)
-            gDebugTrace = true;
+            ctx.debugTrace = true;
         else if (strcmp(argv[i], "small_images") == 0)
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if (strcmp(argv[i], "max_images") == 0)
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if (strcmp(argv[i], "use_pitches") == 0)
-            gEnablePitch = true;
+            ctx.enablePitch = true;
         else if ((chanType = get_channel_type_from_name(argv[i]))
                  != (cl_channel_type)-1)
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
         else if ((chanOrder = get_channel_order_from_name(argv[i]))
                  != (cl_channel_order)-1)
-            gChannelOrderToUse = chanOrder;
+            ctx.channelOrderToUse = chanOrder;
         else
         {
             removed_args.pop_back();
@@ -104,7 +103,7 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if (gTestSmallImages) log_info("Note: Using small test images\n");
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/clReadWriteImage/main.cpp
+++ b/test_conformance/images/clReadWriteImage/main.cpp
@@ -20,11 +20,11 @@
 #include "../harness/compat.h"
 #include "../harness/testHarness.h"
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, cl_mem_object_type image_type,
-                          const context_t &ctx);
+                          const image_test_context_t &ctx);
 
 REGISTER_TEST(1D)
 {

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -18,34 +18,43 @@
 
 extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
-                                        cl_mem_flags flags);
+                                        cl_mem_flags flags,
+                                        const context_t &ctx);
 extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
-                                        cl_mem_flags flags);
-extern int test_read_image_set_1D_buffer(cl_device_id device,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         cl_image_format *format,
-                                         cl_mem_flags flags);
+                                        cl_mem_flags flags,
+                                        const context_t &ctx);
+extern int
+test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
+                              cl_command_queue queue, cl_image_format *format,
+                              cl_mem_flags flags, const context_t &ctx);
 
-int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
+int test_image_type(cl_device_id device, cl_context context,
+                    cl_command_queue queue, cl_mem_object_type imageType,
+                    cl_mem_flags flags, const context_t &ctx)
 {
-  log_info( "Running %s %s %s-only tests...\n", gTestMipmaps?"mipmapped":"",convert_image_type_to_string(imageType), flags == CL_MEM_READ_ONLY ? "read" : "write" );
+    log_info("Running %s %s %s-only tests...\n",
+             ctx.testMipmaps ? "mipmapped" : "",
+             convert_image_type_to_string(imageType),
+             flags == CL_MEM_READ_ONLY ? "read" : "write");
 
     int ret = 0;
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         if (0 == is_extension_available(device, "cl_khr_mipmap_image"))
         {
@@ -63,7 +72,8 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats(formatList, filterFlags, nullptr);
+    filter_formats(formatList, filterFlags, nullptr, ctx.channelTypeToUse,
+                   ctx.channelOrderToUse);
 
     // Run the format list
     for (unsigned int i = 0; i < formatList.size(); i++)
@@ -83,28 +93,28 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
         switch (imageType)
         {
             case CL_MEM_OBJECT_IMAGE1D:
-                test_return = test_read_image_set_1D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_read_image_set_1D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                test_return = test_read_image_set_2D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_read_image_set_2D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                test_return = test_read_image_set_3D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_read_image_set_3D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
                 test_return = test_read_image_set_1D_array(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
                 test_return = test_read_image_set_2D_array(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_BUFFER:
                 test_return = test_read_image_set_1D_buffer(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
         }
 
@@ -122,12 +132,16 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, cl_mem_object_type imageType,
+                   const context_t &ctx)
 {
     int ret = 0;
 
-    ret += test_image_type( device, context, queue, imageType, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, context, queue, imageType, CL_MEM_WRITE_ONLY );
+    ret += test_image_type(device, context, queue, imageType, CL_MEM_READ_ONLY,
+                           ctx);
+    ret += test_image_type(device, context, queue, imageType, CL_MEM_WRITE_ONLY,
+                           ctx);
 
     return ret;
 }

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -38,10 +38,12 @@ extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
                                         const image_test_context_t &ctx);
-extern int
-test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
-                              cl_command_queue queue, cl_image_format *format,
-                              cl_mem_flags flags, const image_test_context_t &ctx);
+extern int test_read_image_set_1D_buffer(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         cl_image_format *format,
+                                         cl_mem_flags flags,
+                                         const image_test_context_t &ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, cl_mem_object_type imageType,

--- a/test_conformance/images/clReadWriteImage/test_loops.cpp
+++ b/test_conformance/images/clReadWriteImage/test_loops.cpp
@@ -19,33 +19,33 @@
 extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int
 test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_image_format *format,
-                              cl_mem_flags flags, const context_t &ctx);
+                              cl_mem_flags flags, const image_test_context_t &ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, cl_mem_object_type imageType,
-                    cl_mem_flags flags, const context_t &ctx)
+                    cl_mem_flags flags, const image_test_context_t &ctx)
 {
     log_info("Running %s %s %s-only tests...\n",
              ctx.testMipmaps ? "mipmapped" : "",
@@ -134,7 +134,7 @@ int test_image_type(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, cl_mem_object_type imageType,
-                   const context_t &ctx)
+                   const image_test_context_t &ctx)
 {
     int ret = 0;
 

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_1D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags, const context_t &ctx)
+                       cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -171,7 +171,7 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -27,24 +27,26 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( ctx.debugTrace )
-  {
-    log_info( " - Creating %s 1D image %d...\n", ctx.testMipmaps?"mipmapped":"", (int)imageInfo->width );
-    log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
-  }
+    if (ctx.debugTrace)
+    {
+        log_info(" - Creating %s 1D image %d...\n",
+                 ctx.testMipmaps ? "mipmapped" : "", (int)imageInfo->width);
+        log_info(" with %llu mip levels\n",
+                 (unsigned long long)imageInfo->num_mip_levels);
+    }
 
     // Construct testing sources
-  if(!ctx.testMipmaps)
-  {
-      image = create_image_1d(context, flags, imageInfo->format,
-                              imageInfo->width, 0, NULL, NULL, &error);
-      if (image == NULL)
-      {
-          log_error("ERROR: Unable to create 1D image of size %d (%s)",
-                    (int)imageInfo->width, IGetErrorString(error));
-          return -1;
-      }
-  }
+    if (!ctx.testMipmaps)
+    {
+        image = create_image_1d(context, flags, imageInfo->format,
+                                imageInfo->width, 0, NULL, NULL, &error);
+        if (image == NULL)
+        {
+            log_error("ERROR: Unable to create 1D image of size %d (%s)",
+                      (int)imageInfo->width, IGetErrorString(error));
+            return -1;
+        }
+    }
   else
   {
     cl_image_desc image_desc = {0};
@@ -63,13 +65,13 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
 
     if (ctx.debugTrace) log_info(" - Writing image...\n");
 
-  size_t origin[ 3 ] = { 0, 0, 0 };
-  size_t region[ 3 ] = { 0, 1, 1 };
-  size_t fullImageSize;
-  if( ctx.testMipmaps )
-  {
-      fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
-  }
+    size_t origin[3] = { 0, 0, 0 };
+    size_t region[3] = { 0, 1, 1 };
+    size_t fullImageSize;
+    if (ctx.testMipmaps)
+    {
+        fullImageSize = (size_t)compute_mipmapped_image_size(*imageInfo);
+    }
   else
   {
       fullImageSize = imageInfo->rowPitch;
@@ -192,47 +194,47 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (ctx.testMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+          if (ctx.testMipmaps)
+              imageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                  2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
-            if( ctx.debugTrace )
-                log_info( "   at size %d\n", (int)imageInfo.width );
+          if (ctx.debugTrace) log_info("   at size %d\n", (int)imageInfo.width);
 
-            int ret =
-                test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx);
-            if( ret )
-                return -1;
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+          int ret =
+              test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx);
+          if (ret) return -1;
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1, maxAllocSize,
+                    memSize, CL_MEM_OBJECT_IMAGE1D, imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[idx][0];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (ctx.testMipmaps)
-                imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
+          if (ctx.testMipmaps)
+              imageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                  2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
-            log_info("Testing %d\n", (int)imageInfo.width);
-            if( ctx.debugTrace )
-                log_info( "   at max size %d\n", (int)maxWidth );
-            if (test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d\n", (int)imageInfo.width);
+          if (ctx.debugTrace) log_info("   at max size %d\n", (int)maxWidth);
+          if (test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )
@@ -244,12 +246,15 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             {
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
 
-        if (ctx.testMipmaps)
-        {
-          imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
-          imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-          size = compute_mipmapped_image_size( imageInfo );
-        }
+                if (ctx.testMipmaps)
+                {
+                    imageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+                        2, (int)compute_max_mip_levels(imageInfo.width, 0, 0),
+                        seed);
+                    imageInfo.rowPitch =
+                        imageInfo.width * get_pixel_size(imageInfo.format);
+                    size = compute_mipmapped_image_size(imageInfo);
+                }
         else
         {
           imageInfo.rowPitch = imageInfo.width * pixelSize;

--- a/test_conformance/images/clReadWriteImage/test_read_1D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_1D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags)
+                       cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -27,14 +27,14 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if( ctx.debugTrace )
   {
-    log_info( " - Creating %s 1D image %d...\n", gTestMipmaps?"mipmapped":"", (int)imageInfo->width );
+    log_info( " - Creating %s 1D image %d...\n", ctx.testMipmaps?"mipmapped":"", (int)imageInfo->width );
     log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
   }
 
     // Construct testing sources
-  if(!gTestMipmaps)
+  if(!ctx.testMipmaps)
   {
       image = create_image_1d(context, flags, imageInfo->format,
                               imageInfo->width, 0, NULL, NULL, &error);
@@ -61,13 +61,12 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
     }
     }
 
-    if( gDebugTrace )
-        log_info( " - Writing image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
   size_t origin[ 3 ] = { 0, 0, 0 };
   size_t region[ 3 ] = { 0, 1, 1 };
   size_t fullImageSize;
-  if( gTestMipmaps )
+  if( ctx.testMipmaps )
   {
       fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
   }
@@ -79,23 +78,27 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
   BufferOwningPtr<char> resultValues(malloc(fullImageSize));
   size_t imgValMipLevelOffset = 0;
 
-  for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+  for (size_t lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+       || (!ctx.testMipmaps && lod < 1);
+       lod++)
   {
     origin[1] = lod;
     size_t width_lod, row_pitch_lod;
 
     width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
-    row_pitch_lod = gTestMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
+    row_pitch_lod = ctx.testMipmaps
+        ? (width_lod * get_pixel_size(imageInfo->format))
+        : imageInfo->rowPitch;
 
     region[0] = width_lod;
 
-    if (gDebugTrace)
-        if (gTestMipmaps)
+    if (ctx.debugTrace)
+        if (ctx.testMipmaps)
         {
             log_info(" - Working at mipLevel :%llu\n", (unsigned long long)lod);
         }
     error = clEnqueueWriteImage(queue, image, CL_FALSE, origin, region,
-                                (gEnablePitch ? row_pitch_lod : 0), 0,
+                                (ctx.enablePitch ? row_pitch_lod : 0), 0,
                                 (char *)imageValues + imgValMipLevelOffset, 0,
                                 NULL, NULL);
     if (error != CL_SUCCESS)
@@ -105,18 +108,17 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
     }
 
     // To verify, we just read the results right back and see whether they match the input
-      if( gDebugTrace )
-      {
+    if (ctx.debugTrace)
+    {
         log_info( " - Initing result array...\n" );
-      }
+    }
 
       // Note: we read back without any pitch, to verify pitch actually WORKED
       size_t scanlineSize = width_lod * get_pixel_size( imageInfo->format );
     size_t imageSize = scanlineSize;
     memset( resultValues, 0xff, imageSize );
 
-    if( gDebugTrace )
-        log_info( " - Reading results...\n" );
+    if (ctx.debugTrace) log_info(" - Reading results...\n");
 
     error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, 0, 0, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read image values" );
@@ -167,7 +169,7 @@ int test_read_image_1D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -190,25 +192,25 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
             int ret =
-                test_read_image_1D(context, queue, &imageInfo, seed, flags);
+                test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx);
             if( ret )
                 return -1;
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -221,13 +223,13 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             imageInfo.width = sizes[idx][0];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
             log_info("Testing %d\n", (int)imageInfo.width);
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d\n", (int)maxWidth );
-            if (test_read_image_1D(context, queue, &imageInfo, seed, flags))
+            if (test_read_image_1D(context, queue, &imageInfo, seed, flags, ctx))
                 return -1;
         }
     }
@@ -242,7 +244,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             {
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
 
-        if (gTestMipmaps)
+        if (ctx.testMipmaps)
         {
           imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
           imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
@@ -251,7 +253,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
         else
         {
           imageInfo.rowPitch = imageInfo.width * pixelSize;
-          if( gEnablePitch )
+          if (ctx.enablePitch)
           {
             size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
             imageInfo.rowPitch += extraWidth * pixelSize;
@@ -261,10 +263,10 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size / 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int ret =
-                test_read_image_1D(context, queue, &imageInfo, seed, flags);
+            int ret = test_read_image_1D(context, queue, &imageInfo, seed,
+                                         flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_1D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags)
+                             cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -27,15 +27,17 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
-        log_info( " - Creating %s image array of size %d by %d...\n", gTestMipmaps?"mipmapped":"", (int)imageInfo->width, (int)imageInfo->arraySize );
-        if( gTestMipmaps )
+        log_info(" - Creating %s image array of size %d by %d...\n",
+                 ctx.testMipmaps ? "mipmapped" : "", (int)imageInfo->width,
+                 (int)imageInfo->arraySize);
+        if (ctx.testMipmaps)
             log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
     }
 
     // Construct testing sources
-    if(!gTestMipmaps)
+    if (!ctx.testMipmaps)
     {
         image = create_image_1d_array(context, flags, imageInfo->format,
                                       imageInfo->width, imageInfo->arraySize, 0,
@@ -62,13 +64,12 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
             return error;
         }
     }
-    if( gDebugTrace )
-        log_info( " - Writing image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
     size_t origin[ 3 ] = { 0, 0, 0 };
     size_t region[ 3 ] = { 0, 0, 1 };
     size_t fullImageSize;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
     }
@@ -80,41 +81,43 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
     size_t imgValMipLevelOffset = 0;
     BufferOwningPtr<char> resultValues(malloc(fullImageSize));
 
-    for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+    for (size_t lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+         || (!ctx.testMipmaps && lod < 1);
+         lod++)
     {
         size_t width_lod, row_pitch_lod, slice_pitch_lod;
-        if( gTestMipmaps )
-            origin[2] = lod;
+        if (ctx.testMipmaps) origin[2] = lod;
 
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
-        row_pitch_lod = gTestMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
+        row_pitch_lod = ctx.testMipmaps
+            ? (width_lod * get_pixel_size(imageInfo->format))
+            : imageInfo->rowPitch;
         slice_pitch_lod = row_pitch_lod;
 
         region[0] = width_lod;
         region[1] = imageInfo->arraySize;
 
-        if ( gDebugTrace && gTestMipmaps )
+        if (ctx.debugTrace && ctx.testMipmaps)
             log_info("Working at mip level %llu\n", (unsigned long long) lod);
 
-        error = clEnqueueWriteImage(queue, image, CL_FALSE,
-                                    origin, region, ( gEnablePitch ? row_pitch_lod : 0 ), 0,
-                                    (char*)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
+        error = clEnqueueWriteImage(queue, image, CL_FALSE, origin, region,
+                                    (ctx.enablePitch ? row_pitch_lod : 0), 0,
+                                    (char *)imageValues + imgValMipLevelOffset,
+                                    0, NULL, NULL);
         if (error != CL_SUCCESS) {
             log_error( "ERROR: Unable to write to 1D image array  of width %d and size %d\n", (int)width_lod, (int)imageInfo->arraySize );
             return -1;
         }
 
         // To verify, we just read the results right back and see whether they match the input
-        if( gDebugTrace )
-            log_info( " - Initing result array...\n" );
+        if (ctx.debugTrace) log_info(" - Initing result array...\n");
 
         // Note: we read back without any pitch, to verify pitch actually WORKED
         size_t scanlineSize = width_lod * get_pixel_size( imageInfo->format );
         size_t imageSize = scanlineSize * imageInfo->arraySize;
         memset( resultValues, 0xff, imageSize );
 
-        if( gDebugTrace )
-            log_info( " - Reading results...\n" );
+        if (ctx.debugTrace) log_info(" - Reading results...\n");
 
         error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, 0, 0, resultValues, 0, NULL, NULL );
         test_error( error, "Unable to read image values" );
@@ -170,7 +173,8 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
-                                 cl_image_format *format, cl_mem_flags flags)
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -194,7 +198,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -202,20 +206,20 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
             for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
                 int ret = test_read_image_1D_array(context, queue, &imageInfo,
-                                                   seed, flags);
+                                                   seed, flags, ctx);
                 if( ret )
                     return -1;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -230,14 +234,14 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.rowPitch;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
 
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.arraySize);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxArraySize );
             if (test_read_image_1D_array(context, queue, &imageInfo, seed,
-                                         flags))
+                                         flags, ctx))
                 return -1;
         }
     }
@@ -252,7 +256,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             {
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
                 imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, 0, 0), seed);
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
@@ -262,7 +266,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 else
                 {
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -273,10 +277,10 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
             int ret = test_read_image_1D_array(context, queue, &imageInfo, seed,
-                                               flags);
+                                               flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_1D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags, const context_t &ctx)
+                             cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -174,7 +174,7 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
 int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_array.cpp
@@ -17,7 +17,8 @@
 
 int test_read_image_1D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags, const image_test_context_t &ctx)
+                             cl_mem_flags flags,
+                             const image_test_context_t &ctx)
 {
     int error;
 

--- a/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
@@ -18,7 +18,7 @@
 
 int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
                               image_descriptor *imageInfo, MTdata d,
-                              cl_mem_flags flags)
+                              cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -29,7 +29,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data(imageInfo, imageValues, d);
 
-    if (gDebugTrace)
+    if (ctx.debugTrace)
     {
         log_info(" - Creating 1D image %d...\n", (int)imageInfo->width);
         log_info(" with %llu mip levels\n",
@@ -53,7 +53,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
         return -1;
     }
 
-    if (gDebugTrace) log_info(" - Writing image...\n");
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
     size_t origin[3] = { 0, 0, 0 };
     size_t region[3] = { imageInfo->width, 1, 1 };
@@ -63,7 +63,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
     size_t imgValMipLevelOffset = 0;
 
     error = clEnqueueWriteImage(queue, image, CL_FALSE, origin, region,
-                                (gEnablePitch ? imageInfo->rowPitch : 0), 0,
+                                (ctx.enablePitch ? imageInfo->rowPitch : 0), 0,
                                 (char *)imageValues + imgValMipLevelOffset, 0,
                                 NULL, NULL);
     if (error != CL_SUCCESS)
@@ -75,7 +75,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
 
     // To verify, we just read the results right back and see whether they
     // match the input
-    if (gDebugTrace)
+    if (ctx.debugTrace)
     {
         log_info(" - Initing result array...\n");
     }
@@ -85,7 +85,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
     size_t imageSize = scanlineSize;
     memset(resultValues, 0xff, imageSize);
 
-    if (gDebugTrace) log_info(" - Reading results...\n");
+    if (ctx.debugTrace) log_info(" - Reading results...\n");
 
     error = clEnqueueReadImage(queue, image, CL_TRUE, origin, region, 0, 0,
                                resultValues, 0, NULL, NULL);
@@ -150,7 +150,8 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags)
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -158,7 +159,7 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
     RandomSeed seed(gRandomSeed);
     size_t pixelSize;
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         // 1D image buffers don't support mipmaps
         // https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image
@@ -184,20 +185,21 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (gDebugTrace) log_info("   at size %d\n", (int)imageInfo.width);
+            if (ctx.debugTrace)
+                log_info("   at size %d\n", (int)imageInfo.width);
 
             int ret = test_read_image_1D_buffer(context, queue, &imageInfo,
-                                                seed, flags);
+                                                seed, flags, ctx);
             if (ret) return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -213,9 +215,9 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
             log_info("Testing %d\n", (int)imageInfo.width);
-            if (gDebugTrace) log_info("   at max size %d\n", (int)maxWidth);
+            if (ctx.debugTrace) log_info("   at max size %d\n", (int)maxWidth);
             if (test_read_image_1D_buffer(context, queue, &imageInfo, seed,
-                                          flags))
+                                          flags, ctx))
                 return -1;
         }
     }
@@ -233,7 +235,7 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                     (size_t)random_log_in_range(16, (int)(maxWidth / 32), seed);
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if (gEnablePitch)
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range(0, 64, seed);
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -242,12 +244,12 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size / 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d (row pitch %d) out of %d\n",
                          (int)imageInfo.width, (int)imageInfo.rowPitch,
                          (int)maxWidth);
             int ret = test_read_image_1D_buffer(context, queue, &imageInfo,
-                                                seed, flags);
+                                                seed, flags, ctx);
             if (ret) return -1;
         }
     }

--- a/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
@@ -18,7 +18,8 @@
 
 int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
                               image_descriptor *imageInfo, MTdata d,
-                              cl_mem_flags flags, const image_test_context_t &ctx)
+                              cl_mem_flags flags,
+                              const image_test_context_t &ctx)
 {
     int error;
 

--- a/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_1D_buffer.cpp
@@ -18,7 +18,7 @@
 
 int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
                               image_descriptor *imageInfo, MTdata d,
-                              cl_mem_flags flags, const context_t &ctx)
+                              cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -151,7 +151,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
 int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_2D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags)
+                       cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -27,15 +27,17 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
-        log_info( " - Creating %s image %d by %d...\n", gTestMipmaps?"mipmapped":"", (int)imageInfo->width, (int)imageInfo->height );
-        if( gTestMipmaps )
+        log_info(" - Creating %s image %d by %d...\n",
+                 ctx.testMipmaps ? "mipmapped" : "", (int)imageInfo->width,
+                 (int)imageInfo->height);
+        if (ctx.testMipmaps)
             log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
     }
 
     // Construct testing sources
-    if(!gTestMipmaps)
+    if (!ctx.testMipmaps)
     {
         image =
             create_image_2d(context, flags, imageInfo->format, imageInfo->width,
@@ -62,13 +64,12 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
             return error;
         }
     }
-    if( gDebugTrace )
-        log_info( " - Writing image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
     size_t origin[ 3 ] = { 0, 0, 0 };
     size_t region[ 3 ] = { 0, 0, 1 };
     size_t fullImageSize;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
     }
@@ -79,31 +80,38 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> resultValues(malloc(fullImageSize));
     size_t imgValMipLevelOffset = 0;
 
-    for( size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+    for (size_t lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+         || (!ctx.testMipmaps && lod < 1);
+         lod++)
     {
         origin[2] = lod;
         size_t width_lod, height_lod, row_pitch_lod;
 
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
         height_lod = (imageInfo->height >> lod) ? (imageInfo->height >> lod) : 1;
-        row_pitch_lod = gTestMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
+        row_pitch_lod = ctx.testMipmaps
+            ? (width_lod * get_pixel_size(imageInfo->format))
+            : imageInfo->rowPitch;
 
         region[0] = width_lod;
         region[1] = height_lod;
 
-        if ( gDebugTrace && gTestMipmaps) {
+        if (ctx.debugTrace && ctx.testMipmaps)
+        {
             log_info(" - Working at mipLevel :%llu\n", (unsigned long long)lod);
         }
-        error = clEnqueueWriteImage(queue, image, CL_FALSE,
-                                    origin, region, ( gEnablePitch ? row_pitch_lod : 0 ), 0,
-                                   (char*)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
+        error = clEnqueueWriteImage(queue, image, CL_FALSE, origin, region,
+                                    (ctx.enablePitch ? row_pitch_lod : 0), 0,
+                                    (char *)imageValues + imgValMipLevelOffset,
+                                    0, NULL, NULL);
         if (error != CL_SUCCESS) {
             log_error( "ERROR: Unable to write to 2D image of size %d x %d \n", (int)width_lod, (int)height_lod );
             return -1;
         }
 
         // To verify, we just read the results right back and see whether they match the input
-        if( gDebugTrace ) {
+        if (ctx.debugTrace)
+        {
             log_info( " - Initing result array...\n" );
         }
 
@@ -112,8 +120,7 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
         size_t imageSize = scanlineSize * height_lod;
         memset( resultValues, 0xff, imageSize );
 
-        if( gDebugTrace )
-            log_info( " - Reading results...\n" );
+        if (ctx.debugTrace) log_info(" - Reading results...\n");
 
         error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, 0, 0, resultValues, 0, NULL, NULL );
         test_error( error, "Unable to read image values" );
@@ -126,7 +133,7 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
         {
             if( memcmp( sourcePtr, destPtr, scanlineSize ) != 0 )
             {
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     log_error("At mip level %llu\n",(unsigned long long) lod);
                 }
@@ -173,7 +180,7 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -197,27 +204,27 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int ret =
-                    test_read_image_2D(context, queue, &imageInfo, seed, flags);
+                int ret = test_read_image_2D(context, queue, &imageInfo, seed,
+                                             flags, ctx);
                 if( ret )
                     return -1;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -231,13 +238,14 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             imageInfo.height = sizes[idx][1];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.height);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)maxWidth, (int)maxHeight );
-            if (test_read_image_2D(context, queue, &imageInfo, seed, flags))
+            if (test_read_image_2D(context, queue, &imageInfo, seed, flags,
+                                   ctx))
                 return -1;
         }
     }
@@ -252,7 +260,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             {
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
                 imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
@@ -261,7 +269,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                 else
                 {
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -271,10 +279,10 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size / 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int ret =
-                test_read_image_2D(context, queue, &imageInfo, seed, flags);
+            int ret = test_read_image_2D(context, queue, &imageInfo, seed,
+                                         flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags, const context_t &ctx)
+                       cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -180,7 +180,7 @@ int test_read_image_2D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags)
+                             cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -27,15 +27,17 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
-        log_info( " - Creating %s image %d by %d by %d...\n", gTestMipmaps?"mipmapped":"", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize );
-        if( gTestMipmaps )
+        log_info(" - Creating %s image %d by %d by %d...\n",
+                 ctx.testMipmaps ? "mipmapped" : "", (int)imageInfo->width,
+                 (int)imageInfo->height, (int)imageInfo->arraySize);
+        if (ctx.testMipmaps)
             log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
     }
 
     // Construct testing sources
-    if(!gTestMipmaps)
+    if (!ctx.testMipmaps)
     {
         image = create_image_2d_array(context, flags, imageInfo->format,
                                       imageInfo->width, imageInfo->height,
@@ -64,13 +66,12 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
         }
     }
 
-    if( gDebugTrace )
-        log_info( " - Writing image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
     size_t origin[ 4 ] = { 0, 0, 0, 0 };
     size_t region[ 3 ] = { 0, 0, 0 };
     size_t fullImageSize;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
     }
@@ -81,34 +82,41 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> resultValues(malloc(fullImageSize));
     size_t imgValMipLevelOffset = 0;
 
-    for(size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+    for (size_t lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+         || (!ctx.testMipmaps && lod < 1);
+         lod++)
     {
         origin[3] = lod;
         size_t width_lod, height_lod, row_pitch_lod, slice_pitch_lod;
 
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
         height_lod = (imageInfo->height >> lod) ? (imageInfo->height >> lod) : 1;
-        row_pitch_lod = gTestMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
-        slice_pitch_lod = gTestMipmaps ? (row_pitch_lod * height_lod): imageInfo->slicePitch;
+        row_pitch_lod = ctx.testMipmaps
+            ? (width_lod * get_pixel_size(imageInfo->format))
+            : imageInfo->rowPitch;
+        slice_pitch_lod = ctx.testMipmaps ? (row_pitch_lod * height_lod)
+                                          : imageInfo->slicePitch;
         region[0] = width_lod;
         region[1] = height_lod;
         region[2] = imageInfo->arraySize;
 
-        if ( gDebugTrace && gTestMipmaps) {
+        if (ctx.debugTrace && ctx.testMipmaps)
+        {
             log_info(" - Working at mipLevel :%llu\n", (unsigned long long)lod);
         }
 
-        error = clEnqueueWriteImage(queue, image, CL_FALSE,
-                                    origin, region, ( gEnablePitch ? row_pitch_lod : 0 ), ( gEnablePitch ? slice_pitch_lod : 0 ),
-                                    (char*)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
+        error = clEnqueueWriteImage(queue, image, CL_FALSE, origin, region,
+                                    (ctx.enablePitch ? row_pitch_lod : 0),
+                                    (ctx.enablePitch ? slice_pitch_lod : 0),
+                                    (char *)imageValues + imgValMipLevelOffset,
+                                    0, NULL, NULL);
         if (error != CL_SUCCESS) {
             log_error( "ERROR: Unable to write to 2D image array of size %d x %d x %d\n", (int)width_lod, (int)height_lod, (int)imageInfo->arraySize );
             return -1;
         }
 
         // To verify, we just read the results right back and see whether they match the input
-        if( gDebugTrace )
-            log_info( " - Initing result array...\n" );
+        if (ctx.debugTrace) log_info(" - Initing result array...\n");
 
         // Note: we read back without any pitch, to verify pitch actually WORKED
         size_t scanlineSize = width_lod * get_pixel_size( imageInfo->format );
@@ -116,8 +124,7 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
         size_t imageSize = pageSize * imageInfo->arraySize;
         memset( resultValues, 0xff, imageSize );
 
-        if( gDebugTrace )
-            log_info( " - Reading results...\n" );
+        if (ctx.debugTrace) log_info(" - Reading results...\n");
 
         error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, 0, 0, resultValues, 0, NULL, NULL );
         test_error( error, "Unable to read image values" );
@@ -148,7 +155,8 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
-                                 cl_image_format *format, cl_mem_flags flags)
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -172,7 +180,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -183,20 +191,20 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
                 {
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_read_image_2D_array(context, queue,
-                                                       &imageInfo, seed, flags);
+                    int ret = test_read_image_2D_array(
+                        context, queue, &imageInfo, seed, flags, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -213,12 +221,12 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
 
             log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize);
             if (test_read_image_2D_array(context, queue, &imageInfo, seed,
-                                         flags))
+                                         flags, ctx))
                 return -1;
         }
     }
@@ -235,7 +243,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
                 imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, 0), seed);
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
@@ -247,7 +255,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
                     imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -260,10 +268,10 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
             int ret = test_read_image_2D_array(context, queue, &imageInfo, seed,
-                                               flags);
+                                               flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags, const context_t &ctx)
+                             cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -156,7 +156,7 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
 int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_2D_array.cpp
@@ -17,7 +17,8 @@
 
 int test_read_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *imageInfo, MTdata d,
-                             cl_mem_flags flags, const image_test_context_t &ctx)
+                             cl_mem_flags flags,
+                             const image_test_context_t &ctx)
 {
     int error;
 

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags, const context_t &ctx)
+                       cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error;
 
@@ -165,7 +165,7 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -92,8 +92,11 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
         height_lod = (imageInfo->height >> lod) ? (imageInfo->height >> lod) : 1;
         depth_lod = (imageInfo->depth >> lod) ? (imageInfo->depth >> lod) : 1;
-        row_pitch_lod = ctx.testMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
-        slice_pitch_lod = ctx.testMipmaps ? (row_pitch_lod * height_lod): imageInfo->slicePitch;
+        row_pitch_lod = ctx.testMipmaps
+            ? (width_lod * get_pixel_size(imageInfo->format))
+            : imageInfo->rowPitch;
+        slice_pitch_lod = ctx.testMipmaps ? (row_pitch_lod * height_lod)
+                                          : imageInfo->slicePitch;
         region[0] = width_lod;
         region[1] = height_lod;
         region[2] = depth_lod;
@@ -102,11 +105,16 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
         {
             log_info(" - Working at mipLevel :%llu\n", (unsigned long long)lod);
         }
-        error = clEnqueueWriteImage(queue, image, CL_FALSE,
-                                    origin, region, ( ctx.enablePitch ? imageInfo->rowPitch : 0 ), ( ctx.enablePitch ? imageInfo->slicePitch : 0 ),
-                                    (char*)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
+        error = clEnqueueWriteImage(
+            queue, image, CL_FALSE, origin, region,
+            (ctx.enablePitch ? imageInfo->rowPitch : 0),
+            (ctx.enablePitch ? imageInfo->slicePitch : 0),
+            (char *)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
         if (error != CL_SUCCESS) {
-            log_error( "ERROR: Unable to write to %s 3D image of size %d x %d x %d\n", ctx.testMipmaps?"mipmapped":"", (int)width_lod, (int)height_lod, (int)depth_lod );
+            log_error(
+                "ERROR: Unable to write to %s 3D image of size %d x %d x %d\n",
+                ctx.testMipmaps ? "mipmapped" : "", (int)width_lod,
+                (int)height_lod, (int)depth_lod);
             return -1;
         }
 
@@ -223,7 +231,11 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
       imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
       if (ctx.testMipmaps)
-        imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
+          imageInfo.num_mip_levels = (cl_uint)random_log_in_range(
+              2,
+              (int)compute_max_mip_levels(imageInfo.width, imageInfo.height,
+                                          imageInfo.depth),
+              seed);
 
       log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth);
       if (test_read_image_3D(context, queue, &imageInfo, seed, flags, ctx))

--- a/test_conformance/images/clReadWriteImage/test_read_3D.cpp
+++ b/test_conformance/images/clReadWriteImage/test_read_3D.cpp
@@ -17,7 +17,7 @@
 
 int test_read_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *imageInfo, MTdata d,
-                       cl_mem_flags flags)
+                       cl_mem_flags flags, const context_t &ctx)
 {
     int error;
 
@@ -27,14 +27,16 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
-        log_info( " - Creating %s image %d by %d by %d...\n", gTestMipmaps?"mipmapped":"", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth );
-        if( gTestMipmaps )
+        log_info(" - Creating %s image %d by %d by %d...\n",
+                 ctx.testMipmaps ? "mipmapped" : "", (int)imageInfo->width,
+                 (int)imageInfo->height, (int)imageInfo->depth);
+        if (ctx.testMipmaps)
             log_info( " with %llu mip levels\n", (unsigned long long) imageInfo->num_mip_levels );
     }
     // Construct testing sources
-    if(!gTestMipmaps)
+    if (!ctx.testMipmaps)
     {
         image = create_image_3d(context, flags, imageInfo->format,
                                 imageInfo->width, imageInfo->height,
@@ -63,13 +65,12 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
         }
     }
 
-    if( gDebugTrace )
-        log_info( " - Writing image...\n" );
+    if (ctx.debugTrace) log_info(" - Writing image...\n");
 
     size_t origin[ 4 ] = { 0, 0, 0, 0 };
     size_t region[ 3 ] = { 0, 0, 0 };
     size_t fullImageSize;
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         fullImageSize = (size_t)compute_mipmapped_image_size( *imageInfo );
     }
@@ -81,7 +82,9 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
     BufferOwningPtr<char> resultValues(malloc(fullImageSize));
     size_t imgValMipLevelOffset = 0;
 
-    for(size_t lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+    for (size_t lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+         || (!ctx.testMipmaps && lod < 1);
+         lod++)
     {
         origin[3] = lod;
         size_t width_lod, height_lod, depth_lod, row_pitch_lod, slice_pitch_lod;
@@ -89,25 +92,27 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
         width_lod = (imageInfo->width >> lod) ? (imageInfo->width >> lod) : 1;
         height_lod = (imageInfo->height >> lod) ? (imageInfo->height >> lod) : 1;
         depth_lod = (imageInfo->depth >> lod) ? (imageInfo->depth >> lod) : 1;
-        row_pitch_lod = gTestMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
-        slice_pitch_lod = gTestMipmaps ? (row_pitch_lod * height_lod): imageInfo->slicePitch;
+        row_pitch_lod = ctx.testMipmaps ? (width_lod * get_pixel_size( imageInfo->format )): imageInfo->rowPitch;
+        slice_pitch_lod = ctx.testMipmaps ? (row_pitch_lod * height_lod): imageInfo->slicePitch;
         region[0] = width_lod;
         region[1] = height_lod;
         region[2] = depth_lod;
 
-        if ( gDebugTrace && gTestMipmaps) {
+        if (ctx.debugTrace && ctx.testMipmaps)
+        {
             log_info(" - Working at mipLevel :%llu\n", (unsigned long long)lod);
         }
         error = clEnqueueWriteImage(queue, image, CL_FALSE,
-                                    origin, region, ( gEnablePitch ? imageInfo->rowPitch : 0 ), ( gEnablePitch ? imageInfo->slicePitch : 0 ),
+                                    origin, region, ( ctx.enablePitch ? imageInfo->rowPitch : 0 ), ( ctx.enablePitch ? imageInfo->slicePitch : 0 ),
                                     (char*)imageValues + imgValMipLevelOffset, 0, NULL, NULL);
         if (error != CL_SUCCESS) {
-            log_error( "ERROR: Unable to write to %s 3D image of size %d x %d x %d\n", gTestMipmaps?"mipmapped":"", (int)width_lod, (int)height_lod, (int)depth_lod );
+            log_error( "ERROR: Unable to write to %s 3D image of size %d x %d x %d\n", ctx.testMipmaps?"mipmapped":"", (int)width_lod, (int)height_lod, (int)depth_lod );
             return -1;
         }
 
         // To verify, we just read the results right back and see whether they match the input
-        if( gDebugTrace ) {
+        if (ctx.debugTrace)
+        {
             log_info( " - Initing result array...\n" );
         }
 
@@ -117,8 +122,7 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
         size_t imageSize = pageSize * depth_lod;
         memset( resultValues, 0xff, imageSize );
 
-        if( gDebugTrace )
-            log_info( " - Reading results...\n" );
+        if (ctx.debugTrace) log_info(" - Reading results...\n");
 
         error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, 0, 0, resultValues, 0, NULL, NULL );
         test_error( error, "Unable to read image values" );
@@ -133,7 +137,7 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
             {
                 if( memcmp( sourcePtr, destPtr, scanlineSize ) != 0 )
                 {
-                    if(gTestMipmaps)
+                    if (ctx.testMipmaps)
                     {
                         log_error("At mip level %llu\n",(unsigned long long) lod);
                     }
@@ -153,7 +157,7 @@ int test_read_image_3D(cl_context context, cl_command_queue queue,
 
 int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -177,7 +181,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -188,20 +192,20 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
                 {
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
                     int ret = test_read_image_3D(context, queue, &imageInfo,
-                                                 seed, flags);
+                                                 seed, flags, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
     // Try a specific set of maximum sizes
     size_t numbeOfSizes;
@@ -218,11 +222,11 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
       imageInfo.rowPitch = imageInfo.width * pixelSize;
       imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
-      if (gTestMipmaps)
+      if (ctx.testMipmaps)
         imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
 
       log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth);
-      if (test_read_image_3D(context, queue, &imageInfo, seed, flags))
+      if (test_read_image_3D(context, queue, &imageInfo, seed, flags, ctx))
           return -1;
     }
   }
@@ -238,7 +242,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
                 imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
                 imageInfo.depth = (size_t)random_log_in_range( 16, (int)maxDepth / 32, seed );
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth), seed);
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
@@ -250,7 +254,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
                     imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -263,10 +267,10 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int ret =
-                test_read_image_3D(context, queue, &imageInfo, seed, flags);
+            int ret = test_read_image_3D(context, queue, &imageInfo, seed,
+                                         flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -58,7 +58,10 @@ std::array<ImageTestTypes, 3> imageTestTypes = { {
 int filter_formats(const std::vector<cl_image_format> &formatList,
                    std::vector<bool> &filterFlags,
                    cl_channel_type *channelDataTypesToFilter,
-                   bool testMipmaps /*=false*/)
+                   cl_channel_type channelTypeToUse,
+                   cl_channel_order channelOrderToUse,
+                   bool testMipmaps /*=false*/
+)
 {
     int numSupported = 0;
     for (unsigned int j = 0; j < formatList.size(); j++)
@@ -75,16 +78,16 @@ int filter_formats(const std::vector<cl_image_format> &formatList,
         }
 
         // Have we already discarded the channel type via the command line?
-        if (gChannelTypeToUse != (cl_channel_type)-1
-            && gChannelTypeToUse != formatList[j].image_channel_data_type)
+        if (channelTypeToUse != (cl_channel_type)-1
+            && channelTypeToUse != formatList[j].image_channel_data_type)
         {
             filterFlags[j] = true;
             continue;
         }
 
         // Have we already discarded the channel order via the command line?
-        if (gChannelOrderToUse != (cl_channel_order)-1
-            && gChannelOrderToUse != formatList[j].image_channel_order)
+        if (channelOrderToUse != (cl_channel_order)-1
+            && channelOrderToUse != formatList[j].image_channel_order)
         {
             filterFlags[j] = true;
             continue;
@@ -171,7 +174,7 @@ static void CL_CALLBACK release_cl_buffer(cl_mem image, void *buf)
 clMemWrapper create_image(cl_context context, cl_command_queue queue,
                           BufferOwningPtr<char> &data,
                           image_descriptor *imageInfo, bool enable_pitch,
-                          bool create_mipmaps, int *error)
+                          bool create_mipmaps, bool debugTrace, int *error)
 {
     clMemWrapper img;
     cl_image_desc imageDesc;
@@ -204,20 +207,20 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
     switch (imageInfo->type)
     {
         case CL_MEM_OBJECT_IMAGE1D:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 1D image %d ...\n",
                          (int)imageInfo->width);
             if (enable_pitch) host_ptr = malloc(imageInfo->rowPitch);
             break;
         case CL_MEM_OBJECT_IMAGE2D:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 2D image %d by %d ...\n",
                          (int)imageInfo->width, (int)imageInfo->height);
             if (enable_pitch)
                 host_ptr = malloc(imageInfo->height * imageInfo->rowPitch);
             break;
         case CL_MEM_OBJECT_IMAGE3D:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 3D image %d by %d by %d...\n",
                          (int)imageInfo->width, (int)imageInfo->height,
                          (int)imageInfo->depth);
@@ -225,14 +228,14 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
                 host_ptr = malloc(imageInfo->depth * imageInfo->slicePitch);
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 1D image array %d by %d...\n",
                          (int)imageInfo->width, (int)imageInfo->arraySize);
             if (enable_pitch)
                 host_ptr = malloc(imageInfo->arraySize * imageInfo->slicePitch);
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 2D image array %d by %d by %d...\n",
                          (int)imageInfo->width, (int)imageInfo->height,
                          (int)imageInfo->arraySize);
@@ -240,7 +243,7 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
                 host_ptr = malloc(imageInfo->arraySize * imageInfo->slicePitch);
             break;
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-            if (gDebugTrace)
+            if (debugTrace)
                 log_info(" - Creating 1D buffer image %d ...\n",
                          (int)imageInfo->width);
             {
@@ -298,7 +301,7 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
             break;
     }
 
-    if (gDebugTrace && create_mipmaps)
+    if (debugTrace && create_mipmaps)
         log_info(" - with %llu mip levels\n",
                  (unsigned long long)imageInfo->num_mip_levels);
 

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -44,6 +44,8 @@ extern std::array<ImageTestTypes, 3> imageTestTypes;
 int filter_formats(const std::vector<cl_image_format> &formatList,
                    std::vector<bool> &filterFlags,
                    cl_channel_type *channelDataTypesToFilter,
+                   cl_channel_type channelTypeToUse,
+                   cl_channel_order channelOrderToUse,
                    bool testMipmaps = false);
 int get_format_list(cl_context context, cl_mem_object_type imageType,
                     std::vector<cl_image_format> &outFormatList,
@@ -53,6 +55,6 @@ size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d);
 clMemWrapper create_image(cl_context context, cl_command_queue queue,
                           BufferOwningPtr<char> &data,
                           image_descriptor *imageInfo, bool enable_pitch,
-                          bool create_mipmaps, int *error);
+                          bool create_mipmaps, bool debugTrace, int *error);
 
 #endif // IMAGES_COMMON_H

--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -21,9 +21,9 @@
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, cl_mem_object_type imageType,
-                          const context_t &ctx);
+                          const image_test_context_t &ctx);
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 REGISTER_TEST(1D)
 {
@@ -67,8 +67,6 @@ static test_status parseArgs(int &argc, const char *argv[],
         max_images - Runs every format through a set of size combinations with the max values, max values - 1, and max values / 128
         randomize - Uses random seed
 )";
-
-    init_context(ctx);
 
     // Parse arguments
     for( int i = 1; i < argc; i++ )

--- a/test_conformance/images/kernel_image_methods/main.cpp
+++ b/test_conformance/images/kernel_image_methods/main.cpp
@@ -19,38 +19,38 @@
 #include "../testBase.h"
 #include "../harness/compat.h"
 
-bool gDebugTrace;
-bool gTestSmallImages;
-bool gTestMaxImages;
+extern int test_image_set(cl_device_id device, cl_context context,
+                          cl_command_queue queue, cl_mem_object_type imageType,
+                          const context_t &ctx);
 
-cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-
-extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
+static context_t ctx;
 
 REGISTER_TEST(1D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D, ctx);
 }
 REGISTER_TEST(2D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D, ctx);
 }
 REGISTER_TEST(3D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE3D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY,
+                          ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY,
+                          ctx);
 }
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER);
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER,
+                          ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -58,6 +58,7 @@ static test_status parseArgs(int &argc, const char *argv[],
                              std::string &help)
 {
     cl_channel_type chanType;
+    cl_channel_order chanOrder;
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
 
@@ -67,20 +68,25 @@ static test_status parseArgs(int &argc, const char *argv[],
         randomize - Uses random seed
 )";
 
+    init_context(ctx);
+
     // Parse arguments
     for( int i = 1; i < argc; i++ )
     {
         removed_args.push_back(argv[i]);
         if( strcmp( argv[i], "debug_trace" ) == 0 )
-            gDebugTrace = true;
+            ctx.debugTrace = true;
 
         else if( strcmp( argv[i], "small_images" ) == 0 )
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if( strcmp( argv[i], "max_images" ) == 0 )
-            gTestMaxImages = true;
-
-        else if( ( chanType = get_channel_type_from_name( argv[i] ) ) != (cl_channel_type)-1 )
-            gChannelTypeToUse = chanType;
+            ctx.testMaxImages = true;
+        else if ((chanOrder = get_channel_order_from_name(argv[i]))
+                 != (cl_channel_order)-1)
+            ctx.channelOrderToUse = chanOrder;
+        else if ((chanType = get_channel_type_from_name(argv[i]))
+                 != (cl_channel_type)-1)
+            ctx.channelTypeToUse = chanType;
         else
         {
             removed_args.pop_back();
@@ -88,7 +94,7 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if (gTestSmallImages) log_info("Note: Using small test images\n");
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -175,41 +175,40 @@ int test_get_image_info_1D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            if( ctx.debugTrace )
-                log_info( "   at size %d\n", (int)imageInfo.width );
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          if (ctx.debugTrace) log_info("   at size %d\n", (int)imageInfo.width);
 
-            int ret = test_get_1Dimage_info_single(context, queue, &imageInfo,
-                                                   seed, flags, ctx);
-            if( ret )
-                return -1;
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+          int ret = test_get_1Dimage_info_single(context, queue, &imageInfo,
+                                                 seed, flags, ctx);
+          if (ret) return -1;
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, 1, maxAllocSize,
+                    memSize, CL_MEM_OBJECT_IMAGE1D, imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ]);
-            if( ctx.debugTrace )
-                log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            if (test_get_1Dimage_info_single(context, queue, &imageInfo, seed,
-                                             flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d\n", (int)sizes[idx][0]);
+          if (ctx.debugTrace)
+              log_info("   at max size %d\n", (int)sizes[idx][0]);
+          if (test_get_1Dimage_info_single(context, queue, &imageInfo, seed,
+                                           flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -47,7 +47,8 @@ static const char *methodTest1DImageKernelPattern =
 static int test_get_1Dimage_info_single(cl_context context,
                                         cl_command_queue queue,
                                         image_descriptor *imageInfo, MTdata d,
-                                        cl_mem_flags flags)
+                                        cl_mem_flags flags,
+                                        const context_t &ctx)
 {
     int error = 0;
 
@@ -63,7 +64,7 @@ static int test_get_1Dimage_info_single(cl_context context,
     generate_random_image_data( imageInfo, imageValues, d );
 
     // Construct testing source
-    if( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating 1D image %d ...\n", (int)imageInfo->width );
 
     image = create_image_1d(context, flags, imageInfo->format, imageInfo->width,
@@ -151,7 +152,7 @@ static int test_get_1Dimage_info_single(cl_context context,
 
 int test_get_image_info_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -174,21 +175,21 @@ int test_get_image_info_1D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
             int ret = test_get_1Dimage_info_single(context, queue, &imageInfo,
-                                                   seed, flags);
+                                                   seed, flags, ctx);
             if( ret )
                 return -1;
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -202,10 +203,10 @@ int test_get_image_info_1D(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
             log_info( "Testing %d\n", (int)sizes[ idx ][ 0 ]);
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
             if (test_get_1Dimage_info_single(context, queue, &imageInfo, seed,
-                                             flags))
+                                             flags, ctx))
                 return -1;
         }
     }
@@ -232,10 +233,10 @@ int test_get_image_info_1D(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.rowPitch * (cl_ulong)imageInfo.height * 4;
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
             int ret = test_get_1Dimage_info_single(context, queue, &imageInfo,
-                                                   seed, flags);
+                                                   seed, flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_1D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D.cpp
@@ -48,7 +48,7 @@ static int test_get_1Dimage_info_single(cl_context context,
                                         cl_command_queue queue,
                                         image_descriptor *imageInfo, MTdata d,
                                         cl_mem_flags flags,
-                                        const context_t &ctx)
+                                        const image_test_context_t &ctx)
 {
     int error = 0;
 
@@ -152,7 +152,7 @@ static int test_get_1Dimage_info_single(cl_context context,
 
 int test_get_image_info_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -50,7 +50,7 @@ static const char *methodTestKernelPattern =
 int test_get_1Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags)
+                                       cl_mem_flags flags, const context_t &ctx)
 {
     int error = 0;
 
@@ -66,7 +66,7 @@ int test_get_1Dimage_array_info_single(cl_context context,
     generate_random_image_data( imageInfo, imageValues, d );
 
     // Construct testing source
-    if( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating 1D image array %d by %d...\n", (int)imageInfo->width, (int)imageInfo->arraySize );
 
     image = create_image_1d_array(context, flags, imageInfo->format,
@@ -160,7 +160,8 @@ int test_get_1Dimage_array_info_single(cl_context context,
 
 int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
-                                 cl_image_format *format, cl_mem_flags flags)
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -184,7 +185,7 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -192,17 +193,17 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
             for( imageInfo.arraySize = 1; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if( gDebugTrace )
+                if( ctx.debugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
                 int ret = test_get_1Dimage_array_info_single(
-                    context, queue, &imageInfo, seed, flags);
+                    context, queue, &imageInfo, seed, flags, ctx);
                 if( ret )
                     return -1;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -218,10 +219,10 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ]);
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
             if (test_get_1Dimage_array_info_single(context, queue, &imageInfo,
-                                                   seed, flags))
+                                                   seed, flags, ctx))
                 return -1;
         }
     }
@@ -251,10 +252,10 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.rowPitch * (cl_ulong)imageInfo.arraySize * 4;
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
             int ret = test_get_1Dimage_array_info_single(
-                context, queue, &imageInfo, seed, flags);
+                context, queue, &imageInfo, seed, flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -185,47 +185,51 @@ int test_get_image_info_1D_array(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            imageInfo.slicePitch = imageInfo.rowPitch;
-            for( imageInfo.arraySize = 1; imageInfo.arraySize < 9; imageInfo.arraySize++ )
-            {
-                if( ctx.debugTrace )
-                    log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          imageInfo.slicePitch = imageInfo.rowPitch;
+          for (imageInfo.arraySize = 1; imageInfo.arraySize < 9;
+               imageInfo.arraySize++)
+          {
+              if (ctx.debugTrace)
+                  log_info("   at size %d,%d\n", (int)imageInfo.width,
+                           (int)imageInfo.arraySize);
 
-                int ret = test_get_1Dimage_array_info_single(
-                    context, queue, &imageInfo, seed, flags, ctx);
-                if( ret )
-                    return -1;
-            }
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+              int ret = test_get_1Dimage_array_info_single(
+                  context, queue, &imageInfo, seed, flags, ctx);
+              if (ret) return -1;
+          }
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, maxArraySize, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D_ARRAY, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, 1, 1, maxArraySize,
+                    maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE1D_ARRAY,
+                    imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.arraySize = sizes[ idx ][ 2 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            imageInfo.slicePitch = imageInfo.rowPitch;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.arraySize = sizes[idx][2];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          imageInfo.slicePitch = imageInfo.rowPitch;
 
-            log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ]);
-            if( ctx.debugTrace )
-                log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            if (test_get_1Dimage_array_info_single(context, queue, &imageInfo,
-                                                   seed, flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d x %d\n", (int)sizes[idx][0], (int)sizes[idx][2]);
+          if (ctx.debugTrace)
+              log_info("   at max size %d,%d\n", (int)sizes[idx][0],
+                       (int)sizes[idx][2]);
+          if (test_get_1Dimage_array_info_single(context, queue, &imageInfo,
+                                                 seed, flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -50,7 +50,8 @@ static const char *methodTestKernelPattern =
 int test_get_1Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags, const image_test_context_t &ctx)
+                                       cl_mem_flags flags,
+                                       const image_test_context_t &ctx)
 {
     int error = 0;
 

--- a/test_conformance/images/kernel_image_methods/test_1D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_array.cpp
@@ -50,7 +50,7 @@ static const char *methodTestKernelPattern =
 int test_get_1Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags, const context_t &ctx)
+                                       cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error = 0;
 
@@ -161,7 +161,7 @@ int test_get_1Dimage_array_info_single(cl_context context,
 int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
@@ -48,7 +48,8 @@ static const char *methodTest1DImageKernelPattern =
 static int test_get_1Dimage_buffer_info_single(cl_context context,
                                                cl_command_queue queue,
                                                image_descriptor *imageInfo,
-                                               MTdata d, cl_mem_flags flags)
+                                               MTdata d, cl_mem_flags flags,
+                                               const context_t &ctx)
 {
     int error = 0;
 
@@ -64,7 +65,7 @@ static int test_get_1Dimage_buffer_info_single(cl_context context,
     generate_random_image_data(imageInfo, imageValues, d);
 
     // Construct testing source
-    if (gDebugTrace)
+    if (ctx.debugTrace)
         log_info(" - Creating 1D image %d ...\n", (int)imageInfo->width);
 
     buffer = clCreateBuffer(context, flags, imageInfo->rowPitch, NULL, &error);
@@ -177,7 +178,8 @@ static int test_get_1Dimage_buffer_info_single(cl_context context,
 
 int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags)
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;
@@ -204,19 +206,20 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
         maxAllocSize = (cl_ulong)SIZE_MAX;
     }
 
-    if (gTestSmallImages)
+    if (ctx.testSmallImages)
     {
         for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
-            if (gDebugTrace) log_info("   at size %d\n", (int)imageInfo.width);
+            if (ctx.debugTrace)
+                log_info("   at size %d\n", (int)imageInfo.width);
 
             int ret = test_get_1Dimage_buffer_info_single(
-                context, queue, &imageInfo, seed, flags);
+                context, queue, &imageInfo, seed, flags, ctx);
             if (ret) return -1;
         }
     }
-    else if (gTestMaxImages)
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -232,10 +235,10 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
             log_info("Testing %d\n", (int)sizes[idx][0]);
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at max size %d\n", (int)sizes[idx][0]);
             if (test_get_1Dimage_buffer_info_single(context, queue, &imageInfo,
-                                                    seed, flags))
+                                                    seed, flags, ctx))
                 return -1;
         }
     }
@@ -265,12 +268,12 @@ int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.rowPitch * 4;
             } while (size > maxAllocSize || (size * 3) > memSize);
 
-            if (gDebugTrace)
+            if (ctx.debugTrace)
                 log_info("   at size %d (row pitch %d) out of %d\n",
                          (int)imageInfo.width, (int)imageInfo.rowPitch,
                          (int)maxWidth);
             int ret = test_get_1Dimage_buffer_info_single(
-                context, queue, &imageInfo, seed, flags);
+                context, queue, &imageInfo, seed, flags, ctx);
             if (ret) return -1;
         }
     }

--- a/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
+++ b/test_conformance/images/kernel_image_methods/test_1D_buffer.cpp
@@ -49,7 +49,7 @@ static int test_get_1Dimage_buffer_info_single(cl_context context,
                                                cl_command_queue queue,
                                                image_descriptor *imageInfo,
                                                MTdata d, cl_mem_flags flags,
-                                               const context_t &ctx)
+                                               const image_test_context_t &ctx)
 {
     int error = 0;
 
@@ -179,7 +179,7 @@ static int test_get_1Dimage_buffer_info_single(cl_context context,
 int test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     size_t maxWidth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -66,7 +66,7 @@ static const char *depthDimKernelLine = "   outData->depthDim = dim.z;\n";
 
 int test_get_image_info_single(cl_context context, cl_command_queue queue,
                                image_descriptor *imageInfo, MTdata d,
-                               cl_mem_flags flags)
+                               cl_mem_flags flags, const context_t &ctx)
 {
     int error = 0;
 
@@ -82,7 +82,7 @@ int test_get_image_info_single(cl_context context, cl_command_queue queue,
     generate_random_image_data( imageInfo, imageValues, d );
 
     // Construct testing source
-    if( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating image %d by %d...\n", (int)imageInfo->width, (int)imageInfo->height );
 
     if( imageInfo->depth != 0 )
@@ -211,7 +211,7 @@ int test_get_image_info_single(cl_context context, cl_command_queue queue,
 
 int test_get_image_info_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;
@@ -235,24 +235,24 @@ int test_get_image_info_2D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if( gDebugTrace )
+                if( ctx.debugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
                 int ret = test_get_image_info_single(context, queue, &imageInfo,
-                                                     seed, flags);
+                                                     seed, flags, ctx);
                 if( ret )
                     return -1;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -267,10 +267,10 @@ int test_get_image_info_2D(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
             log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
             if (test_get_image_info_single(context, queue, &imageInfo, seed,
-                                           flags))
+                                           flags, ctx))
                 return -1;
         }
     }
@@ -298,10 +298,10 @@ int test_get_image_info_2D(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.rowPitch * (cl_ulong)imageInfo.height * 4;
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
             int ret = test_get_image_info_single(context, queue, &imageInfo,
-                                                 seed, flags);
+                                                 seed, flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -66,7 +66,7 @@ static const char *depthDimKernelLine = "   outData->depthDim = dim.z;\n";
 
 int test_get_image_info_single(cl_context context, cl_command_queue queue,
                                image_descriptor *imageInfo, MTdata d,
-                               cl_mem_flags flags, const context_t &ctx)
+                               cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error = 0;
 
@@ -211,7 +211,7 @@ int test_get_image_info_single(cl_context context, cl_command_queue queue,
 
 int test_get_image_info_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -66,7 +66,8 @@ static const char *depthDimKernelLine = "   outData->depthDim = dim.z;\n";
 
 int test_get_image_info_single(cl_context context, cl_command_queue queue,
                                image_descriptor *imageInfo, MTdata d,
-                               cl_mem_flags flags, const image_test_context_t &ctx)
+                               cl_mem_flags flags,
+                               const image_test_context_t &ctx)
 {
     int error = 0;
 

--- a/test_conformance/images/kernel_image_methods/test_2D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D.cpp
@@ -235,45 +235,48 @@ int test_get_image_info_2D(cl_device_id device, cl_context context,
     maxAllocSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
-            {
-                if( ctx.debugTrace )
-                    log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          for (imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++)
+          {
+              if (ctx.debugTrace)
+                  log_info("   at size %d,%d\n", (int)imageInfo.width,
+                           (int)imageInfo.height);
 
-                int ret = test_get_image_info_single(context, queue, &imageInfo,
-                                                     seed, flags, ctx);
-                if( ret )
-                    return -1;
-            }
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+              int ret = test_get_image_info_single(context, queue, &imageInfo,
+                                                   seed, flags, ctx);
+              if (ret) return -1;
+          }
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE2D, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1, 1,
+                    maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE2D,
+                    imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.height = sizes[ idx ][ 1 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.height = sizes[idx][1];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            log_info( "Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
-            if( ctx.debugTrace )
-                log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            if (test_get_image_info_single(context, queue, &imageInfo, seed,
-                                           flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d x %d\n", (int)sizes[idx][0], (int)sizes[idx][1]);
+          if (ctx.debugTrace)
+              log_info("   at max size %d,%d\n", (int)sizes[idx][0],
+                       (int)sizes[idx][1]);
+          if (test_get_image_info_single(context, queue, &imageInfo, seed,
+                                         flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -53,7 +53,7 @@ static const char *methodTestKernelPattern =
 int test_get_2Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags, const context_t &ctx)
+                                       cl_mem_flags flags, const image_test_context_t &ctx)
 {
     int error = 0;
 
@@ -172,7 +172,7 @@ int test_get_2Dimage_array_info_single(cl_context context,
 int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  cl_image_format *format, cl_mem_flags flags,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -53,7 +53,8 @@ static const char *methodTestKernelPattern =
 int test_get_2Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags, const image_test_context_t &ctx)
+                                       cl_mem_flags flags,
+                                       const image_test_context_t &ctx)
 {
     int error = 0;
 

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -195,51 +195,56 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
     memSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
-            {
-                imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
-                for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
-                {
-                    if( ctx.debugTrace )
-                        log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int ret = test_get_2Dimage_array_info_single(
-                        context, queue, &imageInfo, seed, flags, ctx);
-                    if( ret )
-                        return -1;
-                }
-            }
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+          for (imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++)
+          {
+              imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
+              for (imageInfo.arraySize = 2; imageInfo.arraySize < 9;
+                   imageInfo.arraySize++)
+              {
+                  if (ctx.debugTrace)
+                      log_info("   at size %d,%d,%d\n", (int)imageInfo.width,
+                               (int)imageInfo.height, (int)imageInfo.arraySize);
+                  int ret = test_get_2Dimage_array_info_single(
+                      context, queue, &imageInfo, seed, flags, ctx);
+                  if (ret) return -1;
+              }
+          }
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1, maxArraySize, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE2D_ARRAY, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, 1,
+                    maxArraySize, maxAllocSize, memSize,
+                    CL_MEM_OBJECT_IMAGE2D_ARRAY, imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.height = sizes[ idx ][ 1 ];
-            imageInfo.arraySize = sizes[ idx ][ 2 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.height = sizes[idx][1];
+          imageInfo.arraySize = sizes[idx][2];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
-            log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( ctx.debugTrace )
-                log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if (test_get_2Dimage_array_info_single(context, queue, &imageInfo,
-                                                   seed, flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d x %d x %d\n", (int)sizes[idx][0],
+                   (int)sizes[idx][1], (int)sizes[idx][2]);
+          if (ctx.debugTrace)
+              log_info("   at max size %d,%d,%d\n", (int)sizes[idx][0],
+                       (int)sizes[idx][1], (int)sizes[idx][2]);
+          if (test_get_2Dimage_array_info_single(context, queue, &imageInfo,
+                                                 seed, flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )

--- a/test_conformance/images/kernel_image_methods/test_2D_array.cpp
+++ b/test_conformance/images/kernel_image_methods/test_2D_array.cpp
@@ -53,7 +53,7 @@ static const char *methodTestKernelPattern =
 int test_get_2Dimage_array_info_single(cl_context context,
                                        cl_command_queue queue,
                                        image_descriptor *imageInfo, MTdata d,
-                                       cl_mem_flags flags)
+                                       cl_mem_flags flags, const context_t &ctx)
 {
     int error = 0;
 
@@ -69,7 +69,7 @@ int test_get_2Dimage_array_info_single(cl_context context,
     generate_random_image_data( imageInfo, imageValues, d );
 
     // Construct testing source
-    if( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating 2D image array %d by %d by %d...\n", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize );
 
     image = create_image_2d_array(context, flags, imageInfo->format,
@@ -171,7 +171,8 @@ int test_get_2Dimage_array_info_single(cl_context context,
 
 int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
-                                 cl_image_format *format, cl_mem_flags flags)
+                                 cl_image_format *format, cl_mem_flags flags,
+                                 const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxArraySize;
     cl_ulong maxAllocSize, memSize;
@@ -194,7 +195,7 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
     memSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -205,17 +206,17 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
                 {
-                    if( gDebugTrace )
+                    if( ctx.debugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
                     int ret = test_get_2Dimage_array_info_single(
-                        context, queue, &imageInfo, seed, flags);
+                        context, queue, &imageInfo, seed, flags, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -232,10 +233,10 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if (test_get_2Dimage_array_info_single(context, queue, &imageInfo,
-                                                   seed, flags))
+                                                   seed, flags, ctx))
                 return -1;
         }
     }
@@ -275,10 +276,10 @@ int test_get_image_info_2D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = slicePitch;
             imageInfo.rowPitch = rowPitch;
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
             int ret = test_get_2Dimage_array_info_single(
-                context, queue, &imageInfo, seed, flags);
+                context, queue, &imageInfo, seed, flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -55,51 +55,55 @@ int test_get_image_info_3D(cl_device_id device, cl_context context,
     memSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( ctx.testSmallImages )
-    {
-        for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
-        {
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
+  if (ctx.testSmallImages)
+  {
+      for (imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++)
+      {
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
-            {
-                imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
-                for( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
-                {
-                    if( ctx.debugTrace )
-                        log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int ret = test_get_image_info_single(
-                        context, queue, &imageInfo, seed, flags, ctx);
-                    if( ret )
-                        return -1;
-                }
-            }
-        }
-    }
-    else if( ctx.testMaxImages )
-    {
-        // Try a specific set of maximum sizes
-        size_t numbeOfSizes;
-        size_t sizes[100][3];
+          for (imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++)
+          {
+              imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
+              for (imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++)
+              {
+                  if (ctx.debugTrace)
+                      log_info("   at size %d,%d,%d\n", (int)imageInfo.width,
+                               (int)imageInfo.height, (int)imageInfo.depth);
+                  int ret = test_get_image_info_single(
+                      context, queue, &imageInfo, seed, flags, ctx);
+                  if (ret) return -1;
+              }
+          }
+      }
+  }
+  else if (ctx.testMaxImages)
+  {
+      // Try a specific set of maximum sizes
+      size_t numbeOfSizes;
+      size_t sizes[100][3];
 
-        get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, maxDepth, 1, maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE3D, imageInfo.format);
+      get_max_sizes(&numbeOfSizes, 100, sizes, maxWidth, maxHeight, maxDepth, 1,
+                    maxAllocSize, memSize, CL_MEM_OBJECT_IMAGE3D,
+                    imageInfo.format);
 
-        for( size_t idx = 0; idx < numbeOfSizes; idx++ )
-        {
-            imageInfo.width = sizes[ idx ][ 0 ];
-            imageInfo.height = sizes[ idx ][ 1 ];
-            imageInfo.depth = sizes[ idx ][ 2 ];
-            imageInfo.rowPitch = imageInfo.width * pixelSize;
-            imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
+      for (size_t idx = 0; idx < numbeOfSizes; idx++)
+      {
+          imageInfo.width = sizes[idx][0];
+          imageInfo.height = sizes[idx][1];
+          imageInfo.depth = sizes[idx][2];
+          imageInfo.rowPitch = imageInfo.width * pixelSize;
+          imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
-            log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( ctx.debugTrace )
-                log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if (test_get_image_info_single(context, queue, &imageInfo, seed,
-                                           flags, ctx))
-                return -1;
-        }
-    }
+          log_info("Testing %d x %d x %d\n", (int)sizes[idx][0],
+                   (int)sizes[idx][1], (int)sizes[idx][2]);
+          if (ctx.debugTrace)
+              log_info("   at max size %d,%d,%d\n", (int)sizes[idx][0],
+                       (int)sizes[idx][1], (int)sizes[idx][2]);
+          if (test_get_image_info_single(context, queue, &imageInfo, seed,
+                                         flags, ctx))
+              return -1;
+      }
+  }
     else
     {
         for( int i = 0; i < NUM_IMAGE_ITERATIONS; i++ )

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -18,11 +18,11 @@
 extern int test_get_image_info_single(cl_context context,
                                       cl_command_queue queue,
                                       image_descriptor *imageInfo, MTdata d,
-                                      cl_mem_flags flags, const context_t &ctx);
+                                      cl_mem_flags flags, const image_test_context_t &ctx);
 
 int test_get_image_info_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags, const context_t &ctx)
+                           cl_mem_flags flags, const image_test_context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -18,7 +18,8 @@
 extern int test_get_image_info_single(cl_context context,
                                       cl_command_queue queue,
                                       image_descriptor *imageInfo, MTdata d,
-                                      cl_mem_flags flags, const image_test_context_t &ctx);
+                                      cl_mem_flags flags,
+                                      const image_test_context_t &ctx);
 
 int test_get_image_info_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,

--- a/test_conformance/images/kernel_image_methods/test_3D.cpp
+++ b/test_conformance/images/kernel_image_methods/test_3D.cpp
@@ -18,11 +18,11 @@
 extern int test_get_image_info_single(cl_context context,
                                       cl_command_queue queue,
                                       image_descriptor *imageInfo, MTdata d,
-                                      cl_mem_flags flags);
+                                      cl_mem_flags flags, const context_t &ctx);
 
 int test_get_image_info_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue, cl_image_format *format,
-                           cl_mem_flags flags)
+                           cl_mem_flags flags, const context_t &ctx)
 {
     size_t maxWidth, maxHeight, maxDepth;
     cl_ulong maxAllocSize, memSize;
@@ -55,7 +55,7 @@ int test_get_image_info_3D(cl_device_id device, cl_context context,
     memSize = (cl_ulong)SIZE_MAX;
   }
 
-    if( gTestSmallImages )
+    if( ctx.testSmallImages )
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -66,17 +66,17 @@ int test_get_image_info_3D(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
                 {
-                    if( gDebugTrace )
+                    if( ctx.debugTrace )
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
                     int ret = test_get_image_info_single(
-                        context, queue, &imageInfo, seed, flags);
+                        context, queue, &imageInfo, seed, flags, ctx);
                     if( ret )
                         return -1;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if( ctx.testMaxImages )
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -93,10 +93,10 @@ int test_get_image_info_3D(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
 
             log_info( "Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            if( gDebugTrace )
+            if( ctx.debugTrace )
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
             if (test_get_image_info_single(context, queue, &imageInfo, seed,
-                                           flags))
+                                           flags, ctx))
                 return -1;
         }
     }
@@ -136,10 +136,10 @@ int test_get_image_info_3D(cl_device_id device, cl_context context,
             imageInfo.slicePitch = slicePitch;
             imageInfo.rowPitch = rowPitch;
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
             int ret = test_get_image_info_single(context, queue, &imageInfo,
-                                                 seed, flags);
+                                                 seed, flags, ctx);
             if( ret )
                 return -1;
         }

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -19,28 +19,34 @@
 
 extern int test_get_image_info_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_get_image_info_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_get_image_info_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
-                                  cl_image_format *format, cl_mem_flags flags);
+                                  cl_image_format *format, cl_mem_flags flags,
+                                  const context_t &ctx);
 extern int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
-                                        cl_mem_flags flags);
+                                        cl_mem_flags flags,
+                                        const context_t &ctx);
 extern int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
-                                        cl_mem_flags flags);
-extern int test_get_image_info_1D_buffer(cl_device_id device,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         cl_image_format *format,
-                                         cl_mem_flags flags);
+                                        cl_mem_flags flags,
+                                        const context_t &ctx);
+extern int
+test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
+                              cl_command_queue queue, cl_image_format *format,
+                              cl_mem_flags flags, const context_t &ctx);
 
-int test_image_type( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType, cl_mem_flags flags )
+int test_image_type(cl_device_id device, cl_context context,
+                    cl_command_queue queue, cl_mem_object_type imageType,
+                    cl_mem_flags flags, const context_t &ctx)
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(imageType), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -51,7 +57,8 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     if (get_format_list(context, imageType, formatList, flags)) return -1;
 
     std::vector<bool> filterFlags(formatList.size(), false);
-    filter_formats(formatList, filterFlags, nullptr);
+    filter_formats(formatList, filterFlags, nullptr, ctx.channelTypeToUse,
+                   ctx.channelOrderToUse);
 
     // Run the format list
     for (unsigned int i = 0; i < formatList.size(); i++)
@@ -70,28 +77,28 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
 
         switch (imageType) {
             case CL_MEM_OBJECT_IMAGE1D:
-                test_return = test_get_image_info_1D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_get_image_info_1D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                test_return = test_get_image_info_2D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_get_image_info_2D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                test_return = test_get_image_info_3D(device, context, queue,
-                                                     &formatList[i], flags);
+                test_return = test_get_image_info_3D(
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
                 test_return = test_get_image_info_1D_array(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
                 test_return = test_get_image_info_2D_array(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_BUFFER:
                 test_return = test_get_image_info_1D_buffer(
-                    device, context, queue, &formatList[i], flags);
+                    device, context, queue, &formatList[i], flags, ctx);
                 break;
         }
 
@@ -108,7 +115,9 @@ int test_image_type( cl_device_id device, cl_context context, cl_command_queue q
     return ret;
 }
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, cl_mem_object_type imageType,
+                   const context_t &ctx)
 {
     int version_check;
     auto version = get_device_cl_version(device);
@@ -128,8 +137,10 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     }
 
   int ret = 0;
-    ret += test_image_type( device, context, queue, imageType, CL_MEM_READ_ONLY );
-    ret += test_image_type( device, context, queue, imageType, CL_MEM_WRITE_ONLY );
+  ret +=
+      test_image_type(device, context, queue, imageType, CL_MEM_READ_ONLY, ctx);
+  ret += test_image_type(device, context, queue, imageType, CL_MEM_WRITE_ONLY,
+                         ctx);
 
-    return ret;
+  return ret;
 }

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -20,33 +20,33 @@
 extern int test_get_image_info_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_get_image_info_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_get_image_info_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   cl_image_format *format, cl_mem_flags flags,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_get_image_info_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int
 test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_image_format *format,
-                              cl_mem_flags flags, const context_t &ctx);
+                              cl_mem_flags flags, const image_test_context_t &ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, cl_mem_object_type imageType,
-                    cl_mem_flags flags, const context_t &ctx)
+                    cl_mem_flags flags, const image_test_context_t &ctx)
 {
     log_info( "Running %s %s-only tests...\n", convert_image_type_to_string(imageType), flags == CL_MEM_READ_ONLY ? "read" : "write" );
 
@@ -117,7 +117,7 @@ int test_image_type(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, cl_mem_object_type imageType,
-                   const context_t &ctx)
+                   const image_test_context_t &ctx)
 {
     int version_check;
     auto version = get_device_cl_version(device);

--- a/test_conformance/images/kernel_image_methods/test_loops.cpp
+++ b/test_conformance/images/kernel_image_methods/test_loops.cpp
@@ -39,10 +39,12 @@ extern int test_get_image_info_2D_array(cl_device_id device, cl_context context,
                                         cl_image_format *format,
                                         cl_mem_flags flags,
                                         const image_test_context_t &ctx);
-extern int
-test_get_image_info_1D_buffer(cl_device_id device, cl_context context,
-                              cl_command_queue queue, cl_image_format *format,
-                              cl_mem_flags flags, const image_test_context_t &ctx);
+extern int test_get_image_info_1D_buffer(cl_device_id device,
+                                         cl_context context,
+                                         cl_command_queue queue,
+                                         cl_image_format *format,
+                                         cl_mem_flags flags,
+                                         const image_test_context_t &ctx);
 
 int test_image_type(cl_device_id device, cl_context context,
                     cl_command_queue queue, cl_mem_object_type imageType,

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -27,28 +27,12 @@
 __thread fpu_control_t fpu_control = 0;
 #endif
 
-bool gDebugTrace;
-bool gExtraValidateInfo;
-bool gDisableOffsets;
-bool gTestSmallImages;
-bool gTestMaxImages;
-bool gTestImage2DFromBuffer;
-bool gTestMipmaps;
-cl_filter_mode    gFilterModeToUse = (cl_filter_mode)-1;
-// Default is CL_MEM_USE_HOST_PTR for the test
-cl_mem_flags    gMemFlagsToUse = CL_MEM_USE_HOST_PTR;
-bool            gUseKernelSamplers = false;
-int                gTypesToTest = 0;
-cl_addressing_mode gAddressModeToUse = (cl_addressing_mode)-1;
-int             gNormalizedModeToUse = 7;
-cl_channel_type gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order gChannelOrderToUse = (cl_channel_order)-1;
-bool            gEnablePitch = false;
+static context_t ctx;
 
-int             gtestTypesToRun = 0;
-static int testTypesToRun;
-
-extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, test_format_set_fn formatTestFn, cl_mem_object_type imageType );
+extern int test_image_set(cl_device_id device, cl_context context,
+                          cl_command_queue queue,
+                          test_format_set_fn formatTestFn,
+                          cl_mem_object_type imageType, const context_t &ctx);
 
 extern int cl_image_requirements_size_ext_negative(cl_device_id device,
                                                    cl_context context,
@@ -87,175 +71,151 @@ extern int image_from_buffer_read_positive(cl_device_id device,
                                            cl_context context,
                                            cl_command_queue queue);
 extern int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                                 cl_command_queue queue);
+                                 cl_command_queue queue, const context_t &ctx);
 
-/** read_write images only support sampler-less read buildt-ins which require special settings
-  * for some global parameters. This pair of functions temporarily overwrite those global parameters
-  * and then recover them after completing a read_write test.
-  */
-static void overwrite_global_params_for_read_write_test(  bool            *tTestMipmaps,
-                                                            bool            *tDisableOffsets,
-                                                            bool            *tNormalizedModeToUse,
-                                                            cl_filter_mode  *tFilterModeToUse)
-{
-    log_info("Overwrite global settings for read_write image tests. The overwritten values:\n");
-    log_info("gTestMipmaps = false, gDisableOffsets = true, gNormalizedModeToUse = false, gFilterModeToUse = CL_FILTER_NEAREST\n" );
-    // mipmap images only support sampler read built-in while read_write images only support
-    // sampler-less read built-in. Hence we cannot test mipmap for read_write image.
-    *tTestMipmaps = gTestMipmaps;
-    gTestMipmaps = false;
-
-    // Read_write images are read by sampler-less read which does not handle out-of-bound read
-    // It's application responsibility to make sure that the read happens in-bound
-    // Therefore we should not enable offset in testing read_write images because it will cause out-of-bound
-    *tDisableOffsets    = gDisableOffsets;
-    gDisableOffsets     = true;
-
-    // The sampler-less read image functions behave exactly as the corresponding read image functions
-
-
-    *tNormalizedModeToUse   = gNormalizedModeToUse;
-    gNormalizedModeToUse    = false;
-    *tFilterModeToUse       = gFilterModeToUse;
-    gFilterModeToUse        = CL_FILTER_NEAREST;
-}
-
-/** Recover the global settings overwritten for read_write tests. This is necessary because
-  * there may be other tests (i.e. read or write) are called together with read_write test.
-  */
-static void recover_global_params_from_read_write_test(bool            tTestMipmaps,
-                                                         bool            tDisableOffsets,
-                                                         bool            tNormalizedModeToUse,
-                                                         cl_filter_mode  tFilterModeToUse)
-{
-    gTestMipmaps            = tTestMipmaps;
-    gDisableOffsets         = tDisableOffsets;
-    gNormalizedModeToUse    = tNormalizedModeToUse;
-    gFilterModeToUse        = tFilterModeToUse;
-}
-
-static int doTest( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
+static int doTest(cl_device_id device, cl_context context,
+                  cl_command_queue queue, cl_mem_object_type imageType,
+                  const context_t &ctx)
 {
     int ret = 0;
     bool is_2d_image = imageType == CL_MEM_OBJECT_IMAGE2D;
-    bool            tTestMipMaps = false;
-    bool            tDisableOffsets = false;
-    bool            tNormalizedModeToUse = false;
-    cl_filter_mode  tFilterModeToUse = (cl_filter_mode)-1;
 
-    if( testTypesToRun & kReadTests )
+    if (ctx.testTypesToRun & kReadTests)
     {
-        gtestTypesToRun = kReadTests;
-        ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
+        context_t sub_ctx = ctx;
+        sub_ctx.testTypesToRun = kReadTests;
+        ret += test_image_set(device, context, queue, test_read_image_formats,
+                              imageType, sub_ctx);
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
             log_info( "Testing read_image{f | i | ui} for 2D image from buffer\n" );
 
-            // NOTE: for 2D image from buffer test, gTestSmallImages, gTestMaxImages, gTestRounding and gTestMipmaps must be false
-            if( gTestSmallImages == false && gTestMaxImages == false && gTestRounding == false && gTestMipmaps == false )
+            // NOTE: for 2D image from buffer test, ctx.testSmallImages,
+            // ctx.testMaxImages, gTestRounding and ctx.testMipmaps must be
+            // false
+            if (ctx.testSmallImages == false && ctx.testMaxImages == false
+                && gTestRounding == false && ctx.testMipmaps == false)
             {
-                cl_mem_flags saved_gMemFlagsToUse = gMemFlagsToUse;
-                gTestImage2DFromBuffer = true;
 
-                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
-                gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
+                sub_ctx.testImage2DFromBuffer = true;
+                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this
+                // for 2.0
+                sub_ctx.memFlagsToUse = CL_MEM_COPY_HOST_PTR;
 
-                ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
-
-                gTestImage2DFromBuffer = false;
-                gMemFlagsToUse = saved_gMemFlagsToUse;
+                ret +=
+                    test_image_set(device, context, queue,
+                                   test_read_image_formats, imageType, sub_ctx);
             }
         }
     }
 
-    if( testTypesToRun & kWriteTests )
+    if (ctx.testTypesToRun & kWriteTests)
     {
-        gtestTypesToRun = kWriteTests;
-        ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
+        context_t sub_ctx = ctx;
+        sub_ctx.testTypesToRun = kWriteTests;
+        ret += test_image_set(device, context, queue, test_write_image_formats,
+                              imageType, sub_ctx);
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
             log_info( "Testing write_image{f | i | ui} for 2D image from buffer\n" );
 
-            // NOTE: for 2D image from buffer test, gTestSmallImages, gTestMaxImages,gTestRounding and gTestMipmaps must be false
-            if( gTestSmallImages == false && gTestMaxImages == false && gTestRounding == false && gTestMipmaps == false )
+            // NOTE: for 2D image from buffer test, ctx.testSmallImages,
+            // ctx.testMaxImages,gTestRounding and ctx.testMipmaps must be false
+            if (ctx.testSmallImages == false && ctx.testMaxImages == false
+                && gTestRounding == false && ctx.testMipmaps == false)
             {
-                bool saved_gEnablePitch = gEnablePitch;
-                cl_mem_flags saved_gMemFlagsToUse = gMemFlagsToUse;
-                gEnablePitch = true;
+                sub_ctx.enablePitch = true;
 
                 // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
-                gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
-                gTestImage2DFromBuffer = true;
+                sub_ctx.memFlagsToUse = CL_MEM_COPY_HOST_PTR;
+                sub_ctx.testImage2DFromBuffer = true;
 
-                ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
-
-                gTestImage2DFromBuffer = false;
-                gMemFlagsToUse = saved_gMemFlagsToUse;
-                gEnablePitch = saved_gEnablePitch;
+                ret += test_image_set(device, context, queue,
+                                      test_write_image_formats, imageType,
+                                      sub_ctx);
             }
         }
     }
 
-    if ((testTypesToRun & kReadWriteTests)
+    if ((ctx.testTypesToRun & kReadWriteTests)
         && checkForReadWriteImageSupport(device))
     {
         return ret;
     }
 
-    if( ( testTypesToRun & kReadWriteTests ) && !gTestMipmaps )
+    if ((ctx.testTypesToRun & kReadWriteTests) && !ctx.testMipmaps)
     {
-        gtestTypesToRun = kReadWriteTests;
-        overwrite_global_params_for_read_write_test(&tTestMipMaps, &tDisableOffsets, &tNormalizedModeToUse, &tFilterModeToUse);
-        ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
+        context_t sub_ctx = ctx;
+        sub_ctx.testTypesToRun = kReadWriteTests;
+        // mipmap images only support sampler read built-in while read_write
+        // images only support sampler-less read built-in. Hence we cannot test
+        // mipmap for read_write image.
+        sub_ctx.testMipmaps = false;
+        // Read_write images are read by sampler-less read which does not handle
+        // out-of-bound read It's application responsibility to make sure that
+        // the read happens in-bound Therefore we should not enable offset in
+        // testing read_write images because it will cause out-of-bound
+        sub_ctx.disableOffsets = true;
+        // The sampler-less read image functions behave exactly as the
+        // corresponding read image functions
+        sub_ctx.normalizedModeToUse = false;
+        sub_ctx.filterModeToUse = CL_FILTER_NEAREST;
+
+        ret += test_image_set(device, context, queue, test_read_image_formats,
+                              imageType, sub_ctx);
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
-            log_info("Testing read_image{f | i | ui} for 2D image from buffer\n");
-
-            // NOTE: for 2D image from buffer test, gTestSmallImages, gTestMaxImages, gTestRounding and gTestMipmaps must be false
-            if( gTestSmallImages == false && gTestMaxImages == false && gTestRounding == false && gTestMipmaps == false )
+            // NOTE: for 2D image from buffer test, ctx.testSmallImages,
+            // ctx.testMaxImages, gTestRounding and ctx.testMipmaps must be
+            // false
+            if (ctx.testSmallImages == false && ctx.testMaxImages == false
+                && gTestRounding == false && ctx.testMipmaps == false)
             {
-                cl_mem_flags saved_gMemFlagsToUse = gMemFlagsToUse;
-                gTestImage2DFromBuffer = true;
+                log_info("Testing read_image{f | i | ui} for 2D image from "
+                         "buffer\n");
 
-                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
-                gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
+                context_t sub_sub_ctx = sub_ctx;
+                sub_sub_ctx.testImage2DFromBuffer = true;
 
-                ret += test_image_set( device, context, queue, test_read_image_formats, imageType );
+                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this
+                // for 2.0
+                sub_sub_ctx.memFlagsToUse = CL_MEM_COPY_HOST_PTR;
 
-                gTestImage2DFromBuffer = false;
-                gMemFlagsToUse = saved_gMemFlagsToUse;
+                ret += test_image_set(device, context, queue,
+                                      test_read_image_formats, imageType,
+                                      sub_sub_ctx);
             }
         }
 
-        ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
+        ret += test_image_set(device, context, queue, test_write_image_formats,
+                              imageType, sub_ctx);
 
         if( is_2d_image && is_extension_available( device, "cl_khr_image2d_from_buffer" ) )
         {
-            log_info("Testing write_image{f | i | ui} for 2D image from buffer\n");
-
-            // NOTE: for 2D image from buffer test, gTestSmallImages, gTestMaxImages,gTestRounding and gTestMipmaps must be false
-            if( gTestSmallImages == false && gTestMaxImages == false && gTestRounding == false && gTestMipmaps == false )
+            // NOTE: for 2D image from buffer test, ctx.testSmallImages,
+            // ctx.testMaxImages,gTestRounding and ctx.testMipmaps must be false
+            if (ctx.testSmallImages == false && ctx.testMaxImages == false
+                && gTestRounding == false && ctx.testMipmaps == false)
             {
-                bool saved_gEnablePitch = gEnablePitch;
-                cl_mem_flags saved_gMemFlagsToUse = gMemFlagsToUse;
-                gEnablePitch = true;
+                log_info("Testing write_image{f | i | ui} for 2D image from "
+                         "buffer\n");
 
-                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this for 2.0
-                gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
-                gTestImage2DFromBuffer = true;
+                context_t sub_sub_ctx = sub_ctx;
+                sub_sub_ctx.enablePitch = true;
 
-                ret += test_image_set( device, context, queue, test_write_image_formats, imageType );
+                // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this
+                // for 2.0
+                sub_sub_ctx.memFlagsToUse = CL_MEM_COPY_HOST_PTR;
+                sub_sub_ctx.testImage2DFromBuffer = true;
 
-                gTestImage2DFromBuffer = false;
-                gMemFlagsToUse = saved_gMemFlagsToUse;
-                gEnablePitch = saved_gEnablePitch;
+                ret += test_image_set(device, context, queue,
+                                      test_write_image_formats, imageType,
+                                      sub_sub_ctx);
             }
         }
-
-        recover_global_params_from_read_write_test( tTestMipMaps, tDisableOffsets, tNormalizedModeToUse, tFilterModeToUse );
     }
 
     return ret;
@@ -263,23 +223,23 @@ static int doTest( cl_device_id device, cl_context context, cl_command_queue que
 
 REGISTER_TEST(1D)
 {
-    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE1D );
+    return doTest(device, context, queue, CL_MEM_OBJECT_IMAGE1D, ctx);
 }
 REGISTER_TEST(2D)
 {
-    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
+    return doTest(device, context, queue, CL_MEM_OBJECT_IMAGE2D, ctx);
 }
 REGISTER_TEST(3D)
 {
-    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
+    return doTest(device, context, queue, CL_MEM_OBJECT_IMAGE3D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return doTest(device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY, ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return doTest( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return doTest(device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY, ctx);
 }
 
 REGISTER_TEST_VERSION(cl_image_requirements_size_ext_negative, Version(3, 0))
@@ -334,7 +294,7 @@ REGISTER_TEST_VERSION(image_from_buffer_read_positive, Version(3, 0))
 
 REGISTER_TEST_VERSION(cl_ext_image_raw10_raw12, Version(1, 2))
 {
-    return ext_image_raw10_raw12(device, context, queue);
+    return ext_image_raw10_raw12(device, context, queue, ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -391,87 +351,89 @@ static test_status parseArgs(int &argc, const char *argv[],
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
 
+    init_context(ctx);
+
     // Parse arguments
     for( int i = 1; i < argc; i++ )
     {
         removed_args.push_back(argv[i]);
         if( strcmp( argv[i], "debug_trace" ) == 0 )
-            gDebugTrace = true;
+            ctx.debugTrace = true;
 
         else if( strcmp( argv[i], "CL_FILTER_NEAREST" ) == 0 || strcmp( argv[i], "NEAREST" ) == 0 )
-            gFilterModeToUse = CL_FILTER_NEAREST;
+            ctx.filterModeToUse = CL_FILTER_NEAREST;
         else if( strcmp( argv[i], "CL_FILTER_LINEAR" ) == 0 || strcmp( argv[i], "LINEAR" ) == 0 )
-            gFilterModeToUse = CL_FILTER_LINEAR;
+            ctx.filterModeToUse = CL_FILTER_LINEAR;
 
         else if( strcmp( argv[i], "CL_ADDRESS_NONE" ) == 0 )
-            gAddressModeToUse = CL_ADDRESS_NONE;
+            ctx.addressModeToUse = CL_ADDRESS_NONE;
         else if( strcmp( argv[i], "CL_ADDRESS_CLAMP" ) == 0 )
-            gAddressModeToUse = CL_ADDRESS_CLAMP;
+            ctx.addressModeToUse = CL_ADDRESS_CLAMP;
         else if( strcmp( argv[i], "CL_ADDRESS_CLAMP_TO_EDGE" ) == 0 )
-            gAddressModeToUse = CL_ADDRESS_CLAMP_TO_EDGE;
+            ctx.addressModeToUse = CL_ADDRESS_CLAMP_TO_EDGE;
         else if( strcmp( argv[i], "CL_ADDRESS_REPEAT" ) == 0 )
-            gAddressModeToUse = CL_ADDRESS_REPEAT;
+            ctx.addressModeToUse = CL_ADDRESS_REPEAT;
         else if( strcmp( argv[i], "CL_ADDRESS_MIRRORED_REPEAT" ) == 0 )
-            gAddressModeToUse = CL_ADDRESS_MIRRORED_REPEAT;
+            ctx.addressModeToUse = CL_ADDRESS_MIRRORED_REPEAT;
 
         else if( strcmp( argv[i], "NORMALIZED" ) == 0 )
-            gNormalizedModeToUse = true;
+            ctx.normalizedModeToUse = true;
         else if( strcmp( argv[i], "UNNORMALIZED" ) == 0 )
-            gNormalizedModeToUse = false;
+            ctx.normalizedModeToUse = false;
 
 
         else if( strcmp( argv[i], "no_offsets" ) == 0 )
-            gDisableOffsets = true;
+            ctx.disableOffsets = true;
         else if( strcmp( argv[i], "small_images" ) == 0 )
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if( strcmp( argv[i], "max_images" ) == 0 )
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if( strcmp( argv[i], "use_pitches" ) == 0 )
-            gEnablePitch = true;
+            ctx.enablePitch = true;
         else if( strcmp( argv[i], "rounding" ) == 0 )
             gTestRounding = true;
         else if( strcmp( argv[i], "extra_validate" ) == 0 )
-            gExtraValidateInfo = true;
+            ctx.extraValidateInfo = true;
         else if( strcmp( argv[i], "test_mipmaps" ) == 0 ) {
             // 2.0 Spec does not allow using mem flags, unnormalized coordinates with mipmapped images
-            gTestMipmaps = true;
-            gMemFlagsToUse = 0;
-            gNormalizedModeToUse = true;
+            ctx.testMipmaps = true;
+            ctx.memFlagsToUse = 0;
+            ctx.normalizedModeToUse = true;
         }
 
         else if( strcmp( argv[i], "read" ) == 0 )
-            testTypesToRun |= kReadTests;
+            ctx.testTypesToRun |= kReadTests;
         else if( strcmp( argv[i], "write" ) == 0 )
-            testTypesToRun |= kWriteTests;
+            ctx.testTypesToRun |= kWriteTests;
         else if( strcmp( argv[i], "read_write" ) == 0 )
         {
-            testTypesToRun |= kReadWriteTests;
+            ctx.testTypesToRun |= kReadWriteTests;
         }
 
         else if( strcmp( argv[i], "local_samplers" ) == 0 )
-            gUseKernelSamplers = true;
+            ctx.useKernelSamplers = true;
 
         else if( strcmp( argv[i], "int" ) == 0 )
-            gTypesToTest |= kTestInt;
+            ctx.typesToTest |= kTestInt;
         else if( strcmp( argv[i], "uint" ) == 0 )
-            gTypesToTest |= kTestUInt;
+            ctx.typesToTest |= kTestUInt;
         else if( strcmp( argv[i], "float" ) == 0 )
-            gTypesToTest |= kTestFloat;
+            ctx.typesToTest |= kTestFloat;
 
         else if( strcmp( argv[i], "CL_MEM_COPY_HOST_PTR" ) == 0 || strcmp( argv[i], "COPY_HOST_PTR" ) == 0 )
-            gMemFlagsToUse = CL_MEM_COPY_HOST_PTR;
+            ctx.memFlagsToUse = CL_MEM_COPY_HOST_PTR;
         else if( strcmp( argv[i], "CL_MEM_USE_HOST_PTR" ) == 0 || strcmp( argv[i], "USE_HOST_PTR" ) == 0 )
-            gMemFlagsToUse = CL_MEM_USE_HOST_PTR;
+            ctx.memFlagsToUse = CL_MEM_USE_HOST_PTR;
         else if( strcmp( argv[i], "CL_MEM_ALLOC_HOST_PTR" ) == 0 || strcmp( argv[i], "ALLOC_HOST_PTR" ) == 0 )
-            gMemFlagsToUse = CL_MEM_ALLOC_HOST_PTR;
+            ctx.memFlagsToUse = CL_MEM_ALLOC_HOST_PTR;
         else if( strcmp( argv[i], "NO_HOST_PTR" ) == 0 )
-            gMemFlagsToUse = 0;
+            ctx.memFlagsToUse = 0;
 
         else if( ( chanType = get_channel_type_from_name( argv[i] ) ) != (cl_channel_type)-1 )
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
 
         else if( ( chanOrder = get_channel_order_from_name( argv[i] ) ) != (cl_channel_order)-1 )
-            gChannelOrderToUse = chanOrder;
+            ctx.channelOrderToUse = chanOrder;
         else
         {
             removed_args.pop_back();
@@ -479,13 +441,10 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if( testTypesToRun == 0 )
-        testTypesToRun = kAllTests;
-    if( gTypesToTest == 0 )
-        gTypesToTest = kTestAllTypes;
+    if (ctx.testTypesToRun == 0) ctx.testTypesToRun = kAllTests;
+    if (ctx.typesToTest == 0) ctx.typesToTest = kTestAllTypes;
 
-    if( gTestSmallImages )
-        log_info( "Note: Using small test images\n" );
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -27,12 +27,12 @@
 __thread fpu_control_t fpu_control = 0;
 #endif
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue,
                           test_format_set_fn formatTestFn,
-                          cl_mem_object_type imageType, const context_t &ctx);
+                          cl_mem_object_type imageType, const image_test_context_t &ctx);
 
 extern int cl_image_requirements_size_ext_negative(cl_device_id device,
                                                    cl_context context,
@@ -71,18 +71,18 @@ extern int image_from_buffer_read_positive(cl_device_id device,
                                            cl_context context,
                                            cl_command_queue queue);
 extern int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                                 cl_command_queue queue, const context_t &ctx);
+                                 cl_command_queue queue, const image_test_context_t &ctx);
 
 static int doTest(cl_device_id device, cl_context context,
                   cl_command_queue queue, cl_mem_object_type imageType,
-                  const context_t &ctx)
+                  const image_test_context_t &ctx)
 {
     int ret = 0;
     bool is_2d_image = imageType == CL_MEM_OBJECT_IMAGE2D;
 
     if (ctx.testTypesToRun & kReadTests)
     {
-        context_t sub_ctx = ctx;
+        image_test_context_t sub_ctx = ctx;
         sub_ctx.testTypesToRun = kReadTests;
         ret += test_image_set(device, context, queue, test_read_image_formats,
                               imageType, sub_ctx);
@@ -112,7 +112,7 @@ static int doTest(cl_device_id device, cl_context context,
 
     if (ctx.testTypesToRun & kWriteTests)
     {
-        context_t sub_ctx = ctx;
+        image_test_context_t sub_ctx = ctx;
         sub_ctx.testTypesToRun = kWriteTests;
         ret += test_image_set(device, context, queue, test_write_image_formats,
                               imageType, sub_ctx);
@@ -147,7 +147,7 @@ static int doTest(cl_device_id device, cl_context context,
 
     if ((ctx.testTypesToRun & kReadWriteTests) && !ctx.testMipmaps)
     {
-        context_t sub_ctx = ctx;
+        image_test_context_t sub_ctx = ctx;
         sub_ctx.testTypesToRun = kReadWriteTests;
         // mipmap images only support sampler read built-in while read_write
         // images only support sampler-less read built-in. Hence we cannot test
@@ -177,7 +177,7 @@ static int doTest(cl_device_id device, cl_context context,
                 log_info("Testing read_image{f | i | ui} for 2D image from "
                          "buffer\n");
 
-                context_t sub_sub_ctx = sub_ctx;
+                image_test_context_t sub_sub_ctx = sub_ctx;
                 sub_sub_ctx.testImage2DFromBuffer = true;
 
                 // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this
@@ -203,7 +203,7 @@ static int doTest(cl_device_id device, cl_context context,
                 log_info("Testing write_image{f | i | ui} for 2D image from "
                          "buffer\n");
 
-                context_t sub_sub_ctx = sub_ctx;
+                image_test_context_t sub_sub_ctx = sub_ctx;
                 sub_sub_ctx.enablePitch = true;
 
                 // disable CL_MEM_USE_HOST_PTR for 1.2 extension but enable this
@@ -350,8 +350,6 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-
-    init_context(ctx);
 
     // Parse arguments
     for( int i = 1; i < argc; i++ )

--- a/test_conformance/images/kernel_read_write/main.cpp
+++ b/test_conformance/images/kernel_read_write/main.cpp
@@ -32,7 +32,8 @@ static image_test_context_t ctx;
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue,
                           test_format_set_fn formatTestFn,
-                          cl_mem_object_type imageType, const image_test_context_t &ctx);
+                          cl_mem_object_type imageType,
+                          const image_test_context_t &ctx);
 
 extern int cl_image_requirements_size_ext_negative(cl_device_id device,
                                                    cl_context context,
@@ -71,7 +72,8 @@ extern int image_from_buffer_read_positive(cl_device_id device,
                                            cl_context context,
                                            cl_command_queue queue);
 extern int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                                 cl_command_queue queue, const image_test_context_t &ctx);
+                                 cl_command_queue queue,
+                                 const image_test_context_t &ctx);
 
 static int doTest(cl_device_id device, cl_context context,
                   cl_command_queue queue, cl_mem_object_type imageType,

--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
@@ -18,14 +18,9 @@
 #include "../common.h"
 #include "test_cl_ext_image_buffer.hpp"
 
-extern int gTypesToTest;
-extern int gtestTypesToRun;
-extern int gNormalizedModeToUse;
-extern bool gTestImage2DFromBuffer;
-extern cl_mem_flags gMemFlagsToUse;
-
 static int test_image_set(cl_device_id device, cl_context context,
-                          cl_command_queue queue, cl_mem_object_type imageType)
+                          cl_command_queue queue, cl_mem_object_type imageType,
+                          const context_t &ctx)
 {
     int ret = 0;
 
@@ -46,7 +41,7 @@ static int test_image_set(cl_device_id device, cl_context context,
     image_sampler_data imageSampler;
     ImageTestTypes test{ kTestUInt, kUInt, uintFormats, "uint" };
 
-    if (gTypesToTest & test.type)
+    if (ctx.typesToTest & test.type)
     {
         std::vector<bool> filterFlags(formatList.size(), false);
         imageSampler.filter_mode = CL_FILTER_NEAREST;
@@ -55,17 +50,17 @@ static int test_image_set(cl_device_id device, cl_context context,
         imageSampler.normalized_coords = false;
         ret = test_read_image_formats(device, context, queue, formatList,
                                       filterFlags, &imageSampler,
-                                      test.explicitType, imageType);
+                                      test.explicitType, imageType, ctx);
     }
     return ret;
 }
 
 int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                          cl_command_queue queue)
+                          cl_command_queue queue, const context_t &ctx)
 {
     int ret = 0;
 
-    if (true != gNormalizedModeToUse)
+    if (true != ctx.normalizedModeToUse)
     {
         if (0 == is_extension_available(device, "cl_ext_image_raw10_raw12"))
         {
@@ -80,15 +75,16 @@ int ext_image_raw10_raw12(cl_device_id device, cl_context context,
         }
         else
         {
-            gtestTypesToRun = kReadTests;
-            ret +=
-                test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D);
+            context_t sub_ctx = ctx;
+            sub_ctx.testTypesToRun = kReadTests;
+            ret += test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D,
+                                  sub_ctx);
         }
     }
     else
     {
         // skip the test if it is forced to be NORMALIZED from the command line
-        // argument i.e. gNormalizedModeToUse is true
+        // argument i.e. ctx.normalizedModeToUse is true
         log_info("cl_ext_image_raw10_raw12 does not support normalized channel "
                  "components. Skipping the test.\n");
         ret = TEST_SKIPPED_ITSELF;

--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
@@ -56,7 +56,8 @@ static int test_image_set(cl_device_id device, cl_context context,
 }
 
 int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                          cl_command_queue queue, const image_test_context_t &ctx)
+                          cl_command_queue queue,
+                          const image_test_context_t &ctx)
 {
     int ret = 0;
 

--- a/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
+++ b/test_conformance/images/kernel_read_write/test_cl_ext_image_raw10_raw12.cpp
@@ -20,7 +20,7 @@
 
 static int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, cl_mem_object_type imageType,
-                          const context_t &ctx)
+                          const image_test_context_t &ctx)
 {
     int ret = 0;
 
@@ -56,7 +56,7 @@ static int test_image_set(cl_device_id device, cl_context context,
 }
 
 int ext_image_raw10_raw12(cl_device_id device, cl_context context,
-                          cl_command_queue queue, const context_t &ctx)
+                          cl_command_queue queue, const image_test_context_t &ctx)
 {
     int ret = 0;
 
@@ -75,7 +75,7 @@ int ext_image_raw10_raw12(cl_device_id device, cl_context context,
         }
         else
         {
-            context_t sub_ctx = ctx;
+            image_test_context_t sub_ctx = ctx;
             sub_ctx.testTypesToRun = kReadTests;
             ret += test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D,
                                   sub_ctx);

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -80,7 +80,7 @@ static bool InitFloatCoordsCommon(image_descriptor *imageInfo,
                                   float *xOffsets, float *yOffsets,
                                   float *zOffsets, float xfract, float yfract,
                                   float zfract, int normalized_coords, MTdata d,
-                                  int lod)
+                                  int lod, const context_t &ctx)
 {
     size_t i = 0;
     size_t width_loop, height_loop, depth_loop;
@@ -88,7 +88,7 @@ static bool InitFloatCoordsCommon(image_descriptor *imageInfo,
         get_image_dimensions(imageInfo, width_loop, height_loop, depth_loop);
     if (!error)
     {
-        if (gDisableOffsets)
+        if (ctx.disableOffsets)
         {
             for (size_t z = 0; z < depth_loop; z++)
             {
@@ -148,7 +148,7 @@ static bool InitFloatCoordsCommon(image_descriptor *imageInfo,
             }
         }
 
-        if (normalized_coords || gTestMipmaps)
+        if (normalized_coords || ctx.testMipmaps)
         {
             i = 0;
             if (lod == 0)
@@ -175,7 +175,7 @@ static bool InitFloatCoordsCommon(image_descriptor *imageInfo,
                     }
                 }
             }
-            else if (gTestMipmaps)
+            else if (ctx.testMipmaps)
             {
                 size_t width_lod =
                     (width_loop >> lod) ? (width_loop >> lod) : 1;
@@ -281,7 +281,7 @@ static size_t get_image_num_pixels(image_descriptor *imageInfo, size_t width,
 int test_read_image(cl_context context, cl_command_queue queue,
                     cl_kernel kernel, image_descriptor *imageInfo,
                     image_sampler_data *imageSampler, bool useFloatCoords,
-                    ExplicitType outputType, MTdata d)
+                    ExplicitType outputType, MTdata d, const context_t &ctx)
 {
     bool image_type_3D = ((imageInfo->type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
                           || (imageInfo->type == CL_MEM_OBJECT_IMAGE3D));
@@ -327,7 +327,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
     clMemWrapper unprotImage;
     cl_mem image;
 
-    if (gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         image_read_write_flags = CL_MEM_READ_ONLY;
     }
@@ -336,19 +336,19 @@ int test_read_image(cl_context context, cl_command_queue queue,
         image_read_write_flags = CL_MEM_READ_WRITE;
     }
 
-    if (gMemFlagsToUse == CL_MEM_USE_HOST_PTR)
+    if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
     {
         // clProtectedImage uses USE_HOST_PTR, so just rely on that for the
         // testing (via Ian) Do not use protected images for max image size test
         // since it rounds the row size to a page size
-        if (gTestMaxImages)
+        if (ctx.testMaxImages)
         {
             generate_random_image_data(imageInfo,
                                        maxImageUseHostPtrBackingStore, d);
             unprotImage = create_image_of_type(
                 context, image_read_write_flags | CL_MEM_USE_HOST_PTR,
-                imageInfo, (gEnablePitch ? imageInfo->rowPitch : 0),
-                (gEnablePitch ? imageInfo->slicePitch : 0),
+                imageInfo, (ctx.enablePitch ? imageInfo->rowPitch : 0),
+                (ctx.enablePitch ? imageInfo->slicePitch : 0),
                 maxImageUseHostPtrBackingStore, &error);
         }
         else
@@ -368,19 +368,19 @@ int test_read_image(cl_context context, cl_command_queue queue,
                       IGetErrorString(error));
             return error;
         }
-        if (gTestMaxImages)
+        if (ctx.testMaxImages)
             image = (cl_mem)unprotImage;
         else
             image = (cl_mem)protImage;
     }
-    else if (gMemFlagsToUse == CL_MEM_COPY_HOST_PTR)
+    else if (ctx.memFlagsToUse == CL_MEM_COPY_HOST_PTR)
     {
         // Don't use clEnqueueWriteImage; just use copy host ptr to get the data
         // in
         unprotImage = create_image_of_type(
             context, image_read_write_flags | CL_MEM_COPY_HOST_PTR, imageInfo,
-            (gEnablePitch ? imageInfo->rowPitch : 0),
-            (gEnablePitch ? imageInfo->slicePitch : 0), imageValues, &error);
+            (ctx.enablePitch ? imageInfo->rowPitch : 0),
+            (ctx.enablePitch ? imageInfo->slicePitch : 0), imageValues, &error);
         if (error != CL_SUCCESS)
         {
             log_error("ERROR: Unable to create image of size %d x %d x %d x %d "
@@ -398,12 +398,12 @@ int test_read_image(cl_context context, cl_command_queue queue,
         // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can
         // be accessed by the host, but otherwise it works just as if no flag is
         // specified, so we just do the same thing either way
-        if (!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             unprotImage = create_image_of_type(
-                context, image_read_write_flags | gMemFlagsToUse, imageInfo,
-                (gEnablePitch ? imageInfo->rowPitch : 0),
-                (gEnablePitch ? imageInfo->slicePitch : 0), imageValues,
+                context, image_read_write_flags | ctx.memFlagsToUse, imageInfo,
+                (ctx.enablePitch ? imageInfo->rowPitch : 0),
+                (ctx.enablePitch ? imageInfo->slicePitch : 0), imageValues,
                 &error);
             if (error != CL_SUCCESS)
             {
@@ -447,20 +447,20 @@ int test_read_image(cl_context context, cl_command_queue queue,
 
     test_assert_error(nullptr != image, "Image creation failed");
 
-    if (gMemFlagsToUse != CL_MEM_COPY_HOST_PTR)
+    if (ctx.memFlagsToUse != CL_MEM_COPY_HOST_PTR)
     {
         size_t origin[4] = { 0, 0, 0, 0 };
         size_t region[3] = { width_size, height_size, depth_size };
 
-        if (gDebugTrace) log_info(" - Writing image...\n");
+        if (ctx.debugTrace) log_info(" - Writing image...\n");
 
-        if (!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
 
             error =
                 clEnqueueWriteImage(queue, image, CL_TRUE, origin, region,
-                                    gEnablePitch ? imageInfo->rowPitch : 0,
-                                    gEnablePitch ? imageInfo->slicePitch : 0,
+                                    ctx.enablePitch ? imageInfo->rowPitch : 0,
+                                    ctx.enablePitch ? imageInfo->slicePitch : 0,
                                     imageValues, 0, NULL, NULL);
 
             if (error != CL_SUCCESS)
@@ -531,14 +531,15 @@ int test_read_image(cl_context context, cl_command_queue queue,
     test_error(error, "Unable to create result buffer");
 
     // Create sampler to use
-    actualSampler = create_sampler(context, imageSampler, gTestMipmaps, &error);
+    actualSampler =
+        create_sampler(context, imageSampler, ctx.testMipmaps, &error);
     test_error(error, "Unable to create image sampler");
 
     // Set arguments
     int idx = 0;
     error = clSetKernelArg(kernel, idx++, sizeof(cl_mem), &image);
     test_error(error, "Unable to set kernel arguments");
-    if (!gUseKernelSamplers)
+    if (!ctx.useKernelSamplers)
     {
         error =
             clSetKernelArg(kernel, idx++, sizeof(cl_sampler), &actualSampler);
@@ -571,7 +572,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
     int numTries = MAX_TRIES, numClamped = MAX_CLAMPED;
     int loopCount = 2 * float_offset_count;
     if (!useFloatCoords) loopCount = 1;
-    if (gTestMaxImages)
+    if (ctx.testMaxImages)
     {
         loopCount = 1;
         log_info("Testing each size only once with pixel offsets of %g for max "
@@ -582,7 +583,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
     // Get the maximum absolute error for this format
     double formatAbsoluteError =
         get_max_absolute_error(imageInfo->format, imageSampler);
-    if (gDebugTrace)
+    if (ctx.debugTrace)
         log_info("\tformatAbsoluteError is %e\n", formatAbsoluteError);
 
     if (0 == initHalf
@@ -600,8 +601,8 @@ int test_read_image(cl_context context, cl_command_queue queue,
            depth_lod = depth_size;
 
     // Loop over all mipmap levels, if we are testing mipmapped images.
-    for (int lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels)
-         || (!gTestMipmaps && lod < 1);
+    for (int lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+         || (!ctx.testMipmaps && lod < 1);
          lod++)
     {
         size_t image_lod_size = get_image_num_pixels(
@@ -611,10 +612,10 @@ int test_read_image(cl_context context, cl_command_queue queue,
             image_lod_size * get_explicit_type_size(outputType) * 4;
         BufferOwningPtr<char> resultValues(malloc(resultValuesSize));
         float lod_float = (float)lod;
-        if (gTestMipmaps)
+        if (ctx.testMipmaps)
         {
             // Set the lod kernel arg
-            if (gDebugTrace) log_info(" - Working at mip level %d\n", lod);
+            if (ctx.debugTrace) log_info(" - Working at mip level %d\n", lod);
             error = clSetKernelArg(kernel, idx, sizeof(float), &lod_float);
             test_error(error, "Unable to set kernel arguments");
         }
@@ -629,7 +630,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                 zOffsetValues, q >= float_offset_count ? -offset : offset,
                 q >= float_offset_count ? offset : -offset,
                 q >= float_offset_count ? -offset : offset,
-                imageSampler->normalized_coords, d, lod);
+                imageSampler->normalized_coords, d, lod, ctx);
             test_error(error, "Unable to initialise coordinates");
 
             error = clEnqueueWriteBuffer(queue, xOffsets, CL_TRUE, 0,
@@ -671,7 +672,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                 image_lod_size * get_explicit_type_size(outputType) * 4,
                 resultValues, 0, NULL, NULL);
             test_error(error, "Unable to read results from kernel");
-            if (gDebugTrace) log_info("    results read\n");
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = (char *)imageValues + nextLevelOffset;
@@ -876,7 +877,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                                         norm_offset_y,
                                                         norm_offset_z, j,
                                                         numTries, numClamped,
-                                                        true, lod);
+                                                        true, lod, ctx);
                                                 log_error("Step by step:\n");
                                                 sample_image_pixel_float_offset(
                                                     imagePtr, imageInfo,
@@ -1235,7 +1236,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                                             ? norm_offset_z
                                                             : 0.0f,
                                                         j, numTries, numClamped,
-                                                        true, lod);
+                                                        true, lod, ctx);
                                                 log_error("Step by step:\n");
                                                 sample_image_pixel_float_offset(
                                                     imagePtr, imageInfo,
@@ -1624,7 +1625,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                                             ? norm_offset_z
                                                             : 0.0f,
                                                         j, numTries, numClamped,
-                                                        true, lod);
+                                                        true, lod, ctx);
                                                 log_error("Step by step:\n");
                                                 sample_image_pixel_float_offset(
                                                     imagePtr, imageInfo,
@@ -1871,7 +1872,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                                             ? norm_offset_z
                                                             : 0.0f,
                                                         j, numTries, numClamped,
-                                                        false, lod);
+                                                        false, lod, ctx);
                                             }
                                             else
                                             {
@@ -2077,7 +2078,7 @@ int test_read_image(cl_context context, cl_command_queue queue,
                                                             ? norm_offset_z
                                                             : 0.0f,
                                                         j, numTries, numClamped,
-                                                        false, lod);
+                                                        false, lod, ctx);
                                             }
                                             else
                                             {

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -281,7 +281,8 @@ static size_t get_image_num_pixels(image_descriptor *imageInfo, size_t width,
 int test_read_image(cl_context context, cl_command_queue queue,
                     cl_kernel kernel, image_descriptor *imageInfo,
                     image_sampler_data *imageSampler, bool useFloatCoords,
-                    ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
+                    ExplicitType outputType, MTdata d,
+                    const image_test_context_t &ctx)
 {
     bool image_type_3D = ((imageInfo->type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
                           || (imageInfo->type == CL_MEM_OBJECT_IMAGE3D));

--- a/test_conformance/images/kernel_read_write/test_common.cpp
+++ b/test_conformance/images/kernel_read_write/test_common.cpp
@@ -80,7 +80,7 @@ static bool InitFloatCoordsCommon(image_descriptor *imageInfo,
                                   float *xOffsets, float *yOffsets,
                                   float *zOffsets, float xfract, float yfract,
                                   float zfract, int normalized_coords, MTdata d,
-                                  int lod, const context_t &ctx)
+                                  int lod, const image_test_context_t &ctx)
 {
     size_t i = 0;
     size_t width_loop, height_loop, depth_loop;
@@ -281,7 +281,7 @@ static size_t get_image_num_pixels(image_descriptor *imageInfo, size_t width,
 int test_read_image(cl_context context, cl_command_queue queue,
                     cl_kernel kernel, image_descriptor *imageInfo,
                     image_sampler_data *imageSampler, bool useFloatCoords,
-                    ExplicitType outputType, MTdata d, const context_t &ctx)
+                    ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
 {
     bool image_type_3D = ((imageInfo->type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
                           || (imageInfo->type == CL_MEM_OBJECT_IMAGE3D));

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -28,19 +28,11 @@ extern cl_sampler create_sampler(cl_context context, image_sampler_data *sdata, 
 extern void read_image_pixel_float(void *imageData, image_descriptor *imageInfo,
                                    int x, int y, int z, float *outData);
 
-extern bool gExtraValidateInfo;
-extern bool gDisableOffsets;
-extern bool gUseKernelSamplers;
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-extern uint64_t gRoundingStartValue;
-extern bool gPrintOptions;
-
 extern int test_read_image(cl_context context, cl_command_queue queue,
                            cl_kernel kernel, image_descriptor *imageInfo,
                            image_sampler_data *imageSampler,
                            bool useFloatCoords, ExplicitType outputType,
-                           MTdata d);
+                           MTdata d, const context_t &ctx);
 
 extern bool get_image_dimensions(image_descriptor *imageInfo, size_t &width,
                                  size_t &height, size_t &depth);
@@ -51,7 +43,7 @@ int determine_validation_error_offset(
     image_sampler_data *imageSampler, T *resultPtr, T *expected, float error,
     float x, float y, float z, float xAddressOffset, float yAddressOffset,
     float zAddressOffset, size_t j, int &numTries, int &numClamped,
-    bool printAsFloat, int lod)
+    bool printAsFloat, int lod, const context_t &ctx)
 {
     bool image_type_3D = ((imageInfo->type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
                           || (imageInfo->type == CL_MEM_OBJECT_IMAGE3D));
@@ -187,7 +179,7 @@ int determine_validation_error_offset(
             clampedX, clampedY, clampedZ, (int)imageWidth, (int)imageHeight,
             (int)imageDepth);
 
-        if (printAsFloat && gExtraValidateInfo)
+        if (printAsFloat && ctx.extraValidateInfo)
         {
             log_error("\nNearby values:\n");
             for (int zOff = -1; zOff <= 1; zOff++)

--- a/test_conformance/images/kernel_read_write/test_common.h
+++ b/test_conformance/images/kernel_read_write/test_common.h
@@ -32,7 +32,7 @@ extern int test_read_image(cl_context context, cl_command_queue queue,
                            cl_kernel kernel, image_descriptor *imageInfo,
                            image_sampler_data *imageSampler,
                            bool useFloatCoords, ExplicitType outputType,
-                           MTdata d, const context_t &ctx);
+                           MTdata d, const image_test_context_t &ctx);
 
 extern bool get_image_dimensions(image_descriptor *imageInfo, size_t &width,
                                  size_t &height, size_t &depth);
@@ -43,7 +43,7 @@ int determine_validation_error_offset(
     image_sampler_data *imageSampler, T *resultPtr, T *expected, float error,
     float x, float y, float z, float xAddressOffset, float yAddressOffset,
     float zAddressOffset, size_t j, int &numTries, int &numClamped,
-    bool printAsFloat, int lod, const context_t &ctx)
+    bool printAsFloat, int lod, const image_test_context_t &ctx)
 {
     bool image_type_3D = ((imageInfo->type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
                           || (imageInfo->type == CL_MEM_OBJECT_IMAGE3D));

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -712,19 +712,34 @@ int validate_image_2D_results(void *imageValues, void *resultValues,
                                 log_error("FAILED norm_offsets: %g , %g:\n", norm_offset_x, norm_offset_y);
 
                                 float tempOut[4];
-                                shouldReturn |= determine_validation_error<float>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                  expected, error, xOffsetValues[ j ], yOffsetValues[ j ], norm_offset_x, norm_offset_y, j, numTries, numClamped, true, lod, ctx );
+                                shouldReturn |=
+                                    determine_validation_error<float>(
+                                        imagePtr, imageInfo, imageSampler,
+                                        resultPtr, expected, error,
+                                        xOffsetValues[j], yOffsetValues[j],
+                                        norm_offset_x, norm_offset_y, j,
+                                        numTries, numClamped, true, lod, ctx);
 
                                 log_error( "Step by step:\n" );
                                 FloatPixel temp;
-                                if( ctx.testMipmaps )
-                                     temp = sample_image_pixel_float_offset( imagePtr, imageInfo,
-                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
-                                                                                    imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/, lod );
-                                 else
-                                     temp = sample_image_pixel_float_offset( imageValues, imageInfo,
-                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
-                                                                                    imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/ );
+                                if (ctx.testMipmaps)
+                                    temp = sample_image_pixel_float_offset(
+                                        imagePtr, imageInfo, xOffsetValues[j],
+                                        yOffsetValues[j], 0.f, norm_offset_x,
+                                        norm_offset_y, 0.0f, imageSampler,
+                                        tempOut, 1 /* verbose */,
+                                        &containsDenormals /*dont flush while
+                                                              error reporting*/
+                                        ,
+                                        lod);
+                                else
+                                    temp =
+                                        sample_image_pixel_float_offset(
+                                            imageValues, imageInfo,
+                                            xOffsetValues[j], yOffsetValues[j],
+                                            0.f, norm_offset_x, norm_offset_y,
+                                            0.0f, imageSampler, tempOut,
+                                            1 /* verbose */, &containsDenormals /*dont flush while error reporting*/);
                                 log_error( "\tulps: %2.2f, %2.2f, %2.2f, %2.2f  (max allowed: %2.2f)\n\n",
                                                     Ulp_Error( resultPtr[0], expected[0] ),
                                                     Ulp_Error( resultPtr[1], expected[1] ),
@@ -1147,14 +1162,24 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues,
 
                                 log_error( "Step by step:\n" );
                                 FloatPixel temp;
-                                if( ctx.testMipmaps )
-                                     temp = sample_image_pixel_float_offset( imagePtr, imageInfo,
-                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
-                                                                                    imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/, lod );
-                                 else
-                                     temp = sample_image_pixel_float_offset( imageValues, imageInfo,
-                                                                                    xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
-                                                                                    imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/ );
+                                if (ctx.testMipmaps)
+                                    temp = sample_image_pixel_float_offset(
+                                        imagePtr, imageInfo, xOffsetValues[j],
+                                        yOffsetValues[j], 0.f, norm_offset_x,
+                                        norm_offset_y, 0.0f, imageSampler,
+                                        tempOut, 1 /* verbose */,
+                                        &containsDenormals /*dont flush while
+                                                              error reporting*/
+                                        ,
+                                        lod);
+                                else
+                                    temp =
+                                        sample_image_pixel_float_offset(
+                                            imageValues, imageInfo,
+                                            xOffsetValues[j], yOffsetValues[j],
+                                            0.f, norm_offset_x, norm_offset_y,
+                                            0.0f, imageSampler, tempOut,
+                                            1 /* verbose */, &containsDenormals /*dont flush while error reporting*/);
                                 log_error( "\tulps: %2.2f, %2.2f, %2.2f, %2.2f  (max allowed: %2.2f)\n\n",
                                                     Ulp_Error( resultPtr[0], expected[0] ),
                                                     Ulp_Error( resultPtr[1], expected[1] ),
@@ -1741,10 +1766,15 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
 
             for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if( ctx.testMipmaps )
-                imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
+                if (ctx.testMipmaps)
+                    imageInfo.num_mip_levels = (size_t)random_in_range(
+                        2,
+                        compute_max_mip_levels(imageInfo.width,
+                                               imageInfo.height, 0)
+                            - 1,
+                        seed);
 
-                if( ctx.debugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
                 int retCode = test_read_image_2D(

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -83,7 +83,8 @@ int determine_validation_error(void *imagePtr, image_descriptor *imageInfo,
                                T *expected, float error, float x, float y,
                                float xAddressOffset, float yAddressOffset,
                                size_t j, int &numTries, int &numClamped,
-                               bool printAsFloat, int lod, const image_test_context_t &ctx)
+                               bool printAsFloat, int lod,
+                               const image_test_context_t &ctx)
 {
     int actualX, actualY;
     int found = debug_find_pixel_in_image( imagePtr, imageInfo, resultPtr, &actualX, &actualY, NULL, lod );
@@ -353,14 +354,12 @@ static void InitFloatCoords(image_descriptor *imageInfo,
     }
 }
 
-int validate_image_2D_depth_results(void *imageValues, void *resultValues,
-                                    double formatAbsoluteError,
-                                    float *xOffsetValues, float *yOffsetValues,
-                                    ExplicitType outputType, int &numTries,
-                                    int &numClamped,
-                                    image_sampler_data *imageSampler,
-                                    image_descriptor *imageInfo, size_t lod,
-                                    char *imagePtr, const image_test_context_t &ctx)
+int validate_image_2D_depth_results(
+    void *imageValues, void *resultValues, double formatAbsoluteError,
+    float *xOffsetValues, float *yOffsetValues, ExplicitType outputType,
+    int &numTries, int &numClamped, image_sampler_data *imageSampler,
+    image_descriptor *imageInfo, size_t lod, char *imagePtr,
+    const image_test_context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -977,14 +976,12 @@ int validate_image_2D_results(void *imageValues, void *resultValues,
     return 0;
 }
 
-int validate_image_2D_sRGB_results(void *imageValues, void *resultValues,
-                                   double formatAbsoluteError,
-                                   float *xOffsetValues, float *yOffsetValues,
-                                   ExplicitType outputType, int &numTries,
-                                   int &numClamped,
-                                   image_sampler_data *imageSampler,
-                                   image_descriptor *imageInfo, size_t lod,
-                                   char *imagePtr, const image_test_context_t &ctx)
+int validate_image_2D_sRGB_results(
+    void *imageValues, void *resultValues, double formatAbsoluteError,
+    float *xOffsetValues, float *yOffsetValues, ExplicitType outputType,
+    int &numTries, int &numClamped, image_sampler_data *imageSampler,
+    image_descriptor *imageInfo, size_t lod, char *imagePtr,
+    const image_test_context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -1255,7 +1252,8 @@ bool validate_half_write_results( cl_half *expected, cl_half *actual, image_desc
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler, bool useFloatCoords,
-                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
+                       ExplicitType outputType, MTdata d,
+                       const image_test_context_t &ctx)
 {
     int error;
     static int initHalf = 0;
@@ -1651,7 +1649,8 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -83,7 +83,7 @@ int determine_validation_error(void *imagePtr, image_descriptor *imageInfo,
                                T *expected, float error, float x, float y,
                                float xAddressOffset, float yAddressOffset,
                                size_t j, int &numTries, int &numClamped,
-                               bool printAsFloat, int lod, const context_t &ctx)
+                               bool printAsFloat, int lod, const image_test_context_t &ctx)
 {
     int actualX, actualY;
     int found = debug_find_pixel_in_image( imagePtr, imageInfo, resultPtr, &actualX, &actualY, NULL, lod );
@@ -293,7 +293,7 @@ static void InitFloatCoords(image_descriptor *imageInfo,
                             image_sampler_data *imageSampler, float *xOffsets,
                             float *yOffsets, float xfract, float yfract,
                             int normalized_coords, MTdata d, size_t lod,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     size_t i = 0;
     size_t width_lod = imageInfo->width, height_lod = imageInfo->height;
@@ -360,7 +360,7 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues,
                                     int &numClamped,
                                     image_sampler_data *imageSampler,
                                     image_descriptor *imageInfo, size_t lod,
-                                    char *imagePtr, const context_t &ctx)
+                                    char *imagePtr, const image_test_context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -530,7 +530,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues,
                               int &numTries, int &numClamped,
                               image_sampler_data *imageSampler,
                               image_descriptor *imageInfo, size_t lod,
-                              char *imagePtr, const context_t &ctx)
+                              char *imagePtr, const image_test_context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -984,7 +984,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues,
                                    int &numClamped,
                                    image_sampler_data *imageSampler,
                                    image_descriptor *imageInfo, size_t lod,
-                                   char *imagePtr, const context_t &ctx)
+                                   char *imagePtr, const image_test_context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -1255,7 +1255,7 @@ bool validate_half_write_results( cl_half *expected, cl_half *actual, image_desc
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler, bool useFloatCoords,
-                       ExplicitType outputType, MTdata d, const context_t &ctx)
+                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
 {
     int error;
     static int initHalf = 0;
@@ -1651,7 +1651,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -25,8 +25,6 @@
     #include <setjmp.h>
 #endif
 
-extern bool gTestImage2DFromBuffer;
-
 // Utility function to clamp down image sizes for certain tests to avoid
 // using too much memory.
 static size_t reduceImageSizeRange(size_t maxDimSize) {
@@ -79,9 +77,13 @@ static const char *lodOffsetSource =
 static const char *offsetSource =
 "   int offset = tidY*get_image_width(input) + tidX;\n";
 
-template <class T> int determine_validation_error( void *imagePtr, image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                                                T *resultPtr, T * expected, float error,
-                                float x, float y, float xAddressOffset, float yAddressOffset, size_t j, int &numTries, int &numClamped, bool printAsFloat, int lod = 0 )
+template <class T>
+int determine_validation_error(void *imagePtr, image_descriptor *imageInfo,
+                               image_sampler_data *imageSampler, T *resultPtr,
+                               T *expected, float error, float x, float y,
+                               float xAddressOffset, float yAddressOffset,
+                               size_t j, int &numTries, int &numClamped,
+                               bool printAsFloat, int lod, const context_t &ctx)
 {
     int actualX, actualY;
     int found = debug_find_pixel_in_image( imagePtr, imageInfo, resultPtr, &actualX, &actualY, NULL, lod );
@@ -213,7 +215,7 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
         {
             log_error( " which would clamp to %d,%d\n", clampedX, clampedY );
         }
-        if( printAsFloat && gExtraValidateInfo)
+        if (printAsFloat && ctx.extraValidateInfo)
         {
             log_error( "Nearby values:\n" );
             log_error( "\t%d\t%d\t%d\t%d\n", clampedX - 2, clampedX - 1, clampedX, clampedX + 1 );
@@ -287,17 +289,21 @@ template <class T> int determine_validation_error( void *imagePtr, image_descrip
     return 0;
 }
 
-static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *imageSampler, float *xOffsets, float *yOffsets, float xfract, float yfract, int normalized_coords, MTdata d, size_t lod)
+static void InitFloatCoords(image_descriptor *imageInfo,
+                            image_sampler_data *imageSampler, float *xOffsets,
+                            float *yOffsets, float xfract, float yfract,
+                            int normalized_coords, MTdata d, size_t lod,
+                            const context_t &ctx)
 {
     size_t i = 0;
     size_t width_lod = imageInfo->width, height_lod = imageInfo->height;
 
-    if( gTestMipmaps )
+    if (ctx.testMipmaps)
     {
         width_lod = (imageInfo->width >> lod)?(imageInfo->width >> lod):1;
         height_lod = (imageInfo->height >> lod)?(imageInfo->height >> lod):1;
     }
-    if( gDisableOffsets )
+    if (ctx.disableOffsets)
     {
         for( size_t y = 0; y < height_lod; y++ )
         {
@@ -347,8 +353,14 @@ static void InitFloatCoords( image_descriptor *imageInfo, image_sampler_data *im
     }
 }
 
-int validate_image_2D_depth_results(void *imageValues, void *resultValues, double formatAbsoluteError, float *xOffsetValues, float *yOffsetValues,
-                                                        ExplicitType outputType, int &numTries, int &numClamped, image_sampler_data *imageSampler, image_descriptor *imageInfo, size_t lod, char *imagePtr)
+int validate_image_2D_depth_results(void *imageValues, void *resultValues,
+                                    double formatAbsoluteError,
+                                    float *xOffsetValues, float *yOffsetValues,
+                                    ExplicitType outputType, int &numTries,
+                                    int &numClamped,
+                                    image_sampler_data *imageSampler,
+                                    image_descriptor *imageInfo, size_t lod,
+                                    char *imagePtr, const context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -473,8 +485,13 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
                                 log_error("FAILED norm_offsets: %g , %g:\n", norm_offset_x, norm_offset_y);
 
                                 float tempOut[4];
-                                shouldReturn |= determine_validation_error<float>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                  expected, error, xOffsetValues[ j ], yOffsetValues[ j ], norm_offset_x, norm_offset_y, j, numTries, numClamped, true, lod );
+                                shouldReturn |=
+                                    determine_validation_error<float>(
+                                        imagePtr, imageInfo, imageSampler,
+                                        resultPtr, expected, error,
+                                        xOffsetValues[j], yOffsetValues[j],
+                                        norm_offset_x, norm_offset_y, j,
+                                        numTries, numClamped, true, lod, ctx);
 
                                 log_error( "Step by step:\n" );
                                 FloatPixel temp;
@@ -507,8 +524,13 @@ int validate_image_2D_depth_results(void *imageValues, void *resultValues, doubl
     return 0;
 }
 
-int validate_image_2D_results(void *imageValues, void *resultValues, double formatAbsoluteError, float *xOffsetValues, float *yOffsetValues,
-                                                        ExplicitType outputType, int &numTries, int &numClamped, image_sampler_data *imageSampler, image_descriptor *imageInfo, size_t lod, char *imagePtr)
+int validate_image_2D_results(void *imageValues, void *resultValues,
+                              double formatAbsoluteError, float *xOffsetValues,
+                              float *yOffsetValues, ExplicitType outputType,
+                              int &numTries, int &numClamped,
+                              image_sampler_data *imageSampler,
+                              image_descriptor *imageInfo, size_t lod,
+                              char *imagePtr, const context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -550,7 +572,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                         // Try sampling the pixel, without flushing denormals.
                         int containsDenormals = 0;
                         FloatPixel maxPixel;
-                        if ( gTestMipmaps )
+                        if (ctx.testMipmaps)
                             maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                         imageSampler, expected, 0, &containsDenormals, lod );
@@ -591,7 +613,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                 maxErr3 += 4 * FLT_MIN;
                                 maxErr4 += 4 * FLT_MIN;
 
-                                if(gTestMipmaps)
+                                if (ctx.testMipmaps)
                                     maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL,lod );
@@ -635,7 +657,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                             int containsDenormals = 0;
                             FloatPixel maxPixel;
-                            if(gTestMipmaps)
+                            if (ctx.testMipmaps)
                                 maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals, lod );
@@ -669,7 +691,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                     maxErr3 += 4 * FLT_MIN;
                                     maxErr4 += 4 * FLT_MIN;
 
-                                    if(gTestMipmaps)
+                                    if (ctx.testMipmaps)
                                         maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                      xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                      imageSampler, expected, 0, NULL, lod );
@@ -691,11 +713,11 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
 
                                 float tempOut[4];
                                 shouldReturn |= determine_validation_error<float>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                  expected, error, xOffsetValues[ j ], yOffsetValues[ j ], norm_offset_x, norm_offset_y, j, numTries, numClamped, true, lod );
+                                                                                  expected, error, xOffsetValues[ j ], yOffsetValues[ j ], norm_offset_x, norm_offset_y, j, numTries, numClamped, true, lod, ctx );
 
                                 log_error( "Step by step:\n" );
                                 FloatPixel temp;
-                                if( gTestMipmaps )
+                                if( ctx.testMipmaps )
                                      temp = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                     imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/, lod );
@@ -756,7 +778,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                             checkOnlyOnePixel = 1;
                         }
 
-                        if ( gTestMipmaps )
+                        if (ctx.testMipmaps)
                             sample_image_pixel_offset<unsigned int>( (char*)imagePtr, imageInfo,
                                                                                              xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                              imageSampler, expected, lod );
@@ -794,7 +816,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                 checkOnlyOnePixel = 1;
                             }
 
-                            if( gTestMipmaps )
+                            if (ctx.testMipmaps)
                                 sample_image_pixel_offset<unsigned int>( imagePtr , imageInfo,
                                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                                  imageSampler, expected, lod );
@@ -811,8 +833,13 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                             {
                                 log_error("FAILED norm_offsets: %g , %g:\n", norm_offset_x, norm_offset_y);
 
-                                shouldReturn |= determine_validation_error<unsigned int>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                         expected, error, xOffsetValues[j], yOffsetValues[j], norm_offset_x, norm_offset_y, j, numTries, numClamped, false, lod );
+                                shouldReturn |=
+                                    determine_validation_error<unsigned int>(
+                                        imagePtr, imageInfo, imageSampler,
+                                        resultPtr, expected, error,
+                                        xOffsetValues[j], yOffsetValues[j],
+                                        norm_offset_x, norm_offset_y, j,
+                                        numTries, numClamped, false, lod, ctx);
                             } else {
                                 log_error("Test error: we should have detected this passing above.\n");
                             }
@@ -858,7 +885,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                             checkOnlyOnePixel = 1;
                         }
 
-                        if ( gTestMipmaps )
+                        if (ctx.testMipmaps)
                             sample_image_pixel_offset<int>( imagePtr, imageInfo,
                                                             xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                             imageSampler, expected , lod);
@@ -896,7 +923,7 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                                 checkOnlyOnePixel = 1;
                             }
 
-                            if ( gTestMipmaps )
+                            if (ctx.testMipmaps)
                                 sample_image_pixel_offset<int>( imageValues, imageInfo,
                                                                 xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                 imageSampler, expected, lod );
@@ -913,8 +940,12 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
                             {
                                 log_error("FAILED norm_offsets: %g , %g:\n", norm_offset_x, norm_offset_y);
 
-                                shouldReturn |= determine_validation_error<int>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                expected, error, xOffsetValues[j], yOffsetValues[j], norm_offset_x, norm_offset_y, j, numTries, numClamped, false, lod );
+                                shouldReturn |= determine_validation_error<int>(
+                                    imagePtr, imageInfo, imageSampler,
+                                    resultPtr, expected, error,
+                                    xOffsetValues[j], yOffsetValues[j],
+                                    norm_offset_x, norm_offset_y, j, numTries,
+                                    numClamped, false, lod, ctx);
                             } else {
                                 log_error("Test error: we should have detected this passing above.\n");
                             }
@@ -931,8 +962,14 @@ int validate_image_2D_results(void *imageValues, void *resultValues, double form
     return 0;
 }
 
-int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double formatAbsoluteError, float *xOffsetValues, float *yOffsetValues,
-                                                        ExplicitType outputType, int &numTries, int &numClamped, image_sampler_data *imageSampler, image_descriptor *imageInfo, size_t lod, char *imagePtr)
+int validate_image_2D_sRGB_results(void *imageValues, void *resultValues,
+                                   double formatAbsoluteError,
+                                   float *xOffsetValues, float *yOffsetValues,
+                                   ExplicitType outputType, int &numTries,
+                                   int &numClamped,
+                                   image_sampler_data *imageSampler,
+                                   image_descriptor *imageInfo, size_t lod,
+                                   char *imagePtr, const context_t &ctx)
 {
     // Validate results element by element
     size_t width_lod = (imageInfo->width >> lod ) ?(imageInfo->width >> lod ) : 1;
@@ -974,7 +1011,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                         // Try sampling the pixel, without flushing denormals.
                         int containsDenormals = 0;
                         FloatPixel maxPixel;
-                        if ( gTestMipmaps )
+                        if (ctx.testMipmaps)
                             maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.0f, norm_offset_x, norm_offset_y, 0.0f,
                                                                         imageSampler, expected, 0, &containsDenormals, lod );
@@ -1002,7 +1039,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                 // max error needs to be adjusted
                                 maxErr += 4 * FLT_MIN;
 
-                                if(gTestMipmaps)
+                                if (ctx.testMipmaps)
                                     maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                  xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                  imageSampler, expected, 0, NULL,lod );
@@ -1049,7 +1086,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
 
                             int containsDenormals = 0;
                             FloatPixel maxPixel;
-                            if(gTestMipmaps)
+                            if (ctx.testMipmaps)
                                 maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                         xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                         imageSampler, expected, 0, &containsDenormals, lod );
@@ -1076,7 +1113,7 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                     // If implementation decide to flush subnormals to zero,
                                     // max error needs to be adjusted
                                     maxErr += 4 * FLT_MIN;
-                                    if(gTestMipmaps)
+                                    if (ctx.testMipmaps)
                                         maxPixel = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                      xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                      imageSampler, expected, 0, NULL, lod );
@@ -1100,12 +1137,17 @@ int validate_image_2D_sRGB_results(void *imageValues, void *resultValues, double
                                 log_error("FAILED norm_offsets: %g , %g:\n", norm_offset_x, norm_offset_y);
 
                                 float tempOut[4];
-                                shouldReturn |= determine_validation_error<float>( imagePtr, imageInfo, imageSampler, resultPtr,
-                                                                                  expected, error, xOffsetValues[ j ], yOffsetValues[ j ], norm_offset_x, norm_offset_y, j, numTries, numClamped, true, lod );
+                                shouldReturn |=
+                                    determine_validation_error<float>(
+                                        imagePtr, imageInfo, imageSampler,
+                                        resultPtr, expected, error,
+                                        xOffsetValues[j], yOffsetValues[j],
+                                        norm_offset_x, norm_offset_y, j,
+                                        numTries, numClamped, true, lod, ctx);
 
                                 log_error( "Step by step:\n" );
                                 FloatPixel temp;
-                                if( gTestMipmaps )
+                                if( ctx.testMipmaps )
                                      temp = sample_image_pixel_float_offset( imagePtr, imageInfo,
                                                                                     xOffsetValues[ j ], yOffsetValues[ j ], 0.f, norm_offset_x, norm_offset_y, 0.0f,
                                                                                     imageSampler, tempOut, 1 /* verbose */, &containsDenormals /*dont flush while error reporting*/, lod );
@@ -1185,9 +1227,10 @@ bool validate_half_write_results( cl_half *expected, cl_half *actual, image_desc
     return pass;
 }
 
-int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                       bool useFloatCoords, ExplicitType outputType, MTdata d )
+int test_read_image_2D(cl_context context, cl_command_queue queue,
+                       cl_kernel kernel, image_descriptor *imageInfo,
+                       image_sampler_data *imageSampler, bool useFloatCoords,
+                       ExplicitType outputType, MTdata d, const context_t &ctx)
 {
     int error;
     static int initHalf = 0;
@@ -1211,10 +1254,10 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if( gDebugTrace )
+    if (ctx.debugTrace)
     {
         log_info( " - Creating image %d by %d...\n", (int)imageInfo->width, (int)imageInfo->height );
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             log_info( " - with %d mip levels", (int) imageInfo->num_mip_levels );
         }
@@ -1225,7 +1268,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     clMemWrapper unprotImage;
     cl_mem image;
 
-    if(gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         image_read_write_flags = CL_MEM_READ_ONLY;
     }
@@ -1234,9 +1277,9 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         image_read_write_flags = CL_MEM_READ_WRITE;
     }
 
-    if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+    if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
     {
-        if (gTestImage2DFromBuffer)
+        if (ctx.testImage2DFromBuffer)
         {
             generate_random_image_data( imageInfo, maxImageUseHostPtrBackingStore, d );
             imageBuffer = clCreateBuffer( context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
@@ -1253,13 +1296,14 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         {
             // clProtectedImage uses USE_HOST_PTR, so just rely on that for the testing (via Ian)
             // Do not use protected images for max image size test since it rounds the row size to a page size
-            if (gTestMaxImages) {
+            if (ctx.testMaxImages)
+            {
                 generate_random_image_data( imageInfo, maxImageUseHostPtrBackingStore, d );
-                unprotImage = create_image_2d( context,
-                                        image_read_write_flags | CL_MEM_USE_HOST_PTR,
-                                        imageInfo->format,
-                                        imageInfo->width, imageInfo->height, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                        maxImageUseHostPtrBackingStore, &error );
+                unprotImage = create_image_2d(
+                    context, image_read_write_flags | CL_MEM_USE_HOST_PTR,
+                    imageInfo->format, imageInfo->width, imageInfo->height,
+                    (ctx.enablePitch ? imageInfo->rowPitch : 0),
+                    maxImageUseHostPtrBackingStore, &error);
             }
             else
             {
@@ -1271,7 +1315,8 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
 
         if( error != CL_SUCCESS )
         {
-            if (gTestImage2DFromBuffer) {
+            if (ctx.testImage2DFromBuffer)
+            {
                 clReleaseMemObject(imageBuffer);
                 if (error == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR) {
                     log_info( "Format not supported for cl_khr_image2d_from_buffer skipping...\n" );
@@ -1283,14 +1328,14 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
             return error;
         }
 
-        if (gTestMaxImages || gTestImage2DFromBuffer)
+        if (ctx.testMaxImages || ctx.testImage2DFromBuffer)
             image = (cl_mem)unprotImage;
         else
             image = (cl_mem)protImage;
     }
-    else if( gMemFlagsToUse == CL_MEM_COPY_HOST_PTR )
+    else if (ctx.memFlagsToUse == CL_MEM_COPY_HOST_PTR)
     {
-        if (gTestImage2DFromBuffer)
+        if (ctx.testImage2DFromBuffer)
         {
             imageBuffer = clCreateBuffer( context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
                                          imageInfo->rowPitch * imageInfo->height, imageValues, &error);
@@ -1305,15 +1350,16 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         else
         {
             // Don't use clEnqueueWriteImage; just use copy host ptr to get the data in
-            unprotImage = create_image_2d( context,
-                                      image_read_write_flags | CL_MEM_COPY_HOST_PTR,
-                                      imageInfo->format,
-                                      imageInfo->width, imageInfo->height, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                      imageValues, &error );
+            unprotImage = create_image_2d(
+                context, image_read_write_flags | CL_MEM_COPY_HOST_PTR,
+                imageInfo->format, imageInfo->width, imageInfo->height,
+                (ctx.enablePitch ? imageInfo->rowPitch : 0), imageValues,
+                &error);
         }
         if( error != CL_SUCCESS )
         {
-            if (gTestImage2DFromBuffer) {
+            if (ctx.testImage2DFromBuffer)
+            {
                 clReleaseMemObject(imageBuffer);
                 if (error == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR) {
                     log_info( "Format not supported for cl_khr_image2d_from_buffer skipping...\n" );
@@ -1328,7 +1374,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     }
     else // Either CL_MEM_ALLOC_HOST_PTR or none
     {
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             cl_image_desc image_desc = {0};
             image_desc.image_type = CL_MEM_OBJECT_IMAGE2D;
@@ -1337,10 +1383,11 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
             image_desc.num_mip_levels = imageInfo->num_mip_levels;
             unprotImage = clCreateImage( context, CL_MEM_READ_ONLY, imageInfo->format, &image_desc, NULL, &error);
         }
-        else if (gTestImage2DFromBuffer)
+        else if (ctx.testImage2DFromBuffer)
         {
-            imageBuffer = clCreateBuffer( context, CL_MEM_READ_WRITE | gMemFlagsToUse,
-                                         imageInfo->rowPitch * imageInfo->height, imageValues, &error);
+            imageBuffer = clCreateBuffer(
+                context, CL_MEM_READ_WRITE | ctx.memFlagsToUse,
+                imageInfo->rowPitch * imageInfo->height, imageValues, &error);
             test_error( error, "Unable to create buffer" );
             unprotImage = create_image_2d_buffer( context,
                                                  image_read_write_flags,
@@ -1353,15 +1400,16 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         {
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
-            unprotImage = create_image_2d( context,
-                                      image_read_write_flags | gMemFlagsToUse,
-                                      imageInfo->format,
-                                      imageInfo->width, imageInfo->height, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                      imageValues, &error );
+            unprotImage = create_image_2d(
+                context, image_read_write_flags | ctx.memFlagsToUse,
+                imageInfo->format, imageInfo->width, imageInfo->height,
+                (ctx.enablePitch ? imageInfo->rowPitch : 0), imageValues,
+                &error);
         }
         if( error != CL_SUCCESS )
         {
-            if (gTestImage2DFromBuffer) {
+            if (ctx.testImage2DFromBuffer)
+            {
                 clReleaseMemObject(imageBuffer);
                 if (error == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR) {
                     log_info( "Format not supported for cl_khr_image2d_from_buffer skipping...\n" );
@@ -1375,19 +1423,19 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         image = unprotImage;
     }
 
-    if( gMemFlagsToUse != CL_MEM_COPY_HOST_PTR )
+    if (ctx.memFlagsToUse != CL_MEM_COPY_HOST_PTR)
     {
-        if( gDebugTrace )
-            log_info( " - Writing image...\n" );
+        if (ctx.debugTrace) log_info(" - Writing image...\n");
 
         size_t origin[ 3 ] = { 0, 0, 0 };
         size_t region[ 3 ] = { imageInfo->width, imageInfo->height, 1 };
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
-            error = clEnqueueWriteImage(queue, image, CL_TRUE,
-                                        origin, region, ( gEnablePitch ? imageInfo->rowPitch : 0 ), 0,
-                                       imageValues, 0, NULL, NULL);
+            error =
+                clEnqueueWriteImage(queue, image, CL_TRUE, origin, region,
+                                    (ctx.enablePitch ? imageInfo->rowPitch : 0),
+                                    0, imageValues, 0, NULL, NULL);
             if (error != CL_SUCCESS)
             {
                 log_error( "ERROR: Unable to write to 2D image of size %d x %d\n", (int)imageInfo->width, (int)imageInfo->height );
@@ -1400,9 +1448,12 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
             for(size_t level = 0; level < imageInfo->num_mip_levels; level++)
             {
                 origin[2] = level;
-                error = clEnqueueWriteImage(queue, image, CL_TRUE,
-                                            origin, region, (( gEnablePitch || gTestImage2DFromBuffer) ? imageInfo->rowPitch : 0 ), 0,
-                                            (char*)imageValues + tmpNextLevelOffset, 0, NULL, NULL);
+                error = clEnqueueWriteImage(
+                    queue, image, CL_TRUE, origin, region,
+                    ((ctx.enablePitch || ctx.testImage2DFromBuffer)
+                         ? imageInfo->rowPitch
+                         : 0),
+                    0, (char *)imageValues + tmpNextLevelOffset, 0, NULL, NULL);
                 tmpNextLevelOffset += region[0]*region[1]*get_pixel_size(imageInfo->format);
                 region[0] = (region[0] >> 1) ? (region[0] >> 1) : 1;
                 region[1] = (region[1] >> 1) ? (region[1] >> 1) : 1;
@@ -1410,8 +1461,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         }
     }
 
-    if( gDebugTrace )
-        log_info( " - Creating kernel arguments...\n" );
+    if (ctx.debugTrace) log_info(" - Creating kernel arguments...\n");
 
     xOffsets =
         clCreateBuffer(context, CL_MEM_COPY_HOST_PTR,
@@ -1430,14 +1480,15 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     test_error( error, "Unable to create result buffer" );
 
     // Create sampler to use
-    actualSampler = create_sampler(context, imageSampler, gTestMipmaps, &error);
+    actualSampler =
+        create_sampler(context, imageSampler, ctx.testMipmaps, &error);
     test_error(error, "Unable to create image sampler");
 
     // Set arguments
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &image );
     test_error( error, "Unable to set kernel arguments" );
-    if( !gUseKernelSamplers )
+    if (!ctx.useKernelSamplers)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_sampler ), &actualSampler );
         test_error( error, "Unable to set kernel arguments" );
@@ -1456,19 +1507,21 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     int loopCount = 2 * float_offset_count;
     if( ! useFloatCoords )
         loopCount = 1;
-    if (gTestMaxImages) {
+    if (ctx.testMaxImages)
+    {
         loopCount = 1;
       log_info("Testing each size only once with pixel offsets of %g for max sized images.\n", float_offsets[0]);
     }
 
-    if(gtestTypesToRun & kReadWriteTests)
+    if (ctx.testTypesToRun & kReadWriteTests)
     {
         loopCount = 1;
     }
 
     // Get the maximum absolute error for this format
     double formatAbsoluteError = get_max_absolute_error(imageInfo->format, imageSampler);
-    if (gDebugTrace) log_info("\tformatAbsoluteError is %e\n", formatAbsoluteError);
+    if (ctx.debugTrace)
+        log_info("\tformatAbsoluteError is %e\n", formatAbsoluteError);
 
     if (0 == initHalf && imageInfo->format->image_channel_data_type == CL_HALF_FLOAT ) {
         initHalf = CL_SUCCESS == DetectFloatToHalfRoundingMode( queue );
@@ -1479,15 +1532,17 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
 
     size_t nextLevelOffset = 0;
     size_t width_lod = imageInfo->width, height_lod = imageInfo->height;
-    for( size_t lod = 0; (gTestMipmaps && (lod < imageInfo->num_mip_levels))|| (!gTestMipmaps && lod < 1); lod ++)
+    for (size_t lod = 0; (ctx.testMipmaps && (lod < imageInfo->num_mip_levels))
+         || (!ctx.testMipmaps && lod < 1);
+         lod++)
     {
         size_t resultValuesSize = width_lod * height_lod * get_explicit_type_size( outputType ) * 4;
         BufferOwningPtr<char> resultValues(malloc(resultValuesSize));
         float lod_float = (float)lod;
         char *imagePtr = (char *)imageValues + nextLevelOffset;
-        if( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
-            if (gDebugTrace) log_info("\t- Working at mip level %zu\n", lod);
+            if (ctx.debugTrace) log_info("\t- Working at mip level %zu\n", lod);
             error = clSetKernelArg( kernel, idx, sizeof(float), &lod_float);
         }
 
@@ -1497,9 +1552,11 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
             float offset = float_offsets[ q % float_offset_count ];
 
             // Init the coordinates
-            InitFloatCoords( imageInfo, imageSampler, xOffsetValues, yOffsetValues,
-                                q>=float_offset_count ? -offset: offset,
-                                q>=float_offset_count ? offset: -offset, imageSampler->normalized_coords, d, lod );
+            InitFloatCoords(imageInfo, imageSampler, xOffsetValues,
+                            yOffsetValues,
+                            q >= float_offset_count ? -offset : offset,
+                            q >= float_offset_count ? offset : -offset,
+                            imageSampler->normalized_coords, d, lod, ctx);
 
             error = clEnqueueWriteBuffer( queue, xOffsets, CL_TRUE, 0, sizeof(cl_float) * imageInfo->height * imageInfo->width, xOffsetValues, 0, NULL, NULL );
             test_error( error, "Unable to write x offsets" );
@@ -1516,32 +1573,43 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
             error = clEnqueueNDRangeKernel( queue, kernel, 2, NULL, threads, NULL, 0, NULL, NULL );
             test_error( error, "Unable to run kernel" );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( width_lod * height_lod * get_explicit_type_size( outputType ) * 4 / 1024 ) );
 
             error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, width_lod * height_lod * get_explicit_type_size( outputType ) * 4, resultValues, 0, NULL, NULL ); //XXX check
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             int retCode;
             switch (imageInfo->format->image_channel_order) {
             case CL_DEPTH:
-                retCode = validate_image_2D_depth_results((char*)imageValues + nextLevelOffset, resultValues, formatAbsoluteError, xOffsetValues, yOffsetValues, outputType, numTries, numClamped, imageSampler, imageInfo, lod, imagePtr);
+                retCode = validate_image_2D_depth_results(
+                    (char *)imageValues + nextLevelOffset, resultValues,
+                    formatAbsoluteError, xOffsetValues, yOffsetValues,
+                    outputType, numTries, numClamped, imageSampler, imageInfo,
+                    lod, imagePtr, ctx);
                 break;
             case CL_sRGB:
             case CL_sRGBx:
             case CL_sRGBA:
             case CL_sBGRA:
-                retCode = validate_image_2D_sRGB_results((char*)imageValues + nextLevelOffset, resultValues, formatAbsoluteError, xOffsetValues, yOffsetValues, outputType, numTries, numClamped, imageSampler, imageInfo, lod, imagePtr);
+                retCode = validate_image_2D_sRGB_results(
+                    (char *)imageValues + nextLevelOffset, resultValues,
+                    formatAbsoluteError, xOffsetValues, yOffsetValues,
+                    outputType, numTries, numClamped, imageSampler, imageInfo,
+                    lod, imagePtr, ctx);
                 break;
             default:
-                retCode = validate_image_2D_results((char*)imageValues + nextLevelOffset, resultValues, formatAbsoluteError, xOffsetValues, yOffsetValues, outputType, numTries, numClamped, imageSampler, imageInfo, lod, imagePtr);
+                retCode = validate_image_2D_results(
+                    (char *)imageValues + nextLevelOffset, resultValues,
+                    formatAbsoluteError, xOffsetValues, yOffsetValues,
+                    outputType, numTries, numClamped, imageSampler, imageInfo,
+                    lod, imagePtr, ctx);
             }
             if (retCode)
                 return retCode;
         }
-        if ( gTestMipmaps )
+        if (ctx.testMipmaps)
         {
             nextLevelOffset += width_lod * height_lod * get_pixel_size( imageInfo->format );
             width_lod = (width_lod >> 1) ? (width_lod >> 1) : 1;
@@ -1549,7 +1617,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         }
     }
 
-    if (gTestImage2DFromBuffer) clReleaseMemObject(imageBuffer);
+    if (ctx.testImage2DFromBuffer) clReleaseMemObject(imageBuffer);
 
     return numTries != MAX_TRIES || numClamped != MAX_CLAMPED;
 }
@@ -1558,7 +1626,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -1567,7 +1635,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
     clKernelWrapper kernel;
     const char *KernelSourcePattern = NULL;
 
-    if (gTestImage2DFromBuffer)
+    if (ctx.testImage2DFromBuffer)
     {
         if (format->image_channel_order == CL_RGB || format->image_channel_order == CL_RGBx)
         {
@@ -1630,13 +1698,13 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
     // Construct the source
     const char *samplerArg = samplerKernelArg;
     char samplerVar[ 1024 ] = "";
-    if( gUseKernelSamplers )
+    if (ctx.useKernelSamplers)
     {
         get_sampler_kernel_code( imageSampler, samplerVar );
         samplerArg = "";
     }
 
-    if(gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         KernelSourcePattern = read2DKernelSourcePattern;
     }
@@ -1647,24 +1715,24 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
 
 
     sprintf(programSrc, KernelSourcePattern,
-            gTestMipmaps
+            ctx.testMipmaps
                 ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
                 : "",
             (format->image_channel_order == CL_DEPTH) ? "image2d_depth_t"
                                                       : "image2d_t",
             samplerArg, get_explicit_type_name(outputType),
             (format->image_channel_order == CL_DEPTH) ? "" : "4",
-            gTestMipmaps ? ", float lod" : " ", samplerVar,
-            gTestMipmaps ? lodOffsetSource : offsetSource,
+            ctx.testMipmaps ? ", float lod" : " ", samplerVar,
+            ctx.testMipmaps ? lodOffsetSource : offsetSource,
             floatCoords ? floatKernelSource : intCoordKernelSource, readFormat,
-            gTestMipmaps ? ", lod" : " ");
+            ctx.testMipmaps ? ", lod" : " ");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -1673,19 +1741,21 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
 
             for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if( gTestMipmaps )
+                if( ctx.testMipmaps )
                 imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
 
-                if( gDebugTrace )
+                if( ctx.debugTrace )
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                int retCode = test_read_image_2D(
+                    context, queue, kernel, &imageInfo, imageSampler,
+                    floatCoords, outputType, seed, ctx);
                 if( retCode )
                     return retCode;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -1718,12 +1788,14 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             log_info("Testing %d x %d\n", (int)imageInfo.width,
                      (int)imageInfo.height);
 
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D(context, queue, kernel, &imageInfo,
+                                             imageSampler, floatCoords,
+                                             outputType, seed, ctx);
             if( retCode )
                 return retCode;
         }
@@ -1744,26 +1816,29 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             imageInfo.width >>= 1;
         imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-        gRoundingStartValue = 0;
+        uint64_t roundingStartValue = 0;
         do
         {
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d, starting round ramp at %" PRIu64
                          " for range %" PRIu64 "\n",
                          (int)imageInfo.width, (int)imageInfo.height,
-                         gRoundingStartValue, typeRange);
-            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+                         roundingStartValue, typeRange);
+            int retCode = test_read_image_2D(context, queue, kernel, &imageInfo,
+                                             imageSampler, floatCoords,
+                                             outputType, seed, ctx);
             if( retCode )
                 return retCode;
 
-            gRoundingStartValue += imageInfo.width * imageInfo.height * pixelSize / get_format_type_size( imageInfo.format );
+            roundingStartValue += imageInfo.width * imageInfo.height * pixelSize
+                / get_format_type_size(imageInfo.format);
 
-        } while( gRoundingStartValue < typeRange );
+        } while (roundingStartValue < typeRange);
     }
     else
     {
         cl_uint imagePitchAlign = 0;
-        if (gTestImage2DFromBuffer)
+        if (ctx.testImage2DFromBuffer)
         {
 #if defined(CL_DEVICE_IMAGE_PITCH_ALIGNMENT)
             error = clGetDeviceInfo( device, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, sizeof( cl_uint ), &imagePitchAlign, NULL );
@@ -1789,21 +1864,21 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
 
                 imageInfo.rowPitch = calculate_row_pitch(imageInfo, pixelSize);
 
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
                     size = 4 * compute_mipmapped_image_size(imageInfo);
                 }
                 else
                 {
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
                     }
 
                 // if we are creating a 2D image from a buffer, make sure that the rowpitch is aligned to CL_DEVICE_IMAGE_PITCH_ALIGNMENT_APPLE
-                    if (gTestImage2DFromBuffer)
+                    if (ctx.testImage2DFromBuffer)
                     {
                         size_t pitch = imagePitchAlign * pixelSize;
                         imageInfo.rowPitch = ((imageInfo.rowPitch + pitch - 1) / pitch ) * pitch;
@@ -1814,9 +1889,11 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             } while (size > maxAllocSize || (size * 3) > memSize
                      || !is_width_compatible(imageInfo));
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, floatCoords, outputType, seed );
+            int retCode = test_read_image_2D(context, queue, kernel, &imageInfo,
+                                             imageSampler, floatCoords,
+                                             outputType, seed, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -16,44 +16,38 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern cl_filter_mode gFilterModeToUse;
-extern cl_addressing_mode gAddressModeToUse;
-extern int gNormalizedModeToUse;
-extern int gTypesToTest;
-extern int gtestTypesToRun;
-
 extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType);
+                                  bool floatCoords, ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType);
+                                  bool floatCoords, ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  bool floatCoords, ExplicitType outputType);
-extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
-                                        cl_command_queue queue,
-                                        const cl_image_format *format,
-                                        image_sampler_data *imageSampler,
-                                        bool floatCoords,
-                                        ExplicitType outputType);
-extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
-                                        cl_command_queue queue,
-                                        const cl_image_format *format,
-                                        image_sampler_data *imageSampler,
-                                        bool floatCoords,
-                                        ExplicitType outputType);
+                                  bool floatCoords, ExplicitType outputType,
+                                  const context_t &ctx);
+extern int test_read_image_set_1D_array(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const cl_image_format *format, image_sampler_data *imageSampler,
+    bool floatCoords, ExplicitType outputType, const context_t &ctx);
+extern int test_read_image_set_2D_array(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const cl_image_format *format, image_sampler_data *imageSampler,
+    bool floatCoords, ExplicitType outputType, const context_t &ctx);
 
 int test_read_image_type(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
                          bool floatCoords, image_sampler_data *imageSampler,
-                         ExplicitType outputType, cl_mem_object_type imageType)
+                         ExplicitType outputType, cl_mem_object_type imageType,
+                         const context_t &ctx)
 {
     int ret = 0;
     cl_addressing_mode *addressModes = NULL;
@@ -70,7 +64,7 @@ int test_read_image_type(cl_device_id device, cl_context context,
         CL_ADDRESS_REPEAT, CL_ADDRESS_MIRRORED_REPEAT, (cl_addressing_mode)-1
     };
 
-    if (gtestTypesToRun & kReadWriteTests)
+    if (ctx.testTypesToRun & kReadWriteTests)
     {
         addressModes = addressModes_rw;
     }
@@ -106,8 +100,8 @@ int test_read_image_type(cl_device_id device, cl_context context,
             continue; // Repeat doesn't make sense for non-normalized coords
 
         // Use this run if we were told to only run a certain filter mode
-        if (gAddressModeToUse != (cl_addressing_mode)-1
-            && imageSampler->addressing_mode != gAddressModeToUse)
+        if (ctx.addressModeToUse != (cl_addressing_mode)-1
+            && imageSampler->addressing_mode != ctx.addressModeToUse)
             continue;
 
         /*
@@ -127,27 +121,27 @@ int test_read_image_type(cl_device_id device, cl_context context,
             case CL_MEM_OBJECT_IMAGE1D:
                 retCode = test_read_image_set_1D(device, context, queue, format,
                                                  imageSampler, floatCoords,
-                                                 outputType);
+                                                 outputType, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                retCode = test_read_image_set_1D_array(device, context, queue,
-                                                       format, imageSampler,
-                                                       floatCoords, outputType);
+                retCode = test_read_image_set_1D_array(
+                    device, context, queue, format, imageSampler, floatCoords,
+                    outputType, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
                 retCode = test_read_image_set_2D(device, context, queue, format,
                                                  imageSampler, floatCoords,
-                                                 outputType);
+                                                 outputType, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                retCode = test_read_image_set_2D_array(device, context, queue,
-                                                       format, imageSampler,
-                                                       floatCoords, outputType);
+                retCode = test_read_image_set_2D_array(
+                    device, context, queue, format, imageSampler, floatCoords,
+                    outputType, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
                 retCode = test_read_image_set_3D(device, context, queue, format,
                                                  imageSampler, floatCoords,
-                                                 outputType);
+                                                 outputType, ctx);
                 break;
         }
         if (retCode != 0)
@@ -169,13 +163,13 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType)
+                            cl_mem_object_type imageType, const context_t &ctx)
 {
     int ret = 0;
     bool flipFlop[2] = { false, true };
     int normalizedIdx, floatCoordIdx;
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         if (0 == is_extension_available(device, "cl_khr_mipmap_image"))
         {
@@ -189,16 +183,16 @@ int test_read_image_formats(cl_device_id device, cl_context context,
     }
 
     // Use this run if we were told to only run a certain filter mode
-    if (gFilterModeToUse != (cl_filter_mode)-1
-        && imageSampler->filter_mode != gFilterModeToUse)
+    if (ctx.filterModeToUse != (cl_filter_mode)-1
+        && imageSampler->filter_mode != ctx.filterModeToUse)
         return 0;
 
     // Test normalized/non-normalized
     for (normalizedIdx = 0; normalizedIdx < 2; normalizedIdx++)
     {
         imageSampler->normalized_coords = flipFlop[normalizedIdx];
-        if (gNormalizedModeToUse != 7
-            && gNormalizedModeToUse != (int)imageSampler->normalized_coords)
+        if (ctx.normalizedModeToUse != 7
+            && ctx.normalizedModeToUse != (int)imageSampler->normalized_coords)
             continue;
 
         for (floatCoordIdx = 0; floatCoordIdx < 2; floatCoordIdx++)
@@ -212,7 +206,8 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                                              // no sense (they'd all be zero)
                     continue;
 
-            if (flipFlop[floatCoordIdx] && (gtestTypesToRun & kReadWriteTests))
+            if (flipFlop[floatCoordIdx]
+                && (ctx.testTypesToRun & kReadWriteTests))
                 // sampler-less read in read_write tests run only integer coord
                 continue;
 
@@ -234,7 +229,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                 ret |=
                     test_read_image_type(device, context, queue, &imageFormat,
                                          flipFlop[floatCoordIdx], imageSampler,
-                                         outputType, imageType);
+                                         outputType, imageType, ctx);
             }
         }
     }
@@ -244,7 +239,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, test_format_set_fn formatTestFn,
-                   cl_mem_object_type imageType)
+                   cl_mem_object_type imageType, const context_t &ctx)
 {
     int ret = 0;
     static int printedFormatList = -1;
@@ -265,7 +260,7 @@ int test_image_set(cl_device_id device, cl_context context,
         }
     }
 
-    if (gTestMipmaps)
+    if (ctx.testMipmaps)
     {
         if (0 == is_extension_available(device, "cl_khr_mipmap_image"))
         {
@@ -309,7 +304,7 @@ int test_image_set(cl_device_id device, cl_context context,
     const char *flagNames;
     if (formatTestFn == test_read_image_formats)
     {
-        if (gtestTypesToRun & kReadTests)
+        if (ctx.testTypesToRun & kReadTests)
         {
             flags = CL_MEM_READ_ONLY;
             flagNames = "read";
@@ -322,7 +317,7 @@ int test_image_set(cl_device_id device, cl_context context,
     }
     else
     {
-        if (gtestTypesToRun & kWriteTests)
+        if (ctx.testTypesToRun & kWriteTests)
         {
             flags = CL_MEM_WRITE_ONLY;
             flagNames = "write";
@@ -365,11 +360,12 @@ int test_image_set(cl_device_id device, cl_context context,
 
     for (auto test : imageTestTypes)
     {
-        if (gTypesToTest & test.type)
+        if (ctx.typesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
             if (filter_formats(formatList, filterFlags, test.channelTypes,
-                               gTestMipmaps)
+                               ctx.channelTypeToUse, ctx.channelOrderToUse,
+                               ctx.testMipmaps)
                 == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);
@@ -379,7 +375,7 @@ int test_image_set(cl_device_id device, cl_context context,
                 imageSampler.filter_mode = CL_FILTER_NEAREST;
                 ret += formatTestFn(device, context, queue, formatList,
                                     filterFlags, &imageSampler,
-                                    test.explicitType, imageType);
+                                    test.explicitType, imageType, ctx);
 
                 // Linear filtering is only supported with floats
                 if (test.type == kTestFloat)
@@ -387,7 +383,7 @@ int test_image_set(cl_device_id device, cl_context context,
                     imageSampler.filter_mode = CL_FILTER_LINEAR;
                     ret += formatTestFn(device, context, queue, formatList,
                                         filterFlags, &imageSampler,
-                                        test.explicitType, imageType);
+                                        test.explicitType, imageType, ctx);
                 }
             }
         }

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -163,7 +163,8 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType, const image_test_context_t &ctx)
+                            cl_mem_object_type imageType,
+                            const image_test_context_t &ctx)
 {
     int ret = 0;
     bool flipFlop[2] = { false, true };
@@ -239,7 +240,8 @@ int test_read_image_formats(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, test_format_set_fn formatTestFn,
-                   cl_mem_object_type imageType, const image_test_context_t &ctx)
+                   cl_mem_object_type imageType,
+                   const image_test_context_t &ctx)
 {
     int ret = 0;
     static int printedFormatList = -1;

--- a/test_conformance/images/kernel_read_write/test_loops.cpp
+++ b/test_conformance/images/kernel_read_write/test_loops.cpp
@@ -21,33 +21,33 @@ extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   bool floatCoords, ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_1D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const cl_image_format *format, image_sampler_data *imageSampler,
-    bool floatCoords, ExplicitType outputType, const context_t &ctx);
+    bool floatCoords, ExplicitType outputType, const image_test_context_t &ctx);
 extern int test_read_image_set_2D_array(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const cl_image_format *format, image_sampler_data *imageSampler,
-    bool floatCoords, ExplicitType outputType, const context_t &ctx);
+    bool floatCoords, ExplicitType outputType, const image_test_context_t &ctx);
 
 int test_read_image_type(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
                          bool floatCoords, image_sampler_data *imageSampler,
                          ExplicitType outputType, cl_mem_object_type imageType,
-                         const context_t &ctx)
+                         const image_test_context_t &ctx)
 {
     int ret = 0;
     cl_addressing_mode *addressModes = NULL;
@@ -163,7 +163,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType, const context_t &ctx)
+                            cl_mem_object_type imageType, const image_test_context_t &ctx)
 {
     int ret = 0;
     bool flipFlop[2] = { false, true };
@@ -239,7 +239,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, test_format_set_fn formatTestFn,
-                   cl_mem_object_type imageType, const context_t &ctx)
+                   cl_mem_object_type imageType, const image_test_context_t &ctx)
 {
     int ret = 0;
     static int printedFormatList = -1;

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -62,7 +62,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -106,13 +106,13 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
     // Construct the source
     const char *samplerArg = samplerKernelArg;
     char samplerVar[ 1024 ] = "";
-    if( gUseKernelSamplers )
+    if (ctx.useKernelSamplers)
     {
         get_sampler_kernel_code( imageSampler, samplerVar );
         samplerArg = "";
     }
 
-    if(gtestTypesToRun & kReadWriteTests)
+    if (ctx.testTypesToRun & kReadWriteTests)
     {
         KernelSourcePattern = read_write1DKernelSourcePattern;
     }
@@ -121,13 +121,13 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
         KernelSourcePattern = read1DKernelSourcePattern;
     }
     sprintf(programSrc, KernelSourcePattern,
-            gTestMipmaps
+            ctx.testMipmaps
                 ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
                 : "",
             samplerArg, get_explicit_type_name(outputType),
-            gTestMipmaps ? ", float lod" : "", samplerVar,
+            ctx.testMipmaps ? ", float lod" : "", samplerVar,
             floatCoords ? float1DKernelSource : int1DCoordKernelSource,
-            readFormat, gTestMipmaps ? ", lod" : "");
+            readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
 
@@ -140,26 +140,26 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d\n", (int)imageInfo.width );
 
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -172,13 +172,13 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             log_info("Testing %d\n", (int)sizes[ idx ][ 0 ]);
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }
@@ -193,22 +193,23 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             imageInfo.width >>= 1;
         imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-        gRoundingStartValue = 0;
+        uint64_t roundingStartValue = 0;
         do
         {
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d, starting round ramp at %" PRIu64
                          " for range %" PRIu64 "\n",
-                         (int)imageInfo.width, gRoundingStartValue, typeRange);
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+                         (int)imageInfo.width, roundingStartValue, typeRange);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
 
-            gRoundingStartValue += imageInfo.width * pixelSize / get_format_type_size( imageInfo.format );
+            roundingStartValue += imageInfo.width * pixelSize
+                / get_format_type_size(imageInfo.format);
 
-        } while( gRoundingStartValue < typeRange );
+        } while (roundingStartValue < typeRange);
     }
     else
     {
@@ -222,14 +223,14 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
                     size = (cl_ulong) compute_mipmapped_image_size(imageInfo) * 4;
                 }
                 else
                 {
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -239,11 +240,11 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -62,7 +62,8 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -62,7 +62,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -69,7 +69,8 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 bool floatCoords, ExplicitType outputType)
+                                 bool floatCoords, ExplicitType outputType,
+                                 const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -112,13 +113,13 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
     // Construct the source
     const char *samplerArg = samplerKernelArg;
     char samplerVar[ 1024 ] = "";
-    if( gUseKernelSamplers )
+    if (ctx.useKernelSamplers)
     {
         get_sampler_kernel_code( imageSampler, samplerVar );
         samplerArg = "";
     }
 
-    if(gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         KernelSourcePattern = read1DArrayKernelSourcePattern;
     }
@@ -129,41 +130,42 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
 
     sprintf(
         programSrc, KernelSourcePattern,
-        gTestMipmaps ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
-                     : "",
+        ctx.testMipmaps ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
+                        : "",
         samplerArg, get_explicit_type_name(outputType),
-        gTestMipmaps ? ", float lod" : "", samplerVar,
-        gTestMipmaps ? offset1DArrayLodKernelSource : offset1DArrayKernelSource,
+        ctx.testMipmaps ? ", float lod" : "", samplerVar,
+        ctx.testMipmaps ? offset1DArrayLodKernelSource
+                        : offset1DArrayKernelSource,
         floatCoords ? floatKernelSource1DArray : intCoordKernelSource1DArray,
-        readFormat, gTestMipmaps ? ", lod" : "");
+        readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.slicePitch = imageInfo.width * pixelSize;
             for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int retCode = test_read_image(context, queue, kernel,
-                                              &imageInfo, imageSampler,
-                                              floatCoords, outputType, seed);
+                int retCode = test_read_image(
+                    context, queue, kernel, &imageInfo, imageSampler,
+                    floatCoords, outputType, seed, ctx);
                 if( retCode )
                     return retCode;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -177,13 +179,13 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ]; // 3rd dimension in get_max_sizes
             imageInfo.rowPitch = imageInfo.slicePitch = imageInfo.width * pixelSize;
             log_info("Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }
@@ -204,23 +206,24 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.width >>= 1;
         imageInfo.rowPitch = imageInfo.slicePitch = imageInfo.width * pixelSize;
 
-        gRoundingStartValue = 0;
+        uint64_t roundingStartValue = 0;
         do
         {
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %d,%d, starting round ramp at %" PRIu64
                          " for range %" PRIu64 "\n",
                          (int)imageInfo.width, (int)imageInfo.arraySize,
-                         gRoundingStartValue, typeRange);
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+                         roundingStartValue, typeRange);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
 
-            gRoundingStartValue += imageInfo.width * imageInfo.arraySize * pixelSize / get_format_type_size( imageInfo.format );
+            roundingStartValue += imageInfo.width * imageInfo.arraySize
+                * pixelSize / get_format_type_size(imageInfo.format);
 
-        } while( gRoundingStartValue < typeRange );
+        } while (roundingStartValue < typeRange);
     }
     else
     {
@@ -235,14 +238,14 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), seed);
                     size = (cl_ulong) compute_mipmapped_image_size(imageInfo) * 4;
                 }
                 else
                 {
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -253,11 +256,11 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -70,7 +70,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
                                  bool floatCoords, ExplicitType outputType,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -89,7 +89,8 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 bool floatCoords, ExplicitType outputType)
+                                 bool floatCoords, ExplicitType outputType,
+                                 const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -135,7 +136,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
     // Construct the source
     const char *samplerArg = samplerKernelArg;
     char samplerVar[ 1024 ] = "";
-    if( gUseKernelSamplers )
+    if (ctx.useKernelSamplers)
     {
         get_sampler_kernel_code( imageSampler, samplerVar );
         samplerArg = "";
@@ -155,7 +156,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
     }
 
     // Construct the source
-    if(gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         KernelSourcePattern = read2DArrayKernelSourcePattern;
     }
@@ -166,15 +167,15 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
 
     // Construct the source
     sprintf(programSrc, KernelSourcePattern,
-            gTestMipmaps
+            ctx.testMipmaps
                 ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
                 : "",
             imageType, samplerArg, get_explicit_type_name(outputType),
-            imageElement, gTestMipmaps ? ", float lod" : " ", samplerVar,
-            gTestMipmaps ? offset2DarraySourceLod : offset2DarraySource,
+            imageElement, ctx.testMipmaps ? ", float lod" : " ", samplerVar,
+            ctx.testMipmaps ? offset2DarraySourceLod : offset2DarraySource,
             floatCoords ? float2DArrayUnnormalizedCoordKernelSource
                         : int2DArrayCoordKernelSource,
-            readFormat, gTestMipmaps ? ", lod" : " ");
+            readFormat, ctx.testMipmaps ? ", lod" : " ");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -183,7 +184,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
 
     // Run tests
 
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -194,21 +195,21 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
                 {
-                    if( gTestMipmaps )
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
                     int retCode = test_read_image(
                         context, queue, kernel, &imageInfo, imageSampler,
-                        floatCoords, outputType, seed);
+                        floatCoords, outputType, seed, ctx);
                     if( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -223,7 +224,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, seed);
             cl_ulong size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.arraySize * 4 * 4;
             // Loop until we get a size that a) will fit in the max alloc size and b) that an allocation of that
@@ -246,11 +247,11 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.arraySize * 4 * 4;
             }
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }
@@ -266,7 +267,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
         int retCode =
             test_read_image(context, queue, kernel, &imageInfo, imageSampler,
-                            floatCoords, outputType, seed);
+                            floatCoords, outputType, seed, ctx);
         if( retCode )
             return retCode;
     }
@@ -290,7 +291,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = random_in_range(2,compute_max_mip_levels(imageInfo.width, imageInfo.height, 0) - 1, seed);
                     //Need to take into account the output buffer size, otherwise we will end up with input buffer that is exceeding MaxAlloc
@@ -298,7 +299,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 }
                 else
                 {
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -311,15 +312,15 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
             {
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-                if ( gTestMipmaps )
+                if (ctx.testMipmaps)
                     log_info("  and %d mip levels\n", (int) imageInfo.num_mip_levels);
             }
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -90,7 +90,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
                                  bool floatCoords, ExplicitType outputType,
-                                 const context_t &ctx)
+                                 const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -86,7 +86,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -129,14 +129,14 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
     // Construct the source
     const char *samplerArg = samplerKernelArg;
     char samplerVar[ 1024 ] = "";
-    if( gUseKernelSamplers )
+    if (ctx.useKernelSamplers)
     {
         get_sampler_kernel_code( imageSampler, samplerVar );
         samplerArg = "";
     }
 
     // Construct the source
-    if(gtestTypesToRun & kReadTests)
+    if (ctx.testTypesToRun & kReadTests)
     {
         KernelSourcePattern = read3DKernelSourcePattern;
     }
@@ -146,15 +146,15 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
     }
 
     sprintf(programSrc, KernelSourcePattern,
-            gTestMipmaps
+            ctx.testMipmaps
                 ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable"
                 : "",
             samplerArg, get_explicit_type_name(outputType),
-            gTestMipmaps ? ", float lod" : " ", samplerVar,
-            gTestMipmaps ? offset3DLodKernelSource : offset3DKernelSource,
+            ctx.testMipmaps ? ", float lod" : " ", samplerVar,
+            ctx.testMipmaps ? offset3DLodKernelSource : offset3DKernelSource,
             floatCoords ? float3DUnnormalizedCoordKernelSource
                         : int3DCoordKernelSource,
-            readFormat, gTestMipmaps ? ",lod" : " ");
+            readFormat, ctx.testMipmaps ? ",lod" : " ");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -162,7 +162,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -173,21 +173,21 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
                 {
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (cl_uint) (2+rand()%(compute_max_mip_levels(imageInfo.width,imageInfo.height,imageInfo.depth) - 1));
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
                     int retCode = test_read_image(
                         context, queue, kernel, &imageInfo, imageSampler,
-                        floatCoords, outputType, seed);
+                        floatCoords, outputType, seed, ctx);
                     if( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -202,14 +202,14 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
             imageInfo.depth = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (cl_uint) (2+rand()%(compute_max_mip_levels(imageInfo.width,imageInfo.height,imageInfo.depth) - 1));
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }
@@ -225,7 +225,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
         int retCode =
             test_read_image(context, queue, kernel, &imageInfo, imageSampler,
-                            floatCoords, outputType, seed);
+                            floatCoords, outputType, seed, ctx);
         if( retCode )
             return retCode;
     }
@@ -242,7 +242,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.height = reduceImageSizeRange(maxHeight, seed );
                 imageInfo.depth = reduceImageDepth(maxDepth, seed );
 
-                if (gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     //imageInfo.num_mip_levels = (cl_uint) random_log_in_range(2, (int)compute_max_mip_levels(imageInfo.width, imageInfo.depth, imageInfo.depth), seed);
                     imageInfo.num_mip_levels = (cl_uint) (2+rand()%(compute_max_mip_levels(imageInfo.width,imageInfo.height,imageInfo.depth) - 1));
@@ -256,7 +256,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
                     imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                         imageInfo.rowPitch += extraWidth * get_pixel_size( imageInfo.format );
@@ -269,15 +269,15 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
             {
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-                if ( gTestMipmaps )
+                if (ctx.testMipmaps)
                     log_info( "   and number of mip levels :%d\n", (int)imageInfo.num_mip_levels );
             }
-            int retCode =
-                test_read_image(context, queue, kernel, &imageInfo,
-                                imageSampler, floatCoords, outputType, seed);
+            int retCode = test_read_image(context, queue, kernel, &imageInfo,
+                                          imageSampler, floatCoords, outputType,
+                                          seed, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -86,7 +86,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -86,7 +86,8 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler, bool floatCoords,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -202,7 +202,9 @@ int test_write_image_1D(cl_device_id device, cl_context context,
                 unprotImage = create_image_1d( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
                                               imageInfo->width, 0,
                                               maxImageUseHostPtrBackingStore, NULL, &error );
-            } else {
+            }
+            else
+            {
                 error = protImage.Create( context, mem_flag_types[mem_flag_index], imageInfo->format, imageInfo->width );
             }
             if( error != CL_SUCCESS )

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -20,9 +20,6 @@
 #include <sys/mman.h>
 #endif
 
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor* imageInfo );
 
@@ -46,8 +43,10 @@ const char *write1DKernelSourcePattern =
     "   write_image%s( output, tidX %s, input[ offset ]);\n"
     "}";
 
-int test_write_image_1D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
-                     image_descriptor *imageInfo, ExplicitType inputType, MTdata d )
+int test_write_image_1D(cl_device_id device, cl_context context,
+                        cl_command_queue queue, cl_kernel kernel,
+                        image_descriptor *imageInfo, ExplicitType inputType,
+                        MTdata d, const context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -58,7 +57,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
     const cl_mem_flags  read_write_mem_flag_types[1] = {  CL_MEM_READ_WRITE};
     const char *        read_write_mem_flag_names[1] = { "CL_MEM_READ_WRITE"};
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         mem_flag_types = write_only_mem_flag_types;
         mem_flag_names = write_only_mem_flag_names;
@@ -91,7 +90,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
 
         create_random_image_data( inputType, imageInfo, imageValues, d );
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             if( inputType == kFloat && imageInfo->format->image_channel_data_type != CL_FLOAT && imageInfo->format->image_channel_data_type != CL_HALF_FLOAT )
             {
@@ -192,11 +191,12 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
         clMemWrapper unprotImage;
         cl_mem image;
 
-        if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+        if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
         {
             // clProtectedImage uses USE_HOST_PTR, so just rely on that for the testing (via Ian)
             // Do not use protected images for max image size test since it rounds the row size to a page size
-            if (gTestMaxImages) {
+            if (ctx.testMaxImages)
+            {
                 create_random_image_data( inputType, imageInfo, maxImageUseHostPtrBackingStore, d );
 
                 unprotImage = create_image_1d( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
@@ -215,7 +215,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                 return error;
             }
 
-            if (gTestMaxImages)
+            if (ctx.testMaxImages)
                 image = (cl_mem)unprotImage;
             else
                 image = (cl_mem)protImage;
@@ -225,7 +225,7 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 cl_image_desc image_desc = {0};
                 image_desc.image_type = imageInfo->type;
@@ -233,8 +233,11 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
                 image_desc.image_width = imageInfo->width;
                 image_desc.image_array_size = imageInfo->arraySize;
 
-                unprotImage = clCreateImage( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ),
-                                             imageInfo->format, &image_desc, NULL, &error);
+                unprotImage = clCreateImage(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create %d level 1D image of "
@@ -247,9 +250,12 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_1d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, 0,
-                                              imageValues, NULL, &error );
+                unprotImage = create_image_1d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, 0, imageValues, NULL,
+                    &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create 1D image of size %zu "
@@ -271,9 +277,11 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
         size_t region[ 3 ] = { imageInfo->width, 1, 1 };
         size_t resultSize;
 
-        for( int lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+        for (int lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+             || (!ctx.testMipmaps && lod < 1);
+             lod++)
         {
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 error = clSetKernelArg( kernel, 2, sizeof( int ), &lod );
             }
@@ -297,23 +305,25 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             test_error( error, "Unable to run kernel" );
 
             // Get results
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 resultSize = width_lod * get_pixel_size( imageInfo->format );
             else
                 resultSize = imageInfo->rowPitch;
             clProtectedArray PA(resultSize);
             char *resultValues = (char *)((void *)PA);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( resultSize / 1024 ) );
 
             origin[ 1 ] = lod;
             region[ 0 ] = width_lod;
 
-            error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, gEnablePitch ? imageInfo->rowPitch : 0, 0, resultValues, 0, NULL, NULL );
+            error =
+                clEnqueueReadImage(queue, image, CL_TRUE, origin, region,
+                                   ctx.enablePitch ? imageInfo->rowPitch : 0, 0,
+                                   resultValues, 0, NULL, NULL);
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = imageValues + nextLevelOffset;
@@ -586,7 +596,8 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
 int test_write_image_1D_set(cl_device_id device, cl_context context,
                             cl_command_queue queue,
                             const cl_image_format *format,
-                            ExplicitType inputType, MTdata d)
+                            ExplicitType inputType, MTdata d,
+                            const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -627,7 +638,7 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
         readFormat = "f";
 
     // Construct the source
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         KernelSourcePattern = write1DKernelSourcePattern;
     }
@@ -638,12 +649,12 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
 
     sprintf(
         programSrc, KernelSourcePattern,
-        gTestMipmaps
+        ctx.testMipmaps
             ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable\n#pragma "
               "OPENCL EXTENSION cl_khr_mipmap_image_writes: enable"
             : "",
-        get_explicit_type_name(inputType), gTestMipmaps ? ", int lod" : "",
-        readFormat, gTestMipmaps ? ", lod" : "");
+        get_explicit_type_name(inputType), ctx.testMipmaps ? ", int lod" : "",
+        readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -651,23 +662,24 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
 
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d\n", (int)imageInfo.width );
-            int retCode = test_write_image_1D( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_1D(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -679,10 +691,11 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
         {
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
             log_info("Testing %d\n", (int)imageInfo.width);
-            int retCode = test_write_image_1D( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_1D(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -693,7 +706,8 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
         imageInfo.width = typeRange / 256;
 
         imageInfo.rowPitch = imageInfo.width * pixelSize;
-        int retCode = test_write_image_1D( device, context, queue, kernel, &imageInfo, inputType, d );
+        int retCode = test_write_image_1D(device, context, queue, kernel,
+                                          &imageInfo, inputType, d, ctx);
         if( retCode )
             return retCode;
     }
@@ -708,7 +722,7 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
             {
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, d );
 
-                if( gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
                     size = (cl_ulong) compute_mipmapped_image_size(imageInfo) * 4;
@@ -716,7 +730,7 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
                 else
                 {
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, d );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -726,14 +740,15 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
             {
                 log_info( "   at size %d (pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                     log_info( " and %d mip levels\n", (int)imageInfo.num_mip_levels );
             }
 
-            int retCode = test_write_image_1D( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_1D(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -46,7 +46,7 @@ const char *write1DKernelSourcePattern =
 int test_write_image_1D(cl_device_id device, cl_context context,
                         cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, ExplicitType inputType,
-                        MTdata d, const context_t &ctx)
+                        MTdata d, const image_test_context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -599,7 +599,7 @@ int test_write_image_1D_set(cl_device_id device, cl_context context,
                             cl_command_queue queue,
                             const cl_image_format *format,
                             ExplicitType inputType, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -214,7 +214,9 @@ int test_write_image_1D_array(cl_device_id device, cl_context context,
                 unprotImage = create_image_1d_array( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
                                               imageInfo->width, imageInfo->arraySize, 0, 0,
                                               maxImageUseHostPtrBackingStore, &error );
-            } else {
+            }
+            else
+            {
                 error = protImage.Create( context, (cl_mem_object_type)CL_MEM_OBJECT_IMAGE1D_ARRAY, mem_flag_types[mem_flag_index], imageInfo->format, imageInfo->width, 1, 1, imageInfo->arraySize );
             }
             if( error != CL_SUCCESS )

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -20,9 +20,6 @@
 #include <sys/mman.h>
 #endif
 
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
 
@@ -53,8 +50,11 @@ const char *offset1DArrayLodSource =
 "   int width_lod = ( get_image_width(output) >> lod ) ? ( get_image_width(output) >> lod ) : 1;\n"
 "   int offset = tidY*width_lod + tidX;\n";
 
-int test_write_image_1D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
-                     image_descriptor *imageInfo, ExplicitType inputType, MTdata d )
+int test_write_image_1D_array(cl_device_id device, cl_context context,
+                              cl_command_queue queue, cl_kernel kernel,
+                              image_descriptor *imageInfo,
+                              ExplicitType inputType, MTdata d,
+                              const context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -65,7 +65,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
     const cl_mem_flags  read_write_mem_flag_types[1] = {  CL_MEM_READ_WRITE};
     const char *        read_write_mem_flag_names[1] = { "CL_MEM_READ_WRITE"};
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         mem_flag_types = write_only_mem_flag_types;
         mem_flag_names = write_only_mem_flag_names;
@@ -101,7 +101,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 
         create_random_image_data( inputType, imageInfo, imageValues, d );
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             if( inputType == kFloat && imageInfo->format->image_channel_data_type != CL_FLOAT && imageInfo->format->image_channel_data_type != CL_HALF_FLOAT )
             {
@@ -203,11 +203,12 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
         clMemWrapper unprotImage;
         cl_mem image;
 
-        if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+        if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
         {
             // clProtectedImage uses USE_HOST_PTR, so just rely on that for the testing (via Ian)
             // Do not use protected images for max image size test since it rounds the row size to a page size
-            if (gTestMaxImages) {
+            if (ctx.testMaxImages)
+            {
                 create_random_image_data( inputType, imageInfo, maxImageUseHostPtrBackingStore, d );
 
                 unprotImage = create_image_1d_array( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
@@ -226,7 +227,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                 return error;
             }
 
-            if (gTestMaxImages)
+            if (ctx.testMaxImages)
                 image = (cl_mem)unprotImage;
             else
                 image = (cl_mem)protImage;
@@ -236,7 +237,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 cl_image_desc image_desc = {0};
                 image_desc.image_type = imageInfo->type;
@@ -244,8 +245,11 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
                 image_desc.image_width = imageInfo->width;
                 image_desc.image_array_size = imageInfo->arraySize;
 
-                unprotImage = clCreateImage( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ),
-                                             imageInfo->format, &image_desc, NULL, &error);
+                unprotImage = clCreateImage(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create %d level 1D image array "
@@ -258,9 +262,12 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_1d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->arraySize, 0, 0,
-                                              imageValues, &error );
+                unprotImage = create_image_1d_array(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->arraySize,
+                    0, 0, imageValues, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create 1D image array of size "
@@ -282,9 +289,11 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
         size_t region[ 3 ] = { imageInfo->width, imageInfo->arraySize, 1 };
         size_t resultSize;
 
-        for( int lod = 0; (gTestMipmaps && lod < imageInfo->num_mip_levels) || (!gTestMipmaps && lod < 1); lod++)
+        for (int lod = 0; (ctx.testMipmaps && lod < imageInfo->num_mip_levels)
+             || (!ctx.testMipmaps && lod < 1);
+             lod++)
         {
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 error = clSetKernelArg( kernel, 2, sizeof( int ), &lod );
 
@@ -310,7 +319,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             test_error( error, "Unable to run kernel" );
 
             // Get results
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 resultSize = width_lod * get_pixel_size(imageInfo->format) * imageInfo->arraySize;
             else
                 resultSize = imageInfo->rowPitch * imageInfo->arraySize;
@@ -318,17 +327,19 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             clProtectedArray PA(resultSize);
             char *resultValues = (char *)((void *)PA);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( resultSize / 1024 ) );
 
 
             origin[2] = lod;
             region[0] = width_lod;
-            error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region,
-                                        gEnablePitch ? imageInfo->rowPitch : 0, gEnablePitch ? imageInfo->slicePitch : 0, resultValues, 0, NULL, NULL );
+            error =
+                clEnqueueReadImage(queue, image, CL_TRUE, origin, region,
+                                   ctx.enablePitch ? imageInfo->rowPitch : 0,
+                                   ctx.enablePitch ? imageInfo->slicePitch : 0,
+                                   resultValues, 0, NULL, NULL);
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = imageValues + nextLevelOffset;
@@ -336,7 +347,7 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             for( size_t y = 0, i = 0; y < imageInfo->arraySize; y++ )
             {
                 char *resultPtr;
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                     resultPtr = (char *)resultValues + y * width_lod * pixelSize;
                 else
                     resultPtr = (char*)resultValues + y * imageInfo->rowPitch;
@@ -608,7 +619,8 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
 int test_write_image_1D_array_set(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
-                                  ExplicitType inputType, MTdata d)
+                                  ExplicitType inputType, MTdata d,
+                                  const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -649,7 +661,7 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
     else // kFloat
         readFormat = "f";
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         KernelSourcePattern = write1DArrayKernelSourcePattern;
     }
@@ -661,13 +673,13 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
     // Construct the source
     sprintf(
         programSrc, KernelSourcePattern,
-        gTestMipmaps
+        ctx.testMipmaps
             ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable\n#pragma "
               "OPENCL EXTENSION cl_khr_mipmap_image_writes: enable"
             : "",
-        get_explicit_type_name(inputType), gTestMipmaps ? ", int lod" : "",
-        gTestMipmaps ? offset1DArrayLodSource : offset1DArraySource, readFormat,
-        gTestMipmaps ? ", lod" : "");
+        get_explicit_type_name(inputType), ctx.testMipmaps ? ", int lod" : "",
+        ctx.testMipmaps ? offset1DArrayLodSource : offset1DArraySource,
+        readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -675,7 +687,7 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -683,18 +695,20 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
             for( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
-                int retCode = test_write_image_1D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+                int retCode =
+                    test_write_image_1D_array(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
                 if( retCode )
                     return retCode;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -708,10 +722,11 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.rowPitch;
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.arraySize);
-            int retCode = test_write_image_1D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_1D_array(
+                device, context, queue, kernel, &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -724,7 +739,8 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
 
         imageInfo.rowPitch = imageInfo.width * pixelSize;
         imageInfo.slicePitch = imageInfo.rowPitch;
-        int retCode = test_write_image_1D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+        int retCode = test_write_image_1D_array(device, context, queue, kernel,
+                                                &imageInfo, inputType, d, ctx);
         if( retCode )
             return retCode;
     }
@@ -740,7 +756,7 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, d );
                 imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, d );
 
-                if( gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t)random_in_range(2, (compute_max_mip_levels(imageInfo.width, 0, 0)-1), d);
                     size = (cl_ulong) compute_mipmapped_image_size(imageInfo) * 4;
@@ -748,7 +764,7 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
                 else
                 {
                     imageInfo.rowPitch = imageInfo.width * pixelSize;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, d );
                         imageInfo.rowPitch += extraWidth * pixelSize;
@@ -759,10 +775,11 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
 
-            int retCode = test_write_image_1D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_1D_array(
+                device, context, queue, kernel, &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -54,7 +54,7 @@ int test_write_image_1D_array(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_kernel kernel,
                               image_descriptor *imageInfo,
                               ExplicitType inputType, MTdata d,
-                              const context_t &ctx)
+                              const image_test_context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -622,7 +622,7 @@ int test_write_image_1D_array_set(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   ExplicitType inputType, MTdata d,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -20,9 +20,6 @@
 #include <sys/mman.h>
 #endif
 
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
 
@@ -80,8 +77,11 @@ const char *offset2DArrayLodKernelSource =
 "   int height_lod = ( get_image_height(output) >> lod ) ? ( get_image_height(output) >> lod ) : 1;\n"
 "   int offset = tidZ*width_lod*height_lod + tidY*width_lod + tidX;\n";
 
-int test_write_image_2D_array( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, ExplicitType inputType, MTdata d )
+int test_write_image_2D_array(cl_device_id device, cl_context context,
+                              cl_command_queue queue, cl_kernel kernel,
+                              image_descriptor *imageInfo,
+                              ExplicitType inputType, MTdata d,
+                              const context_t &ctx)
 {
     int                 totalErrors = 0;
 
@@ -92,7 +92,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
     const char *        write_only_mem_flag_names[2] = { "CL_MEM_WRITE_ONLY", "CL_MEM_READ_WRITE" };
     const cl_mem_flags  read_write_mem_flag_types[1] = {  CL_MEM_READ_WRITE};
     const char *        read_write_mem_flag_names[1] = { "CL_MEM_READ_WRITE"};
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         mem_flag_types = write_only_mem_flag_types;
         mem_flag_names = write_only_mem_flag_names;
@@ -128,7 +128,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 
         create_random_image_data( inputType, imageInfo, imageValues, d );
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             if( inputType == kFloat && imageInfo->format->image_channel_data_type != CL_FLOAT )
             {
@@ -235,7 +235,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
         clMemWrapper unprotImage;
         cl_mem image;
 
-        if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+        if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
         {
             create_random_image_data( inputType, imageInfo, maxImageUseHostPtrBackingStore, d );
 
@@ -260,7 +260,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 cl_image_desc image_desc = {0};
                 image_desc.image_type = imageInfo->type;
@@ -269,8 +269,11 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                 image_desc.image_height = imageInfo->height;
                 image_desc.image_array_size = imageInfo->arraySize;
 
-                unprotImage = clCreateImage( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ),
-                                             imageInfo->format, &image_desc, NULL, &error);
+                unprotImage = clCreateImage(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create %d level 2D image array "
@@ -284,8 +287,12 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_2d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, imageValues, &error );
+                unprotImage = create_image_2d_array(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height,
+                    imageInfo->arraySize, 0, 0, imageValues, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create 2D image array of size "
@@ -307,10 +314,10 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
         size_t region[ 3 ] = { imageInfo->width, imageInfo->height, imageInfo->arraySize };
         size_t resultSize;
 
-        int num_lod_loops = (gTestMipmaps)? imageInfo->num_mip_levels : 1;
+        int num_lod_loops = (ctx.testMipmaps) ? imageInfo->num_mip_levels : 1;
         for( int lod = 0; lod < num_lod_loops; lod++)
         {
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 error = clSetKernelArg( kernel, 2, sizeof( int ), &lod );
             }
@@ -337,24 +344,27 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
             test_error( error, "Unable to run kernel" );
 
             // Get results
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 resultSize = width_lod * height_lod *imageInfo->arraySize * pixelSize;
             else
                 resultSize = imageInfo->slicePitch *imageInfo->arraySize;
             clProtectedArray PA(resultSize);
             char *resultValues = (char *)((void *)PA);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( resultSize / 1024 ) );
 
             origin[3] = lod;
             region[0] = width_lod;
             region[1] = height_lod;
 
-            error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, gEnablePitch ? imageInfo->rowPitch : 0, gEnablePitch ? imageInfo->slicePitch : 0, resultValues, 0, NULL, NULL );
+            error =
+                clEnqueueReadImage(queue, image, CL_TRUE, origin, region,
+                                   ctx.enablePitch ? imageInfo->rowPitch : 0,
+                                   ctx.enablePitch ? imageInfo->slicePitch : 0,
+                                   resultValues, 0, NULL, NULL);
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = imageValues + nextLevelOffset;
@@ -364,7 +374,7 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
                 for( size_t y = 0; y < height_lod; y++ )
                 {
                     char *resultPtr;
-                    if( gTestMipmaps )
+                    if (ctx.testMipmaps)
                         resultPtr = (char *)resultValues + y * width_lod * pixelSize + z * width_lod * height_lod * pixelSize;
                     else
                         resultPtr = (char*)resultValues + y * imageInfo->rowPitch + z * imageInfo->slicePitch;
@@ -652,7 +662,8 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
 int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
-                                  ExplicitType inputType, MTdata d)
+                                  ExplicitType inputType, MTdata d,
+                                  const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -692,7 +703,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
     else // kFloat
         readFormat = "f";
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         KernelSourcePattern = write2DArrayKernelSourcePattern;
     }
@@ -704,7 +715,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
     // Construct the source
     sprintf(
         programSrc, KernelSourcePattern,
-        gTestMipmaps
+        ctx.testMipmaps
             ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable\n#pragma "
               "OPENCL EXTENSION cl_khr_mipmap_image_writes: enable"
             : "",
@@ -712,9 +723,10 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
         (format->image_channel_order == CL_DEPTH) ? "" : "4",
         (format->image_channel_order == CL_DEPTH) ? "image2d_array_depth_t"
                                                   : "image2d_array_t",
-        gTestMipmaps ? " , int lod" : "",
-        gTestMipmaps ? offset2DArrayLodKernelSource : offset2DArrayKernelSource,
-        readFormat, gTestMipmaps ? ", lod" : "");
+        ctx.testMipmaps ? " , int lod" : "",
+        ctx.testMipmaps ? offset2DArrayLodKernelSource
+                        : offset2DArrayKernelSource,
+        readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -722,7 +734,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -732,19 +744,21 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
                 for( imageInfo.arraySize = 2; imageInfo.arraySize < 7; imageInfo.arraySize++ )
                 {
-                    if( gTestMipmaps )
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, d);
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+                    int retCode = test_write_image_2D_array(
+                        device, context, queue, kernel, &imageInfo, inputType,
+                        d, ctx);
                     if( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -759,10 +773,11 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
             imageInfo.arraySize = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t) random_in_range(2, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, d);
             log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize);
-            int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_2D_array(
+                device, context, queue, kernel, &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -776,7 +791,8 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
 
         imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-        int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+        int retCode = test_write_image_2D_array(device, context, queue, kernel,
+                                                &imageInfo, inputType, d, ctx);
         if( retCode )
             return retCode;
     }
@@ -797,7 +813,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                 imageInfo.height = (size_t)random_log_in_range( 16, maxHeighthRange, d );
                 imageInfo.arraySize = (size_t)random_log_in_range( 8, maxArraySizeRange, d );
 
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t) random_in_range(2,(compute_max_mip_levels(imageInfo.width, imageInfo.height, 0) - 1), d);
                     //Need to take into account the input buffer size, otherwise we will end up with input buffer that is exceeding MaxAlloc
@@ -808,7 +824,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                 {
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
                     imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, d );
                         imageInfo.rowPitch += extraWidth * get_pixel_size( imageInfo.format );
@@ -826,14 +842,15 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || buffSize > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of "
                          "%zu,%zu,%zu\n",
                          imageInfo.width, imageInfo.height, imageInfo.arraySize,
                          imageInfo.rowPitch, imageInfo.slicePitch, maxWidth,
                          maxHeight, maxArraySize);
 
-            int retCode = test_write_image_2D_array( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_2D_array(
+                device, context, queue, kernel, &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -81,7 +81,7 @@ int test_write_image_2D_array(cl_device_id device, cl_context context,
                               cl_command_queue queue, cl_kernel kernel,
                               image_descriptor *imageInfo,
                               ExplicitType inputType, MTdata d,
-                              const context_t &ctx)
+                              const image_test_context_t &ctx)
 {
     int                 totalErrors = 0;
 
@@ -663,7 +663,7 @@ int test_write_image_2D_array_set(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   ExplicitType inputType, MTdata d,
-                                  const context_t &ctx)
+                                  const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -20,9 +20,6 @@
 #include <sys/mman.h>
 #endif
 
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
 
@@ -82,8 +79,10 @@ const char *offset3DLodSource =
 "   int height_lod = ( get_image_height(output) >> lod ) ? ( get_image_height(output) >> lod ) : 1;\n"
 "   int offset = tidZ*width_lod*height_lod + tidY*width_lod + tidX;\n";
 
-int test_write_image_3D( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, ExplicitType inputType, MTdata d )
+int test_write_image_3D(cl_device_id device, cl_context context,
+                        cl_command_queue queue, cl_kernel kernel,
+                        image_descriptor *imageInfo, ExplicitType inputType,
+                        MTdata d, const context_t &ctx)
 {
     int                 totalErrors = 0;
 
@@ -95,7 +94,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
     const cl_mem_flags  read_write_mem_flag_types[1] = {  CL_MEM_READ_WRITE};
     const char *        read_write_mem_flag_names[1] = { "CL_MEM_READ_WRITE"};
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         mem_flag_types = write_only_mem_flag_types;
         mem_flag_names = write_only_mem_flag_names;
@@ -131,7 +130,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 
         create_random_image_data( inputType, imageInfo, imageValues, d );
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             if( inputType == kFloat && imageInfo->format->image_channel_data_type != CL_FLOAT )
             {
@@ -239,7 +238,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
         clMemWrapper unprotImage;
         cl_mem image;
 
-        if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+        if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
         {
             create_random_image_data( inputType, imageInfo, maxImageUseHostPtrBackingStore, d );
 
@@ -263,7 +262,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 cl_image_desc image_desc = {0};
                 image_desc.image_type = imageInfo->type;
@@ -272,8 +271,11 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                 image_desc.image_height = imageInfo->height;
                 image_desc.image_depth = imageInfo->depth;
 
-                unprotImage = clCreateImage( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ),
-                                             imageInfo->format, &image_desc, NULL, &error);
+                unprotImage = clCreateImage(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create %d level mipmapped 3D "
@@ -287,8 +289,12 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_3d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, imageValues, &error );
+                unprotImage = create_image_3d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height,
+                    imageInfo->depth, 0, 0, imageValues, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create 3D image of size %zu x "
@@ -312,10 +318,10 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
         size_t origin[ 4 ] = { 0, 0, 0, 0 };
         size_t region[ 3 ] = { imageInfo->width, imageInfo->height, imageInfo->depth };
 
-        int num_lod_loops = (gTestMipmaps)? imageInfo->num_mip_levels : 1;
+        int num_lod_loops = (ctx.testMipmaps) ? imageInfo->num_mip_levels : 1;
         for( int lod = 0; lod < num_lod_loops; lod++)
         {
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 error = clSetKernelArg( kernel, 2, sizeof( int ), &lod );
             }
@@ -343,24 +349,27 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 
             // Get results
             size_t resultSize;
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
                 resultSize = width_lod * height_lod * depth_lod * pixelSize;
             else
                 resultSize = imageInfo->slicePitch *imageInfo->depth;
             clProtectedArray PA(resultSize);
             char *resultValues = (char *)((void *)PA);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( resultSize / 1024 ) );
 
             origin[3] = lod;
             region[0] = width_lod;
             region[1] = height_lod;
             region[2] = depth_lod;
-            error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, gEnablePitch ? imageInfo->rowPitch : 0, gEnablePitch ? imageInfo->slicePitch : 0, resultValues, 0, NULL, NULL );
+            error =
+                clEnqueueReadImage(queue, image, CL_TRUE, origin, region,
+                                   ctx.enablePitch ? imageInfo->rowPitch : 0,
+                                   ctx.enablePitch ? imageInfo->slicePitch : 0,
+                                   resultValues, 0, NULL, NULL);
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = (char*)imageValues + nextLevelOffset;
@@ -370,7 +379,7 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
                 for( size_t y = 0; y < height_lod; y++ )
                 {
                     char *resultPtr;
-                    if( gTestMipmaps )
+                    if (ctx.testMipmaps)
                         resultPtr = (char *)resultValues + y * width_lod * pixelSize + z * width_lod * height_lod * pixelSize;
                     else
                         resultPtr = (char *)resultValues + y * imageInfo->rowPitch + z * imageInfo->slicePitch;
@@ -659,7 +668,8 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
 int test_write_image_3D_set(cl_device_id device, cl_context context,
                             cl_command_queue queue,
                             const cl_image_format *format,
-                            ExplicitType inputType, MTdata d)
+                            ExplicitType inputType, MTdata d,
+                            const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -698,7 +708,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
     else // kFloat
         readFormat = "f";
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         KernelSourcePattern = write3DKernelSourcePattern;
     }
@@ -710,13 +720,13 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
     // Construct the source
     sprintf(
         programSrc, KernelSourcePattern, khr3DWritesPragma,
-        gTestMipmaps
+        ctx.testMipmaps
             ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable\n#pragma "
               "OPENCL EXTENSION cl_khr_mipmap_image_writes: enable"
             : "",
-        get_explicit_type_name(inputType), gTestMipmaps ? ", int lod" : "",
-        gTestMipmaps ? offset3DLodSource : offset3DSource, readFormat,
-        gTestMipmaps ? ", lod" : "");
+        get_explicit_type_name(inputType), ctx.testMipmaps ? ", int lod" : "",
+        ctx.testMipmaps ? offset3DLodSource : offset3DSource, readFormat,
+        ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -724,7 +734,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -734,19 +744,21 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
                 for( imageInfo.depth = 2; imageInfo.depth < 7; imageInfo.depth++ )
                 {
-                    if (gTestMipmaps)
+                    if (ctx.testMipmaps)
                         imageInfo.num_mip_levels = (size_t) random_in_range(2,(compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth) - 1), d);
 
-                    if( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );
+                    int retCode =
+                        test_write_image_3D(device, context, queue, kernel,
+                                            &imageInfo, inputType, d, ctx);
                     if( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -761,10 +773,11 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
             imageInfo.depth = sizes[ idx ][ 2 ];
             imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-            if (gTestMipmaps)
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t) random_in_range(2,(compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth) - 1), d);
             log_info("Testing %d x %d x %d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth);
-            int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_3D(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -778,7 +791,8 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
 
         imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
         imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-        int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );
+        int retCode = test_write_image_3D(device, context, queue, kernel,
+                                          &imageInfo, inputType, d, ctx);
         if( retCode )
             return retCode;
     }
@@ -795,7 +809,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
                 imageInfo.height = reduceImageSizeRange(maxHeight, d );
                 imageInfo.depth = reduceImageDepth(maxDepth, d );
 
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t) random_in_range(2,(compute_max_mip_levels(imageInfo.width, imageInfo.height, imageInfo.depth) - 1), d);
                     //Need to take into account the input buffer size, otherwise we will end up with input buffer that is exceeding MaxAlloc
@@ -805,7 +819,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
                 {
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
                     imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, d );
                         imageInfo.rowPitch += extraWidth * get_pixel_size( imageInfo.format );
@@ -819,14 +833,15 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info("   at size %zu,%zu,%zu (pitch %zu, slice %zu) out of "
                          "%zu,%zu,%zu\n",
                          imageInfo.width, imageInfo.height, imageInfo.depth,
                          imageInfo.rowPitch, imageInfo.slicePitch, maxWidth,
                          maxHeight, maxDepth);
 
-            int retCode = test_write_image_3D( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image_3D(device, context, queue, kernel,
+                                              &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -82,7 +82,7 @@ const char *offset3DLodSource =
 int test_write_image_3D(cl_device_id device, cl_context context,
                         cl_command_queue queue, cl_kernel kernel,
                         image_descriptor *imageInfo, ExplicitType inputType,
-                        MTdata d, const context_t &ctx)
+                        MTdata d, const image_test_context_t &ctx)
 {
     int                 totalErrors = 0;
 
@@ -669,7 +669,7 @@ int test_write_image_3D_set(cl_device_id device, cl_context context,
                             cl_command_queue queue,
                             const cl_image_format *format,
                             ExplicitType inputType, MTdata d,
-                            const context_t &ctx)
+                            const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -24,24 +24,24 @@ extern int test_write_image_1D_set(cl_device_id device, cl_context context,
                                    cl_command_queue queue,
                                    const cl_image_format *format,
                                    ExplicitType inputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 extern int test_write_image_3D_set(cl_device_id device, cl_context context,
                                    cl_command_queue queue,
                                    const cl_image_format *format,
                                    ExplicitType inputType, MTdata d,
-                                   const context_t &ctx);
+                                   const image_test_context_t &ctx);
 extern int test_write_image_1D_array_set(cl_device_id device,
                                          cl_context context,
                                          cl_command_queue queue,
                                          const cl_image_format *format,
                                          ExplicitType inputType, MTdata d,
-                                         const context_t &ctx);
+                                         const image_test_context_t &ctx);
 extern int test_write_image_2D_array_set(cl_device_id device,
                                          cl_context context,
                                          cl_command_queue queue,
                                          const cl_image_format *format,
                                          ExplicitType inputType, MTdata d,
-                                         const context_t &ctx);
+                                         const image_test_context_t &ctx);
 
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
@@ -76,7 +76,7 @@ const char *offset2DLodKernelSource =
 int test_write_image(cl_device_id device, cl_context context,
                      cl_command_queue queue, cl_kernel kernel,
                      image_descriptor *imageInfo, ExplicitType inputType,
-                     MTdata d, const context_t &ctx)
+                     MTdata d, const image_test_context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -691,7 +691,7 @@ int test_write_image(cl_device_id device, cl_context context,
 
 int test_write_image_set(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
-                         ExplicitType inputType, MTdata d, const context_t &ctx)
+                         ExplicitType inputType, MTdata d, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -907,7 +907,7 @@ int test_write_image_formats(cl_device_id device, cl_context context,
                              const std::vector<bool> &filterFlags,
                              image_sampler_data *imageSampler,
                              ExplicitType inputType,
-                             cl_mem_object_type imageType, const context_t &ctx)
+                             cl_mem_object_type imageType, const image_test_context_t &ctx)
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
         // No need to run for linear filters

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -20,28 +20,28 @@
 #include <sys/mman.h>
 #endif
 
-extern bool gTestImage2DFromBuffer;
-extern cl_mem_flags gMemFlagsToUse;
-extern int gtestTypesToRun;
-
 extern int test_write_image_1D_set(cl_device_id device, cl_context context,
                                    cl_command_queue queue,
                                    const cl_image_format *format,
-                                   ExplicitType inputType, MTdata d);
+                                   ExplicitType inputType, MTdata d,
+                                   const context_t &ctx);
 extern int test_write_image_3D_set(cl_device_id device, cl_context context,
                                    cl_command_queue queue,
                                    const cl_image_format *format,
-                                   ExplicitType inputType, MTdata d);
+                                   ExplicitType inputType, MTdata d,
+                                   const context_t &ctx);
 extern int test_write_image_1D_array_set(cl_device_id device,
                                          cl_context context,
                                          cl_command_queue queue,
                                          const cl_image_format *format,
-                                         ExplicitType inputType, MTdata d);
+                                         ExplicitType inputType, MTdata d,
+                                         const context_t &ctx);
 extern int test_write_image_2D_array_set(cl_device_id device,
                                          cl_context context,
                                          cl_command_queue queue,
                                          const cl_image_format *format,
-                                         ExplicitType inputType, MTdata d);
+                                         ExplicitType inputType, MTdata d,
+                                         const context_t &ctx);
 
 extern bool validate_float_write_results( float *expected, float *actual, image_descriptor *imageInfo );
 extern bool validate_half_write_results( cl_half *expected, cl_half *actual, image_descriptor *imageInfo );
@@ -73,8 +73,10 @@ const char *offset2DLodKernelSource =
 "   int width_lod = ( get_image_width(output) >> lod ) ? ( get_image_width(output) >> lod ) : 1;\n"
 "   int offset = tidY * width_lod + tidX;\n";
 
-int test_write_image( cl_device_id device, cl_context context, cl_command_queue queue, cl_kernel kernel,
-                     image_descriptor *imageInfo, ExplicitType inputType, MTdata d )
+int test_write_image(cl_device_id device, cl_context context,
+                     cl_command_queue queue, cl_kernel kernel,
+                     image_descriptor *imageInfo, ExplicitType inputType,
+                     MTdata d, const context_t &ctx)
 {
     int                 totalErrors = 0;
     size_t              num_flags   = 0;
@@ -85,7 +87,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
     const cl_mem_flags  read_write_mem_flag_types[1] = {  CL_MEM_READ_WRITE};
     const char *        read_write_mem_flag_names[1] = { "CL_MEM_READ_WRITE"};
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         mem_flag_types = write_only_mem_flag_types;
         mem_flag_names = write_only_mem_flag_names;
@@ -120,9 +122,10 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 
         BufferOwningPtr<char> maxImageUseHostPtrBackingStore, imageValues, imageBufferValues;
 
-        create_random_image_data( inputType, imageInfo, imageValues, d, gTestImage2DFromBuffer );
+        create_random_image_data(inputType, imageInfo, imageValues, d,
+                                 ctx.testImage2DFromBuffer);
 
-        if(!gTestMipmaps)
+        if (!ctx.testMipmaps)
         {
             if( inputType == kFloat && imageInfo->format->image_channel_data_type != CL_FLOAT && imageInfo->format->image_channel_data_type != CL_HALF_FLOAT )
             {
@@ -225,9 +228,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
         cl_mem image;
         cl_mem imageBuffer = nullptr;
 
-        if( gMemFlagsToUse == CL_MEM_USE_HOST_PTR )
+        if (ctx.memFlagsToUse == CL_MEM_USE_HOST_PTR)
         {
-            if (gTestImage2DFromBuffer)
+            if (ctx.testImage2DFromBuffer)
             {
                 imageBuffer = clCreateBuffer( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR,
                                              imageInfo->rowPitch * imageInfo->height, maxImageUseHostPtrBackingStore, &error);
@@ -241,7 +244,8 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
             {
                 // clProtectedImage uses USE_HOST_PTR, so just rely on that for the testing (via Ian)
                 // Do not use protected images for max image size test since it rounds the row size to a page size
-                if (gTestMaxImages) {
+                if (ctx.testMaxImages)
+                {
                     create_random_image_data( inputType, imageInfo, maxImageUseHostPtrBackingStore, d );
 
                     unprotImage = create_image_2d( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
@@ -253,7 +257,8 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
             }
             if( error != CL_SUCCESS )
             {
-                if (gTestImage2DFromBuffer) {
+                if (ctx.testImage2DFromBuffer)
+                {
                     clReleaseMemObject(imageBuffer);
                     if (error == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR) {
                         log_info( "Format not supported for cl_khr_image2d_from_buffer skipping...\n" );
@@ -269,14 +274,14 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                 return error;
             }
 
-            if (gTestMaxImages || gTestImage2DFromBuffer)
+            if (ctx.testMaxImages || ctx.testImage2DFromBuffer)
                 image = (cl_mem)unprotImage;
             else
                 image = (cl_mem)protImage;
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
             {
                 cl_image_desc image_desc = {0};
                 image_desc.image_type = imageInfo->type;
@@ -284,8 +289,11 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                 image_desc.image_width = imageInfo->width;
                 image_desc.image_height = imageInfo->height;
 
-                unprotImage = clCreateImage( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ),
-                                             imageInfo->format, &image_desc, NULL, &error);
+                unprotImage = clCreateImage(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, &image_desc, NULL, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error("ERROR: Unable to create %d level 2D image of "
@@ -296,7 +304,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                     return error;
                 }
             }
-            else if (gTestImage2DFromBuffer)
+            else if (ctx.testImage2DFromBuffer)
             {
                 generate_random_image_data( imageInfo, imageBufferValues, d );
                 imageBuffer = clCreateBuffer( context, CL_MEM_COPY_HOST_PTR,
@@ -312,13 +320,17 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                 // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
                 // it works just as if no flag is specified, so we just do the same thing either way
                 // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-                unprotImage = create_image_2d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                          imageInfo->width, imageInfo->height, 0,
-                                          imageValues, &error );
+                unprotImage = create_image_2d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (ctx.memFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height, 0,
+                    imageValues, &error);
             }
             if( error != CL_SUCCESS )
             {
-                if (gTestImage2DFromBuffer) {
+                if (ctx.testImage2DFromBuffer)
+                {
                     clReleaseMemObject(imageBuffer);
                     if (error == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR) {
                         log_info( "Format not supported for cl_khr_image2d_from_buffer skipping...\n" );
@@ -344,10 +356,10 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
         size_t region[ 3 ] = { imageInfo->width, imageInfo->height, 1 };
         size_t resultSize;
 
-        int num_lod_loops = (gTestMipmaps)? imageInfo->num_mip_levels : 1;
+        int num_lod_loops = (ctx.testMipmaps) ? imageInfo->num_mip_levels : 1;
         for( int lod = 0; lod < num_lod_loops; lod++)
         {
-            if(gTestMipmaps)
+            if (ctx.testMipmaps)
             {
                 error = clSetKernelArg( kernel, 2, sizeof( int ), &lod );
             }
@@ -374,23 +386,25 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
             test_error( error, "Unable to run kernel" );
 
             // Get results
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 resultSize = width_lod * height_lod * get_pixel_size(imageInfo->format);
             else
                 resultSize = imageInfo->rowPitch * imageInfo->height;
             clProtectedArray PA(resultSize);
             char *resultValues = (char *)((void *)PA);
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "    reading results, %ld kbytes\n", (unsigned long)( resultSize / 1024 ) );
 
             origin[2] = lod;
             region[0] = width_lod;
             region[1] = height_lod;
-            error = clEnqueueReadImage( queue, image, CL_TRUE, origin, region, gEnablePitch ? imageInfo->rowPitch : 0, 0, resultValues, 0, NULL, NULL );
+            error =
+                clEnqueueReadImage(queue, image, CL_TRUE, origin, region,
+                                   ctx.enablePitch ? imageInfo->rowPitch : 0, 0,
+                                   resultValues, 0, NULL, NULL);
             test_error( error, "Unable to read results from kernel" );
-            if( gDebugTrace )
-                log_info( "    results read\n" );
+            if (ctx.debugTrace) log_info("    results read\n");
 
             // Validate results element by element
             char *imagePtr = (char*)imageValues + nextLevelOffset;
@@ -398,7 +412,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
             for( size_t y = 0, i = 0; y < height_lod; y++ )
             {
                 char *resultPtr;
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                     resultPtr = (char *)resultValues + y * width_lod * pixelSize;
                 else
                     resultPtr = (char*)resultValues + y * imageInfo->rowPitch;
@@ -664,7 +678,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
             }
         }
 
-        if (gTestImage2DFromBuffer) clReleaseMemObject(imageBuffer);
+        if (ctx.testImage2DFromBuffer) clReleaseMemObject(imageBuffer);
     }
 
 
@@ -675,7 +689,7 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
 
 int test_write_image_set(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
-                         ExplicitType inputType, MTdata d)
+                         ExplicitType inputType, MTdata d, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -685,7 +699,7 @@ int test_write_image_set(cl_device_id device, cl_context context,
     const char *KernelSourcePattern = NULL;
     int error;
 
-    if (gTestImage2DFromBuffer)
+    if (ctx.testImage2DFromBuffer)
     {
       if (format->image_channel_order == CL_RGB || format->image_channel_order == CL_RGBx)
       {
@@ -740,7 +754,7 @@ int test_write_image_set(cl_device_id device, cl_context context,
     else // kFloat
         readFormat = "f";
 
-    if(gtestTypesToRun & kWriteTests)
+    if (ctx.testTypesToRun & kWriteTests)
     {
         KernelSourcePattern = writeKernelSourcePattern;
     }
@@ -752,7 +766,7 @@ int test_write_image_set(cl_device_id device, cl_context context,
     // Construct the source
     sprintf(
         programSrc, KernelSourcePattern,
-        gTestMipmaps
+        ctx.testMipmaps
             ? "#pragma OPENCL EXTENSION cl_khr_mipmap_image: enable\n#pragma "
               "OPENCL EXTENSION cl_khr_mipmap_image_writes: enable"
             : "",
@@ -760,9 +774,9 @@ int test_write_image_set(cl_device_id device, cl_context context,
         (format->image_channel_order == CL_DEPTH) ? "" : "4",
         (format->image_channel_order == CL_DEPTH) ? "image2d_depth_t"
                                                   : "image2d_t",
-        gTestMipmaps ? ", int lod" : "",
-        gTestMipmaps ? offset2DLodKernelSource : offset2DKernelSource,
-        readFormat, gTestMipmaps ? ", lod" : "");
+        ctx.testMipmaps ? ", int lod" : "",
+        ctx.testMipmaps ? offset2DLodKernelSource : offset2DKernelSource,
+        readFormat, ctx.testMipmaps ? ", lod" : "");
 
     ptr = programSrc;
     error = create_single_kernel_helper(context, &program, &kernel, 1, &ptr,
@@ -770,25 +784,26 @@ int test_write_image_set(cl_device_id device, cl_context context,
     test_error( error, "Unable to create testing kernel" );
 
     // Run tests
-    if( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
             for( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if( gTestMipmaps )
+                if (ctx.testMipmaps)
                     imageInfo.num_mip_levels = (size_t) random_in_range(1, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, d);
 
-                if( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
-                int retCode = test_write_image( device, context, queue, kernel, &imageInfo, inputType, d );
+                int retCode = test_write_image(device, context, queue, kernel,
+                                               &imageInfo, inputType, d, ctx);
                 if( retCode )
                     return retCode;
             }
         }
     }
-    else if( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -801,10 +816,11 @@ int test_write_image_set(cl_device_id device, cl_context context,
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.height = sizes[ idx ][ 1 ];
             imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-            if( gTestMipmaps )
+            if (ctx.testMipmaps)
                 imageInfo.num_mip_levels = (size_t) random_in_range(1, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0)-1, d);
             log_info("Testing %d x %d\n", (int)imageInfo.width, (int)imageInfo.height);
-            int retCode = test_write_image( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image(device, context, queue, kernel,
+                                           &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -816,7 +832,8 @@ int test_write_image_set(cl_device_id device, cl_context context,
         imageInfo.width = (size_t)( typeRange / (cl_ulong)imageInfo.height );
 
         imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-        int retCode = test_write_image( device, context, queue, kernel, &imageInfo, inputType, d );
+        int retCode = test_write_image(device, context, queue, kernel,
+                                       &imageInfo, inputType, d, ctx);
         if( retCode )
             return retCode;
     }
@@ -824,7 +841,7 @@ int test_write_image_set(cl_device_id device, cl_context context,
     {
 
         cl_uint imagePitchAlign = 0;
-        if (gTestImage2DFromBuffer)
+        if (ctx.testImage2DFromBuffer)
         {
 #if defined(CL_DEVICE_IMAGE_PITCH_ALIGNMENT)
             error = clGetDeviceInfo( device, CL_DEVICE_IMAGE_PITCH_ALIGNMENT, sizeof( cl_uint ), &imagePitchAlign, NULL );
@@ -844,7 +861,7 @@ int test_write_image_set(cl_device_id device, cl_context context,
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, d );
                 imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, d );
 
-                if(gTestMipmaps)
+                if (ctx.testMipmaps)
                 {
                     imageInfo.num_mip_levels = (size_t) random_in_range(1, compute_max_mip_levels(imageInfo.width, imageInfo.height, 0) - 1, d);
                     size = 4 * compute_mipmapped_image_size(imageInfo);
@@ -852,14 +869,14 @@ int test_write_image_set(cl_device_id device, cl_context context,
                 else
                 {
                     imageInfo.rowPitch = imageInfo.width * get_pixel_size( imageInfo.format );
-                    if( gEnablePitch )
+                    if (ctx.enablePitch)
                     {
                         size_t extraWidth = (int)random_log_in_range( 0, 64, d );
                         imageInfo.rowPitch += extraWidth * get_pixel_size( imageInfo.format );
                     }
 
                     // if we are creating a 2D image from a buffer, make sure that the rowpitch is aligned to CL_DEVICE_IMAGE_PITCH_ALIGNMENT_APPLE
-                    if (gTestImage2DFromBuffer)
+                    if (ctx.testImage2DFromBuffer)
                     {
                         size_t pitch = imagePitchAlign * get_pixel_size( imageInfo.format );
                         imageInfo.rowPitch = ((imageInfo.rowPitch + pitch - 1) / pitch ) * pitch;
@@ -869,10 +886,11 @@ int test_write_image_set(cl_device_id device, cl_context context,
                 }
             } while(  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
 
-            int retCode = test_write_image( device, context, queue, kernel, &imageInfo, inputType, d );
+            int retCode = test_write_image(device, context, queue, kernel,
+                                           &imageInfo, inputType, d, ctx);
             if( retCode )
                 return retCode;
         }
@@ -887,7 +905,7 @@ int test_write_image_formats(cl_device_id device, cl_context context,
                              const std::vector<bool> &filterFlags,
                              image_sampler_data *imageSampler,
                              ExplicitType inputType,
-                             cl_mem_object_type imageType)
+                             cl_mem_object_type imageType, const context_t &ctx)
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
         // No need to run for linear filters
@@ -914,19 +932,24 @@ int test_write_image_formats(cl_device_id device, cl_context context,
         switch (imageType)
         {
             case CL_MEM_OBJECT_IMAGE1D:
-                retCode = test_write_image_1D_set( device, context, queue, &imageFormat, inputType, seed );
+                retCode = test_write_image_1D_set(
+                    device, context, queue, &imageFormat, inputType, seed, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D:
-                retCode = test_write_image_set( device, context, queue, &imageFormat, inputType, seed );
+                retCode = test_write_image_set(
+                    device, context, queue, &imageFormat, inputType, seed, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE3D:
-                retCode = test_write_image_3D_set( device, context, queue, &imageFormat, inputType, seed );
+                retCode = test_write_image_3D_set(
+                    device, context, queue, &imageFormat, inputType, seed, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                retCode = test_write_image_1D_array_set( device, context, queue, &imageFormat, inputType, seed );
+                retCode = test_write_image_1D_array_set(
+                    device, context, queue, &imageFormat, inputType, seed, ctx);
                 break;
             case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                retCode = test_write_image_2D_array_set( device, context, queue, &imageFormat, inputType, seed );
+                retCode = test_write_image_2D_array_set(
+                    device, context, queue, &imageFormat, inputType, seed, ctx);
                 break;
         }
 

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -251,7 +251,9 @@ int test_write_image(cl_device_id device, cl_context context,
                     unprotImage = create_image_2d( context, mem_flag_types[mem_flag_index] | CL_MEM_USE_HOST_PTR, imageInfo->format,
                                               imageInfo->width, imageInfo->height, 0,
                                               maxImageUseHostPtrBackingStore, &error );
-                } else {
+                }
+                else
+                {
                     error = protImage.Create( context, mem_flag_types[mem_flag_index], imageInfo->format, imageInfo->width, imageInfo->height );
                 }
             }

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -691,7 +691,8 @@ int test_write_image(cl_device_id device, cl_context context,
 
 int test_write_image_set(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
-                         ExplicitType inputType, MTdata d, const image_test_context_t &ctx)
+                         ExplicitType inputType, MTdata d,
+                         const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -907,7 +908,8 @@ int test_write_image_formats(cl_device_id device, cl_context context,
                              const std::vector<bool> &filterFlags,
                              image_sampler_data *imageSampler,
                              ExplicitType inputType,
-                             cl_mem_object_type imageType, const image_test_context_t &ctx)
+                             cl_mem_object_type imageType,
+                             const image_test_context_t &ctx)
 {
     if( imageSampler->filter_mode == CL_FILTER_LINEAR )
         // No need to run for linear filters

--- a/test_conformance/images/samplerlessReads/main.cpp
+++ b/test_conformance/images/samplerlessReads/main.cpp
@@ -27,40 +27,38 @@
 __thread fpu_control_t fpu_control = 0;
 #endif
 
-bool                gTestReadWrite;
-bool                gDebugTrace;
-bool                gTestMaxImages;
-bool                gTestSmallImages;
-int                 gTypesToTest;
-cl_channel_type     gChannelTypeToUse = (cl_channel_type)-1;
-cl_channel_order    gChannelOrderToUse = (cl_channel_order)-1;
-bool                gEnablePitch = false;
+extern int test_image_set(cl_device_id device, cl_context context,
+                          cl_command_queue queue, cl_mem_object_type imageType,
+                          const context_t &ctx);
 
-extern int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType );
+static context_t ctx;
 
 REGISTER_TEST(1D)
 {
-    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D);
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D, ctx);
 }
 REGISTER_TEST(1Dbuffer)
 {
-    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER);
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_BUFFER,
+                          ctx);
 }
 REGISTER_TEST(2D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D, ctx);
 }
 REGISTER_TEST(3D)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE3D );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE3D, ctx);
 }
 REGISTER_TEST(1Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE1D_ARRAY,
+                          ctx);
 }
 REGISTER_TEST(2Darray)
 {
-    return test_image_set( device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY );
+    return test_image_set(device, context, queue, CL_MEM_OBJECT_IMAGE2D_ARRAY,
+                          ctx);
 }
 
 static test_status parseArgs(int &argc, const char *argv[],
@@ -91,33 +89,35 @@ static test_status parseArgs(int &argc, const char *argv[],
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
 
+    init_context(ctx);
+
     // Parse arguments
     for ( int i = 1; i < argc; i++ )
     {
         removed_args.push_back(argv[i]);
         if ( strcmp( argv[i], "debug_trace" ) == 0 )
-            gDebugTrace = true;
+            ctx.debugTrace = true;
         else if ( strcmp( argv[i], "read_write" ) == 0 )
-            gTestReadWrite = true;
+            ctx.testReadWrite = true;
         else if ( strcmp( argv[i], "small_images" ) == 0 )
-            gTestSmallImages = true;
+            ctx.testSmallImages = true;
         else if ( strcmp( argv[i], "max_images" ) == 0 )
-            gTestMaxImages = true;
+            ctx.testMaxImages = true;
         else if ( strcmp( argv[i], "use_pitches" ) == 0 )
-            gEnablePitch = true;
+            ctx.enablePitch = true;
 
         else if ( strcmp( argv[i], "int" ) == 0 )
-            gTypesToTest |= kTestInt;
+            ctx.typesToTest |= kTestInt;
         else if ( strcmp( argv[i], "uint" ) == 0 )
-            gTypesToTest |= kTestUInt;
+            ctx.typesToTest |= kTestUInt;
         else if ( strcmp( argv[i], "float" ) == 0 )
-            gTypesToTest |= kTestFloat;
+            ctx.typesToTest |= kTestFloat;
 
         else if ( ( chanType = get_channel_type_from_name( argv[i] ) ) != (cl_channel_type)-1 )
-            gChannelTypeToUse = chanType;
+            ctx.channelTypeToUse = chanType;
 
         else if ( ( chanOrder = get_channel_order_from_name( argv[i] ) ) != (cl_channel_order)-1 )
-            gChannelOrderToUse = chanOrder;
+            ctx.channelOrderToUse = chanOrder;
         else
         {
             removed_args.pop_back();
@@ -125,11 +125,9 @@ static test_status parseArgs(int &argc, const char *argv[],
         }
     }
 
-    if ( gTypesToTest == 0 )
-        gTypesToTest = kTestAllTypes;
+    if (ctx.typesToTest == 0) ctx.typesToTest = kTestAllTypes;
 
-    if ( gTestSmallImages )
-        log_info( "Note: Using small test images\n" );
+    if (ctx.testSmallImages) log_info("Note: Using small test images\n");
 
     update_argc_argv_from_args_list(argList, argc, argv);
     return TEST_PASS;

--- a/test_conformance/images/samplerlessReads/main.cpp
+++ b/test_conformance/images/samplerlessReads/main.cpp
@@ -29,9 +29,9 @@ __thread fpu_control_t fpu_control = 0;
 
 extern int test_image_set(cl_device_id device, cl_context context,
                           cl_command_queue queue, cl_mem_object_type imageType,
-                          const context_t &ctx);
+                          const image_test_context_t &ctx);
 
-static context_t ctx;
+static image_test_context_t ctx;
 
 REGISTER_TEST(1D)
 {
@@ -88,8 +88,6 @@ static test_status parseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-
-    init_context(ctx);
 
     // Parse arguments
     for ( int i = 1; i < argc; i++ )

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -22,8 +22,6 @@
     #include <setjmp.h>
 #endif
 
-extern bool gTestReadWrite;
-
 const char *read2DKernelSourcePattern =
 "__kernel void sample_kernel( read_only %s input, sampler_t sampler, __global int *results )\n"
 "{\n"
@@ -54,9 +52,10 @@ const char *read_write2DKernelSourcePattern =
 "   else\n"
 "      results[offset] = 0;\n"
 "}";
-int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_2D(cl_context context, cl_command_queue queue,
+                       cl_kernel kernel, image_descriptor *imageInfo,
+                       image_sampler_data *imageSampler,
+                       ExplicitType outputType, MTdata d, const context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -66,7 +65,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating image %d by %d...\n", (int)imageInfo->width, (int)imageInfo->height );
 
     // Construct testing sources
@@ -77,7 +76,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     image_desc.image_type = CL_MEM_OBJECT_IMAGE2D;
     image_desc.image_width = imageInfo->width;
     image_desc.image_height = imageInfo->height;
-    image_desc.image_row_pitch = ( gEnablePitch ? imageInfo->rowPitch : 0 );
+    image_desc.image_row_pitch = (ctx.enablePitch ? imageInfo->rowPitch : 0);
     image_desc.num_mip_levels = 0;
     read_only_image = clCreateImage( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, imageInfo->format,
                                        &image_desc, imageValues, &error );
@@ -87,7 +86,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         return error;
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         read_write_image = clCreateImage(context,
                                          CL_MEM_READ_WRITE,
@@ -106,8 +105,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         }
     }
 
-    if ( gDebugTrace )
-        log_info( " - Creating kernel arguments...\n" );
+    if (ctx.debugTrace) log_info(" - Creating kernel arguments...\n");
 
     // Create sampler to use
     actualSampler = clCreateSampler( context, CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST, &error );
@@ -126,7 +124,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_only_image );
     test_error( error, "Unable to set kernel arguments" );
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_write_image );
         test_error( error, "Unable to set kernel arguments" );
@@ -142,13 +140,12 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     error = clEnqueueNDRangeKernel( queue, kernel, 2, NULL, threads, NULL, 0, NULL, NULL );
     test_error( error, "Unable to run kernel" );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( "    reading results, %ld kbytes\n", (unsigned long)( imageInfo->width * imageInfo->height * sizeof(cl_int) / 1024 ) );
 
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -168,7 +165,7 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
     clReleaseSampler(actualSampler);
     clReleaseMemObject(results);
     clReleaseMemObject(read_only_image);
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         clReleaseMemObject(read_write_image);
     }
@@ -180,7 +177,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -197,7 +194,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
     image_descriptor imageInfo = { 0 };
     size_t pixelSize;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -235,7 +232,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
         dataType = (format->image_channel_order == CL_DEPTH) ? "float" : "float4";
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         sprintf(programSrc,
                 read_write2DKernelSourcePattern,
@@ -261,23 +258,25 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             for ( imageInfo.height = 1; imageInfo.height < 9; imageInfo.height++ )
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.height );
 
-                int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode =
+                    test_read_image_2D(context, queue, kernel, &imageInfo,
+                                       imageSampler, outputType, seed, ctx);
                 if ( retCode )
                     return retCode;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -291,9 +290,11 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
             imageInfo.height = sizes[ idx ][ 1 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             log_info("Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ] );
-            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_2D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -311,7 +312,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                 imageInfo.height = (size_t)random_log_in_range( 16, (int)maxHeight / 32, seed );
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if ( gEnablePitch )
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -320,9 +321,11 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.height * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxHeight );
-            int retCode = test_read_image_2D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_2D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -55,7 +55,7 @@ const char *read_write2DKernelSourcePattern =
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const context_t &ctx)
+                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -177,7 +177,7 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_iterations.cpp
+++ b/test_conformance/images/samplerlessReads/test_iterations.cpp
@@ -55,7 +55,8 @@ const char *read_write2DKernelSourcePattern =
 int test_read_image_2D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
+                       ExplicitType outputType, MTdata d,
+                       const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -177,7 +178,8 @@ int test_read_image_set_2D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -16,45 +16,46 @@
 #include "../testBase.h"
 #include "../common.h"
 
-extern int gTypesToTest;
-extern bool gTestReadWrite;
-
 extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType);
-extern int test_read_image_set_1D_buffer(cl_device_id device,
-                                         cl_context context,
-                                         cl_command_queue queue,
-                                         const cl_image_format *format,
-                                         image_sampler_data *imageSampler,
-                                         ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
+extern int test_read_image_set_1D_buffer(
+    cl_device_id device, cl_context context, cl_command_queue queue,
+    const cl_image_format *format, image_sampler_data *imageSampler,
+    ExplicitType outputType, const context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType);
+                                  ExplicitType outputType,
+                                  const context_t &ctx);
 extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         const cl_image_format *format,
                                         image_sampler_data *imageSampler,
-                                        ExplicitType outputType);
+                                        ExplicitType outputType,
+                                        const context_t &ctx);
 extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         const cl_image_format *format,
                                         image_sampler_data *imageSampler,
-                                        ExplicitType outputType);
+                                        ExplicitType outputType,
+                                        const context_t &ctx);
 
 int test_read_image_type(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
                          image_sampler_data *imageSampler,
-                         ExplicitType outputType, cl_mem_object_type imageType)
+                         ExplicitType outputType, cl_mem_object_type imageType,
+                         const context_t &ctx)
 {
     int ret = 0;
     imageSampler->addressing_mode = CL_ADDRESS_NONE;
@@ -66,22 +67,28 @@ int test_read_image_type(cl_device_id device, cl_context context,
     switch (imageType)
     {
         case CL_MEM_OBJECT_IMAGE1D:
-            ret = test_read_image_set_1D( device, context, queue, format, imageSampler, outputType );
+            ret = test_read_image_set_1D(device, context, queue, format,
+                                         imageSampler, outputType, ctx);
             break;
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-            ret += test_read_image_set_1D_buffer( device, context, queue, format, imageSampler, outputType );
+            ret += test_read_image_set_1D_buffer(device, context, queue, format,
+                                                 imageSampler, outputType, ctx);
             break;
         case CL_MEM_OBJECT_IMAGE2D:
-            ret = test_read_image_set_2D( device, context, queue, format, imageSampler, outputType );
+            ret = test_read_image_set_2D(device, context, queue, format,
+                                         imageSampler, outputType, ctx);
             break;
         case CL_MEM_OBJECT_IMAGE3D:
-            ret = test_read_image_set_3D( device, context, queue, format, imageSampler, outputType );
+            ret = test_read_image_set_3D(device, context, queue, format,
+                                         imageSampler, outputType, ctx);
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            ret = test_read_image_set_1D_array( device, context, queue, format, imageSampler, outputType );
+            ret = test_read_image_set_1D_array(device, context, queue, format,
+                                               imageSampler, outputType, ctx);
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            ret = test_read_image_set_2D_array( device, context, queue, format, imageSampler, outputType );
+            ret = test_read_image_set_2D_array(device, context, queue, format,
+                                               imageSampler, outputType, ctx);
             break;
     }
 
@@ -101,7 +108,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType)
+                            cl_mem_object_type imageType, const context_t &ctx)
 {
     int ret = 0;
     imageSampler->normalized_coords = false;
@@ -115,13 +122,16 @@ int test_read_image_formats(cl_device_id device, cl_context context,
 
         const cl_image_format &imageFormat = formatList[i];
 
-        ret |= test_read_image_type( device, context, queue, &imageFormat, imageSampler, outputType, imageType );
+        ret |= test_read_image_type(device, context, queue, &imageFormat,
+                                    imageSampler, outputType, imageType, ctx);
     }
     return ret;
 }
 
 
-int test_image_set( cl_device_id device, cl_context context, cl_command_queue queue, cl_mem_object_type imageType )
+int test_image_set(cl_device_id device, cl_context context,
+                   cl_command_queue queue, cl_mem_object_type imageType,
+                   const context_t &ctx)
 {
     int ret = 0;
     static int printedFormatList = -1;
@@ -129,7 +139,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     // Grab the list of supported image formats
     std::vector<cl_image_format> formatList;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -138,7 +148,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
     if (get_format_list(context, imageType, readOnlyFormats, CL_MEM_READ_ONLY))
         return -1;
 
-    if (gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         std::vector<cl_image_format> readWriteFormats;
         if (get_format_list(context, imageType, readWriteFormats,
@@ -182,10 +192,12 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
 
     for (auto test : imageTestTypes)
     {
-        if (gTypesToTest & test.type)
+        if (ctx.typesToTest & test.type)
         {
             std::vector<bool> filterFlags(formatList.size(), false);
-            if (filter_formats(formatList, filterFlags, test.channelTypes) == 0)
+            if (filter_formats(formatList, filterFlags, test.channelTypes,
+                               ctx.channelTypeToUse, ctx.channelOrderToUse)
+                == 0)
             {
                 log_info("No formats supported for %s type\n", test.name);
             }
@@ -194,7 +206,7 @@ int test_image_set( cl_device_id device, cl_context context, cl_command_queue qu
                 imageSampler.filter_mode = CL_FILTER_NEAREST;
                 ret += test_read_image_formats(
                     device, context, queue, formatList, filterFlags,
-                    &imageSampler, test.explicitType, imageType);
+                    &imageSampler, test.explicitType, imageType, ctx);
             }
         }
     }

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -108,7 +108,8 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType, const image_test_context_t &ctx)
+                            cl_mem_object_type imageType,
+                            const image_test_context_t &ctx)
 {
     int ret = 0;
     imageSampler->normalized_coords = false;

--- a/test_conformance/images/samplerlessReads/test_loops.cpp
+++ b/test_conformance/images/samplerlessReads/test_loops.cpp
@@ -21,41 +21,41 @@ extern int test_read_image_set_1D(cl_device_id device, cl_context context,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_1D_buffer(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const cl_image_format *format, image_sampler_data *imageSampler,
-    ExplicitType outputType, const context_t &ctx);
+    ExplicitType outputType, const image_test_context_t &ctx);
 extern int test_read_image_set_2D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_3D(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
                                   ExplicitType outputType,
-                                  const context_t &ctx);
+                                  const image_test_context_t &ctx);
 extern int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         const cl_image_format *format,
                                         image_sampler_data *imageSampler,
                                         ExplicitType outputType,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 extern int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                         cl_command_queue queue,
                                         const cl_image_format *format,
                                         image_sampler_data *imageSampler,
                                         ExplicitType outputType,
-                                        const context_t &ctx);
+                                        const image_test_context_t &ctx);
 
 int test_read_image_type(cl_device_id device, cl_context context,
                          cl_command_queue queue, const cl_image_format *format,
                          image_sampler_data *imageSampler,
                          ExplicitType outputType, cl_mem_object_type imageType,
-                         const context_t &ctx)
+                         const image_test_context_t &ctx)
 {
     int ret = 0;
     imageSampler->addressing_mode = CL_ADDRESS_NONE;
@@ -108,7 +108,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
                             const std::vector<bool> &filterFlags,
                             image_sampler_data *imageSampler,
                             ExplicitType outputType,
-                            cl_mem_object_type imageType, const context_t &ctx)
+                            cl_mem_object_type imageType, const image_test_context_t &ctx)
 {
     int ret = 0;
     imageSampler->normalized_coords = false;
@@ -131,7 +131,7 @@ int test_read_image_formats(cl_device_id device, cl_context context,
 
 int test_image_set(cl_device_id device, cl_context context,
                    cl_command_queue queue, cl_mem_object_type imageType,
-                   const context_t &ctx)
+                   const image_test_context_t &ctx)
 {
     int ret = 0;
     static int printedFormatList = -1;

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -22,8 +22,6 @@
     #include <setjmp.h>
 #endif
 
-extern bool gTestReadWrite;
-
 const char *read1DKernelSourcePattern =
 "__kernel void sample_kernel( read_only image1d_t input, sampler_t sampler, __global int *results )\n"
 "{\n"
@@ -52,9 +50,10 @@ const char *read_write1DKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_1D(cl_context context, cl_command_queue queue,
+                       cl_kernel kernel, image_descriptor *imageInfo,
+                       image_sampler_data *imageSampler,
+                       ExplicitType outputType, MTdata d, const context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -64,7 +63,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating image %d by %d...\n", (int)imageInfo->width, (int)imageInfo->height );
 
     // Construct testing sources
@@ -74,7 +73,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     memset(&image_desc, 0x0, sizeof(cl_image_desc));
     image_desc.image_type = CL_MEM_OBJECT_IMAGE1D;
     image_desc.image_width = imageInfo->width;
-    image_desc.image_row_pitch = ( gEnablePitch ? imageInfo->rowPitch : 0 );
+    image_desc.image_row_pitch = (ctx.enablePitch ? imageInfo->rowPitch : 0);
     image_desc.num_mip_levels = 0;
 
     read_only_image = clCreateImage(context,
@@ -89,7 +88,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
         return error;
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
@@ -108,8 +107,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     }
 
 
-    if ( gDebugTrace )
-        log_info( " - Creating kernel arguments...\n" );
+    if (ctx.debugTrace) log_info(" - Creating kernel arguments...\n");
 
     // Create sampler to use
     actualSampler = clCreateSampler( context, CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST, &error );
@@ -128,7 +126,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_only_image );
     test_error( error, "Unable to set kernel arguments" );
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_write_image );
         test_error( error, "Unable to set kernel arguments" );
@@ -143,13 +141,12 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     error = clEnqueueNDRangeKernel( queue, kernel, 1, NULL, threads, NULL, 0, NULL, NULL );
     test_error( error, "Unable to run kernel" );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( "    reading results, %ld kbytes\n", (unsigned long)( imageInfo->width * sizeof(cl_int) / 1024 ) );
 
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -169,7 +166,7 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
     clReleaseSampler(actualSampler);
     clReleaseMemObject(results);
     clReleaseMemObject(read_only_image);
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         clReleaseMemObject(read_write_image);
     }
@@ -181,7 +178,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -192,7 +189,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
     RandomSeed seed( gRandomSeed );
     int error;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -235,7 +232,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
         dataType = "float4";
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         sprintf( programSrc,
                  read_write1DKernelSourcePattern,
@@ -259,22 +256,24 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d\n", (int)imageInfo.width );
 
-                int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode =
+                    test_read_image_1D(context, queue, kernel, &imageInfo,
+                                       imageSampler, outputType, seed, ctx);
                 if ( retCode )
                     return retCode;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -287,9 +286,11 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             log_info("Testing %d\n", (int)sizes[ idx ][ 0 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -306,7 +307,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                 imageInfo.width = (size_t)random_log_in_range( 16, (int)maxWidth / 32, seed );
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if ( gEnablePitch )
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -315,9 +316,11 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode = test_read_image_1D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -53,7 +53,8 @@ const char *read_write1DKernelSourcePattern =
 int test_read_image_1D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
+                       ExplicitType outputType, MTdata d,
+                       const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -178,7 +179,8 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D.cpp
@@ -53,7 +53,7 @@ const char *read_write1DKernelSourcePattern =
 int test_read_image_1D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const context_t &ctx)
+                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -178,7 +178,7 @@ int test_read_image_set_1D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -22,8 +22,6 @@
     #include <setjmp.h>
 #endif
 
-extern bool gTestReadWrite;
-
 const char *read1DArrayKernelSourcePattern =
 "__kernel void sample_kernel( read_only image1d_array_t input, sampler_t sampler, __global int *results )\n"
 "{\n"
@@ -54,9 +52,11 @@ const char *read_write1DArrayKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_1D_array(cl_context context, cl_command_queue queue,
+                             cl_kernel kernel, image_descriptor *imageInfo,
+                             image_sampler_data *imageSampler,
+                             ExplicitType outputType, MTdata d,
+                             const context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -66,7 +66,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating image %d by %d...\n", (int)imageInfo->width, (int)imageInfo->arraySize );
 
     // Construct testing sources
@@ -78,7 +78,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     image_desc.image_width = imageInfo->width;
     image_desc.image_height = imageInfo->height;
     image_desc.image_array_size = imageInfo->arraySize;
-    image_desc.image_row_pitch = ( gEnablePitch ? imageInfo->rowPitch : 0 );
+    image_desc.image_row_pitch = (ctx.enablePitch ? imageInfo->rowPitch : 0);
     image_desc.image_slice_pitch = 0;
     image_desc.num_mip_levels = 0;
     read_only_image = clCreateImage( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, imageInfo->format,
@@ -89,7 +89,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
         return error;
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
@@ -103,8 +103,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
             return error;
         }
     }
-    if ( gDebugTrace )
-        log_info( " - Creating kernel arguments...\n" );
+    if (ctx.debugTrace) log_info(" - Creating kernel arguments...\n");
 
     // Create sampler to use
     actualSampler = clCreateSampler( context, CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST, &error );
@@ -123,7 +122,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_only_image );
     test_error( error, "Unable to set kernel arguments" );
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_write_image );
         test_error( error, "Unable to set kernel arguments" );
@@ -140,13 +139,12 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     error = clEnqueueNDRangeKernel( queue, kernel, 2, NULL, threads, NULL, 0, NULL, NULL );
     test_error( error, "Unable to run kernel" );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( "    reading results, %ld kbytes\n", (unsigned long)( imageInfo->width * imageInfo->arraySize * sizeof(cl_int) / 1024 ) );
 
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -170,7 +168,7 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
     clReleaseMemObject(results);
     clReleaseMemObject(read_only_image);
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         clReleaseMemObject(read_write_image);
     }
@@ -181,7 +179,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType)
+                                 ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -198,7 +196,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
     image_descriptor imageInfo = { 0 };
     size_t pixelSize;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -236,7 +234,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
         dataType = "float4";
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         sprintf( programSrc,
                  read_write1DArrayKernelSourcePattern,
@@ -260,7 +258,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -268,16 +266,18 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.slicePitch = imageInfo.rowPitch;
             for ( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize );
 
-                int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_1D_array(context, queue, kernel,
+                                                       &imageInfo, imageSampler,
+                                                       outputType, seed, ctx);
                 if ( retCode )
                     return retCode;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -292,9 +292,11 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.rowPitch;
             log_info("Testing %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D_array(context, queue, kernel, &imageInfo,
+                                         imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -312,7 +314,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 imageInfo.arraySize = (size_t)random_log_in_range( 16, (int)maxArraySize / 32, seed );
 
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
-                if ( gEnablePitch )
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -323,9 +325,11 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * (size_t)imageInfo.arraySize * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d (row pitch %d) out of %d,%d\n", (int)imageInfo.width, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)maxWidth, (int)maxArraySize );
-            int retCode = test_read_image_1D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D_array(context, queue, kernel, &imageInfo,
+                                         imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -56,7 +56,7 @@ int test_read_image_1D_array(cl_context context, cl_command_queue queue,
                              cl_kernel kernel, image_descriptor *imageInfo,
                              image_sampler_data *imageSampler,
                              ExplicitType outputType, MTdata d,
-                             const context_t &ctx)
+                             const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -179,7 +179,7 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType, const context_t &ctx)
+                                 ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_array.cpp
@@ -179,7 +179,8 @@ int test_read_image_set_1D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType, const image_test_context_t &ctx)
+                                 ExplicitType outputType,
+                                 const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -37,9 +37,11 @@ const char *read1DBufferKernelSourcePattern =
 "}";
 
 
-int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
+                              cl_kernel kernel, image_descriptor *imageInfo,
+                              image_sampler_data *imageSampler,
+                              ExplicitType outputType, MTdata d,
+                              const context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -48,7 +50,7 @@ int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_ke
     BufferOwningPtr<char> imageValues;
     generate_random_image_data( imageInfo, imageValues, d );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( " - Creating 1D image from buffer %d ...\n", (int)imageInfo->width );
 
     // Construct testing sources
@@ -98,8 +100,7 @@ int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_ke
         return error;
     }
 
-    if ( gDebugTrace )
-        log_info( " - Creating kernel arguments...\n" );
+    if (ctx.debugTrace) log_info(" - Creating kernel arguments...\n");
 
     // Create sampler to use
     actualSampler = clCreateSampler( context, CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST, &error );
@@ -130,13 +131,12 @@ int test_read_image_1D_buffer( cl_context context, cl_command_queue queue, cl_ke
     error = clEnqueueNDRangeKernel( queue, kernel, 1, NULL, threads, NULL, 0, NULL, NULL );
     test_error( error, "Unable to run kernel" );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( "    reading results, %ld kbytes\n", (unsigned long)( imageInfo->width * sizeof(cl_int) / 1024 ) );
 
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -165,7 +165,7 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType)
+                                  ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -252,22 +252,24 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                         "sample_kernel");
     test_error( error, "Unable to create testing kernel" );
 
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             {
-                if ( gDebugTrace )
+                if (ctx.debugTrace)
                     log_info( "   at size %d\n", (int)imageInfo.width );
 
-                int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                int retCode = test_read_image_1D_buffer(
+                    context, queue, kernel, &imageInfo, imageSampler,
+                    outputType, seed, ctx);
                 if ( retCode )
                     return retCode;
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -280,9 +282,11 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
             imageInfo.width = sizes[ idx ][ 0 ];
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             log_info("Testing %d\n", (int)sizes[ idx ][ 0 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d\n", (int)sizes[ idx ][ 0 ] );
-            int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D_buffer(context, queue, kernel, &imageInfo,
+                                          imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -301,9 +305,11 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                 size = (size_t)imageInfo.rowPitch * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d (row pitch %d) out of %d\n", (int)imageInfo.width, (int)imageInfo.rowPitch, (int)maxWidth );
-            int retCode = test_read_image_1D_buffer( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_1D_buffer(context, queue, kernel, &imageInfo,
+                                          imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -41,7 +41,7 @@ int test_read_image_1D_buffer(cl_context context, cl_command_queue queue,
                               cl_kernel kernel, image_descriptor *imageInfo,
                               image_sampler_data *imageSampler,
                               ExplicitType outputType, MTdata d,
-                              const context_t &ctx)
+                              const image_test_context_t &ctx)
 {
     int error;
     size_t threads[2];
@@ -165,7 +165,7 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType, const context_t &ctx)
+                                  ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp
@@ -165,7 +165,8 @@ int test_read_image_set_1D_buffer(cl_device_id device, cl_context context,
                                   cl_command_queue queue,
                                   const cl_image_format *format,
                                   image_sampler_data *imageSampler,
-                                  ExplicitType outputType, const image_test_context_t &ctx)
+                                  ExplicitType outputType,
+                                  const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -16,8 +16,6 @@
 #include "../testBase.h"
 #include <float.h>
 
-extern bool gTestReadWrite;
-
 const char *read2DArrayKernelSourcePattern =
 "__kernel void sample_kernel( read_only %s input, sampler_t sampler, __global int *results )\n"
 "{\n"
@@ -48,9 +46,11 @@ const char *read_write2DArrayKernelSourcePattern =
 "      results[offset] = 0;\n"
 "}";
 
-int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_2D_array(cl_context context, cl_command_queue queue,
+                             cl_kernel kernel, image_descriptor *imageInfo,
+                             image_sampler_data *imageSampler,
+                             ExplicitType outputType, MTdata d,
+                             const context_t &ctx)
 {
     int error;
     size_t threads[3];
@@ -67,8 +67,9 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     image_desc.image_width = imageInfo->width;
     image_desc.image_height = imageInfo->height;
     image_desc.image_array_size = imageInfo->arraySize;
-    image_desc.image_row_pitch = ( gEnablePitch ? imageInfo->rowPitch : 0 );
-    image_desc.image_slice_pitch = ( gEnablePitch ? imageInfo->slicePitch : 0 );
+    image_desc.image_row_pitch = (ctx.enablePitch ? imageInfo->rowPitch : 0);
+    image_desc.image_slice_pitch =
+        (ctx.enablePitch ? imageInfo->slicePitch : 0);
     image_desc.num_mip_levels = 0;
     read_only_image = clCreateImage( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, imageInfo->format,
                                        &image_desc, imageValues, &error );
@@ -78,7 +79,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
         return error;
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
@@ -110,7 +111,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_only_image );
     test_error( error, "Unable to set kernel arguments" );
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_write_image );
         test_error( error, "Unable to set kernel arguments" );
@@ -132,8 +133,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     // Get results
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -153,7 +153,7 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
     clReleaseSampler(actualSampler);
     clReleaseMemObject(results);
     clReleaseMemObject(read_only_image);
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         clReleaseMemObject(read_write_image);
     }
@@ -165,7 +165,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType)
+                                 ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -175,7 +175,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
 
     int error;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -223,7 +223,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
     }
 
     // Construct the source
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         sprintf( programSrc, read_write2DArrayKernelSourcePattern,
                  (format->image_channel_order == CL_DEPTH) ? "image2d_array_depth_t" : "image2d_array_t",
@@ -250,7 +250,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
 
 
     // Run tests
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -261,16 +261,18 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for ( imageInfo.arraySize = 2; imageInfo.arraySize < 9; imageInfo.arraySize++ )
                 {
-                    if ( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize );
-                    int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                    int retCode = test_read_image_2D_array(
+                        context, queue, kernel, &imageInfo, imageSampler,
+                        outputType, seed, ctx);
                     if ( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -286,9 +288,11 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_2D_array(context, queue, kernel, &imageInfo,
+                                         imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -309,7 +313,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                if ( gEnablePitch )
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -321,9 +325,11 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.arraySize * 4 * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.arraySize, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxArraySize );
-            int retCode = test_read_image_2D_array( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_2D_array(context, queue, kernel, &imageInfo,
+                                         imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -165,7 +165,8 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType, const image_test_context_t &ctx)
+                                 ExplicitType outputType,
+                                 const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_2D_array.cpp
@@ -50,7 +50,7 @@ int test_read_image_2D_array(cl_context context, cl_command_queue queue,
                              cl_kernel kernel, image_descriptor *imageInfo,
                              image_sampler_data *imageSampler,
                              ExplicitType outputType, MTdata d,
-                             const context_t &ctx)
+                             const image_test_context_t &ctx)
 {
     int error;
     size_t threads[3];
@@ -165,7 +165,7 @@ int test_read_image_set_2D_array(cl_device_id device, cl_context context,
                                  cl_command_queue queue,
                                  const cl_image_format *format,
                                  image_sampler_data *imageSampler,
-                                 ExplicitType outputType, const context_t &ctx)
+                                 ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -16,8 +16,6 @@
 #include "../testBase.h"
 #include <float.h>
 
-extern bool gTestReadWrite;
-
 const char *read3DKernelSourcePattern =
 "__kernel void sample_kernel( read_only image3d_t input, sampler_t sampler, __global int *results )\n"
 "{\n"
@@ -47,9 +45,10 @@ const char *read_write3DKernelSourcePattern =
 "   else\n"
 "      results[offset] = 0;\n"
 "}";
-int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel kernel,
-                        image_descriptor *imageInfo, image_sampler_data *imageSampler,
-                        ExplicitType outputType, MTdata d )
+int test_read_image_3D(cl_context context, cl_command_queue queue,
+                       cl_kernel kernel, image_descriptor *imageInfo,
+                       image_sampler_data *imageSampler,
+                       ExplicitType outputType, MTdata d, const context_t &ctx)
 {
     int error;
     size_t threads[3];
@@ -66,8 +65,9 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     image_desc.image_width = imageInfo->width;
     image_desc.image_height = imageInfo->height;
     image_desc.image_depth = imageInfo->depth;
-    image_desc.image_row_pitch = ( gEnablePitch ? imageInfo->rowPitch : 0 );
-    image_desc.image_slice_pitch = ( gEnablePitch ? imageInfo->slicePitch : 0 );
+    image_desc.image_row_pitch = (ctx.enablePitch ? imageInfo->rowPitch : 0);
+    image_desc.image_slice_pitch =
+        (ctx.enablePitch ? imageInfo->slicePitch : 0);
     image_desc.num_mip_levels = 0;
     read_only_image = clCreateImage( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, imageInfo->format,
                                        &image_desc, imageValues, &error );
@@ -77,7 +77,7 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
         return error;
     }
 
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         read_write_image = clCreateImage(context,
                                         CL_MEM_READ_WRITE,
@@ -109,7 +109,7 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     int idx = 0;
     error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_only_image );
     test_error( error, "Unable to set kernel arguments" );
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         error = clSetKernelArg( kernel, idx++, sizeof( cl_mem ), &read_write_image );
         test_error( error, "Unable to set kernel arguments" );
@@ -128,14 +128,13 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     error = clEnqueueNDRangeKernel( queue, kernel, 3, NULL, threads, NULL, 0, NULL, NULL );
     test_error( error, "Unable to run kernel" );
 
-    if ( gDebugTrace )
+    if (ctx.debugTrace)
         log_info( "    reading results, %ld kbytes\n", (unsigned long)( imageInfo->width * imageInfo->height * imageInfo->depth * sizeof(cl_int) / 1024 ) );
 
     // Get results
     error = clEnqueueReadBuffer( queue, results, CL_TRUE, 0, resultValuesSize, resultValues, 0, NULL, NULL );
     test_error( error, "Unable to read results from kernel" );
-    if ( gDebugTrace )
-        log_info( "    results read\n" );
+    if (ctx.debugTrace) log_info("    results read\n");
 
     // Check for non-zero comps
     bool allZeroes = true;
@@ -158,7 +157,7 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
     clReleaseSampler(actualSampler);
     clReleaseMemObject(results);
     clReleaseMemObject(read_only_image);
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         clReleaseMemObject(read_write_image);
     }
@@ -170,7 +169,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType)
+                           ExplicitType outputType, const context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;
@@ -180,7 +179,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
 
     int error;
 
-    if (gTestReadWrite && checkForReadWriteImageSupport(device))
+    if (ctx.testReadWrite && checkForReadWriteImageSupport(device))
     {
         return TEST_SKIPPED_ITSELF;
     }
@@ -229,7 +228,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
     }
 
     // Construct the source
-    if(gTestReadWrite)
+    if (ctx.testReadWrite)
     {
         sprintf( programSrc,
                  read_write3DKernelSourcePattern,
@@ -255,7 +254,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
 
 
     // Run tests
-    if ( gTestSmallImages )
+    if (ctx.testSmallImages)
     {
         for ( imageInfo.width = 1; imageInfo.width < 13; imageInfo.width++ )
         {
@@ -266,16 +265,18 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
                 for ( imageInfo.depth = 2; imageInfo.depth < 9; imageInfo.depth++ )
                 {
-                    if ( gDebugTrace )
+                    if (ctx.debugTrace)
                         log_info( "   at size %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth );
-                    int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+                    int retCode =
+                        test_read_image_3D(context, queue, kernel, &imageInfo,
+                                           imageSampler, outputType, seed, ctx);
                     if ( retCode )
                         return retCode;
                 }
             }
         }
     }
-    else if ( gTestMaxImages )
+    else if (ctx.testMaxImages)
     {
         // Try a specific set of maximum sizes
         size_t numbeOfSizes;
@@ -291,9 +292,11 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
             imageInfo.rowPitch = imageInfo.width * pixelSize;
             imageInfo.slicePitch = imageInfo.height * imageInfo.rowPitch;
             log_info("Testing %d x %d x %d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ]);
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at max size %d,%d,%d\n", (int)sizes[ idx ][ 0 ], (int)sizes[ idx ][ 1 ], (int)sizes[ idx ][ 2 ] );
-            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_3D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }
@@ -314,7 +317,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 imageInfo.rowPitch = imageInfo.width * pixelSize;
                 imageInfo.slicePitch = imageInfo.rowPitch * imageInfo.height;
 
-                if ( gEnablePitch )
+                if (ctx.enablePitch)
                 {
                     size_t extraWidth = (int)random_log_in_range( 0, 64, seed );
                     imageInfo.rowPitch += extraWidth * pixelSize;
@@ -326,9 +329,11 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                 size = (cl_ulong)imageInfo.slicePitch * (cl_ulong)imageInfo.depth * 4 * 4;
             } while (  size > maxAllocSize || ( size * 3 ) > memSize );
 
-            if ( gDebugTrace )
+            if (ctx.debugTrace)
                 log_info( "   at size %d,%d,%d (pitch %d,%d) out of %d,%d,%d\n", (int)imageInfo.width, (int)imageInfo.height, (int)imageInfo.depth, (int)imageInfo.rowPitch, (int)imageInfo.slicePitch, (int)maxWidth, (int)maxHeight, (int)maxDepth );
-            int retCode = test_read_image_3D( context, queue, kernel, &imageInfo, imageSampler, outputType, seed );
+            int retCode =
+                test_read_image_3D(context, queue, kernel, &imageInfo,
+                                   imageSampler, outputType, seed, ctx);
             if ( retCode )
                 return retCode;
         }

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -48,7 +48,8 @@ const char *read_write3DKernelSourcePattern =
 int test_read_image_3D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
+                       ExplicitType outputType, MTdata d,
+                       const image_test_context_t &ctx)
 {
     int error;
     size_t threads[3];
@@ -169,7 +170,8 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const image_test_context_t &ctx)
+                           ExplicitType outputType,
+                           const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/samplerlessReads/test_read_3D.cpp
+++ b/test_conformance/images/samplerlessReads/test_read_3D.cpp
@@ -48,7 +48,7 @@ const char *read_write3DKernelSourcePattern =
 int test_read_image_3D(cl_context context, cl_command_queue queue,
                        cl_kernel kernel, image_descriptor *imageInfo,
                        image_sampler_data *imageSampler,
-                       ExplicitType outputType, MTdata d, const context_t &ctx)
+                       ExplicitType outputType, MTdata d, const image_test_context_t &ctx)
 {
     int error;
     size_t threads[3];
@@ -169,7 +169,7 @@ int test_read_image_set_3D(cl_device_id device, cl_context context,
                            cl_command_queue queue,
                            const cl_image_format *format,
                            image_sampler_data *imageSampler,
-                           ExplicitType outputType, const context_t &ctx)
+                           ExplicitType outputType, const image_test_context_t &ctx)
 {
     char programSrc[10240];
     const char *ptr;

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -22,14 +22,52 @@
 #include "harness/clImageHelper.h"
 #include "harness/imageHelpers.h"
 
-extern bool gDebugTrace;
-extern bool gTestSmallImages;
-extern bool gEnablePitch;
-extern bool gTestMaxImages;
-extern bool gTestMipmaps;
-
 // Amount to offset pixels for checking normalized reads
 #define NORM_OFFSET 0.1f
+
+typedef struct
+{
+    bool debugTrace;
+    bool testSmallImages;
+    bool testMaxImages;
+    bool enablePitch;
+    bool testMipmaps;
+    bool extraValidateInfo;
+    bool disableOffsets;
+    bool testImage2DFromBuffer;
+    bool useKernelSamplers;
+    bool testReadWrite;
+    int typesToTest;
+    int testTypesToRun;
+    int normalizedModeToUse;
+    cl_addressing_mode addressModeToUse;
+    cl_mem_flags memFlagsToUse;
+    cl_filter_mode filterModeToUse;
+    cl_channel_type channelTypeToUse;
+    cl_channel_order channelOrderToUse;
+} context_t;
+
+static inline void init_context(context_t &ctx)
+{
+    ctx.debugTrace = false;
+    ctx.testSmallImages = false;
+    ctx.testMaxImages = false;
+    ctx.enablePitch = false;
+    ctx.testMipmaps = false;
+    ctx.extraValidateInfo = false;
+    ctx.disableOffsets = false;
+    ctx.testImage2DFromBuffer = false;
+    ctx.useKernelSamplers = false;
+    ctx.testReadWrite = false;
+    ctx.typesToTest = 0;
+    ctx.testTypesToRun = 0;
+    ctx.normalizedModeToUse = 7;
+    ctx.addressModeToUse = (cl_addressing_mode)-1;
+    ctx.memFlagsToUse = CL_MEM_USE_HOST_PTR;
+    ctx.filterModeToUse = (cl_filter_mode)-1;
+    ctx.channelTypeToUse = (cl_channel_type)-1;
+    ctx.channelOrderToUse = (cl_channel_order)-1;
+}
 
 enum TypesToTest
 {
@@ -71,18 +109,21 @@ typedef int (*test_format_set_fn)(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
-    ExplicitType outputType, cl_mem_object_type imageType);
+    ExplicitType outputType, cl_mem_object_type imageType,
+    const context_t &ctx);
 
 extern int test_read_image_formats(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
-    ExplicitType outputType, cl_mem_object_type imageType);
+    ExplicitType outputType, cl_mem_object_type imageType,
+    const context_t &ctx);
 extern int test_write_image_formats(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
-    ExplicitType outputType, cl_mem_object_type imageType);
+    ExplicitType outputType, cl_mem_object_type imageType,
+    const context_t &ctx);
 
 #endif // _testBase_h
 

--- a/test_conformance/images/testBase.h
+++ b/test_conformance/images/testBase.h
@@ -25,49 +25,27 @@
 // Amount to offset pixels for checking normalized reads
 #define NORM_OFFSET 0.1f
 
-typedef struct
+struct image_test_context_t
 {
-    bool debugTrace;
-    bool testSmallImages;
-    bool testMaxImages;
-    bool enablePitch;
-    bool testMipmaps;
-    bool extraValidateInfo;
-    bool disableOffsets;
-    bool testImage2DFromBuffer;
-    bool useKernelSamplers;
-    bool testReadWrite;
-    int typesToTest;
-    int testTypesToRun;
-    int normalizedModeToUse;
-    cl_addressing_mode addressModeToUse;
-    cl_mem_flags memFlagsToUse;
-    cl_filter_mode filterModeToUse;
-    cl_channel_type channelTypeToUse;
-    cl_channel_order channelOrderToUse;
-} context_t;
-
-static inline void init_context(context_t &ctx)
-{
-    ctx.debugTrace = false;
-    ctx.testSmallImages = false;
-    ctx.testMaxImages = false;
-    ctx.enablePitch = false;
-    ctx.testMipmaps = false;
-    ctx.extraValidateInfo = false;
-    ctx.disableOffsets = false;
-    ctx.testImage2DFromBuffer = false;
-    ctx.useKernelSamplers = false;
-    ctx.testReadWrite = false;
-    ctx.typesToTest = 0;
-    ctx.testTypesToRun = 0;
-    ctx.normalizedModeToUse = 7;
-    ctx.addressModeToUse = (cl_addressing_mode)-1;
-    ctx.memFlagsToUse = CL_MEM_USE_HOST_PTR;
-    ctx.filterModeToUse = (cl_filter_mode)-1;
-    ctx.channelTypeToUse = (cl_channel_type)-1;
-    ctx.channelOrderToUse = (cl_channel_order)-1;
-}
+    bool debugTrace = false;
+    bool testSmallImages = false;
+    bool testMaxImages = false;
+    bool enablePitch = false;
+    bool testMipmaps = false;
+    bool extraValidateInfo = false;
+    bool disableOffsets = false;
+    bool testImage2DFromBuffer = false;
+    bool useKernelSamplers = false;
+    bool testReadWrite = false;
+    int typesToTest = 0;
+    int testTypesToRun = 0;
+    int normalizedModeToUse = 7;
+    cl_addressing_mode addressModeToUse = (cl_addressing_mode)-1;
+    cl_mem_flags memFlagsToUse = CL_MEM_USE_HOST_PTR;
+    cl_filter_mode filterModeToUse = (cl_filter_mode)-1;
+    cl_channel_type channelTypeToUse = (cl_channel_type)-1;
+    cl_channel_order channelOrderToUse = (cl_channel_order)-1;
+};
 
 enum TypesToTest
 {
@@ -110,20 +88,20 @@ typedef int (*test_format_set_fn)(
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
     ExplicitType outputType, cl_mem_object_type imageType,
-    const context_t &ctx);
+    const image_test_context_t &ctx);
 
 extern int test_read_image_formats(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
     ExplicitType outputType, cl_mem_object_type imageType,
-    const context_t &ctx);
+    const image_test_context_t &ctx);
 extern int test_write_image_formats(
     cl_device_id device, cl_context context, cl_command_queue queue,
     const std::vector<cl_image_format> &formatList,
     const std::vector<bool> &filterFlags, image_sampler_data *imageSampler,
     ExplicitType outputType, cl_mem_object_type imageType,
-    const context_t &ctx);
+    const image_test_context_t &ctx);
 
 #endif // _testBase_h
 


### PR DESCRIPTION
This patch removes the use of global state across the image conformance tests and replaces it with a passed `context_t` structure.

The goal of this change is to be able to run `image_streams` in parallel by removing global variables as they were not thread-safe. This refactoring had to be applied everywhere because `image_streams` needs to update `test_format_set_fn`, which is used by all the image tests.

Key changes:
* Removed global flags such as `gTestSmallImages`, `gTestMipmaps`, `gDebugTrace`, `gEnablePitch`, etc.
* Initialized a `context_t` struct in the `main.cpp` files to store test configuration.
* Updated test function signatures across `clCopyImage`, `clFillImage`, `clGetInfo`, and `kernel_read_write` to accept `const context_t &ctx`.

[run-test: test_image_streams --num-worker-threads 2 CL_A CL_FILTER_NEAREST 1D]