### PR TITLE
commonfns: Fix conv_to_flt return type from double to float

### DIFF
--- a/test_conformance/commonfns/test_base.h
+++ b/test_conformance/commonfns/test_base.h
@@ -167,7 +167,7 @@ template <typename T> inline double conv_to_dbl(const T &val)
         return (double)val;
 }
 
-template <typename T> inline double conv_to_flt(const T &val)
+template <typename T> inline float conv_to_flt(const T &val)
 {
     if (std::is_same<T, half>::value)
         return (float)cl_half_to_float(val);


### PR DESCRIPTION
The function explicitly casts to float but was returning double, causing an unnecessary implicit float-to-double conversion.