### PR TITLE
Skip CL_FP_DENORM checks when device lacks denorm support in mathbruteforce edge cases

### DIFF
--- a/test_conformance/math_brute_force/edge_cases.cpp
+++ b/test_conformance/math_brute_force/edge_cases.cpp
@@ -686,15 +686,15 @@ struct EdgeCasesTest
             {
                 const auto &aec = cases[i];
                 bool skip = false;
+
+                if (aec.requires_denorm && !(gFloatCapabilities & CL_FP_DENORM))
+                {
+                    log_info("SKIP (no CL_FP_DENORM): %s\n", aec.func_name);
+                    skip = true;
+                }
+
                 if (gIsEmbedded)
                 {
-                    if (aec.requires_denorm
-                        && !(gFloatCapabilities & CL_FP_DENORM))
-                    {
-                        log_info("SKIP (no CL_FP_DENORM): %s\n", aec.func_name);
-                        skip = true;
-                    }
-
                     if (aec.requires_inf_nan
                         && !(gFloatCapabilities & CL_FP_INF_NAN))
                     {


### PR DESCRIPTION
Fixes #2703

@karolherbst I will appreciate your review, thanks