### PR TITLE
harness: Unify thread pool disabling option

### DIFF
--- a/test_common/harness/ThreadPool.cpp
+++ b/test_common/harness/ThreadPool.cpp
@@ -16,6 +16,7 @@
 #include "ThreadPool.h"
 #include "errorHelpers.h"
 #include "fpcontrol.h"
+#include "parseParameters.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -273,7 +274,7 @@ pthread_cond_t caller_cond_var;
 std::atomic<cl_int> gRunning{ 0 };
 
 // The total number of threads launched.
-std::atomic<cl_int> gThreadCount{ 0 };
+static std::atomic<cl_int> gThreadCount{ 0 };
 
 #ifdef _WIN32
 void ThreadPool_WorkerFunc(void *p)
@@ -470,31 +471,6 @@ exit:
 #endif
 }
 
-// SetThreadCount() may be used to artifically set the number of worker threads
-// If the value is 0 (the default) the number of threads will be determined
-// based on the number of CPU cores.  If it is a unicore machine, then 2 will be
-// used, so that we still get some testing for thread safety.
-//
-// If count < 2 or the CL_TEST_SINGLE_THREADED environment variable is set then
-// the code will run single threaded, but will report an error to indicate that
-// the test is invalid.  This option is intended for debugging purposes only. It
-// is suggested as a convention that test apps set the thread count to 1 in
-// response to the -m flag.
-//
-// SetThreadCount() must be called before the first call to GetThreadCount() or
-// ThreadPool_Do(), otherwise the behavior is indefined.
-void SetThreadCount(int count)
-{
-    if (threadPoolInitErr == CL_SUCCESS)
-    {
-        log_error("Error: It is illegal to set the thread count after the "
-                  "first call to ThreadPool_Do or GetThreadCount\n");
-        abort();
-    }
-
-    gThreadCount = count;
-}
-
 void ThreadPool_Init(void)
 {
     cl_int i;
@@ -503,10 +479,14 @@ void ThreadPool_Init(void)
 
     // Check for manual override of multithreading code. We add this for better
     // debuggability.
-    if (getenv("CL_TEST_SINGLE_THREADED"))
+    if (getenv("CL_TEST_SINGLE_THREADED") || !gThreadPoolEnabled)
     {
-        log_error("ERROR: CL_TEST_SINGLE_THREADED is set in the environment. "
-                  "Running single threaded.\n*** TEST IS INVALID! ***\n");
+        log_info("\n");
+        log_info("*******************************************************\n");
+        log_info("***                  !! WARNING !!                  ***\n");
+        log_info("*** ThreadPool is disabled, running single threaded ***\n");
+        log_info("*******************************************************\n");
+        log_info("\n");
         gThreadCount = 1;
         return;
     }
@@ -591,16 +571,6 @@ void ThreadPool_Init(void)
         gThreadCount = 12;
     }
 #endif
-
-    // Allow the app to set thread count to <0 for debugging purposes.
-    // This will cause the test to run single threaded.
-    if (gThreadCount < 2)
-    {
-        log_error("ERROR: Running single threaded because thread count < 2. "
-                  "\n*** TEST IS INVALID! ***\n");
-        gThreadCount = 1;
-        return;
-    }
 
 #if defined(_WIN32)
     InitializeCriticalSection(gThreadPoolLock);
@@ -1056,10 +1026,5 @@ cl_int ThreadPool_Do(TPFuncPtr func_ptr, cl_uint count, void *userInfo)
 }
 
 cl_uint GetThreadCount(void) { return 1; }
-
-void SetThreadCount(int count)
-{
-    if (count > 1) log_info("WARNING: SetThreadCount(%d) ignored\n", count);
-}
 
 #endif

--- a/test_common/harness/ThreadPool.cpp
+++ b/test_common/harness/ThreadPool.cpp
@@ -479,15 +479,15 @@ void ThreadPool_Init(void)
 
     // Check for manual override of multithreading code. We add this for better
     // debuggability.
