### PR TITLE
Format fixes commonfns

### DIFF
--- a/test_conformance/commonfns/CMakeLists.txt
+++ b/test_conformance/commonfns/CMakeLists.txt
@@ -10,6 +10,4 @@ set(${MODULE_NAME}_SOURCES
     test_binary_fn.cpp
 )
 
-set_gnulike_module_compile_flags("-Wno-format")
-
 include(../CMakeCommon.txt)

--- a/test_conformance/commonfns/test_binary_fn.cpp
+++ b/test_conformance/commonfns/test_binary_fn.cpp
@@ -220,12 +220,15 @@ int max_verify(const T* const x, const T* const y, const T* const out,
                               "(index %d is "
                               "vector %d, element %d, for vector size %d)\n",
                               k, conv_to_flt(x[k]), l, conv_to_flt(y[l]), k,
-                              conv_to_flt(out[k]), v, k, i, j, vecSize);
+                              conv_to_flt(out[k]), conv_to_flt(v), k, i, j,
+                              vecSize);
                 else
                     log_error("x[%d]=%g y[%d]=%g out[%d]=%g, expected %g. "
                               "(index %d is "
                               "vector %d, element %d, for vector size %d)\n",
-                              k, x[k], l, y[l], k, out[k], v, k, i, j, vecSize);
+                              k, conv_to_flt(x[k]), l, conv_to_flt(y[l]), k,
+                              conv_to_flt(out[k]), conv_to_flt(v), k, i, j,
+                              vecSize);
                 return -1;
             }
         }
@@ -251,12 +254,15 @@ int min_verify(const T* const x, const T* const y, const T* const out,
                               "(index %d is "
                               "vector %d, element %d, for vector size %d)\n",
                               k, conv_to_flt(x[k]), l, conv_to_flt(y[l]), k,
-                              conv_to_flt(out[k]), v, k, i, j, vecSize);
+                              conv_to_flt(out[k]), conv_to_flt(v), k, i, j,
+                              vecSize);
                 else
                     log_error("x[%d]=%g y[%d]=%g out[%d]=%g, expected %g. "
                               "(index %d is "
                               "vector %d, element %d, for vector size %d)\n",
-                              k, x[k], l, y[l], k, out[k], v, k, i, j, vecSize);
+                              k, conv_to_flt(x[k]), l, conv_to_flt(y[l]), k,
+                              conv_to_flt(out[k]), conv_to_flt(v), k, i, j,
+                              vecSize);
                 return -1;
             }
         }

--- a/test_conformance/commonfns/test_clamp.cpp
+++ b/test_conformance/commonfns/test_clamp.cpp
@@ -138,7 +138,9 @@ int verify_clamp(const T *const x, const T *const minval, const T *const maxval,
             {
                 log_error(
                     "%d) verification error: clamp( %a, %a, %a) = *%a vs. %a\n",
-                    i, x[i], minval[i], maxval[i], t, outptr[i]);
+                    i, conv_to_flt(x[i]), conv_to_flt(minval[i]),
+                    conv_to_flt(maxval[i]), conv_to_flt(t),
+                    conv_to_flt(outptr[i]));
                 return -1;
             }
         }

--- a/test_conformance/commonfns/test_mix.cpp
+++ b/test_conformance/commonfns/test_mix.cpp
@@ -82,7 +82,9 @@ int verify_mix(const T *const inptrX, const T *const inptrY,
                 {
                     log_error("%d) verification error: mix(%a, %a, %a) = *%a "
                               "vs. %a\n",
-                              i, inptrX[i], inptrY[i], inptrA[i], r, outptr[i]);
+                              i, conv_to_flt(inptrX[i]), conv_to_flt(inptrY[i]),
+                              conv_to_flt(inptrA[i]), r,
+                              conv_to_flt(outptr[i]));
                     return -1;
                 }
             }
@@ -111,8 +113,9 @@ int verify_mix(const T *const inptrX, const T *const inptrY,
                         log_error(
                             "{%d, element %d}) verification error: mix(%a, "
                             "%a, %a) = *%a vs. %a\n",
-                            ii, j, inptrX[vi], inptrY[vi], inptrA[i], r,
-                            outptr[vi]);
+                            ii, j, conv_to_flt(inptrX[vi]),
+                            conv_to_flt(inptrY[vi]), conv_to_flt(inptrA[i]), r,
+                            conv_to_flt(outptr[vi]));
                         return -1;
                     }
                 }

--- a/test_conformance/commonfns/test_smoothstep.cpp
+++ b/test_conformance/commonfns/test_smoothstep.cpp
@@ -84,7 +84,8 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
                     log_error(
                         "%d) verification error: smoothstep(%a, %a, %a) = "
                         "*%a vs. %a\n",
-                        i, x[i], edge0[i], edge1[i], r, outptr[i]);
+                        i, conv_to_flt(x[i]), conv_to_flt(edge0[i]),
+                        conv_to_flt(edge1[i]), r, conv_to_flt(outptr[i]));
                     return -1;
                 }
             }
