### PR TITLE
math_brute_force: fix loop range in unary_u_half.cpp.

### DIFF
--- a/test_conformance/math_brute_force/unary_u_half.cpp
+++ b/test_conformance/math_brute_force/unary_u_half.cpp
@@ -65,7 +65,7 @@ int TestFunc_Half_UShort(const Func *f, MTdata d, bool relaxedMode)
         return error;
     }
 
-    for (uint64_t i = 0; i < (1ULL << 32); i += step)
+    for (uint64_t i = 0; i < (1ULL << 16); i += step)
     {
         if (gSkipCorrectnessTesting) break;
 


### PR DESCRIPTION
The test loop for half precision values should iterate through all possible 16-bit patterns. This change corrects the loop upper bound from 1ULL << 32 to 1ULL << 16.

Ref #2669