### PR TITLE
Fix CTS brute_math fp64 asinh/atanh test errors on Windows

### DIFF
--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -3989,8 +3989,14 @@ long double reference_log1pl(long double x)
 {
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)                            \
     && !defined(__INTEL_LLVM_COMPILER)
-    // unimplemented
-    return x;
+    // log1pl unavailable on MSVC; long double == double.
+    // For |x| >= 0.5: 1+x >= 1.5, no cancellation; reference_logl uses
+    // double-double __log2_ep giving ~0.5 ULP accuracy.
+    // For |x| < 0.5: delegate to MSVC's log1p(double) which handles small
+    // arguments correctly without precision loss from computing 1+x.
+    if (reference_fabsl(x) >= 0.5L)
+        return reference_logl(1.0L + x);
+    return (long double)log1p((double)x);
 #elif defined(__PPC__)
     // log1pl on PPC inadvertantly returns NaN for very large values. Work
     // around this limitation by returning logl for large values.

--- a/test_conformance/math_brute_force/reference_math.cpp
+++ b/test_conformance/math_brute_force/reference_math.cpp
@@ -3994,8 +3994,7 @@ long double reference_log1pl(long double x)
     // double-double __log2_ep giving ~0.5 ULP accuracy.
     // For |x| < 0.5: delegate to MSVC's log1p(double) which handles small
     // arguments correctly without precision loss from computing 1+x.
-    if (reference_fabsl(x) >= 0.5L)
-        return reference_logl(1.0L + x);
+    if (reference_fabsl(x) >= 0.5L) return reference_logl(1.0L + x);
     return (long double)log1p((double)x);
 #elif defined(__PPC__)
     // log1pl on PPC inadvertantly returns NaN for very large values. Work


### PR DESCRIPTION
Fix CTS brute_math fp64 asinh/atanh test failures with MSVC on Windows