### PR TITLE
Add test_compiler spv file into install target

### DIFF
--- a/test_conformance/compiler/CMakeLists.txt
+++ b/test_conformance/compiler/CMakeLists.txt
@@ -64,3 +64,7 @@ install(DIRECTORY
             ${CLConform_SOURCE_DIR}/test_conformance/compiler/includeTestDirectory
             ${CLConform_SOURCE_DIR}/test_conformance/compiler/secondIncludeTestDirectory
         DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>)
+
+install(DIRECTORY
+            ${COMPILER_SPV_PATH}
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>)


### PR DESCRIPTION
The compiler tests assemble SPIR-V binaries into the build directory (COMPILER_SPV_PATH, i.e. spirv_bin) at build time, but the existing install() rules only copied the includeTestDirectory and secondIncludeTestDirectory resources. As a result, the spirv_bin directory was missing from the install tree, causing the compiler tests to fail at runtime when run from an installed location.

Add an install(DIRECTORY) rule for COMPILER_SPV_PATH so the assembled SPIR-V binaries are placed alongside the other compiler test resources under CMAKE_INSTALL_BINDIR.

Fixes #2746