### PR TITLE
Fix VVL errors in Vulkan wrapper

### DIFF
--- a/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/test_conformance/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -1763,7 +1763,7 @@ VulkanCommandBuffer::operator VkCommandBuffer() const
 VulkanBuffer::VulkanBuffer(const VulkanBuffer &buffer)
     : m_device(buffer.m_device), m_vkBuffer(buffer.m_vkBuffer),
       m_size(buffer.m_size), m_alignment(buffer.m_alignment),
-      m_memoryTypeList(buffer.m_memoryTypeList)
+      m_dedicated(buffer.m_dedicated), m_memoryTypeList(buffer.m_memoryTypeList)
 {}
 
 bool VulkanBuffer::isDedicated() const { return m_dedicated; }
@@ -1819,6 +1819,10 @@ VulkanBuffer::VulkanBuffer(
 
     vkCreateBuffer(m_device, &vkBufferCreateInfo, NULL, &m_vkBuffer);
 
+    VkMemoryRequirements vkBasicMemoryRequirements = {};
+    vkGetBufferMemoryRequirements(m_device, m_vkBuffer,
+                                  &vkBasicMemoryRequirements);
+
     VkMemoryDedicatedRequirements vkMemoryDedicatedRequirements = {};
     vkMemoryDedicatedRequirements.sType =
         VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
@@ -1827,6 +1831,7 @@ VulkanBuffer::VulkanBuffer(
     VkMemoryRequirements2 vkMemoryRequirements = {};
     vkMemoryRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     vkMemoryRequirements.pNext = &vkMemoryDedicatedRequirements;
+    vkMemoryRequirements.memoryRequirements = vkBasicMemoryRequirements;
 
     VkBufferMemoryRequirementsInfo2 vkMemoryRequirementsInfo = {};
 
@@ -1838,6 +1843,11 @@ VulkanBuffer::VulkanBuffer(
     vkGetBufferMemoryRequirements2(m_device, &vkMemoryRequirementsInfo,
                                    &vkMemoryRequirements);
 
+    if (vkMemoryRequirements.memoryRequirements.size == 0)
+    {
+        vkMemoryRequirements.memoryRequirements = vkBasicMemoryRequirements;
+    }
+
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
 
     m_size = vkMemoryRequirements.memoryRequirements.size;
@@ -1846,7 +1856,7 @@ VulkanBuffer::VulkanBuffer(
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];
-        if ((1 << memoryTypeIndex)
+        if ((1u << memoryTypeIndex)
             & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
         {
             m_memoryTypeList.add(memoryTypeList[mtIdx]);
@@ -1875,8 +1885,9 @@ VulkanImage::VulkanImage(const VulkanImage &image)
     : m_device(image.m_device), m_imageType(image.m_imageType),
       m_extent3D(image.m_extent3D), m_format(image.m_format),
       m_numMipLevels(image.m_numMipLevels), m_numLayers(image.m_numLayers),
-      m_vkImage(image.m_vkImage), m_size(image.m_size),
-      m_alignment(image.m_alignment), m_memoryTypeList(image.m_memoryTypeList)
+      m_dedicated(image.m_dedicated), m_vkImage(image.m_vkImage),
+      m_size(image.m_size), m_alignment(image.m_alignment),
+      m_memoryTypeList(image.m_memoryTypeList)
 {}
 
 VulkanImage::VulkanImage(
@@ -1929,6 +1940,10 @@ VulkanImage::VulkanImage(
 
     VulkanImageCreateInfo = vkImageCreateInfo;
 
+    VkMemoryRequirements vkBasicMemoryRequirements = {};
+    vkGetImageMemoryRequirements(m_device, m_vkImage,
+                                 &vkBasicMemoryRequirements);
+
     VkMemoryDedicatedRequirements vkMemoryDedicatedRequirements = {};
     vkMemoryDedicatedRequirements.sType =
         VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
@@ -1937,6 +1952,7 @@ VulkanImage::VulkanImage(
     VkMemoryRequirements2 vkMemoryRequirements = {};
     vkMemoryRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     vkMemoryRequirements.pNext = &vkMemoryDedicatedRequirements;
+    vkMemoryRequirements.memoryRequirements = vkBasicMemoryRequirements;
 
     VkImageMemoryRequirementsInfo2 vkMemoryRequirementsInfo = {};
 
@@ -1947,6 +1963,12 @@ VulkanImage::VulkanImage(
 
     vkGetImageMemoryRequirements2(m_device, &vkMemoryRequirementsInfo,
                                   &vkMemoryRequirements);
+
+    if (vkMemoryRequirements.memoryRequirements.size == 0)
+    {
+        vkMemoryRequirements.memoryRequirements = vkBasicMemoryRequirements;
+    }
+
     m_size = vkMemoryRequirements.memoryRequirements.size;
     m_alignment = vkMemoryRequirements.memoryRequirements.alignment;
     m_dedicated = vkMemoryDedicatedRequirements.requiresDedicatedAllocation;
@@ -1955,7 +1977,7 @@ VulkanImage::VulkanImage(
     for (size_t mtIdx = 0; mtIdx < memoryTypeList.size(); mtIdx++)
     {
         uint32_t memoryTypeIndex = memoryTypeList[mtIdx];
-        if ((1 << memoryTypeIndex)
+        if ((1u << memoryTypeIndex)
             & vkMemoryRequirements.memoryRequirements.memoryTypeBits)
         {
             m_memoryTypeList.add(memoryTypeList[mtIdx]);


### PR DESCRIPTION
Seed VkMemoryRequirements2 from vkGet*MemoryRequirements before querying the extended requirements with VkMemoryDedicatedRequirements chained in. Keep the basic requirements if the extended query returns a zero size, so buffer and image allocation still has valid size, alignment, and memory type bits.

Also preserve the cached dedicated-allocation flag in buffer and image copy constructors, and use unsigned shifts when filtering memory types.

Fixes VVL errors observed in test_buffer_single_queue and test_buffer_multiple_queue.