### PR TITLE
Fix the "set but not used" error

### DIFF
--- a/test_conformance/c11_atomics/host_atomics.h
+++ b/test_conformance/c11_atomics/host_atomics.h
@@ -361,7 +361,6 @@ bool host_atomic_compare_exchange(volatile AtomicType *a, CorrespondingType *exp
                                   TExplicitMemoryOrderType order_success,
                                   TExplicitMemoryOrderType order_failure)
 {
-    CorrespondingType tmp;
     if constexpr (is_host_atomic_fp_v<AtomicType>)
     {
         static std::mutex mtx;
@@ -378,6 +377,7 @@ bool host_atomic_compare_exchange(volatile AtomicType *a, CorrespondingType *exp
     }
     else
     {
+        CorrespondingType tmp;
 #if defined(_MSC_VER) || (defined(__INTEL_COMPILER) && defined(WIN32))
         tmp = InterlockedCompareExchange(a, desired, *expected);
 #elif defined(__GNUC__)


### PR DESCRIPTION
When "-Werror=unused-but-set-variable" flag is set.