@@ -115,8 +116,9 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
                     {
                         log_error("{%d, element %d}) verification error: "
                                   "smoothstep(%a, %a, %a) = *%a vs. %a\n",
-                                  ii, j, x[vi], edge0[i], edge1[i], r,
-                                  outptr[vi]);
+                                  ii, j, conv_to_flt(x[vi]),
+                                  conv_to_flt(edge0[i]), conv_to_flt(edge1[i]),
+                                  r, conv_to_flt(outptr[vi]));
                         return -1;
                     }
                 }

--- a/test_conformance/commonfns/test_step.cpp
+++ b/test_conformance/commonfns/test_step.cpp
@@ -81,12 +81,15 @@ int verify_step(const T *const inptrA, const T *const inptrB,
                             "Failure @ {%d, element %d}: step(%a,%a) -> *%a "
                             "vs %a\n",
                             ii, j, conv_to_flt(inptrA[ii]),
-                            conv_to_flt(inptrB[i]), r, conv_to_flt(outptr[i]));
+                            conv_to_flt(inptrB[i]), conv_to_dbl(r),
+                            conv_to_flt(outptr[i]));
                     else
                         log_error(
                             "Failure @ {%d, element %d}: step(%a,%a) -> *%a "
                             "vs %a\n",
-                            ii, j, inptrA[ii], inptrB[i], r, outptr[i]);
+                            ii, j, conv_to_flt(inptrA[ii]),
+                            conv_to_flt(inptrB[i]), conv_to_dbl(r),
+                            conv_to_flt(outptr[i]));
                     return -1;
                 }
             }

--- a/test_conformance/commonfns/test_unary_fn.cpp
+++ b/test_conformance/commonfns/test_unary_fn.cpp
@@ -82,7 +82,8 @@ int verify_degrees(const T *const inptr, const T *const outptr, int n)
                 else
                     log_error(
                         "%d) Error @ %a: *%a vs %a  (*%g vs %g) ulps: %f\n", i,
-                        inptr[i], r, outptr[i], r, outptr[i], error);
+                        conv_to_flt(inptr[i]), r, conv_to_flt(outptr[i]), r,
+                        conv_to_flt(outptr[i]), error);
                 return 1;
             }
         }
@@ -98,7 +99,8 @@ int verify_degrees(const T *const inptr, const T *const outptr, int n)
         log_info("degrees: Max error %f ulps at %d, input %a: *%a vs %a  (*%g "
                  "vs %g)\n",
                  max_error, max_index, conv_to_flt(inptr[max_index]), max_val,
-                 outptr[max_index], max_val, outptr[max_index]);
+                 conv_to_flt(outptr[max_index]), max_val,
+                 conv_to_flt(outptr[max_index]));
 
     return 0;
 }
@@ -131,7 +133,8 @@ int verify_radians(const T *const inptr, const T *const outptr, int n)
                 else
                     log_error(
                         "%d) Error @ %a: *%a vs %a  (*%g vs %g) ulps: %f\n", i,
-                        inptr[i], r, outptr[i], r, outptr[i], error);
+                        conv_to_flt(inptr[i]), r, conv_to_flt(outptr[i]), r,
+                        conv_to_flt(outptr[i]), error);
                 return 1;
             }
         }
@@ -147,7 +150,8 @@ int verify_radians(const T *const inptr, const T *const outptr, int n)
         log_info("radians: Max error %f ulps at %d, input %a: *%a vs %a  (*%g "
                  "vs %g)\n",
                  max_error, max_index, conv_to_flt(inptr[max_index]), max_val,
-                 outptr[max_index], max_val, outptr[max_index]);
+                 conv_to_flt(outptr[max_index]), max_val,
+                 conv_to_flt(outptr[max_index]));
 
     return 0;
 }


### PR DESCRIPTION
For replication, setup info:
GCC: 16.1
glibc: 2.43
target architecture build: aarch64
Config used to setup Yocto layers: [Config](https://git.ti.com/cgit/arago-project/oe-layersetup/tree/configs/arago-master-config.txt)

While building Yocto wrynose, recipe in meta-oe layer, following error appears multiple times:

```
test_conformance/commonfns/test_binary_fn.cpp:274:40:   required from here
  274 |         error = test_binary_fn<cl_half>(device, context, queue, num_elems,
      |                 ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  275 |                                         fnName.c_str(), vecParam,
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~
  276 |                                         max_verify<cl_half>);
      |                                         ~~~~~~~~~~~~~~~~~~~~

test_conformance/commonfns/test_binary_fn.cpp:219:72: error: format '%g' expects argument of type 'double', but argument 8 has type 'int' [-Werror=format=]
  219 |                     log_error("x[%d]=%g y[%d]=%g out[%d]=%g, expected %g. "
      |                                                                       ~^
      |                                                                        |
      |                                                                        double
      |                                                                       %d
......
  223 |                               conv_to_flt(out[k]), v, k, i, j, vecSize);
      |                                                    ~
      |                                                    |
      |                                                    int


```
The [commonfns: fix type mismatches across function templates](https://github.com/KhronosGroup/OpenCL-CTS/commit/d85a92794aca418359d60cedc56ad1288e4dbd12) patch fixes the above. This is also the only format error when building, so 
[commonfns: Remove -Wno-format flag](https://github.com/KhronosGroup/OpenCL-CTS/commit/5b099b9c63ebf7b0ded4bc2470326de22c7296a4) re-enables -W-format 