### PR TITLE
clCopyImage: improve performance by removing redundant copies

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -124,7 +124,20 @@
     },
     "test_cl_copy_images": {
         "--num-worker-threads 2 small_images": {
-            "1D": "pass"
+            "1D": "pass",
+            "2D": "pass",
+            "3D": "pass",
+            "1Dbuffer": "pass",
+            "1DTo1Dbuffer": "pass",
+            "1DbufferTo1D": "pass",
+            "1Darray": "pass",
+            "2Darray": "pass",
+            "2Dto3D": "pass",
+            "3Dto2D": "pass",
+            "2Darrayto2D": "pass",
+            "2Dto2Darray": "pass",
+            "2Darrayto3D": "pass",
+            "3Dto2Darray": "pass"
         }
     },
     "test_computeinfo": {

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -13,15 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
@@ -69,9 +61,19 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
         regionSize[ 0 ] = width_lod;
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
       return retCode;
     else
@@ -107,9 +109,9 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
 
 
       // Go for it!
-      retCode =
-          test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                  sourcePos, destPos, regionSize, d, ctx);
+      retCode = test_copy_image_generic(
+          context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+          srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
       if( retCode < 0 )
         return retCode;
       else

--- a/test_conformance/images/clCopyImage/test_copy_1D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D.cpp
@@ -61,18 +61,15 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
         regionSize[ 0 ] = width_lod;
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
       return retCode;
@@ -109,11 +106,11 @@ int test_copy_image_size_1D(cl_context context, cl_command_queue queue,
 
 
       // Go for it!
-      retCode = test_copy_image_generic(
-          context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-          srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
-      if( retCode < 0 )
-        return retCode;
+      retCode =
+          test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                  sourcePos, destPos, regionSize);
+      if (retCode < 0)
+          return retCode;
       else
         ret += retCode;
     }

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -13,15 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
                                   image_descriptor *srcImageInfo,
@@ -68,9 +60,19 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
         regionSize[ 0 ] = width_lod;
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
         return retCode;
     else
@@ -116,10 +118,10 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
-        if( retCode < 0 )
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        if (retCode < 0)
             return retCode;
         else
             ret += retCode;

--- a/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_array.cpp
@@ -60,18 +60,15 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
         regionSize[ 0 ] = width_lod;
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
         return retCode;
@@ -118,9 +115,9 @@ int test_copy_image_size_1D_array(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
@@ -13,15 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
                                    image_descriptor *srcImageInfo,
@@ -39,9 +31,19 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
     regionSize[1] = 1;
     regionSize[2] = 1;
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if (retCode < 0)
         return retCode;
     else
@@ -65,9 +67,9 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, srcImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_1D_buffer.cpp
@@ -31,18 +31,15 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
     regionSize[1] = 1;
     regionSize[2] = 1;
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if (retCode < 0)
         return retCode;
@@ -67,9 +64,9 @@ int test_copy_image_size_1D_buffer(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -13,15 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
                             image_descriptor *srcImageInfo,
@@ -78,9 +70,19 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
         regionSize[ 1 ] = height_lod;
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
         return retCode;
     else
@@ -123,10 +125,10 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
         destPos[ 1 ] = ( height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
-        if( retCode < 0 )
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        if (retCode < 0)
             return retCode;
         else
             ret += retCode;

--- a/test_conformance/images/clCopyImage/test_copy_2D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D.cpp
@@ -70,18 +70,15 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
         regionSize[ 1 ] = height_lod;
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
         return retCode;
@@ -125,9 +122,9 @@ int test_copy_image_size_2D(cl_context context, cl_command_queue queue,
         destPos[ 1 ] = ( height_lod > regionSize[ 1 ] ) ? (size_t)random_in_range( 0, (int)( height_lod - regionSize[ 1 ] - 1 ), d ) : 0;
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,16 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
 #include "../common.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t arraySize,
@@ -133,9 +125,19 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
         }
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
         return retCode;
     else
@@ -211,10 +213,10 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
         }
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
-        if( retCode < 0 )
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        if (retCode < 0)
             return retCode;
         else
             ret += retCode;

--- a/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_2D_array.cpp
@@ -125,18 +125,15 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
         }
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
         return retCode;
@@ -213,9 +210,9 @@ int test_copy_image_size_2D_2D_array(cl_context context, cl_command_queue queue,
         }
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,16 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
 #include "../common.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t depth, size_t rowPadding,
@@ -130,9 +122,19 @@ int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
         }
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
         return retCode;
     else
@@ -207,9 +209,9 @@ int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
         }
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
         if( retCode < 0 )
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_3D.cpp
@@ -122,18 +122,15 @@ int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
         }
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
         return retCode;
@@ -209,9 +206,9 @@ int test_copy_image_size_2D_3D(cl_context context, cl_command_queue queue,
         }
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if( retCode < 0 )
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -13,16 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-// Defined in test_copy_generic.cpp
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
                              image_descriptor *srcImageInfo,
@@ -65,9 +56,19 @@ int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
         region[ 1 ] = height_lod;
         srcPos[ 3 ] = src_lod;
         dstPos[ 3 ] = dst_lod;
