### PR TITLE
Fix binaries path in test_spirv_new

### DIFF
--- a/test_conformance/opencl_conformance_tests_full.csv
+++ b/test_conformance/opencl_conformance_tests_full.csv
@@ -95,7 +95,7 @@ Workgroups,workgroups/test_workgroups
 # OpenCL 2.1 tests
 #####################################
 Device timer,device_timer/test_device_timer
-SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+SPIRV new,spirv_new/test_spirv_new
 
 #########################################
 # Extensions

--- a/test_conformance/opencl_conformance_tests_full_binary.csv
+++ b/test_conformance/opencl_conformance_tests_full_binary.csv
@@ -95,7 +95,7 @@ Workgroups,workgroups/test_workgroups --compilation-mode binary --compilation-ca
 # OpenCL 2.1 tests
 #####################################
 Device timer,device_timer/test_device_timer
-SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+SPIRV new,spirv_new/test_spirv_new
 
 #########################################
 # Extensions

--- a/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
+++ b/test_conformance/opencl_conformance_tests_full_no_math_or_conversions.csv
@@ -93,7 +93,7 @@ Workgroups,workgroups/test_workgroups
 # OpenCL 2.1 tests
 #####################################
 Device timer,device_timer/test_device_timer
-SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+SPIRV new,spirv_new/test_spirv_new
 
 #########################################
 # Extensions

--- a/test_conformance/opencl_conformance_tests_full_spirv.csv
+++ b/test_conformance/opencl_conformance_tests_full_spirv.csv
@@ -95,7 +95,7 @@ Workgroups,workgroups/test_workgroups --compilation-mode spir-v --compilation-ca
 # OpenCL 2.1 tests
 #####################################
 Device timer,device_timer/test_device_timer
-SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+SPIRV new,spirv_new/test_spirv_new
 
 #########################################
 # Extensions

--- a/test_conformance/opencl_conformance_tests_quick.csv
+++ b/test_conformance/opencl_conformance_tests_quick.csv
@@ -95,7 +95,7 @@ Workgroups,workgroups/test_workgroups
 # OpenCL 2.1 tests
 #####################################
 Device timer,device_timer/test_device_timer
-SPIRV new,spirv_new/test_spirv_new --spirv-binaries-path spirv_bin
+SPIRV new,spirv_new/test_spirv_new
 
 #########################################
 # Extensions

--- a/test_conformance/spirv_new/main.cpp
+++ b/test_conformance/spirv_new/main.cpp
@@ -14,17 +14,13 @@
 // limitations under the License.
 //
 
-#include <stdio.h>
-#include <string.h>
-#include "procs.h"
-#if !defined(_WIN32)
-#include <unistd.h>
-#endif
-
-#include <iostream>
 #include <fstream>
 #include <string>
-#include <sstream>
+#include <filesystem>
+
+#include "procs.h"
+#include "harness/os_helpers.h"
+#include "harness/stringHelpers.h"
 
 #if defined(_WIN32)
 const std::string slash = "\\";
@@ -40,9 +36,26 @@ std::string spvBinariesPath = "spirv_bin";
 const std::string spvBinariesPathArg = "--spirv-binaries-path";
 const std::string spvVersionSkipArg = "--skip-spirv-version-check";
 
-std::vector<unsigned char> readBinary(const char *file_name)
+static std::filesystem::path binaries_path()
 {
-    std::ifstream file(file_name,
+    std::filesystem::path path(spvBinariesPath);
+
+    if (path.is_relative())
+    {
+        path = std::filesystem::path(exe_dir()) / path;
+    }
+
+    return path;
+}
+
+static std::string binaries_path_str()
+{
+    return to_string(binaries_path().u8string());
+}
+
+std::vector<unsigned char> readBinary(const std::string &file_name)
+{
+    std::ifstream file(file_name.c_str(),
                        std::ios::in | std::ios::binary | std::ios::ate);
 
     std::vector<char> tmpBuffer(0);
@@ -54,7 +67,7 @@ std::vector<unsigned char> readBinary(const char *file_name)
         file.read(&tmpBuffer[0], size);
         file.close();
     } else {
-        log_error("File %s not found\n", file_name);
+        log_error("File %s not found\n", file_name.c_str());
     }
 
     std::vector<unsigned char> result(tmpBuffer.begin(), tmpBuffer.end());
@@ -62,11 +75,14 @@ std::vector<unsigned char> readBinary(const char *file_name)
     return result;
 }
 
