### PR TITLE
Fix non-uniform workgroups atomics tests

### DIFF
--- a/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
+++ b/test_conformance/non_uniform_work_group/TestNonUniformWorkGroup.cpp
@@ -536,6 +536,8 @@ int TestNonUniformWorkGroup::prepareDevice () {
       }
   }
 
+  _numOfGlobalWorkItems = _globalSize[0] * _globalSize[1] * _globalSize[2];
+
   if(_localSize_IsNull == false)
     calculateExpectedValues();
 


### PR DESCRIPTION
On devices that don't support non-uniform workgroups, recompute `_numOfGlobalWorkItems` after any global-size adjustments.

This fixes the issue introduced by #2598.