### PR TITLE
compiler: Add test for clLinkProgram returning program on linker failure

### DIFF
--- a/test_conformance/compiler/test_compile.cpp
+++ b/test_conformance/compiler/test_compile.cpp
@@ -16,6 +16,7 @@
 #include "testBase.h"
 
 #include <filesystem>
+#include <vector>
 
 #if defined(_WIN32)
 #include <time.h>
@@ -1625,6 +1626,66 @@ REGISTER_TEST(simple_link_only)
 
     return 0;
 }
+
+REGISTER_TEST(link_error_returns_program)
+{
+    int error;
+    clProgramWrapper program;
+
+    log_info("Testing clLinkProgram failure returns a valid program...\n");
+    error = create_single_kernel_helper_create_program(context, &program, 1,
+                                                       &another_simple_kernel);
+    if (program == NULL || error != CL_SUCCESS)
+    {
+        log_error(
+            "ERROR: Unable to create a simple test program! (%s in %s:%d)\n",
+            IGetErrorString(error), __FILE__, __LINE__);
+        return -1;
+    }
+
+    error =
+        clCompileProgram(program, 1, &device, NULL, 0, NULL, NULL, NULL, NULL);
+    test_error(error, "Unable to compile a simple program");
+
+    clProgramWrapper my_newly_linked_program = clLinkProgram(
+        context, 1, &device, NULL, 1, &program, NULL, NULL, &error);
+
+    if (error != CL_LINK_PROGRAM_FAILURE)
+    {
+        log_error("ERROR: Expected clLinkProgram to fail with "
+                  "CL_LINK_PROGRAM_FAILURE, but got: %s\n",
+                  IGetErrorString(error));
+        return -1;
+    }
+
+    if (my_newly_linked_program == NULL)
+    {
+        log_error("ERROR: clLinkProgram returned NULL on linker failure, "
+                  "but must return a valid program\n");
+        return -1;
+    }
+
+    // Test that build log is queryable
+    size_t size_ret;
+    error = clGetProgramBuildInfo(my_newly_linked_program, device,
+                                  CL_PROGRAM_BUILD_LOG, 0, NULL, &size_ret);
+    test_error(error, "clGetProgramBuildInfo CL_PROGRAM_BUILD_LOG failed");
+    if (size_ret == 0)
+    {
+        log_error("ERROR: Expected build log to be non-empty\n");
+        return -1;
+    }
+
+    std::vector<char> log(size_ret);
+    error =
+        clGetProgramBuildInfo(my_newly_linked_program, device,
+                              CL_PROGRAM_BUILD_LOG, size_ret, log.data(), NULL);
+    test_error(error, "clGetProgramBuildInfo CL_PROGRAM_BUILD_LOG failed");
+    log_info("Expected Link Failure Build Log:\n%s\n", log.data());
+
+    return 0;
+}
+
 
 REGISTER_TEST(two_file_regular_variable_access)
 {


### PR DESCRIPTION
According to the OpenCL specification (Section 5.6.2), clLinkProgram must return a valid non-zero cl_program object when a linker failure occurs (setting errcode_ret to CL_LINK_PROGRAM_FAILURE). This allows applications to query the build log via clGetProgramBuildInfo to diagnose the linking errors.

See: https://registry.khronos.org/OpenCL/specs/unified/refpages/man/html/clLinkProgram.html

This commit adds a test case that compiles a kernel with an unresolved symbol, links it, and asserts that a valid program object is returned along with CL_LINK_PROGRAM_FAILURE, and that the build log is queryable.