### PR TITLE
Added checks to query support for MEMORY_SCOPE_ALL_SVM_DEVICES

### DIFF
--- a/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
+++ b/test_conformance/SVM/test_fine_grain_memory_consistency.cpp
@@ -157,6 +157,21 @@ REGISTER_TEST(svm_fine_grain_memory_consistency)
 
     char *source[] = { hash_table_kernel };
 
+    {
+        cl_device_atomic_capabilities atomicCaps;
+        err = clGetDeviceInfo(device, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES,
+                              sizeof(atomicCaps), &atomicCaps, nullptr);
+        test_error(err,
+                   "clGetDeviceInfo for CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES "
+                   "failed");
+        if (!(atomicCaps & CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES))
+        {
+            log_info("memory_scope_all_svm_devices not supported, test not "
+                     "executed.\n");
+            return 0;
+        }
+    }
+
     err = create_cl_objects(
         device, (const char **)source, &contextWrapper, &program, &queues[0],
         &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER | CL_DEVICE_SVM_ATOMICS,

--- a/test_conformance/SVM/test_fine_grain_sync_buffers.cpp
+++ b/test_conformance/SVM/test_fine_grain_sync_buffers.cpp
@@ -52,6 +52,21 @@ REGISTER_TEST(svm_fine_grain_sync_buffers)
     cl_int err = CL_SUCCESS;
     clCommandQueueWrapper queues[MAXQ];
 
+    {
+        cl_device_atomic_capabilities atomicCaps;
+        err = clGetDeviceInfo(device, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES,
+                              sizeof(atomicCaps), &atomicCaps, nullptr);
+        test_error(err,
+                   "clGetDeviceInfo for CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES "
+                   "failed");
+        if (!(atomicCaps & CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES))
+        {
+            log_info("memory_scope_all_svm_devices not supported, test not "
+                     "executed.\n");
+            return 0;
+        }
+    }
+
     err = create_cl_objects(
         device, &find_targets_kernel[0], &contextWrapper, &program, &queues[0],
         &num_devices, CL_DEVICE_SVM_FINE_GRAIN_BUFFER | CL_DEVICE_SVM_ATOMICS);

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -4419,6 +4419,28 @@ public:
     {
         std::string memoryOrderScope = MemoryOrderScopeStr();
         std::string postfix(memoryOrderScope.empty() ? "" : "_explicit");
+
+        // Derive the fence scope from the test's MemoryScope so the kernel only
+        // references scope names that the atomic operation itself already uses.
+        // This avoids requiring the compiler to define wider-scope identifiers
+        // (e.g. memory_scope_all_svm_devices) for subtests that don't need them.
+        std::string fenceScopeStr;
+        switch (this->MemoryScope())
+        {
+            case MEMORY_SCOPE_WORK_GROUP:
+                fenceScopeStr = "memory_scope_work_group";
+                break;
+            case MEMORY_SCOPE_ALL_DEVICES:
+                fenceScopeStr = "memory_scope_all_devices";
+                break;
+            case MEMORY_SCOPE_ALL_SVM_DEVICES:
+                fenceScopeStr = "memory_scope_all_svm_devices";
+                break;
+            default: // MEMORY_SCOPE_EMPTY, MEMORY_SCOPE_DEVICE
+                fenceScopeStr = "memory_scope_device";
+                break;
+        }
+
         std::string program =
             "  uint cnt, stop = 0;\n"
             "  for(cnt = 0; !stop && cnt < threadCount; cnt++) // each thread "
@@ -4434,10 +4456,8 @@ public:
                                ? "CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE, "
                                : "CLK_GLOBAL_MEM_FENCE, ")
                 + "memory_order_acquire,"
-                + std::string(LocalMemory()
-                                  ? "memory_scope_work_group"
-                                  : (UseSVM() ? "memory_scope_all_svm_devices"
-                                              : "memory_scope_device"))
+                + std::string(LocalMemory() ? "memory_scope_work_group"
+                                            : fenceScopeStr)
                 + ");\n";
 
         program += "    if (!set)\n"
@@ -4469,10 +4489,8 @@ public:
                                ? "CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE, "
                                : "CLK_GLOBAL_MEM_FENCE, ")
                 + "memory_order_release,"
-                + std::string(LocalMemory()
-                                  ? "memory_scope_work_group"
-                                  : (UseSVM() ? "memory_scope_all_svm_devices"
-                                              : "memory_scope_device"))
+                + std::string(LocalMemory() ? "memory_scope_work_group"
+                                            : fenceScopeStr)
                 + ");\n";
 
         program += "      atomic_flag_clear" + postfix + "(&destMemory[cnt]"

--- a/test_conformance/c11_atomics/test_atomics.cpp
+++ b/test_conformance/c11_atomics/test_atomics.cpp
@@ -4423,7 +4423,8 @@ public:
         // Derive the fence scope from the test's MemoryScope so the kernel only
         // references scope names that the atomic operation itself already uses.
         // This avoids requiring the compiler to define wider-scope identifiers
-        // (e.g. memory_scope_all_svm_devices) for subtests that don't need them.
+        // (e.g. memory_scope_all_svm_devices) for subtests that don't need
+        // them.
         std::string fenceScopeStr;
         switch (this->MemoryScope())
         {


### PR DESCRIPTION
A few kernels in the SVM and C11_atomics tests use MEMORY_SCOPE_ALL_SVM_DEVICES without querying for its support.

Added a fix to either use a narrower scope or skip the subtest altogether if the support is not present.