### PR TITLE
conversions: Refactor tests to reduce dataset size

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -155,6 +155,11 @@
             "pci_bus_info": "skip"
         }
     },
+    "test_conversions": {
+        "--wimpy": {
+            "conversions": "fail"
+        }
+    },
     "test_geometrics": {
         "": {
             "geom_cross": "pass"

--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -51,6 +51,7 @@
 #include <vector>
 #include <type_traits>
 #include <cmath>
+#include <mutex>
 
 #include "basic_test_conversions.h"
 
@@ -95,48 +96,14 @@ int gMinVectorSize = 0;
 int gMaxVectorSize = sizeof(vectorSizes) / sizeof(vectorSizes[0]);
 MTdata gMTdata;
 std::vector<const char *> argList;
-
+bool gTestAll = false;
+std::recursive_mutex gLock;
 
 cl_half_rounding_mode DataInitInfo::halfRoundingMode = CL_HALF_RTE;
 cl_half_rounding_mode ConversionsTest::defaultHalfRoundingMode = CL_HALF_RTE;
 
 // clang-format off
 // for readability sake keep this section unformatted
-
-std::vector<unsigned int> DataInitInfo::specialValuesUInt = {
-      uint32_t(INT_MIN), uint32_t(INT_MIN + 1), uint32_t(INT_MIN + 2),
-      uint32_t(-(1 << 30) - 3), uint32_t(-(1 << 30) - 2), uint32_t(-(1 << 30) - 1), uint32_t(-(1 << 30)),
-      uint32_t(-(1 << 30) + 1), uint32_t(-(1 << 30) + 2), uint32_t(-(1 << 30) + 3),
-      uint32_t(-(1 << 24) - 3), uint32_t(-(1 << 24) - 2),uint32_t(-(1 << 24) - 1),
-      uint32_t(-(1 << 24)), uint32_t(-(1 << 24) + 1), uint32_t(-(1 << 24) + 2), uint32_t(-(1 << 24) + 3),
-      uint32_t(-(1 << 23) - 3), uint32_t(-(1 << 23) - 2),uint32_t(-(1 << 23) - 1),
-      uint32_t(-(1 << 23)), uint32_t(-(1 << 23) + 1), uint32_t(-(1 << 23) + 2), uint32_t(-(1 << 23) + 3),
-      uint32_t(-(1 << 22) - 3), uint32_t(-(1 << 22) - 2),uint32_t(-(1 << 22) - 1),
-      uint32_t(-(1 << 22)), uint32_t(-(1 << 22) + 1), uint32_t(-(1 << 22) + 2), uint32_t(-(1 << 22) + 3),
-      uint32_t(-(1 << 21) - 3), uint32_t(-(1 << 21) - 2),uint32_t(-(1 << 21) - 1),
-      uint32_t(-(1 << 21)), uint32_t(-(1 << 21) + 1), uint32_t(-(1 << 21) + 2), uint32_t(-(1 << 21) + 3),
-      uint32_t(-(1 << 16) - 3), uint32_t(-(1 << 16) - 2),uint32_t(-(1 << 16) - 1),
-      uint32_t(-(1 << 16)), uint32_t(-(1 << 16) + 1), uint32_t(-(1 << 16) + 2), uint32_t(-(1 << 16) + 3),
-      uint32_t(-(1 << 15) - 3), uint32_t(-(1 << 15) - 2),uint32_t(-(1 << 15) - 1),
-      uint32_t(-(1 << 15)), uint32_t(-(1 << 15) + 1), uint32_t(-(1 << 15) + 2), uint32_t(-(1 << 15) + 3),
-      uint32_t(-(1 << 8) - 3), uint32_t(-(1 << 8) - 2),uint32_t(-(1 << 8) - 1),
-      uint32_t(-(1 << 8)), uint32_t(-(1 << 8) + 1), uint32_t(-(1 << 8) + 2), uint32_t(-(1 << 8) + 3),
-      uint32_t(-(1 << 7) - 3), uint32_t(-(1 << 7) - 2),uint32_t(-(1 << 7) - 1),
-      uint32_t(-(1 << 7)), uint32_t(-(1 << 7) + 1), uint32_t(-(1 << 7) + 2), uint32_t(-(1 << 7) + 3),
-      uint32_t(-4), uint32_t(-3), uint32_t(-2), uint32_t(-1), 0, 1, 2, 3, 4,
-      (1 << 7) - 3,(1 << 7) - 2,(1 << 7) - 1, (1 << 7), (1 << 7) + 1, (1 << 7) + 2, (1 << 7) + 3,
-      (1 << 8) - 3,(1 << 8) - 2,(1 << 8) - 1, (1 << 8), (1 << 8) + 1, (1 << 8) + 2, (1 << 8) + 3,
-      (1 << 15) - 3,(1 << 15) - 2,(1 << 15) - 1, (1 << 15), (1 << 15) + 1, (1 << 15) + 2, (1 << 15) + 3,
-      (1 << 16) - 3,(1 << 16) - 2,(1 << 16) - 1, (1 << 16), (1 << 16) + 1, (1 << 16) + 2, (1 << 16) + 3,
-      (1 << 21) - 3,(1 << 21) - 2,(1 << 21) - 1, (1 << 21), (1 << 21) + 1, (1 << 21) + 2, (1 << 21) + 3,
-      (1 << 22) - 3,(1 << 22) - 2,(1 << 22) - 1, (1 << 22), (1 << 22) + 1, (1 << 22) + 2, (1 << 22) + 3,
-      (1 << 23) - 3,(1 << 23) - 2,(1 << 23) - 1, (1 << 23), (1 << 23) + 1, (1 << 23) + 2, (1 << 23) + 3,
-      (1 << 24) - 3,(1 << 24) - 2,(1 << 24) - 1, (1 << 24), (1 << 24) + 1, (1 << 24) + 2, (1 << 24) + 3,
-      (1 << 30) - 3,(1 << 30) - 2,(1 << 30) - 1, (1 << 30), (1 << 30) + 1, (1 << 30) + 2, (1 << 30) + 3,
-      INT_MAX - 3, INT_MAX - 2, INT_MAX - 1, INT_MAX, // 0x80000000, 0x80000001 0x80000002 already covered above
-      UINT_MAX - 3, UINT_MAX - 2, UINT_MAX - 1, UINT_MAX
-};
-
 std::vector<float> DataInitInfo::specialValuesFloat = {
     -NAN, -INFINITY, -FLT_MAX,
     MAKE_HEX_FLOAT(-0x1.000002p64f, -0x1000002L, 40), MAKE_HEX_FLOAT(-0x1.0p64f, -0x1L, 64), MAKE_HEX_FLOAT(-0x1.fffffep63f, -0x1fffffeL, 39),
@@ -254,29 +221,6 @@ std::vector<double> DataInitInfo::specialValuesDouble = {
     MAKE_HEX_DOUBLE(-0x1.ffffffffp62, -0x1ffffffffLL, 30), MAKE_HEX_DOUBLE(-0x1.ffffffff00001p62, -0x1ffffffff00001LL, 10),
     MAKE_HEX_DOUBLE(0x1.fffffffefffffp62, 0x1fffffffefffffLL, 10), MAKE_HEX_DOUBLE(0x1.ffffffffp62, 0x1ffffffffLL, 30),
     MAKE_HEX_DOUBLE(0x1.ffffffff00001p62, 0x1ffffffff00001LL, 10),
-};
-
-// A table of more difficult cases to get right
-std::vector<cl_half> DataInitInfo::specialValuesHalf = {
-    0xffff,
-    0x0000,
-    0x0001,
-    0x7c00, /*INFINITY*/
-    0xfc00, /*-INFINITY*/
-    0x8000, /*-0*/
-    0x7bff, /*HALF_MAX*/
-    0x0400, /*HALF_MIN*/
-    0x03ff, /* Largest denormal */
-    0x3c00, /* 1 */
-    0xbc00, /* -1 */
-    0x3555, /*nearest value to 1/3*/
-    0x3bff, /*largest number less than one*/
-    0xc000, /* -2 */
-    0xfbff, /* -HALF_MAX */
-    0x8400, /* -HALF_MIN */
-    0x4248, /* M_PI_H */
-    0xc248, /* -M_PI_H */
-    0xbbff, /* Largest negative fraction */
 };
 // clang-format on
 
@@ -690,29 +634,42 @@ int ConversionsTest::DoTest(Type outType, Type inType, SaturationMode sat,
             init_info.round = round = kRoundTowardZero;
     }
 
-    // Figure out how many elements are in a work block
-    // we handle 64-bit types a bit differently.
-    uint64_t lastCase = (8 * gTypeSizes[inType] > 32)
-        ? 0x100000000ULL
-        : 1ULL << (8 * gTypeSizes[inType]);
+    uint64_t nbInputs = (1ULL << 25);
+    if constexpr (sizeof(InType) <= 2)
+    {
+        nbInputs = (1ULL << (sizeof(InType) * 8));
+    }
+    else
+    {
+        if (gTestAll)
+        {
+            nbInputs = (1ULL << 32);
+        }
+        else
+        {
+            if (gWimpyMode)
+            {
+                nbInputs /= gWimpyReductionFactor;
+            }
+            if (gIsEmbedded)
+            {
+                nbInputs /= EMBEDDED_REDUCTION_FACTOR;
+            }
+        }
+    }
 
-    if (!gWimpyMode && gIsEmbedded)
-        step = blockCount * EMBEDDED_REDUCTION_FACTOR;
-
-    if (gWimpyMode) step = (size_t)blockCount * (size_t)gWimpyReductionFactor;
     vlog("Testing... ");
     fflush(stdout);
-    for (i = 0; i < (uint64_t)lastCase; i += step)
+    for (i = 0; i < (uint64_t)nbInputs; i += step)
     {
 
-        if (0 == (i & ((lastCase >> 3) - 1)))
+        if (0 == (i & ((nbInputs >> 3) - 1)))
         {
             vlog(".");
             fflush(stdout);
         }
 
-        cl_uint count = (uint32_t)std::min((uint64_t)blockCount, lastCase - i);
-        writeInputBufferInfo.count = count;
+        writeInputBufferInfo.count = blockCount;
 
         // Crate a user event to represent the status of the reference value
         // computation completion
@@ -761,14 +718,14 @@ int ConversionsTest::DoTest(Type outType, Type inType, SaturationMode sat,
         //      Call this in a multithreaded manner
         cl_uint chunks = RoundUpToNextPowerOfTwo(threads) * 2;
         init_info.start = i;
-        init_info.size = count / chunks;
+        init_info.size = blockCount / chunks;
         if (init_info.size < 16384)
         {
             chunks = RoundUpToNextPowerOfTwo(threads);
-            init_info.size = count / chunks;
+            init_info.size = blockCount / chunks;
             if (init_info.size < 16384)
             {
-                init_info.size = count;
+                init_info.size = blockCount;
                 chunks = 1;
             }
         }
@@ -777,8 +734,8 @@ int ConversionsTest::DoTest(Type outType, Type inType, SaturationMode sat,
 
         // Copy the results to the device
         if ((error = clEnqueueWriteBuffer(gQueue, gInBuffer, CL_TRUE, 0,
-                                          count * gTypeSizes[inType], gIn, 0,
-                                          NULL, NULL)))
+                                          blockCount * gTypeSizes[inType], gIn,
+                                          0, NULL, NULL)))
         {
             vlog_error("ERROR: clEnqueueWriteBuffer failed. (%d)\n", error);
             gFailCount++;

--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -657,6 +657,9 @@ int ConversionsTest::DoTest(Type outType, Type inType, SaturationMode sat,
             }
         }
     }
+    // Make sure we can do at least one step even if the user reduced it with
+    // the wimpy or embedded reduction factor.
+    nbInputs = std::max(nbInputs, (uint64_t)step);
 
     vlog("Testing... ");
     fflush(stdout);

--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -669,7 +669,8 @@ int ConversionsTest::DoTest(Type outType, Type inType, SaturationMode sat,
             fflush(stdout);
         }
 
-        writeInputBufferInfo.count = blockCount;
+        writeInputBufferInfo.count =
+            std::min((uint64_t)blockCount, nbInputs - i);
 
         // Crate a user event to represent the status of the reference value
         // computation completion

--- a/test_conformance/conversions/basic_test_conversions.h
+++ b/test_conformance/conversions/basic_test_conversions.h
@@ -97,6 +97,8 @@ extern void *gOut[];
 
 extern std::vector<const char *> argList;
 
+extern bool gTestAll;
+
 extern const char *sizeNames[];
 extern int vectorSizes[];
 

--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -37,6 +37,9 @@ extern roundingMode qcom_rm;
 
 #include <cmath>
 #include <vector>
+#include <unordered_set>
+#include <cstring>
+#include <mutex>
 
 #if defined(__linux__)
 #include <sys/param.h>
@@ -45,7 +48,8 @@ extern roundingMode qcom_rm;
 
 extern size_t gTypeSizes[kTypeCount];
 extern void *gIn;
-
+extern bool gTestAll;
+extern std::recursive_mutex gLock;
 
 typedef enum
 {
@@ -66,10 +70,8 @@ struct DataInitInfo
     cl_uint threads;
 
     static cl_half_rounding_mode halfRoundingMode;
-    static std::vector<uint32_t> specialValuesUInt;
     static std::vector<float> specialValuesFloat;
     static std::vector<double> specialValuesDouble;
-    static std::vector<cl_half> specialValuesHalf;
 };
 
 #define HFF(num) cl_half_from_float(num, DataInitInfo::halfRoundingMode)
@@ -87,6 +89,249 @@ struct DataInitBase : public DataInitInfo
     virtual void set_allow_zero_array(uint8_t *allow, void *out, void *in,
                                       size_t n)
     {}
+
+private:
+    template <typename InType, typename OutType> OutType bitcast(InType in)
+    {
+        OutType out;
+        assert(sizeof(InType) == sizeof(OutType));
+        std::memcpy(&out, &in, sizeof(InType));
+        return out;
+    }
+
+    // Adds a value to a vector if it is not already present in the set.
+    // The set is used to check for duplicates, and the vector is used to
+    // store the unique values in the order they were added.
+    template <typename Type, typename IntegerType>
+    void push_unique(std::vector<Type> &vec,
+                     std::unordered_set<IntegerType> &set, Type val)
+    {
+        IntegerType set_val;
+        if constexpr (std::is_same<Type, IntegerType>::value)
+        {
+            set_val = val;
+        }
+        else
+        {
+            set_val = bitcast<Type, IntegerType>(val);
+        }
+        if (set.count(set_val) == 0)
+        {
+            set.insert(set_val);
+            vec.push_back(val);
+        }
+    };
+
+public:
+    template <typename T> std::vector<T> GetIntSpecialValues()
+    {
+        std::lock_guard<std::recursive_mutex> lock(gLock);
+        static std::vector<T> vec;
+        if (!vec.empty())
+        {
+            return vec;
+        }
+        std::unordered_set<T> set;
+        const T sign = static_cast<T>(1) << (sizeof(T) * 8 - 1);
+
+        // For each value, add it and its neighbors to the vector. And for each
+        // of those values, add the bitwise not and the XOR with the sign to the
+        // vector.
+        auto push = [&set, &sign, this](T val) {
+            for (const int offset : { -3, -2, -1, 0, 1, 2, 3 })
+            {
+                T v = val + offset;
+                push_unique<T, T>(vec, set, v);
+                push_unique<T, T>(vec, set, ~v);
+                v = v ^ sign;
+                push_unique<T, T>(vec, set, v);
+                push_unique<T, T>(vec, set, ~v);
+            }
+        };
+
+        // Add all the values close to 0, MIN, and MAX.
+        for (unsigned i = 0; i < 256; i++)
+        {
+            push(i);
+        }
+
+        // Add powers of 2, 3, 5, 7, 10.
+        for (const T base : { 2, 3, 5, 7, 10 })
+        {
+            T val = base;
+            T next = val * base;
+            do
+            {
+                push(val);
+                val = next;
+                next *= base;
+            } while (next > val && next < sign);
+        }
+
+        // Generate patterns and masks.
+        // For uint16_t:
+        // patterns: 0x1111, 0x2222, ..., 0xEEEE
+        // masks: 0x0F0F, 0xF0F0, 0x00FF, 0xFF00, 0xFFFF
+        std::vector<T> patterns;
+        std::vector<T> masks;
+        for (T i = 1; i < 15; i++)
+        {
+            T pattern = i;
+            for (unsigned j = 0; j < sizeof(T) * 2; j++)
+            {
+                pattern = pattern << 4 | i;
+            }
+            patterns.push_back(pattern);
+        }
+        for (unsigned chunk_size = 4; chunk_size < (sizeof(T) * 8);
+             chunk_size *= 2)
+        {
+            T mask = (static_cast<T>(1) << chunk_size) - 1;
+            for (unsigned shift = chunk_size * 2;
+                 shift <= ((sizeof(T) * 8) / 2); shift *= 2)
+            {
+                mask |= (mask << shift);
+            }
+            masks.push_back(mask);
+            masks.push_back(~mask);
+        }
+        masks.push_back(~static_cast<T>(0));
+
+        // Add all the combinations of patterns and masks.
+        for (const auto &pattern : patterns)
+        {
+            for (const auto &mask : masks)
+            {
+                push(pattern & mask);
+            }
+        }
+        return vec;
+    }
+
+    template <typename InType, typename InIntegerType, typename OutType>
+    std::vector<InType> GetFpSpecialValues()
+    {
+        std::lock_guard<std::recursive_mutex> lock(gLock);
+        static std::vector<InType> vec;
+        if (!vec.empty())
+        {
+            return vec;
+        }
+        std::unordered_set<InIntegerType> set;
+
+        // Adds a value and its neighbors (values +/- 1 ULP away) to the vector.
+        auto push = [&set, this](InType val) {
+            push_unique<InType, InIntegerType>(vec, set, val);
+            push_unique<InType, InIntegerType>(
+                vec, set,
+                bitcast<InIntegerType, InType>(
+                    bitcast<InType, InIntegerType>(val) + 1));
+            push_unique<InType, InIntegerType>(
+                vec, set,
+                bitcast<InIntegerType, InType>(
+                    bitcast<InType, InIntegerType>(val) - 1));
+        };
+
+        // Add all the values from the special values list.
+        if constexpr (std::is_same<InType, cl_float>::value)
+        {
+            for (const auto &val : specialValuesFloat)
+            {
+                push(val);
+            }
+        }
+        else if constexpr (std::is_same<InType, cl_double>::value)
+        {
+            for (const auto &val : specialValuesDouble)
+            {
+                push(val);
+            }
+        }
+
+        // Add values to the input test set that correspond to values used as
+        // input for the output type.
+        if constexpr (std::is_same<OutType, cl_uchar>::value)
+        {
+            for (uint32_t i = 0; i < 256; i++)
+            {
+                push(static_cast<InType>(i));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_char>::value)
+        {
+            for (int32_t i = -128; i < 128; i++)
+            {
+                push(static_cast<InType>(i));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_ushort>::value)
+        {
+            for (uint32_t i = 0; i < (64 * 1024); i++)
+            {
+                push(static_cast<InType>(i));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_short>::value)
+        {
+            for (int32_t i = -(64 * 1024 / 2 - 1); i <= (64 * 1024 / 2); i++)
+            {
+                push(static_cast<InType>(i));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_uint>::value)
+        {
+            for (const auto val : GetIntSpecialValues<uint32_t>())
+            {
+                push(static_cast<InType>(val));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_int>::value)
+        {
+            for (const auto val : GetIntSpecialValues<uint32_t>())
+            {
+                push(static_cast<InType>(bitcast<uint32_t, OutType>(val)));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_ulong>::value)
+        {
+            for (const auto val : GetIntSpecialValues<uint64_t>())
+            {
+                push(static_cast<InType>(val));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_long>::value)
+        {
+            for (const auto val : GetIntSpecialValues<uint64_t>())
+            {
+                push(static_cast<InType>(bitcast<uint64_t, OutType>(val)));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_half>::value)
+        {
+            for (uint32_t i = 0; i < (64 * 1024); i++)
+            {
+                push(static_cast<InType>(
+                    cl_half_to_float(bitcast<uint16_t, OutType>(i))));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_float>::value
+                           && !std::is_same<InType, cl_float>::value)
+        {
+            for (const auto &val : specialValuesFloat)
+            {
+                push(static_cast<InType>(val));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_double>::value
+                           && !std::is_same<InType, cl_double>::value)
+        {
+            for (const auto &val : specialValuesDouble)
+            {
+                push(static_cast<InType>(val));
+            }
+        }
+        return vec;
+    }
 };
 
 template <typename InType, typename OutType, bool InFP, bool OutFP>
@@ -762,187 +1007,123 @@ template <typename InType, typename OutType, bool InFP, bool OutFP>
 void DataInfoSpec<InType, OutType, InFP, OutFP>::init(const cl_uint &job_id,
                                                       const cl_uint &thread_id)
 {
-    uint64_t ulStart = start;
+    const uint64_t ulStart = start;
     void *pIn = (char *)gIn + job_id * size * gTypeSizes[inType];
 
-    if (is_in_half())
+    if constexpr (sizeof(InType) <= sizeof(uint8_t))
     {
-        cl_half *o = (cl_half *)pIn;
-        int i;
-
-        if (gIsEmbedded)
-            for (i = 0; i < size; i++)
-                o[i] = (cl_half)genrand_int32(mdv[thread_id]);
-        else
-            for (i = 0; i < size; i++) o[i] = (cl_half)((i + ulStart) % 0xffff);
-
-        if (0 == ulStart)
+        uint8_t *o = (uint8_t *)pIn;
+        for (uint32_t i = 0; i < size; i++)
         {
-            size_t tableSize = specialValuesHalf.size()
-                * sizeof(decltype(specialValuesHalf)::value_type);
-            if (sizeof(InType) * size < tableSize)
-                tableSize = sizeof(InType) * size;
-            memcpy((char *)(o + i) - tableSize, &specialValuesHalf.front(),
-                   tableSize);
-        }
-
-        if (kUnsaturated == sat)
-        {
-            for (i = 0; i < size; i++) o[i] = clamp(o[i]);
+            o[i] = (uint8_t)(i + ulStart);
         }
     }
-    else if (std::is_integral<InType>::value)
+    else if constexpr (sizeof(InType) <= sizeof(uint16_t))
     {
-        InType *o = (InType *)pIn;
-        if (sizeof(InType) <= sizeof(cl_short))
-        { // char/uchar/ushort/short
-            for (int i = 0; i < size; i++) o[i] = ulStart++;
+        uint16_t *o = (uint16_t *)pIn;
+        for (uint32_t i = 0; i < size; i++)
+        {
+            o[i] = (uint16_t)(i + ulStart);
         }
-        else if (sizeof(InType) <= sizeof(cl_int))
-        { // int/uint
-            int i = 0;
-            if (gIsEmbedded)
-                for (i = 0; i < size; i++)
-                    o[i] = (InType)genrand_int32(mdv[thread_id]);
-            else
-                for (i = 0; i < size; i++) o[i] = (InType)i + ulStart;
-
-            if (0 == ulStart)
+        if (is_in_half() && kUnsaturated == sat)
+        {
+            for (uint32_t i = 0; i < size; i++)
             {
-                size_t tableSize = specialValuesUInt.size()
-                    * sizeof(decltype(specialValuesUInt)::value_type);
-                if (sizeof(InType) * size < tableSize)
-                    tableSize = sizeof(InType) * size;
-                memcpy((char *)(o + i) - tableSize, &specialValuesUInt.front(),
-                       tableSize);
+                o[i] = clamp(o[i]);
+            }
+        }
+    }
+    else if constexpr (std::is_integral<InType>::value)
+    {
+        if constexpr (sizeof(InType) <= sizeof(cl_int))
+        { // int/uint
+            uint32_t *o = (uint32_t *)pIn;
+            if (gTestAll)
+            {
+                for (uint32_t i = 0; i < size; i++)
+                {
+                    o[i] = (uint32_t)(i + ulStart);
+                }
+                return;
+            }
+            const auto &specialValues = GetIntSpecialValues<uint32_t>();
+            uint32_t i;
+            for (i = 0; i < size && (i + ulStart) < specialValues.size(); i++)
+            {
+                o[i] = specialValues[i + ulStart];
+            }
+            for (; i < size; i++)
+            {
+                o[i] = genrand_int32(mdv[thread_id]);
             }
         }
         else
         { // long/ulong
-            cl_ulong *o = (cl_ulong *)pIn;
-            cl_ulong i, j, k;
-
-            i = 0;
-            if (ulStart == 0)
+            uint64_t *o = (uint64_t *)pIn;
+            const auto &specialValues = GetIntSpecialValues<uint64_t>();
+            uint32_t i;
+            for (i = 0; i < size && (i + ulStart) < specialValues.size(); i++)
             {
-                // Try various powers of two
-                for (j = 0; j < (cl_ulong)size && j < 8 * sizeof(cl_ulong); j++)
-                    o[j] = (cl_ulong)1 << j;
-                i = j;
-
-                // try the complement of those
-                for (j = 0; i < (cl_ulong)size && j < 8 * sizeof(cl_ulong); j++)
-                    o[i++] = ~((cl_ulong)1 << j);
-
-                // Try various negative powers of two
-                for (j = 0; i < (cl_ulong)size && j < 8 * sizeof(cl_ulong); j++)
-                    o[i++] = (cl_ulong)0xFFFFFFFFFFFFFFFEULL << j;
-
-                // try various powers of two plus 1, shifted by various amounts
-                for (j = 0; i < (cl_ulong)size && j < 8 * sizeof(cl_ulong); j++)
-                    for (k = 0;
-                         i < (cl_ulong)size && k < 8 * sizeof(cl_ulong) - j;
-                         k++)
-                        o[i++] = (((cl_ulong)1 << j) + 1) << k;
-
-                // try various powers of two minus 1
-                for (j = 0; i < (cl_ulong)size && j < 8 * sizeof(cl_ulong); j++)
-                    for (k = 0;
-                         i < (cl_ulong)size && k < 8 * sizeof(cl_ulong) - j;
-                         k++)
-                        o[i++] = (((cl_ulong)1 << j) - 1) << k;
-
-                // Other patterns
-                cl_ulong pattern[] = {
-                    0x3333333333333333ULL, 0x5555555555555555ULL,
-                    0x9999999999999999ULL, 0x6666666666666666ULL,
-                    0xccccccccccccccccULL, 0xaaaaaaaaaaaaaaaaULL
-                };
-                cl_ulong mask[] = { 0xffffffffffffffffULL,
-                                    0xff00ff00ff00ff00ULL,
-                                    0xffff0000ffff0000ULL,
-                                    0xffffffff00000000ULL };
-                for (j = 0; i < (cl_ulong)size
-                     && j < sizeof(pattern) / sizeof(pattern[0]);
-                     j++)
-                    for (k = 0; i + 2 <= (cl_ulong)size
-                         && k < sizeof(mask) / sizeof(mask[0]);
-                         k++)
-                    {
-                        o[i++] = pattern[j] & mask[k];
-                        o[i++] = pattern[j] & ~mask[k];
-                    }
+                o[i] = specialValues[i + ulStart];
             }
-
-            auto &md = mdv[thread_id];
-            for (; i < (cl_ulong)size; i++)
-                o[i] = (cl_ulong)genrand_int32(md)
-                    | ((cl_ulong)genrand_int32(md) << 32);
+            for (; i < size; i++)
+            {
+                o[i] = genrand_int64(mdv[thread_id]);
+            }
         }
     } // integrals
-    else if (std::is_same<InType, cl_float>::value)
+    else if constexpr (std::is_same<InType, cl_float>::value)
     {
-        cl_uint *o = (cl_uint *)pIn;
-        int i;
-
-        if (gIsEmbedded)
-            for (i = 0; i < size; i++)
-                o[i] = (cl_uint)genrand_int32(mdv[thread_id]);
-        else
-            for (i = 0; i < size; i++) o[i] = (cl_uint)i + ulStart;
-
-        if (0 == ulStart)
+        uint32_t *o = (uint32_t *)pIn;
+        InType *of = (InType *)pIn;
+        if (gTestAll)
         {
-            size_t tableSize = specialValuesFloat.size()
-                * sizeof(decltype(specialValuesFloat)::value_type);
-            if (sizeof(InType) * size < tableSize)
-                tableSize = sizeof(InType) * size;
-            memcpy((char *)(o + i) - tableSize, &specialValuesFloat.front(),
-                   tableSize);
+            for (uint32_t i = 0; i < size; i++)
+            {
+                o[i] = (uint32_t)(i + ulStart);
+            }
+        }
+        else
+        {
+            const auto &specialValuesFloat =
+                GetFpSpecialValues<InType, uint32_t, OutType>();
+            uint32_t i;
+            for (i = 0; i < size && (i + ulStart) < specialValuesFloat.size();
+                 i++)
+            {
+                of[i] = specialValuesFloat[i + ulStart];
+            }
+            for (; i < size; i++)
+            {
+                o[i] = genrand_int32(mdv[thread_id]);
+            }
         }
 
         if (kUnsaturated == sat)
         {
-            InType *f = (InType *)pIn;
-            for (i = 0; i < size; i++) f[i] = clamp(f[i]);
+            for (uint32_t i = 0; i < size; i++) of[i] = clamp(of[i]);
         }
     }
-    else if (std::is_same<InType, cl_double>::value)
+    else if constexpr (std::is_same<InType, cl_double>::value)
     {
-        InType *o = (InType *)pIn;
-        int i = 0;
-
-        union {
-            uint64_t u;
-            InType d;
-        } u;
-
-        for (i = 0; i < size; i++)
+        uint64_t *o = (uint64_t *)pIn;
+        InType *od = (InType *)pIn;
+        const auto &specialValuesDouble =
+            GetFpSpecialValues<InType, uint64_t, OutType>();
+        uint32_t i;
+        for (i = 0; i < size && (i + ulStart) < specialValuesDouble.size(); i++)
         {
-            uint64_t z = i + ulStart;
-
-            uint32_t bits = ((uint32_t)z ^ (uint32_t)(z >> 32));
-            // split 0x89abcdef to 0x89abc00000000def
-            u.u = bits & 0xfffU;
-            u.u |= (uint64_t)(bits & ~0xfffU) << 32;
-            // sign extend the leading bit of def segment as sign bit so that
-            // the middle region consists of either all 1s or 0s
-            u.u -= (bits & 0x800U) << 1;
-            o[i] = u.d;
+            od[i] = specialValuesDouble[i + ulStart];
+        }
+        for (; i < size; i++)
+        {
+            o[i] = genrand_int64(mdv[thread_id]);
         }
 
-        if (0 == ulStart)
+        if (kUnsaturated == sat)
         {
-            size_t tableSize = specialValuesDouble.size()
-                * sizeof(decltype(specialValuesDouble)::value_type);
-            if (sizeof(InType) * size < tableSize)
-                tableSize = sizeof(InType) * size;
-            memcpy((char *)(o + i) - tableSize, &specialValuesDouble.front(),
-                   tableSize);
+            for (uint32_t i = 0; i < size; i++) od[i] = clamp(od[i]);
         }
-
-        if (0 == sat)
-            for (i = 0; i < size; i++) o[i] = clamp(o[i]);
     }
 }
 

--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -123,7 +123,7 @@ private:
     };
 
 public:
-    template <typename T> std::vector<T> GetIntSpecialValues()
+    template <typename T> std::vector<T> &GetIntSpecialValues()
     {
         std::lock_guard<std::recursive_mutex> lock(gLock);
         static std::vector<T> vec;
@@ -209,7 +209,7 @@ public:
     }
 
     template <typename InType, typename InIntegerType, typename OutType>
-    std::vector<InType> GetFpSpecialValues()
+    std::vector<InType> &GetFpSpecialValues()
     {
         std::lock_guard<std::recursive_mutex> lock(gLock);
         static std::vector<InType> vec;
@@ -273,7 +273,7 @@ public:
         }
         else if constexpr (std::is_same<OutType, cl_short>::value)
         {
-            for (int32_t i = -(64 * 1024 / 2 - 1); i <= (64 * 1024 / 2); i++)
+            for (int32_t i = -(64 * 1024 / 2); i < (64 * 1024 / 2); i++)
             {
                 push(static_cast<InType>(i));
             }
@@ -304,14 +304,6 @@ public:
             for (const auto val : GetIntSpecialValues<uint64_t>())
             {
                 push(static_cast<InType>(bitcast<uint64_t, OutType>(val)));
-            }
-        }
-        else if constexpr (std::is_same<OutType, cl_half>::value)
-        {
-            for (uint32_t i = 0; i < (64 * 1024); i++)
-            {
-                push(static_cast<InType>(
-                    cl_half_to_float(bitcast<uint16_t, OutType>(i))));
             }
         }
         else if constexpr (std::is_same<OutType, cl_float>::value
@@ -1007,7 +999,7 @@ template <typename InType, typename OutType, bool InFP, bool OutFP>
 void DataInfoSpec<InType, OutType, InFP, OutFP>::init(const cl_uint &job_id,
                                                       const cl_uint &thread_id)
 {
-    const uint64_t ulStart = start;
+    const uint64_t ulStart = start + job_id * size;
     void *pIn = (char *)gIn + job_id * size * gTypeSizes[inType];
 
     if constexpr (sizeof(InType) <= sizeof(uint8_t))

--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -165,7 +165,7 @@ public:
                 push(val);
                 val = next;
                 next *= base;
-            } while (next > val && next < sign);
+            } while (next > val && val < sign);
         }
 
         // Generate patterns and masks.
@@ -208,7 +208,8 @@ public:
         return vec;
     }
 
-    template <typename InType, typename InIntegerType, typename OutType>
+    template <typename InType, typename InIntegerType, typename OutType,
+              bool OutFP>
     std::vector<InType> &GetFpSpecialValues()
     {
         std::lock_guard<std::recursive_mutex> lock(gLock);
@@ -264,14 +265,14 @@ public:
                 push(static_cast<InType>(i));
             }
         }
-        else if constexpr (std::is_same<OutType, cl_ushort>::value)
+        else if constexpr (std::is_same<OutType, cl_ushort>::value && !OutFP)
         {
             for (uint32_t i = 0; i < (64 * 1024); i++)
             {
                 push(static_cast<InType>(i));
             }
         }
-        else if constexpr (std::is_same<OutType, cl_short>::value)
+        else if constexpr (std::is_same<OutType, cl_short>::value && !OutFP)
         {
             for (int32_t i = -(64 * 1024 / 2); i < (64 * 1024 / 2); i++)
             {
@@ -304,6 +305,14 @@ public:
             for (const auto val : GetIntSpecialValues<uint64_t>())
             {
                 push(static_cast<InType>(bitcast<uint64_t, OutType>(val)));
+            }
+        }
+        else if constexpr (std::is_same<OutType, cl_half>::value && OutFP)
+        {
+            for (uint32_t i = 0; i < (64 * 1024); i++)
+            {
+                push(static_cast<InType>(
+                    cl_half_to_float(bitcast<uint16_t, OutType>(i))));
             }
         }
         else if constexpr (std::is_same<OutType, cl_float>::value
@@ -1078,7 +1087,7 @@ void DataInfoSpec<InType, OutType, InFP, OutFP>::init(const cl_uint &job_id,
         else
         {
             const auto &specialValuesFloat =
-                GetFpSpecialValues<InType, uint32_t, OutType>();
+                GetFpSpecialValues<InType, uint32_t, OutType, OutFP>();
             uint32_t i;
             for (i = 0; i < size && (i + ulStart) < specialValuesFloat.size();
                  i++)
@@ -1101,7 +1110,7 @@ void DataInfoSpec<InType, OutType, InFP, OutFP>::init(const cl_uint &job_id,
         uint64_t *o = (uint64_t *)pIn;
         InType *od = (InType *)pIn;
         const auto &specialValuesDouble =
-            GetFpSpecialValues<InType, uint64_t, OutType>();
+            GetFpSpecialValues<InType, uint64_t, OutType, OutFP>();
         uint32_t i;
         for (i = 0; i < size && (i + ulStart) < specialValuesDouble.size(); i++)
         {

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -160,6 +160,7 @@ static test_status ParseArgs(int &argc, const char *argv[],
         -[2^n] Set wimpy reduction factor, recommended range of n is 1-12, default factor()"
         + std::to_string(gWimpyReductionFactor) + R"()
         -z     Toggle flush to zero mode  (Default: per device)
+        -a     Test 2^32 values, not just special & random values. (default: off)
         -#     Test just vector size given by #, where # is an element of the set {1,2,3,4,8,16}
 
         You may also pass the number of the test on which to start.
@@ -238,6 +239,7 @@ Test names:
                         gForceFTZ ^= 1;
                         gForceHalfFTZ ^= 1;
                         break;
+                    case 'a': gTestAll ^= 1; break;
                     case '1':
                         if (arg[1] == '6')
                         {


### PR DESCRIPTION
 This commit reduces the overall dataset size for conversion tests
 while maintaining high confidence in edge-case coverage. By replacing
 hardcoded arrays with a dynamically generated set of problematic
 corner cases, the test execution time and memory footprint are
 optimized without sacrificing strict conformance validation.

 It also introduces an exhaustive testing mode (`-a` flag) to test 2^32
 inputs when full coverage is explicitly desired, and corrects the
 workload reduction math for Wimpy and Embedded modes. Thread safety is
 guaranteed via a global `std::recursive_mutex`, and exact bit-level
 deduplication using `std::unordered_set` prevents redundant
 floating-point testing (e.g., collapsing NaNs or signed zeros).

 Special Value Selection Strategies:

 * Integer Types (Base and Conversions)
   Focuses on a dense cluster of known boundary triggers rather than
   sparse randoms. The generator populates a baseline pool (0 to 255),
   calculates powers of 2, 3, 5, 7, and 10 up to the sign bit, and
   creates bitwise combinations of repeating patterns and shifting
   masks. Crucially, to catch off-by-one and alignment errors, every
   base value generates its immediate neighbors (offsets from -3 to
   +3), along with their bitwise NOT and sign-bit XORs.

 * Floating-Point Types
   Focuses strictly on precision loss and rounding boundaries. It seeds
   a core set of known difficult values (-/+ INF, NaN, subnormals, and
   type limits). To test exact rounding thresholds, the generator
   calculates the +/- 1 ULP neighbors for every seeded value via
   integer bitcasting. Finally, to guarantee coverage of saturation and
   overflow thresholds, cross-type boundary values corresponding to the
   specific destination type's domain limits (e.g., injecting exact
   char/short limits into float inputs) are dynamically added to the
   test set.