### PR TITLE
ci: restrict tests job to run only on pull requests

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -182,6 +182,7 @@ jobs:
   tests:
     name: Run Tests (pocl)
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - name: Parse triggers
@@ -214,8 +215,10 @@ jobs:
           git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git ${{ env.cl-headers }}
           git clone --depth 1 https://github.com/KhronosGroup/SPIRV-Headers.git ${{ env.spv-headers }}
       - name: Setup Ninja
+        if: steps.check_triggers.outputs.run_tests == 'true'
         uses: seanmiddleditch/gha-setup-ninja@master
       - name: Install Vulkan SDK
+        if: steps.check_triggers.outputs.run_tests == 'true'
         uses: humbletim/install-vulkan-sdk@main
         with:
           version: 1.4.309.0


### PR DESCRIPTION
The 'tests' job relies on the GitHub CLI (`gh`) to parse the commits and description of an associated pull request to find triggers. When running on a standard branch push (such as to 'main'), there is no pull request context, making it impossible to determine which commits to parse.

Also add missing if on steps to make sure nothing runs when
appropriate.