### PR TITLE
subgroups: Fix maximum subgroup size for tail calculation

### DIFF
--- a/test_conformance/subgroups/test_subgroup_ballot.cpp
+++ b/test_conformance/subgroups/test_subgroup_ballot.cpp
@@ -714,7 +714,7 @@ __kernel void test_sub_group_non_uniform_broadcast(const __global Type *in, __gl
     uint sub_group_size = get_sub_group_size();
     // If we are at the edge, calculate our own sub_group_size as it's implementation defined otherwise.
     if (get_local_size(0) != get_enqueued_local_size(0) && get_sub_group_id() == get_num_sub_groups() - 1) {
-        uint new_sub_group_size = get_local_size(0) % sub_group_size;
+        uint new_sub_group_size = get_local_size(0) % get_max_sub_group_size();
         if (new_sub_group_size != 0)
             sub_group_size = new_sub_group_size;
     }
@@ -735,7 +735,7 @@ __kernel void test_sub_group_broadcast_first(const __global Type *in, __global i
     uint sub_group_size = get_sub_group_size();
     // If we are at the edge, calculate our own sub_group_size as it's implementation defined otherwise.
     if (get_local_size(0) != get_enqueued_local_size(0) && get_sub_group_id() == get_num_sub_groups() - 1) {
-        uint new_sub_group_size = get_local_size(0) % sub_group_size;
+        uint new_sub_group_size = get_local_size(0) % get_max_sub_group_size();
         if (new_sub_group_size != 0)
             sub_group_size = new_sub_group_size;
     }


### PR DESCRIPTION
Use get_max_sub_group_size() when calculating the size of the final subgroup in a non-uniform workgroup.

get_sub_group_size() may already return the size of the current partial subgroup. Using it as the modulus divisor can therefore calculate an incorrect size, split the subgroup at the wrong lane, and pass non-uniform indices to sub_group_non_uniform_broadcast.