-    if (getenv("CL_TEST_SINGLE_THREADED") || !gThreadPoolEnabled)
+    if (getenv("CL_TEST_SINGLE_THREADED") || (gNumThreadPoolThreads != 0))
     {
         log_info("\n");
-        log_info("*******************************************************\n");
-        log_info("***                  !! WARNING !!                  ***\n");
-        log_info("*** ThreadPool is disabled, running single threaded ***\n");
-        log_info("*******************************************************\n");
+        log_info("*****************************************\n");
+        log_info("***           !! WARNING !!           ***\n");
+        log_info("*** ThreadPool is disabled or reduced ***\n");
+        log_info("*****************************************\n");
         log_info("\n");
-        gThreadCount = 1;
+        gThreadCount = gNumThreadPoolThreads;
         return;
     }
 

--- a/test_common/harness/ThreadPool.h
+++ b/test_common/harness/ThreadPool.h
@@ -49,21 +49,4 @@ cl_int ThreadPool_Do(TPFuncPtr func_ptr, cl_uint count, void *userInfo);
 // inclusive. This is safe to call from a TPFuncPtr.
 cl_uint GetThreadCount(void);
 
-// SetThreadCount() may be used to artifically set the number of worker threads
-// If the value is 0 (the default) the number of threads will be determined
-// based on the number of CPU cores.  If it is a unicore machine, then 2 will be
-// used, so that we still get some testing for thread safety.
-//
-// If count < 2 or the CL_TEST_SINGLE_THREADED environment variable is set then
-// the code will run single threaded, but will report an error to indicate that
-// the test is invalid.  This option is intended for debugging purposes only. It
-// is suggested as a convention that test apps set the thread count to 1 in
-// response to the -m flag.
-//
-// SetThreadCount() must be called before the first call to GetThreadCount() or
-// ThreadPool_Do(), otherwise the behavior is indefined. It may not be called
-// from a TPFuncPtr.
-void SetThreadCount(int count);
-
-
 #endif /* THREAD_POOL_H  */

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -35,6 +35,7 @@ std::string gCompilationProgram = DEFAULT_COMPILATION_PROGRAM;
 bool gDisableSPIRVValidation = false;
 std::string gSPIRVValidator = DEFAULT_SPIRV_VALIDATOR;
 unsigned gNumWorkerThreads;
+bool gThreadPoolEnabled = true;
 bool gListTests = false;
 bool gWimpyMode = false;
 
@@ -57,6 +58,8 @@ void helpInfo()
         Enable wimpy mode. It does not impact all tests. Impacted tests will run
         with a very small subset of the tests. This option should not be used
         for conformance submission (default: disabled).
+    -m, --disable-threadpool
+        Disable multi-threading (using the ThreadPool API) within individual tests.
 
     --invalid-object-scenarios=<option_1>,<option_2>....
         Specify different scenarios to use when
@@ -124,6 +127,13 @@ int parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],
             delArg++;
             removed_args.push_back("--wimpy");
             gWimpyMode = true;