-}
-return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                               srcPos, dstPos, region, d, ctx);
+    }
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
+    int retCode =
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
+                                   srcImage, dstImage, srcData, dstData, srcPos,
+                                   dstPos, region, d, ctx);
 }
 
 int test_copy_image_set_2D_array(cl_device_id device, cl_context context,

--- a/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_2D_array.cpp
@@ -57,18 +57,16 @@ int test_copy_image_2D_array(cl_context context, cl_command_queue queue,
         srcPos[ 3 ] = src_lod;
         dstPos[ 3 ] = dst_lod;
     }
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
     int retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+        test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                   srcImage, dstImage, srcData, dstData, srcPos,
-                                   dstPos, region, d, ctx);
+    return test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                   srcPos, dstPos, region);
 }
 
 int test_copy_image_set_2D_array(cl_device_id device, cl_context context,

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -13,16 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
-
-// Defined in test_copy_generic.cpp
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 int test_copy_image_3D(cl_context context, cl_command_queue queue,
                        image_descriptor *srcImageInfo,
@@ -47,8 +38,18 @@ int test_copy_image_3D(cl_context context, cl_command_queue queue,
             (srcImageInfo->depth >> lod) ? (srcImageInfo->depth >> lod) : 1;
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
+    int retCode =
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
     return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                   origin, origin, region, d, ctx);
+                                   srcImage, dstImage, srcData, dstData, origin,
+                                   origin, region, d, ctx);
 }
 
 int test_copy_image_set_3D(cl_device_id device, cl_context context,

--- a/test_conformance/images/clCopyImage/test_copy_3D.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D.cpp
@@ -38,18 +38,16 @@ int test_copy_image_3D(cl_context context, cl_command_queue queue,
             (srcImageInfo->depth >> lod) ? (srcImageInfo->depth >> lod) : 1;
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
     int retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+        test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    return test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                   srcImage, dstImage, srcData, dstData, origin,
-                                   origin, region, d, ctx);
+    return test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                   origin, origin, region);
 }
 
 int test_copy_image_set_3D(cl_device_id device, cl_context context,

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,16 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "../testBase.h"
 #include "../common.h"
-
-extern int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                                   image_descriptor *srcImageInfo,
-                                   image_descriptor *dstImageInfo,
-                                   const size_t sourcePos[],
-                                   const size_t destPos[],
-                                   const size_t regionSize[], MTdata d,
-                                   const image_test_context_t &ctx);
+#include "test_copy_generic.h"
 
 static void set_image_dimensions(image_descriptor *imageInfo, size_t width,
                                  size_t height, size_t depth, size_t arraySize,
@@ -134,9 +126,19 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
         }
     }
 
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
     retCode =
-        test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                sourcePos, destPos, regionSize, d, ctx);
+        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
+                              srcImage, dstImage, srcData, dstData, d, ctx);
+    if (retCode != CL_SUCCESS)
+    {
+        return retCode;
+    }
+    retCode = test_copy_image_generic(
+        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
+        dstData, sourcePos, destPos, regionSize, d, ctx);
+
     if( retCode < 0 )
         return retCode;
     else
@@ -225,10 +227,10 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode =
-            test_copy_image_generic(context, queue, srcImageInfo, dstImageInfo,
-                                    sourcePos, destPos, regionSize, d, ctx);
-        if( retCode < 0 )
+        retCode = test_copy_image_generic(
+            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
+            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        if (retCode < 0)
             return retCode;
         else
             ret += retCode;

--- a/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_3D_2D_array.cpp
@@ -126,18 +126,15 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
         }
     }
 
-    clMemWrapper srcImage, dstImage;
-    BufferOwningPtr<char> srcData, dstData;
-    retCode =
-        test_copy_init_images(context, queue, srcImageInfo, dstImageInfo,
-                              srcImage, dstImage, srcData, dstData, d, ctx);
+    copy_image_env_t env{ context, queue, d, ctx };
+    copy_image_buffers_t buffers;
+    retCode = test_copy_init_images(env, srcImageInfo, dstImageInfo, buffers);
     if (retCode != CL_SUCCESS)
     {
         return retCode;
     }
-    retCode = test_copy_image_generic(
-        context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage, srcData,
-        dstData, sourcePos, destPos, regionSize, d, ctx);
+    retCode = test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                      sourcePos, destPos, regionSize);
 
     if( retCode < 0 )
         return retCode;