-
 std::vector<unsigned char> readSPIRV(const char *file_name)
 {
-    std::string full_name_str = spvBinariesPath + slash + file_name + spvExt + gAddrWidth;
-    return readBinary(full_name_str.c_str());
+    std::string name(file_name);
+    name += spvExt;
+    name += gAddrWidth;
+
+    std::filesystem::path file_path = binaries_path() / name;
+    return readBinary(to_string(file_path.u8string()));
 }
 
 static int offline_get_program_with_il(clProgramWrapper &prog,
@@ -99,7 +115,7 @@ static int offline_get_program_with_il(clProgramWrapper &prog,
     }
 
     // read output file
-    std::vector<unsigned char> buffer_vec = readBinary(outputFilename.c_str());
+    std::vector<unsigned char> buffer_vec = readBinary(outputFilename);
     size_t file_bytes = buffer_vec.size();
     if (file_bytes == 0) {
         log_error("OfflinerCompiler: Failed to open binary file: %s", outputFilename.c_str());
@@ -210,7 +226,7 @@ static test_status parseArgs(int &argc, const char *argv[],
 {
     help = "        " + spvBinariesPathArg
         + " <path> - Set path to read SPIR-V files from (default: "
-        + spvBinariesPath + ")\n" + "        " + spvVersionSkipArg
+        + binaries_path_str() + ")\n" + "        " + spvVersionSkipArg
         + " - Skip the SPIR-V version check\n";
 
     bool modifiedSpvBinariesPath = false;
@@ -228,7 +244,8 @@ static test_status parseArgs(int &argc, const char *argv[],
                 return TEST_FAIL;
             }
             spvBinariesPath = std::string(argv[i + 1]);
-            removed_args.push_back(std::string(argv[i]) + " " + argv[i + 1]);
+            removed_args.push_back(std::string(argv[i]) + " "
+                                   + spvBinariesPath);
             modifiedSpvBinariesPath = true;
             ++i; // skip the value
         }
@@ -246,7 +263,7 @@ static test_status parseArgs(int &argc, const char *argv[],
     if (!modifiedSpvBinariesPath && !gListTests)
     {
         log_info("Reading SPIR-V files from default '%s' path.\n",
-                 spvBinariesPath.c_str());
+                 binaries_path_str().c_str());
         log_info("In case you want to set other directory use '%s' argument.\n",
                  spvBinariesPathArg.c_str());
     }

--- a/test_conformance/spirv_new/test_basic_versions.cpp
+++ b/test_conformance/spirv_new/test_basic_versions.cpp
@@ -43,12 +43,12 @@ REGISTER_TEST(basic_versions)
 
     std::map<std::string, std::string> mapILtoSubdir({
         { "SPIR-V_1.0", "" }, // SPIR-V 1.0 files are in the base directory
-        { "SPIR-V_1.1", "spv1.1" },
-        { "SPIR-V_1.2", "spv1.2" },
-        { "SPIR-V_1.3", "spv1.3" },
-        { "SPIR-V_1.4", "spv1.4" },
-        { "SPIR-V_1.5", "spv1.5" },
-        { "SPIR-V_1.6", "spv1.6" },
+        { "SPIR-V_1.1", "spv1.1/" },
+        { "SPIR-V_1.2", "spv1.2/" },
+        { "SPIR-V_1.3", "spv1.3/" },
+        { "SPIR-V_1.4", "spv1.4/" },
+        { "SPIR-V_1.5", "spv1.5/" },
+        { "SPIR-V_1.6", "spv1.6/" },
     });
 
     size_t sz = 0;
@@ -85,7 +85,7 @@ REGISTER_TEST(basic_versions)
                                 h_src.size() * sizeof(cl_int), 0, NULL, NULL);
         test_error(error, "Unable to initialize destination buffer");
 
-        std::string filename = testCase.second + "/basic";
+        std::string filename = testCase.second + "basic";
 
         clProgramWrapper prog;
         error = get_program_with_il(prog, device, context, filename.c_str());


### PR DESCRIPTION
Update the behaviour of `test_spirv_new` so that the default relative path is resolved in relation to the path of the executable, not the current working directory.

`--spirv-binaries-path` can now handle absolute and relative paths.

Remove the redundant path override from the CSV files, as it is setting it to the default.