+        }
+        else if (!strcmp(argv[i], "-m")
+                 || !strcmp(argv[i], "--disable-threadpool"))
+        {
+            delArg++;
+            removed_args.push_back("--disable-threadpool");
+            gThreadPoolEnabled = false;
         }
         else if (!strcmp(argv[i], "--compilation-mode"))
         {

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -35,7 +35,7 @@ std::string gCompilationProgram = DEFAULT_COMPILATION_PROGRAM;
 bool gDisableSPIRVValidation = false;
 std::string gSPIRVValidator = DEFAULT_SPIRV_VALIDATOR;
 unsigned gNumWorkerThreads;
-bool gThreadPoolEnabled = true;
+unsigned gNumThreadPoolThreads = 0;
 bool gListTests = false;
 bool gWimpyMode = false;
 
@@ -60,6 +60,9 @@ void helpInfo()
         for conformance submission (default: disabled).
     -m, --disable-threadpool
         Disable multi-threading (using the ThreadPool API) within individual tests.
+    -t, --num-threadpool-threads <num>
+        Select the number of threads used by the ThreadPool API.
+        default: All available threads
 
     --invalid-object-scenarios=<option_1>,<option_2>....
         Specify different scenarios to use when
@@ -133,7 +136,26 @@ int parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],
         {
             delArg++;
             removed_args.push_back("--disable-threadpool");
-            gThreadPoolEnabled = false;
+            gNumThreadPoolThreads = 1;
+        }
+        else if (!strcmp(argv[i], "-t")
+                 || !strcmp(argv[i], "--num-threadpool-threads"))
+        {
+            delArg++;
+            if ((i + 1) < argc)
+            {
+                delArg++;
+                const char *numthstr = argv[i + 1];
+
+                gNumThreadPoolThreads = atoi(numthstr);
+            }
+            else
+            {
+                log_error("A parameter to --num-threadpool-threads must be "
+                          "provided!\n");
+                return -1;
+            }
+            removed_args.push_back(std::string(argv[i]) + " " + argv[i + 1]);
         }
         else if (!strcmp(argv[i], "--compilation-mode"))
         {

--- a/test_common/harness/parseParameters.cpp
+++ b/test_common/harness/parseParameters.cpp
@@ -134,6 +134,13 @@ int parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],
         else if (!strcmp(argv[i], "-m")
                  || !strcmp(argv[i], "--disable-threadpool"))
         {
+            if (gNumThreadPoolThreads != 0)
+            {
+                log_info(
+                    "WARNING: -m/--disable-threadpool option overriding "
+                    "previously set gNumThreadPoolThreads value of %d to 1.\n",
+                    gNumThreadPoolThreads);
+            }
             delArg++;
             removed_args.push_back("--disable-threadpool");
             gNumThreadPoolThreads = 1;
@@ -146,8 +153,17 @@ int parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],
             {
                 delArg++;
                 const char *numthstr = argv[i + 1];
+                int new_value = atoi(numthstr);
 
-                gNumThreadPoolThreads = atoi(numthstr);
+                if (gNumThreadPoolThreads != 0)
+                {
+                    log_info("WARNING: -t/--num-threadpool-threads option "
+                             "overriding "
+                             "previously set gNumThreadPoolThreads value of %d "
+                             "to %d.\n",
+                             gNumThreadPoolThreads, new_value);
+                }
+                gNumThreadPoolThreads = new_value;
             }
             else
             {

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -44,7 +44,7 @@ extern std::string gSPIRVValidator;
 extern bool gListTests;
 extern bool gWimpyMode;
 extern unsigned gNumWorkerThreads;
-extern bool gThreadPoolEnabled;
+extern unsigned gNumThreadPoolThreads;
 
 extern int
 parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],

--- a/test_common/harness/parseParameters.h
+++ b/test_common/harness/parseParameters.h
@@ -43,6 +43,8 @@ extern bool gDisableSPIRVValidation;
 extern std::string gSPIRVValidator;
 extern bool gListTests;
 extern bool gWimpyMode;
