### PR TITLE
api/clone_kernel: Fix kernel compilation failure

### DIFF
--- a/test_conformance/api/test_clone_kernel.cpp
+++ b/test_conformance/api/test_clone_kernel.cpp
@@ -57,10 +57,6 @@ const char* clone_kernel_test_kernel[] = {
         int i;
         float f;
     } structArg;
-    
-    typedef struct {
-        __global int *store;
-    } BufPtr;
 
     // value type test
     __kernel void clone_kernel_test0(int iarg, float farg, structArg sarg,
@@ -86,13 +82,21 @@ const char* clone_kernel_test_kernel[] = {
         buf[0] = write_val;
     }
 
-    __kernel void set_kernel_exec_info_kernel(int iarg, __global BufPtr* buffer)
-    {
-        buffer->store[0] = iarg;
-    }
-    
     __kernel void test_kernel_empty(){}
     )"
+};
+
+const char* clone_kernel_exec_info_kernel[]{
+    R"(
+typedef struct {
+    __global int *store;
+} BufPtr;
+
+__kernel void set_kernel_exec_info_kernel(int iarg, __global BufPtr* buffer)
+{
+    buffer->store[0] = iarg;
+}
+)"
 };
 
 struct BufPtr
@@ -604,7 +608,7 @@ REGISTER_TEST_VERSION(clone_kernel_with_exec_info, Version(2, 1))
     if (svmCaps != 0)
     {
         error = create_single_kernel_helper(context, &program, &srcKernel, 1,
-                                            clone_kernel_test_kernel,
+                                            clone_kernel_exec_info_kernel,
                                             "set_kernel_exec_info_kernel");
         test_error(error, "Unable to create srcKernel");
 


### PR DESCRIPTION
Isolate 'set_kernel_exec_info_kernel' into its own program source string to prevent compilation failures on OpenCL 3.0 devices that only support OpenCL C 1.2.

The 'set_kernel_exec_info_kernel' uses a struct containing a pointer member (`__global BufPtr* buffer`), which is passed directly as a kernel argument. This construct triggers a multi-level pointer evaluation (`__global int **`) that violates Section 6.11.a of the OpenCL C 1.2 Specification.

Previously, this kernel was bundled inside
`clone_kernel_test_kernel`. On devices running OpenCL 3.0 but defaulting to OpenCL C 1.2 build options, the compiler would reject the entire source string, causing all unrelated `clone_kernel` API tests to fail program compilation.

This change extracts the problematic kernel into a dedicated `clone_kernel_exec_info_kernel` source, ensuring it is only compiled when SVM features are verified and active, preserving test suite conformance on 1.2-only compilers.