@@ -227,9 +224,9 @@ int test_copy_image_size_3D_2D_array(cl_context context, cl_command_queue queue,
 
 
         // Go for it!
-        retCode = test_copy_image_generic(
-            context, queue, srcImageInfo, dstImageInfo, srcImage, dstImage,
-            srcData, dstData, sourcePos, destPos, regionSize, d, ctx);
+        retCode =
+            test_copy_image_generic(env, srcImageInfo, dstImageInfo, buffers,
+                                    sourcePos, destPos, regionSize);
         if (retCode < 0)
             return retCode;
         else

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -47,16 +47,6 @@ int test_copy_init_images(copy_image_env_t &env, image_descriptor *srcImageInfo,
     int error;
 
     // Generate some data to test against
-    size_t srcBytes = 0;
-    if (env.ctx.testMipmaps)
-    {
-        srcBytes = (size_t)compute_mipmapped_image_size( *srcImageInfo );
-    }
-    else
-    {
-        srcBytes = get_image_size(srcImageInfo);
-    }
-
     if (env.ctx.debugTrace) log_info(" - Resizing random image data...\n");
 
     generate_random_image_data(srcImageInfo, buffers.srcData, env.d);
@@ -72,16 +62,6 @@ int test_copy_init_images(copy_image_env_t &env, image_descriptor *srcImageInfo,
 
 
     // Initialize the destination to empty
-    size_t destImageSize = 0;
-    if (env.ctx.testMipmaps)
-    {
-        destImageSize = (size_t)compute_mipmapped_image_size( *dstImageInfo );
-    }
-    else
-    {
-        destImageSize = get_image_size(dstImageInfo);
-    }
-
     if (env.ctx.debugTrace) log_info(" - Writing destination image...\n");
 
     buffers.dstData.reset(nullptr, nullptr, 0, 0);

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -16,6 +16,7 @@
 #include "../testBase.h"
 #include <CL/cl.h>
 #include "../common.h"
+#include "test_copy_generic.h"
 
 static cl_int cleanup_mapped_image(cl_command_queue queue, cl_mem image,
                                    void *mapped)
@@ -39,23 +40,15 @@ static cl_int cleanup_mapped_image(cl_command_queue queue, cl_mem image,
     return CL_SUCCESS;
 }
 
-int test_copy_image_generic(cl_context context, cl_command_queue queue,
-                            image_descriptor *srcImageInfo,
-                            image_descriptor *dstImageInfo,
-                            const size_t sourcePos[], const size_t destPos[],
-                            const size_t regionSize[], MTdata d,
-                            const image_test_context_t &ctx)
+int test_copy_init_images(cl_context context, cl_command_queue queue,
+                          image_descriptor *srcImageInfo,
+                          image_descriptor *dstImageInfo,
+                          clMemWrapper &srcImage, clMemWrapper &dstImage,
+                          BufferOwningPtr<char> &srcData,
+                          BufferOwningPtr<char> &dstData, MTdata d,
+                          const image_test_context_t &ctx)
 {
     int error;
-
-    clMemWrapper srcImage, dstImage;
-
-    BufferOwningPtr<char> srcData;
-    BufferOwningPtr<char> dstData;
-    BufferOwningPtr<char> srcHost;
-    BufferOwningPtr<char> dstHost;
-
-    if (ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
 
     // Generate some data to test against
     size_t srcBytes = 0;
@@ -68,21 +61,10 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         srcBytes = get_image_size(srcImageInfo);
     }
 
-    if (srcBytes > srcData.getSize())
-    {
-        if (ctx.debugTrace) log_info(" - Resizing random image data...\n");
+    if (ctx.debugTrace) log_info(" - Resizing random image data...\n");
 
-        generate_random_image_data( srcImageInfo, srcData, d  );
+    generate_random_image_data(srcImageInfo, srcData, d);
 
-        // Update the host verification copy of the data.
-        srcHost.reset(malloc(srcBytes),NULL,0,srcBytes);
-        if (srcHost == NULL) {
-            log_error("ERROR: Unable to malloc %zu bytes for srcHost\n",
-                      srcBytes);
-            return -1;
-        }
-        memcpy(srcHost,srcData,srcBytes);
-    }
 
     // Construct testing sources
     if (ctx.debugTrace) log_info(" - Writing source image...\n");
@@ -105,38 +87,42 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         destImageSize = get_image_size(dstImageInfo);
     }
 
-    if (destImageSize > dstData.getSize())
-    {
-        if (ctx.debugTrace) log_info(" - Resizing destination buffer...\n");
-        dstData.reset(malloc(destImageSize),NULL,0,destImageSize);
-        if (dstData == NULL) {
-            log_error("ERROR: Unable to malloc %zu bytes for dstData\n",
-                      destImageSize);
-            return -1;
-        }
-    }
-
-    if (destImageSize > dstHost.getSize())
-    {
-        dstHost.reset(NULL);
-        dstHost.reset(malloc(destImageSize),NULL,0,destImageSize);
-        if (dstHost == NULL) {
-            dstData.reset(NULL);
-            log_error("ERROR: Unable to malloc %zu bytes for dstHost\n",
-                      destImageSize);
-            return -1;
-        }
-    }
-    memset( dstData, 0xff, destImageSize );
-    memset( dstHost, 0xff, destImageSize );
-
     if (ctx.debugTrace) log_info(" - Writing destination image...\n");
 
+    dstData.reset(nullptr, nullptr, 0, 0);
     dstImage =
         create_image(context, queue, dstData, dstImageInfo, ctx.enablePitch,
                      ctx.testMipmaps, ctx.debugTrace, &error);
-    if( dstImage == NULL )
-        return error;
+    if (dstImage == NULL) return error;
+
+    size_t dstDataSize = get_image_size(dstImageInfo);
+    dstData.reset(malloc(dstDataSize), NULL, 0, dstDataSize);
+    if (dstData == NULL)
+    {
+        log_error("ERROR: unable to malloc %zu bytes in test_copy_init_images",
+                  dstDataSize);
+        return CL_OUT_OF_HOST_MEMORY;
+    }
+
+    return CL_SUCCESS;
+}
+
+int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                            image_descriptor *srcImageInfo,
+                            image_descriptor *dstImageInfo,
+                            clMemWrapper &srcImage, clMemWrapper &dstImage,
+                            BufferOwningPtr<char> &srcHost,
+                            BufferOwningPtr<char> &dstHost,
+                            const size_t sourcePos[], const size_t destPos[],
+                            const size_t regionSize[], MTdata d,
+                            const image_test_context_t &ctx)
+{
+    int error;
+
+    if (ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
+
+    memset(dstHost, 0xff, dstHost.getSize());
+    init_image(queue, dstImage, dstImageInfo, dstHost, ctx.testMipmaps);
 
     size_t dstRegion[ 3 ] = { dstImageInfo->width, 1, 1};
     size_t dst_lod = 0;

--- a/test_conformance/images/clCopyImage/test_copy_generic.cpp
+++ b/test_conformance/images/clCopyImage/test_copy_generic.cpp
@@ -40,19 +40,15 @@ static cl_int cleanup_mapped_image(cl_command_queue queue, cl_mem image,
     return CL_SUCCESS;
 }
 
-int test_copy_init_images(cl_context context, cl_command_queue queue,
-                          image_descriptor *srcImageInfo,
+int test_copy_init_images(copy_image_env_t &env, image_descriptor *srcImageInfo,
                           image_descriptor *dstImageInfo,
-                          clMemWrapper &srcImage, clMemWrapper &dstImage,
-                          BufferOwningPtr<char> &srcData,
-                          BufferOwningPtr<char> &dstData, MTdata d,
-                          const image_test_context_t &ctx)
+                          copy_image_buffers_t &buffers)
 {
     int error;
 
     // Generate some data to test against
     size_t srcBytes = 0;
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         srcBytes = (size_t)compute_mipmapped_image_size( *srcImageInfo );
     }
@@ -61,24 +57,23 @@ int test_copy_init_images(cl_context context, cl_command_queue queue,
         srcBytes = get_image_size(srcImageInfo);
     }
 
-    if (ctx.debugTrace) log_info(" - Resizing random image data...\n");
+    if (env.ctx.debugTrace) log_info(" - Resizing random image data...\n");
 
-    generate_random_image_data(srcImageInfo, srcData, d);
+    generate_random_image_data(srcImageInfo, buffers.srcData, env.d);
 
 
     // Construct testing sources
-    if (ctx.debugTrace) log_info(" - Writing source image...\n");
+    if (env.ctx.debugTrace) log_info(" - Writing source image...\n");
 
-    srcImage =
-        create_image(context, queue, srcData, srcImageInfo, ctx.enablePitch,
-                     ctx.testMipmaps, ctx.debugTrace, &error);
-    if( srcImage == NULL )
-        return error;
+    buffers.srcImage = create_image(
+        env.context, env.queue, buffers.srcData, srcImageInfo,
+        env.ctx.enablePitch, env.ctx.testMipmaps, env.ctx.debugTrace, &error);
+    if (buffers.srcImage == NULL) return error;
 
 
     // Initialize the destination to empty
     size_t destImageSize = 0;
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         destImageSize = (size_t)compute_mipmapped_image_size( *dstImageInfo );
     }
@@ -87,17 +82,17 @@ int test_copy_init_images(cl_context context, cl_command_queue queue,
         destImageSize = get_image_size(dstImageInfo);
     }
 
-    if (ctx.debugTrace) log_info(" - Writing destination image...\n");
+    if (env.ctx.debugTrace) log_info(" - Writing destination image...\n");
 
-    dstData.reset(nullptr, nullptr, 0, 0);
-    dstImage =
-        create_image(context, queue, dstData, dstImageInfo, ctx.enablePitch,
-                     ctx.testMipmaps, ctx.debugTrace, &error);
-    if (dstImage == NULL) return error;
+    buffers.dstData.reset(nullptr, nullptr, 0, 0);
+    buffers.dstImage = create_image(
+        env.context, env.queue, buffers.dstData, dstImageInfo,
+        env.ctx.enablePitch, env.ctx.testMipmaps, env.ctx.debugTrace, &error);
+    if (buffers.dstImage == NULL) return error;
 
     size_t dstDataSize = get_image_size(dstImageInfo);
-    dstData.reset(malloc(dstDataSize), NULL, 0, dstDataSize);
-    if (dstData == NULL)
+    buffers.dstData.reset(malloc(dstDataSize), NULL, 0, dstDataSize);
+    if (buffers.dstData == NULL)
     {
         log_error("ERROR: unable to malloc %zu bytes in test_copy_init_images",
                   dstDataSize);
@@ -107,28 +102,30 @@ int test_copy_init_images(cl_context context, cl_command_queue queue,
     return CL_SUCCESS;
 }
 
-int test_copy_image_generic(cl_context context, cl_command_queue queue,
+int test_copy_image_generic(copy_image_env_t &env,
                             image_descriptor *srcImageInfo,
                             image_descriptor *dstImageInfo,
-                            clMemWrapper &srcImage, clMemWrapper &dstImage,
-                            BufferOwningPtr<char> &srcHost,
-                            BufferOwningPtr<char> &dstHost,
+                            copy_image_buffers_t &buffers,
                             const size_t sourcePos[], const size_t destPos[],
-                            const size_t regionSize[], MTdata d,
-                            const image_test_context_t &ctx)
+                            const size_t regionSize[])
 {
     int error;
 
-    if (ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
+    if (env.ctx.debugTrace) log_info(" ++ Entering inner test loop...\n");
 
-    memset(dstHost, 0xff, dstHost.getSize());
-    init_image(queue, dstImage, dstImageInfo, dstHost, ctx.testMipmaps);
+    memset(buffers.dstData, 0xff, buffers.dstData.getSize());
+    error = init_image(env.queue, buffers.dstImage, dstImageInfo,
+                       buffers.dstData, env.ctx.testMipmaps);
+    if (error != CL_SUCCESS)
+    {
+        return error;
+    }
 
     size_t dstRegion[ 3 ] = { dstImageInfo->width, 1, 1};
     size_t dst_lod = 0;
     size_t origin[ 4 ] = { 0, 0, 0, 0 };
 
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         switch(dstImageInfo->type)
         {
@@ -150,11 +147,11 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     {
         case CL_MEM_OBJECT_IMAGE1D_BUFFER:
         case CL_MEM_OBJECT_IMAGE1D:
-            if (ctx.testMipmaps) origin[1] = dst_lod;
+            if (env.ctx.testMipmaps) origin[1] = dst_lod;
             break;
         case CL_MEM_OBJECT_IMAGE2D:
             dstRegion[ 1 ] = dstImageInfo->height;
-            if (ctx.testMipmaps)
+            if (env.ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 origin[ 2 ] = dst_lod;
@@ -163,7 +160,7 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         case CL_MEM_OBJECT_IMAGE3D:
             dstRegion[ 1 ] = dstImageInfo->height;
             dstRegion[ 2 ] = dstImageInfo->depth;
-            if (ctx.testMipmaps)
+            if (env.ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 dstRegion[ 2 ] = (dstImageInfo->depth >> dst_lod) ?(dstImageInfo->depth >> dst_lod): 1;
@@ -172,12 +169,12 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
             break;
         case CL_MEM_OBJECT_IMAGE1D_ARRAY:
             dstRegion[ 1 ] = dstImageInfo->arraySize;
-            if (ctx.testMipmaps) origin[2] = dst_lod;
+            if (env.ctx.testMipmaps) origin[2] = dst_lod;
             break;
         case CL_MEM_OBJECT_IMAGE2D_ARRAY:
             dstRegion[ 1 ] = dstImageInfo->height;
             dstRegion[ 2 ] = dstImageInfo->arraySize;
-            if (ctx.testMipmaps)
+            if (env.ctx.testMipmaps)
             {
                 dstRegion[ 1 ] = (dstImageInfo->height >> dst_lod) ?(dstImageInfo->height >> dst_lod): 1;
                 origin[ 3 ] = dst_lod;
@@ -188,9 +185,9 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     size_t region[ 3 ] = { dstRegion[ 0 ], dstRegion[ 1 ], dstRegion[ 2 ] };
 
     // Now copy a subset to the destination image. This is the meat of what we're testing
-    if (ctx.debugTrace)
+    if (env.ctx.debugTrace)
     {
-        if (ctx.testMipmaps)
+        if (env.ctx.testMipmaps)
         {
             log_info( " - Copying from %d,%d,%d,%d to %d,%d,%d,%d size %d,%d,%d\n", (int)sourcePos[ 0 ], (int)sourcePos[ 1 ], (int)sourcePos[ 2 ],(int)sourcePos[ 3 ],
                      (int)destPos[ 0 ], (int)destPos[ 1 ], (int)destPos[ 2 ],(int)destPos[ 3 ],
@@ -204,7 +201,8 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         }
     }
 
-    error = clEnqueueCopyImage( queue, srcImage, dstImage, sourcePos, destPos, regionSize, 0, NULL, NULL );
+    error = clEnqueueCopyImage(env.queue, buffers.srcImage, buffers.dstImage,
+                               sourcePos, destPos, regionSize, 0, NULL, NULL);
     if( error != CL_SUCCESS )
     {
         log_error( "ERROR: Unable to copy image from pos %d,%d,%d to %d,%d,%d size %d,%d,%d! (%s)\n",
@@ -214,16 +212,19 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     }
 
     // Construct the final dest image values to test against
-    if (ctx.debugTrace) log_info(" - Host verification copy...\n");
+    if (env.ctx.debugTrace) log_info(" - Host verification copy...\n");
 
-    copy_image_data( srcImageInfo, dstImageInfo, srcHost, dstHost, sourcePos, destPos, regionSize );
+    copy_image_data(srcImageInfo, dstImageInfo, buffers.srcData,
+                    buffers.dstData, sourcePos, destPos, regionSize);
 
     // Map the destination image to verify the results with the host
     // copy. The contents of the entire buffer are compared.
-    if (ctx.debugTrace) log_info(" - Mapping results...\n");
+    if (env.ctx.debugTrace) log_info(" - Mapping results...\n");
 
     size_t mappedRow, mappedSlice;
-    void* mapped = (char*)clEnqueueMapImage(queue, dstImage, CL_TRUE, CL_MAP_READ, origin, region, &mappedRow, &mappedSlice, 0, NULL, NULL, &error);
+    void *mapped = (char *)clEnqueueMapImage(
+        env.queue, buffers.dstImage, CL_TRUE, CL_MAP_READ, origin, region,
+        &mappedRow, &mappedSlice, 0, NULL, NULL, &error);
     if (error != CL_SUCCESS)
     {
         log_error( "ERROR: Unable to map image for verification: %s\n", IGetErrorString( error ) );
@@ -231,11 +232,11 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     }
 
     // Verify scanline by scanline, since the pitches are different
-    char *sourcePtr = dstHost;
+    char *sourcePtr = buffers.dstData;
     size_t cur_lod_offset = 0;
     char *destPtr = (char*)mapped;
 
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         cur_lod_offset = compute_mip_level_offset(dstImageInfo, dst_lod);
         sourcePtr += cur_lod_offset;
@@ -245,7 +246,7 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     size_t rowPitch = dstImageInfo->rowPitch;
     size_t slicePitch = dstImageInfo->slicePitch;
     size_t dst_height_lod = dstImageInfo->height;
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         size_t dst_width_lod = (dstImageInfo->width >> dst_lod)?(dstImageInfo->width >> dst_lod) : 1;
         dst_height_lod = (dstImageInfo->height >> dst_lod)?(dstImageInfo->height >> dst_lod) : 1;
@@ -254,7 +255,7 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         slicePitch = rowPitch * dst_height_lod;
     }
 
-    if (ctx.debugTrace) log_info(" - Scanline verification...\n");
+    if (env.ctx.debugTrace) log_info(" - Scanline verification...\n");
 
     size_t thirdDim = 1;
     size_t secondDim = 1;
@@ -286,12 +287,12 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
         default: {
             log_error("ERROR: Unsupported Image type. \n");
             cl_int cleanup_error =
-                cleanup_mapped_image(queue, dstImage, mapped);
+                cleanup_mapped_image(env.queue, buffers.dstImage, mapped);
             return (cleanup_error != CL_SUCCESS) ? cleanup_error : -1;
             break;
         }
     }
-    if (ctx.testMipmaps)
+    if (env.ctx.testMipmaps)
     {
         switch (dstImageInfo->type)
         {
@@ -323,8 +324,8 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
                         where, sourcePtr + pixel_size * where,
                         destPtr + pixel_size * where, dstImageInfo, y,
                         dstImageInfo->depth);
-                    cl_int cleanup_error =
-                        cleanup_mapped_image(queue, dstImage, mapped);
+                    cl_int cleanup_error = cleanup_mapped_image(
+                        env.queue, buffers.dstImage, mapped);
                     if (cleanup_error != CL_SUCCESS) return cleanup_error;
                     return -1;
                 }
@@ -340,7 +341,7 @@ int test_copy_image_generic(cl_context context, cl_command_queue queue,
     }
 
     // Unmap the image.
-    error = cleanup_mapped_image(queue, dstImage, mapped);
+    error = cleanup_mapped_image(env.queue, buffers.dstImage, mapped);
     if (error != CL_SUCCESS) return error;
 
     return 0;

--- a/test_conformance/images/clCopyImage/test_copy_generic.h
+++ b/test_conformance/images/clCopyImage/test_copy_generic.h
@@ -20,22 +20,28 @@
 #include "typeWrappers.h"
 #include "testHarness.h"
 
-int test_copy_init_images(cl_context context, cl_command_queue queue,
-                          image_descriptor *srcImageInfo,
-                          image_descriptor *dstImageInfo,
-                          clMemWrapper &srcImage, clMemWrapper &dstImage,
-                          BufferOwningPtr<char> &srcData,
-                          BufferOwningPtr<char> &dstData, MTdata d,
-                          const image_test_context_t &ctx);
+struct copy_image_buffers_t
+{
+    clMemWrapper srcImage, dstImage;
+    BufferOwningPtr<char> srcData, dstData;
+};
+struct copy_image_env_t
+{
+    cl_context context;
+    cl_command_queue queue;
+    MTdata d;
+    const image_test_context_t &ctx;
+};
 
-int test_copy_image_generic(cl_context context, cl_command_queue queue,
+int test_copy_init_images(copy_image_env_t &env, image_descriptor *srcImageInfo,
+                          image_descriptor *dstImageInfo,
+                          copy_image_buffers_t &buffers);
+
+int test_copy_image_generic(copy_image_env_t &env,
                             image_descriptor *srcImageInfo,
                             image_descriptor *dstImageInfo,
-                            clMemWrapper &srcImage, clMemWrapper &dstImage,
-                            BufferOwningPtr<char> &srcData,
-                            BufferOwningPtr<char> &dstHost,
+                            copy_image_buffers_t &buffers,
                             const size_t sourcePos[], const size_t destPos[],
-                            const size_t regionSize[], MTdata d,
-                            const image_test_context_t &ctx);
+                            const size_t regionSize[]);
 
 #endif

--- a/test_conformance/images/clCopyImage/test_copy_generic.h
+++ b/test_conformance/images/clCopyImage/test_copy_generic.h
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2026 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef IMAGES_COPY_GENERIC_H
+#define IMAGES_COPY_GENERIC_H
+
+#include "../testBase.h"
+#include "typeWrappers.h"
+#include "testHarness.h"
+
+int test_copy_init_images(cl_context context, cl_command_queue queue,
+                          image_descriptor *srcImageInfo,
+                          image_descriptor *dstImageInfo,
+                          clMemWrapper &srcImage, clMemWrapper &dstImage,
+                          BufferOwningPtr<char> &srcData,
+                          BufferOwningPtr<char> &dstData, MTdata d,
+                          const image_test_context_t &ctx);
+
+int test_copy_image_generic(cl_context context, cl_command_queue queue,
+                            image_descriptor *srcImageInfo,
+                            image_descriptor *dstImageInfo,
+                            clMemWrapper &srcImage, clMemWrapper &dstImage,
+                            BufferOwningPtr<char> &srcData,
+                            BufferOwningPtr<char> &dstHost,
+                            const size_t sourcePos[], const size_t destPos[],
+                            const size_t regionSize[], MTdata d,
+                            const image_test_context_t &ctx);
+
+#endif

--- a/test_conformance/images/common.cpp
+++ b/test_conformance/images/common.cpp
@@ -171,6 +171,184 @@ static void CL_CALLBACK release_cl_buffer(cl_mem image, void *buf)
     clReleaseMemObject((cl_mem)buf);
 }
 
+int init_image(cl_command_queue queue, clMemWrapper &img,
+               image_descriptor *imageInfo, BufferOwningPtr<char> &data,
+               bool create_mipmaps)
+{
+    size_t mappedRow, mappedSlice;
+    size_t width = imageInfo->width;
+    size_t height = 1;
+    size_t depth = 1;
+    size_t row_pitch_lod, slice_pitch_lod;
+    row_pitch_lod = imageInfo->rowPitch;
+    slice_pitch_lod = imageInfo->slicePitch;
+
+    switch (imageInfo->type)
+    {
+        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+            height = imageInfo->arraySize;
+            depth = 1;
+            break;
+        case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+        case CL_MEM_OBJECT_IMAGE1D: height = depth = 1; break;
+        case CL_MEM_OBJECT_IMAGE2D:
+            height = imageInfo->height;
+            depth = 1;
+            break;
+        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+            height = imageInfo->height;
+            depth = imageInfo->arraySize;
+            break;
+        case CL_MEM_OBJECT_IMAGE3D:
+            height = imageInfo->height;
+            depth = imageInfo->depth;
+            break;
+        default:
+            log_error("ERROR Invalid imageInfo->type = %d\n", imageInfo->type);
+            height = 0;
+            depth = 0;
+            return -1;
+            break;
+    }
+
+    size_t origin[4] = { 0, 0, 0, 0 };
+    size_t region[3] = { imageInfo->width, height, depth };
+
+    if (data.getSize() == 0) return CL_SUCCESS;
+
+    for (size_t lod = 0; (create_mipmaps && (lod < imageInfo->num_mip_levels))
+         || (!create_mipmaps && (lod < 1));
+         lod++)
+    {
+        // Map the appropriate miplevel to copy the specified data.
+        if (create_mipmaps)
+        {
+            switch (imageInfo->type)
+            {
+                case CL_MEM_OBJECT_IMAGE3D:
+                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+                    origin[0] = origin[1] = origin[2] = 0;
+                    origin[3] = lod;
+                    break;
+                case CL_MEM_OBJECT_IMAGE2D:
+                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+                    origin[0] = origin[1] = origin[3] = 0;
+                    origin[2] = lod;
+                    break;
+                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+                case CL_MEM_OBJECT_IMAGE1D:
+                    origin[0] = origin[2] = origin[3] = 0;
+                    origin[1] = lod;
+                    break;
+            }
+
+            // Adjust image dimensions as per miplevel
+            switch (imageInfo->type)
+            {
+                case CL_MEM_OBJECT_IMAGE3D:
+                    depth = (imageInfo->depth >> lod)
+                        ? (imageInfo->depth >> lod)
+                        : 1;
+                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+                case CL_MEM_OBJECT_IMAGE2D:
+                    height = (imageInfo->height >> lod)
+                        ? (imageInfo->height >> lod)
+                        : 1;
+                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+                case CL_MEM_OBJECT_IMAGE1D:
+                    width = (imageInfo->width >> lod)
+                        ? (imageInfo->width >> lod)
+                        : 1;
+            }
+            row_pitch_lod = width * get_pixel_size(imageInfo->format);
+            slice_pitch_lod = row_pitch_lod * height;
+            region[0] = width;
+            region[1] = height;
+            region[2] = depth;
+        }
+
+        cl_int error;
+        char *mapped = static_cast<char *>(clEnqueueMapImage(
+            queue, img, CL_TRUE, CL_MAP_WRITE, origin, region, &mappedRow,
+            &mappedSlice, 0, nullptr, nullptr, &error));
+        if (error != CL_SUCCESS || !mapped)
+        {
+            log_error("ERROR: Unable to map image for writing: %s\n",
+                      IGetErrorString(error));
+            return error;
+        }
+        size_t mappedSlicePad = mappedSlice - (mappedRow * height);
+
+        // For 1Darray, the height variable actually contains the arraysize,
+        // so it can't be used for calculating the slice padding.
+        if (imageInfo->type == CL_MEM_OBJECT_IMAGE1D_ARRAY)
+            mappedSlicePad = mappedSlice - (mappedRow * 1);
+
+        // Copy the image.
+        size_t scanlineSize = row_pitch_lod;
+        size_t sliceSize = slice_pitch_lod - scanlineSize * height;
+        size_t imageSize = scanlineSize * height * depth;
+        size_t data_lod_offset = 0;
+        if (create_mipmaps)
+        {
+            data_lod_offset = compute_mip_level_offset(imageInfo, lod);
+        }
+
+        char *src = static_cast<char *>(data) + data_lod_offset;
+        char *dst = mapped;
+
+        if ((mappedRow == scanlineSize)
+            && (mappedSlicePad == 0
+                || (imageInfo->depth == 0 && imageInfo->arraySize == 0)))
+        {
+            // Copy the whole image.
+            memcpy(dst, src, imageSize);
+        }
+        else
+        {
+            // Else copy one scan line at a time.
+            size_t dstPitch2D = 0;
+            switch (imageInfo->type)
+            {
+                case CL_MEM_OBJECT_IMAGE3D:
+                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+                case CL_MEM_OBJECT_IMAGE2D: dstPitch2D = mappedRow; break;
+                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+                case CL_MEM_OBJECT_IMAGE1D:
+                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+                    dstPitch2D = mappedSlice;
+                    break;
+            }
+            for (size_t z = 0; z < depth; z++)
+            {
+                for (size_t y = 0; y < height; y++)
+                {
+                    memcpy(dst, src, scanlineSize);
+                    dst += dstPitch2D;
+                    src += scanlineSize;
+                }
+
+                // mappedSlicePad is incorrect for 2D images here, but we
+                // will exit the z loop before this is a problem.
+                dst += mappedSlicePad;
+                src += sliceSize;
+            }
+        }
+
+        // Unmap the image.
+        error =
+            clEnqueueUnmapMemObject(queue, img, mapped, 0, nullptr, nullptr);
+        if (error != CL_SUCCESS)
+        {
+            log_error("ERROR: Unable to unmap image after writing: %s\n",
+                      IGetErrorString(error));
+            return error;
+        }
+    }
+    return CL_SUCCESS;
+}
+
 clMemWrapper create_image(cl_context context, cl_command_queue queue,
                           BufferOwningPtr<char> &data,
                           image_descriptor *imageInfo, bool enable_pitch,
@@ -422,174 +600,12 @@ clMemWrapper create_image(cl_context context, cl_command_queue queue,
         return nullptr;
     }
 
-    // Copy the specified data to the image via a Map operation.
-    size_t mappedRow, mappedSlice;
-    size_t width = imageInfo->width;
-    size_t height = 1;
-    size_t depth = 1;
-    size_t row_pitch_lod, slice_pitch_lod;
-    row_pitch_lod = imageInfo->rowPitch;
-    slice_pitch_lod = imageInfo->slicePitch;
-
-    switch (imageInfo->type)
+    *error = init_image(queue, img, imageInfo, data, create_mipmaps);
+    if (*error != CL_SUCCESS)
     {
-        case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-            height = imageInfo->arraySize;
-            depth = 1;
-            break;
-        case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-        case CL_MEM_OBJECT_IMAGE1D: height = depth = 1; break;
-        case CL_MEM_OBJECT_IMAGE2D:
-            height = imageInfo->height;
-            depth = 1;
-            break;
-        case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-            height = imageInfo->height;
-            depth = imageInfo->arraySize;
-            break;
-        case CL_MEM_OBJECT_IMAGE3D:
-            height = imageInfo->height;
-            depth = imageInfo->depth;
-            break;
-        default:
-            log_error("ERROR Invalid imageInfo->type = %d\n", imageInfo->type);
-            height = 0;
-            depth = 0;
-            return nullptr;
-            break;
+        log_error("ERROR: could not init image");
+        return nullptr;
     }
 
-    size_t origin[4] = { 0, 0, 0, 0 };
-    size_t region[3] = { imageInfo->width, height, depth };
-
-    for (size_t lod = 0; (create_mipmaps && (lod < imageInfo->num_mip_levels))
-         || (!create_mipmaps && (lod < 1));
-         lod++)
-    {
-        // Map the appropriate miplevel to copy the specified data.
-        if (create_mipmaps)
-        {
-            switch (imageInfo->type)
-            {
-                case CL_MEM_OBJECT_IMAGE3D:
-                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                    origin[0] = origin[1] = origin[2] = 0;
-                    origin[3] = lod;
-                    break;
-                case CL_MEM_OBJECT_IMAGE2D:
-                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                    origin[0] = origin[1] = origin[3] = 0;
-                    origin[2] = lod;
-                    break;
-                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-                case CL_MEM_OBJECT_IMAGE1D:
-                    origin[0] = origin[2] = origin[3] = 0;
-                    origin[1] = lod;
-                    break;
-            }
-
-            // Adjust image dimensions as per miplevel
-            switch (imageInfo->type)
-            {
-                case CL_MEM_OBJECT_IMAGE3D:
-                    depth = (imageInfo->depth >> lod)
-                        ? (imageInfo->depth >> lod)
-                        : 1;
-                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                case CL_MEM_OBJECT_IMAGE2D:
-                    height = (imageInfo->height >> lod)
-                        ? (imageInfo->height >> lod)
-                        : 1;
-                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-                case CL_MEM_OBJECT_IMAGE1D:
-                    width = (imageInfo->width >> lod)
-                        ? (imageInfo->width >> lod)
-                        : 1;
-            }
-            row_pitch_lod = width * get_pixel_size(imageInfo->format);
-            slice_pitch_lod = row_pitch_lod * height;
-            region[0] = width;
-            region[1] = height;
-            region[2] = depth;
-        }
-
-        char *mapped = static_cast<char *>(clEnqueueMapImage(
-            queue, img, CL_TRUE, CL_MAP_WRITE, origin, region, &mappedRow,
-            &mappedSlice, 0, nullptr, nullptr, error));
-        if (*error != CL_SUCCESS || !mapped)
-        {
-            log_error("ERROR: Unable to map image for writing: %s\n",
-                      IGetErrorString(*error));
-            return nullptr;
-        }
-        size_t mappedSlicePad = mappedSlice - (mappedRow * height);
-
-        // For 1Darray, the height variable actually contains the arraysize,
-        // so it can't be used for calculating the slice padding.
-        if (imageInfo->type == CL_MEM_OBJECT_IMAGE1D_ARRAY)
-            mappedSlicePad = mappedSlice - (mappedRow * 1);
-
-        // Copy the image.
-        size_t scanlineSize = row_pitch_lod;
-        size_t sliceSize = slice_pitch_lod - scanlineSize * height;
-        size_t imageSize = scanlineSize * height * depth;
-        size_t data_lod_offset = 0;
-        if (create_mipmaps)
-        {
-            data_lod_offset = compute_mip_level_offset(imageInfo, lod);
-        }
-
-        char *src = static_cast<char *>(data) + data_lod_offset;
-        char *dst = mapped;
-
-        if ((mappedRow == scanlineSize)
-            && (mappedSlicePad == 0
-                || (imageInfo->depth == 0 && imageInfo->arraySize == 0)))
-        {
-            // Copy the whole image.
-            memcpy(dst, src, imageSize);
-        }
-        else
-        {
-            // Else copy one scan line at a time.
-            size_t dstPitch2D = 0;
-            switch (imageInfo->type)
-            {
-                case CL_MEM_OBJECT_IMAGE3D:
-                case CL_MEM_OBJECT_IMAGE2D_ARRAY:
-                case CL_MEM_OBJECT_IMAGE2D: dstPitch2D = mappedRow; break;
-                case CL_MEM_OBJECT_IMAGE1D_ARRAY:
-                case CL_MEM_OBJECT_IMAGE1D:
-                case CL_MEM_OBJECT_IMAGE1D_BUFFER:
-                    dstPitch2D = mappedSlice;
-                    break;
-            }
-            for (size_t z = 0; z < depth; z++)
-            {
-                for (size_t y = 0; y < height; y++)
-                {
-                    memcpy(dst, src, scanlineSize);
-                    dst += dstPitch2D;
-                    src += scanlineSize;
-                }
-
-                // mappedSlicePad is incorrect for 2D images here, but we will
-                // exit the z loop before this is a problem.
-                dst += mappedSlicePad;
-                src += sliceSize;
-            }
-        }
-
-        // Unmap the image.
-        *error =
-            clEnqueueUnmapMemObject(queue, img, mapped, 0, nullptr, nullptr);
-        if (*error != CL_SUCCESS)
-        {
-            log_error("ERROR: Unable to unmap image after writing: %s\n",
-                      IGetErrorString(*error));
-            return nullptr;
-        }
-    }
     return img;
 }

--- a/test_conformance/images/common.h
+++ b/test_conformance/images/common.h
@@ -52,6 +52,10 @@ int get_format_list(cl_context context, cl_mem_object_type imageType,
                     cl_mem_flags flags);
 size_t random_in_ranges(size_t minimum, size_t rangeA, size_t rangeB, MTdata d);
 
+int init_image(cl_command_queue queue, clMemWrapper &img,
+               image_descriptor *imageInfo, BufferOwningPtr<char> &data,
+               bool create_mipmaps);
+
 clMemWrapper create_image(cl_context context, cl_command_queue queue,
                           BufferOwningPtr<char> &data,
                           image_descriptor *imageInfo, bool enable_pitch,


### PR DESCRIPTION
This patch restructures the image copy conformance tests to eliminate unnecessary host-side memory allocations and data duplication, significantly improving the execution speed of the test loops.

Key changes include:
* Removed the redundant `srcHost` buffer allocation and its associated `memcpy` operation. The test loop now directly uses `srcData` for validation.
* Split the monolithic `test_copy_image_generic` into `test_copy_init_images` (for setup) and `test_copy_image_generic` (for execution). This hoists buffer sizing, random data generation, and image creation out of the inner testing loops.
* Extracted memory mapping and initialization logic from `create_image` into a standalone `init_image` function in `common.cpp`. This allows destination images to be efficiently reset during test iterations without fully recreating the OpenCL memory objects.
* Consolidated scattered `extern` function declarations across all dimension tests into a new `test_copy_generic.h` header.
* Fixed a minor typo in `test_copy_1D_buffer.cpp` where `srcImageInfo` was incorrectly passed as the destination descriptor.

Ref #2723

[run-test: test_cl_copy_images --num-worker-threads 2 small_images]