+extern unsigned gNumWorkerThreads;
+extern bool gThreadPoolEnabled;
 
 extern int
 parseCommonParamAndGetRemovedArgs(int argc, const char *argv[],

--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -720,7 +720,6 @@ int runTestHarnessWithCheckAndParse(int argc, const char *argv[], int testNum,
     FPU_mode_type oldMode;
     DisableFTZ(&oldMode);
 #endif
-    extern unsigned gNumWorkerThreads;
     test_harness_config config = { forceNoContextCreation, num_elements,
                                    queueProps, gNumWorkerThreads };
 

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -89,9 +89,6 @@ size_t gTypeSizes[kTypeCount] = {
     sizeof(cl_double), sizeof(cl_ulong), sizeof(cl_long),
 };
 
-int gMultithread = 1;
-
-
 REGISTER_TEST(conversions)
 {
     if (argList.size() > 2)
@@ -156,7 +153,6 @@ static test_status ParseArgs(int &argc, const char *argv[],
     help = R"(
         -d     Toggle testing of double precision.  On by default if cl_khr_fp64 is enabled, ignored otherwise.
         -l     Toggle link check mode. When on, testing is skipped, and we just check to see that the kernels build. (Off by default.)
-        -m     Toggle Multithreading. (On by default.)
         -[2^n] Set wimpy reduction factor, recommended range of n is 1-12, default factor()"
         + std::to_string(gWimpyReductionFactor) + R"()
         -z     Toggle flush to zero mode  (Default: per device)
@@ -230,7 +226,6 @@ Test names:
                     case 'd': gTestDouble ^= 1; break;
                     case 'h': gTestHalfs ^= 1; break;
                     case 'l': gSkipTesting ^= 1; break;
-                    case 'm': gMultithread ^= 1; break;
                     case '[':
                         parseWimpyReductionFactor(arg, gWimpyReductionFactor);
                         break;
@@ -317,8 +312,6 @@ Test names:
     vlog("===========================================================\n");
     vlog("Random seed: %u\n", gRandomSeed);
     gMTdata = init_genrand(gRandomSeed);
-
-    if (!gMultithread) SetThreadCount(1);
 
     return TEST_PASS;
 }

--- a/test_conformance/math_brute_force/main.cpp
+++ b/test_conformance/math_brute_force/main.cpp
@@ -404,7 +404,6 @@ static test_status ParseArgs(int &argc, const char *argv[],
         -r     Toggle fast relaxed math precision testing. (Default: on)
         -e     Toggle test as derived implementations for fast relaxed math precision. (Default: on)
         -l     link check only (make sure functions are present, skip accuracy checks.)
-        -m     Toggle run multi-threaded. (Default: on)
         -s     Stop on error
         -[2^n] Set wimpy reduction factor, recommended range of n is 1-10, default factor()"
         + std::to_string(gWimpyReductionFactor) + R"()
@@ -423,9 +422,6 @@ static test_status ParseArgs(int &argc, const char *argv[],
 
     std::vector<const char *> argList;
     argList.push_back(argv[0]);
-
-    int singleThreaded = 0;
-    int forcedWorkerThreads = 0;
 
     for (int i = 1; i < argc; i++)
     {
@@ -450,16 +446,6 @@ static test_status ParseArgs(int &argc, const char *argv[],
                     case 'f': gTestFloat ^= 1; break;
 
                     case 'l': gSkipCorrectnessTesting ^= 1; break;
-
-                    case 'm': singleThreaded ^= 1; break;
-
-                    case 't':
-                        removed_args.pop_back();
-                        removed_args.push_back(std::string(argv[i]) + " "
-                                               + argv[i + 1]);
-                        forcedWorkerThreads = atoi(argv[++i]);
-                        vlog(" %d", forcedWorkerThreads);
-                        break;
 
                     case 'g': gHasHalf ^= 1; break;
 
@@ -545,17 +531,6 @@ static test_status ParseArgs(int &argc, const char *argv[],
              gWimpyReductionFactor);
     }
 
-    if (singleThreaded)
-    {
-        vlog("*** WARNING: Force 1 worker thread                      ***\n");
-        SetThreadCount(1);
-    }
-    else if (forcedWorkerThreads > 0)
-    {
-        vlog("*** WARNING: Force %d worker threads                    ***\n",
-             forcedWorkerThreads);
-        SetThreadCount(forcedWorkerThreads);
-    }
     if (gSkipCorrectnessTesting)
         vlog("*** Skipping correctness testing! ***\n\n");
     else if (gStopOnError)


### PR DESCRIPTION
Replace test-specific thread pool control with a global option. Previously, tests like conversions and math_brute_force had their own `-m` option to disable multi-threading and called `SetThreadCount(1)`. This API is removed and replaced by a global `-m` / `--disable-threadpool` option parsed by the common test harness.

The `SetThreadCount` API is removed from `ThreadPool.h` and the threaded implementation in `ThreadPool.cpp` as it is no longer needed.