### PR TITLE
compiler: skip link_error_returns_program in offline mode

### DIFF
--- a/test_common/harness/errorHelpers.cpp
+++ b/test_common/harness/errorHelpers.cpp
@@ -717,6 +717,7 @@ const char *subtests_to_skip_with_offline_compiler[] = {
     "execute_after_simple_compile_and_link_no_device_info",
     "execute_after_simple_library_with_link",
     "execute_after_two_file_link",
+    "link_error_returns_program",
     "simple_compile_only",
     "simple_compile_with_callback",
     "simple_library_only",


### PR DESCRIPTION
The goal of the `link_error_returns_program` test is to verify that the API returns a usable program object even when linking fails (so that a build log can still be queried).

In offline compilation mode, there isn't necessarily a returned program object to inspect, as an offline compiler may produce just a diagnostic without any binary output.  In that case there won't be a binary to load, so skip this test for offline compilation.