### PR TITLE
Misc Yocto Wrynose (gcc 16.1) fixes

### DIFF
--- a/test_conformance/c11_atomics/CMakeLists.txt
+++ b/test_conformance/c11_atomics/CMakeLists.txt
@@ -8,6 +8,6 @@ set(${MODULE_NAME}_SOURCES
     inclusive_scopes.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-sign-compare -Wno-format")
+set_gnulike_module_compile_flags("-Wno-sign-compare")
 
 include(../CMakeCommon.txt)

--- a/test_conformance/commonfns/test_unary_fn.cpp
+++ b/test_conformance/commonfns/test_unary_fn.cpp
@@ -61,7 +61,7 @@ int verify_degrees(const T *const inptr, const T *const outptr, int n)
     double r, max_val = NAN;
     int max_index = 0;
 
-    for (int i = 0, j = 0; i < n; i++, j++)
+    for (int i = 0; i < n; i++)
     {
         r = (180.0 / M_PI) * conv_to_dbl(inptr[i]);
 
@@ -110,7 +110,7 @@ int verify_radians(const T *const inptr, const T *const outptr, int n)
     double r, max_val = NAN;
     int max_index = 0;
 
-    for (int i = 0, j = 0; i < n; i++, j++)
+    for (int i = 0; i < n; i++)
     {
         r = (M_PI / 180.0) * conv_to_dbl(inptr[i]);
 

--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_printf.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_printf.cpp
@@ -283,7 +283,7 @@ struct CommandBufferPrintfTest : public BasicCommandBufferTest
                 std::max(min_pattern_length, rand() % max_pattern_length);
 
             std::vector<cl_char> pattern(pattern_length + 1, pattern_character);
-            pattern.back() = '\0';
+            pattern[pattern_length] = '\0';
             enqueue_passes[i] = {
                 pattern,
                 { cl_int(i * offset), cl_int(pattern_length) },


### PR DESCRIPTION
For replication, setup info: 

- GCC: 16.1 
- glibc: 2.43
- target architecture build: aarch64
- Config used to setup Yocto layers: [Config](https://git.ti.com/cgit/arago-project/oe-layersetup/tree/configs/arago-master-config.txt)


While building Yocto wrynose, recipe in meta-oe layer,  following errors appeared: 

1\)
```
test_conformance/commonfns/test_unary_fn.cpp:113:21: error: variable 'j' set but not used [-Werror=unused-but-set-variable=]
  113 |     for (int i = 0, j = 0; i < n; i++, j++)
      |                     ^
cc1plus: all warnings being treated as errors
```
2)
```
test_conformance/extensions/cl_khr_command_buffer/command_buffer_printf.cpp:286:25: error: array subscript -1 is outside array bounds of 'signed char []' [-Werror=array-bounds=]
  286 |             pattern.back() = '\0';
      |             ~~~~~~~~~~~~^~
cc1plus: all warnings being treated as errors
```

Patches  [test_unary_fn: Remove unused variable j](https://github.com/KhronosGroup/OpenCL-CTS/commit/51cab19be5be5f011705e75dcef3c360163f41a1) and [command_buffer_printf: Fix out of bounds pattern array](https://github.com/KhronosGroup/OpenCL-CTS/commit/1080490bd80b1f7ee0e58e275eddb2782edd939f) solve the above. 

I am also including [c11_atomics: Remove -Wno-format flag](https://github.com/KhronosGroup/OpenCL-CTS/commit/d2607370dec47198a93fe9abd1f65f269250f929) as there are no format errors that come from c11_atomics dir.
