### PR TITLE
Fix build program errors for half type kernels in work_group_reduce_{add, max, min)

### DIFF
--- a/test_conformance/workgroups/test_wg_scan_reduce.cpp
+++ b/test_conformance/workgroups/test_wg_scan_reduce.cpp
@@ -36,6 +36,7 @@ static std::string make_kernel_string(const std::string &type,
     // }
 
     std::ostringstream os;
+    if (type == "half") os << "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n";
     os << "__kernel void " << kernelName << "(global " << type
        << " *input, global " << type << " *output) {\n";
     os << "    int tid = get_global_id(0);\n";


### PR DESCRIPTION
Add missing cl_khr_fp16 pragma for newly added half type tests in https://github.com/KhronosGroup/OpenCL-CTS/pull/2525.

- work_group_reduce_add
- work_group_reduce_max
- work_group_reduce_min