### PR TITLE
Fix error handling logic in test_kernel_call_kernel_function

### DIFF
--- a/test_conformance/basic/test_kernel_call_kernel_function.cpp
+++ b/test_conformance/basic/test_kernel_call_kernel_function.cpp
@@ -127,14 +127,18 @@ REGISTER_TEST(kernel_call_kernel_function)
     pass = 1;
     int subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-            if (output[i] != expected[i]) {
-                subtest_errors++;
-                pass = 0;
-                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-                if (subtest_errors == 10) {
-                    log_error("Suppressing further results...\n");
-                    break;
-                }
+        if (output[i] != expected[i])
+        {
+            subtest_errors++;
+            pass = 0;
+            log_error(
+                "Results do not match: output[%d]=%d != expected[%d]=%d\n", i,
+                output[i], i, expected[i]);
+            if (subtest_errors == 10)
+            {
+                log_error("Suppressing further results...\n");
+                break;
+            }
         }
     }
     errors += subtest_errors;
@@ -174,14 +178,18 @@ REGISTER_TEST(kernel_call_kernel_function)
     pass = 1;
     subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-            if (output[i] != expected[i]) {
-                subtest_errors++;
-                pass = 0;
-                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-                if (subtest_errors == 10) {
-                    log_error("Suppressing further results...\n");
-                    break;
-                }
+        if (output[i] != expected[i])
+        {
+            subtest_errors++;
+            pass = 0;
+            log_error(
+                "Results do not match: output[%d]=%d != expected[%d]=%d\n", i,
+                output[i], i, expected[i]);
+            if (subtest_errors == 10)
+            {
+                log_error("Suppressing further results...\n");
+                break;
+            }
         }
     }
     errors += subtest_errors;
@@ -225,18 +233,22 @@ REGISTER_TEST(kernel_call_kernel_function)
     error = clEnqueueReadBuffer( queue, streams[1], CL_TRUE, 0, sizeof(cl_int)*num_elements, output, 0, NULL, NULL );
     test_error( error, "clEnqueueReadBuffer failed" );
 
-        // Compare the results
+    // Compare the results
     pass = 1;
     subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-            if (output[i] != expected[i]) {
-                subtest_errors++;
-                pass = 0;
-                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-                if (subtest_errors == 10) {
-                    log_error("Suppressing further results...\n");
-                    break;
-                }
+        if (output[i] != expected[i])
+        {
+            subtest_errors++;
+            pass = 0;
+            log_error(
+                "Results do not match: output[%d]=%d != expected[%d]=%d\n", i,
+                output[i], i, expected[i]);
+            if (subtest_errors == 10)
+            {
+                log_error("Suppressing further results...\n");
+                break;
+            }
         }
     }
     errors += subtest_errors;

--- a/test_conformance/basic/test_kernel_call_kernel_function.cpp
+++ b/test_conformance/basic/test_kernel_call_kernel_function.cpp
@@ -125,19 +125,19 @@ REGISTER_TEST(kernel_call_kernel_function)
 
     // Compare the results
     pass = 1;
+    int subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-        if (output[i] != expected[i]) {
-            if (errors > 10)
-                continue;
-            if (errors == 10) {
-                log_error("Suppressing further results...\n");
-                continue;
-            }
-            log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-            errors++;
-            pass = 0;
+            if (output[i] != expected[i]) {
+                subtest_errors++;
+                pass = 0;
+                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
+                if (subtest_errors == 10) {
+                    log_error("Suppressing further results...\n");
+                    break;
+                }
         }
     }
+    errors += subtest_errors;
     if (pass) log_info("Passed kernel calling kernel...\n");
 
 
@@ -172,19 +172,19 @@ REGISTER_TEST(kernel_call_kernel_function)
 
     // Compare the results
     pass = 1;
+    subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-        if (output[i] != expected[i]) {
-            if (errors > 10)
-                continue;
-            if (errors > 10) {
-                log_error("Suppressing further results...\n");
-                continue;
-            }
-            log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-            errors++;
-            pass = 0;
+            if (output[i] != expected[i]) {
+                subtest_errors++;
+                pass = 0;
+                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
+                if (subtest_errors == 10) {
+                    log_error("Suppressing further results...\n");
+                    break;
+                }
         }
     }
+    errors += subtest_errors;
     if (pass) log_info("Passed kernel calling function...\n");
 
 
@@ -225,21 +225,21 @@ REGISTER_TEST(kernel_call_kernel_function)
     error = clEnqueueReadBuffer( queue, streams[1], CL_TRUE, 0, sizeof(cl_int)*num_elements, output, 0, NULL, NULL );
     test_error( error, "clEnqueueReadBuffer failed" );
 
-    // Compare the results
+        // Compare the results
     pass = 1;
+    subtest_errors = 0;
     for (int i=0; i<num_elements; i++) {
-        if (output[i] != expected[i]) {
-            if (errors > 10)
-                continue;
-            if (errors > 10) {
-                log_error("Suppressing further results...\n");
-                continue;
-            }
-            log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
-            errors++;
-            pass = 0;
+            if (output[i] != expected[i]) {
+                subtest_errors++;
+                pass = 0;
+                log_error("Results do not match: output[%d]=%d != expected[%d]=%d\n", i, output[i], i, expected[i]);
+                if (subtest_errors == 10) {
+                    log_error("Suppressing further results...\n");
+                    break;
+                }
         }
     }
+    errors += subtest_errors;
     if (pass) log_info("Passed calling the kernel we called from another kernel before...\n");
 
     free( input );


### PR DESCRIPTION
Fixes the following issues:

1. Incorrect suppression condition in sections 2 & 3
Both sections use if (errors > 10) twice instead of having a trigger condition (errors == 10). As a result, the "Suppressing further results..." message never prints, and errors are skipped silently.

2. Incorrect pass reporting in section 3
Since errors are global, earlier sub-tests may already push it beyond 10. Section 3 then immediately skips error handling (due to errors > 10), including setting pass = 0, and incorrectly reports "Passed" even when errors occur.

3. Repeated suppression message in section 1
When errors == 10, the code prints the suppression message and continues without incrementing errors. This causes the condition to remain true, printing the message repeatedly for every subsequent error instead of just once, while doing nothing else.