### PR TITLE
Command-buffer testing for recoding with invalid queue props

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/command_buffer_queue_substitution.cpp
@@ -293,6 +293,237 @@ struct QueueOrderTest : public BasicCommandBufferTest
     const cl_int overwritten_pattern = 0xACDC;
     const cl_int pattern_pri = 42;
 };
+
+// Command-queue substitution test which handles the case where a command-buffer
+// is recorded on a command-queue with an unsupported property, and then a
+// substituted queue with required properties used for execution.
+struct RecordUnsupportedPropTest : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    RecordUnsupportedPropTest(cl_device_id device, cl_context context,
+                              cl_command_queue queue)
+        : BasicCommandBufferTest(device, context, queue), recording_prop(),
+          recording_queue(nullptr)
+    {}
+
+    // Record using sync points in case the command-buffer is using an
+    // out-of-order queue
+    cl_int RecordCommandBuffer()
+    {
+        cl_sync_point_khr sync_points[2];
+        const cl_int pattern = pattern_pri;
+        cl_int error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, in_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, &sync_points[0], nullptr);
+        test_error(error, "clCommandFillBufferKHR failed");
+
+        error = clCommandFillBufferKHR(command_buffer, nullptr, nullptr,
+                                       out_mem, &overwritten_pattern,
+                                       sizeof(cl_int), 0, data_size(), 0,
+                                       nullptr, &sync_points[1], nullptr);
+        test_error(error, "clCommandFillBufferKHR failed");
+
+        error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 2, sync_points, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        return CL_SUCCESS;
+    }
+
+    cl_int Run() override
+    {
+        cl_int error = RecordCommandBuffer();
+        test_error(error, "RecordCommandBuffer failed");
+
+        // The default testing queue exactly matches the required properties
+        error = clEnqueueCommandBufferKHR(1, &queue, command_buffer, 0, nullptr,
+                                          nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clFinish(queue);
+        test_error(error, "clFinish failed");
+
+        // Verify output
+        std::vector<cl_int> output_buffer(num_elements);
+        error = clEnqueueReadBuffer(queue, out_mem, CL_TRUE, 0, data_size(),
+                                    output_buffer.data(), 0, nullptr, nullptr);
+        test_error(error, "clEnqueueReadBuffer failed");
+
+        for (size_t i = 0; i < num_elements; i++)
+        {
+            CHECK_VERIFICATION_ERROR(pattern_pri, output_buffer[i], i);
+        }
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        recording_queue =
+            clCreateCommandQueue(context, device, recording_prop, &error);
+        test_error(error, "clCreateCommandQueue failed");
+
+        command_buffer =
+            clCreateCommandBufferKHR(1, &recording_queue, nullptr, &error);
+        test_error(error, "clCreateCommandBufferKHR failed");
+
+        return CL_SUCCESS;
+    }
+
+    bool Skip() override
+    {
+        if (BasicCommandBufferTest::Skip()) return true;
+
+        cl_command_queue_properties supported_properties;
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+            sizeof(supported_properties), &supported_properties, NULL);
+
+        test_error(error,
+                   "Unable to query "
+                   "CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR");
+
+        // Check if either of these properties is unsupported for command-buffer
+        // enqueue, in which case test that it is still valid to use for
+        // command-buffer recording.
+        const cl_command_queue_properties test_props[] = {
+            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, CL_QUEUE_PROFILING_ENABLE
+        };
+        for (const auto& prop : test_props)
+        {
+            if ((supported_properties & prop) == 0)
+            {
+                recording_prop = prop;
+                return false;
+            }
+        }
+
+        // Skip because we need an unsupported property to test
+        return true;
+    }
+
+    cl_command_queue_properties recording_prop;
+    clCommandQueueWrapper recording_queue;
+
+    const cl_int overwritten_pattern = 0xACDC;
+    const cl_int pattern_pri = 42;
+};
+
+// Command-queue substitution test which handles the case where a command-buffer
+// is recorded on a command-queue without any properties, and then a substituted
+// queue with required properties used for execution.
+struct RecordWithoutReqdPropsTest : public BasicCommandBufferTest
+{
+    using BasicCommandBufferTest::BasicCommandBufferTest;
+
+    RecordWithoutReqdPropsTest(cl_device_id device, cl_context context,
+                               cl_command_queue queue)
+        : BasicCommandBufferTest(device, context, queue), required_props(),
+          recording_queue(nullptr), execution_queue(nullptr)
+    {}
+
+    cl_int RecordCommandBuffer()
+    {
+        const cl_int pattern = pattern_pri;
+        cl_int error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, in_mem, &pattern, sizeof(cl_int),
+            0, data_size(), 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandFillBufferKHR failed");
+
+        error = clCommandFillBufferKHR(
+            command_buffer, nullptr, nullptr, out_mem, &overwritten_pattern,
+            sizeof(cl_int), 0, data_size(), 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandFillBufferKHR failed");
+
+        error = clCommandNDRangeKernelKHR(
+            command_buffer, nullptr, nullptr, kernel, 1, nullptr, &num_elements,
+            nullptr, 0, nullptr, nullptr, nullptr);
+        test_error(error, "clCommandNDRangeKernelKHR failed");
+
+        error = clFinalizeCommandBufferKHR(command_buffer);
+        test_error(error, "clFinalizeCommandBufferKHR failed");
+
+        return CL_SUCCESS;
+    }
+
+    cl_int Run() override
+    {
+        cl_int error = RecordCommandBuffer();
+        test_error(error, "RecordCommandBuffer failed");
+
+        error = clEnqueueCommandBufferKHR(1, &execution_queue, command_buffer,
+                                          0, nullptr, nullptr);
+        test_error(error, "clEnqueueCommandBufferKHR failed");
+
+        error = clFinish(execution_queue);
+        test_error(error, "clFinish failed");
+
+        // Verify output
+        std::vector<cl_int> output_buffer(num_elements);
+        error = clEnqueueReadBuffer(execution_queue, out_mem, CL_TRUE, 0,
+                                    data_size(), output_buffer.data(), 0,
+                                    nullptr, nullptr);
+        test_error(error, "clEnqueueReadBuffer failed");
+
+        for (size_t i = 0; i < num_elements; i++)
+        {
+            CHECK_VERIFICATION_ERROR(pattern_pri, output_buffer[i], i);
+        }
+
+        return CL_SUCCESS;
+    }
+
+    cl_int SetUp(int elements) override
+    {
+        cl_int error = BasicCommandBufferTest::SetUp(elements);
+        test_error(error, "BasicCommandBufferTest::SetUp failed");
+
+        recording_queue = clCreateCommandQueue(context, device, 0, &error);
+        test_error(error, "clCreateCommandQueue failed");
+
+        command_buffer =
+            clCreateCommandBufferKHR(1, &recording_queue, nullptr, &error);
+        test_error(error, "clCreateCommandBufferKHR failed");
+
+        execution_queue =
+            clCreateCommandQueue(context, device, required_props, &error);
+        test_error(error, "clCreateCommandQueue failed");
+
+        return CL_SUCCESS;
+    }
+
+    bool Skip() override
+    {
+        // Don't use BasicCommandBufferTest::Skip() because if mandates required
+        // properties
+        cl_int error = clGetDeviceInfo(
+            device, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR,
+            sizeof(required_props), &required_props, NULL);
+        test_error(error,
+                   "Unable to query "
+                   "CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR");
+
+        // Skip if there are no required properties, because we need an required
+        // property to test
+        return required_props == 0;
+    }
+
+    cl_command_queue_properties required_props;
+    clCommandQueueWrapper recording_queue;
+    clCommandQueueWrapper execution_queue;
+
+    const cl_int overwritten_pattern = 0xACDC;
+    const cl_int pattern_pri = 42;
+};
+
 } // anonymous namespace
 
 REGISTER_TEST(queue_substitution)
@@ -307,14 +538,26 @@ REGISTER_TEST(queue_substitution_properties)
                                                      num_elements);
 }
 
-REGISTER_TEST(queue_substitute_in_order)
+REGISTER_TEST(queue_substitution_in_order)
 {
     return MakeAndRunTest<QueueOrderTest<false>>(device, context, queue,
                                                  num_elements);
 }
 
-REGISTER_TEST(queue_substitute_out_of_order)
+REGISTER_TEST(queue_substitution_out_of_order)
 {
     return MakeAndRunTest<QueueOrderTest<true>>(device, context, queue,
                                                 num_elements);
+}
+
+REGISTER_TEST(queue_substitution_record_unsupported_prop)
+{
+    return MakeAndRunTest<RecordUnsupportedPropTest>(device, context, queue,
+                                                     num_elements);
+}
+
+REGISTER_TEST(queue_substitution_record_without_reqd_props)
+{
+    return MakeAndRunTest<RecordWithoutReqdPropsTest>(device, context, queue,
+                                                      num_elements);
 }

--- a/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
+++ b/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp
@@ -410,6 +410,14 @@ struct EnqueueCommandBufferWithUnsupportedQueueProperty
                                "clEnqueueCommandBufferKHR should return "
                                "CL_INCOMPATIBLE_COMMAND_QUEUE_KHR",
                                TEST_FAIL);
+
+        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
+                                          nullptr, nullptr);
+        test_failure_error_ret(error, CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
+                               "clEnqueueCommandBufferKHR should return "
+                               "CL_INCOMPATIBLE_COMMAND_QUEUE_KHR",
+                               TEST_FAIL);
+
         return CL_SUCCESS;
     }
 
@@ -423,6 +431,10 @@ struct EnqueueCommandBufferWithUnsupportedQueueProperty
         test_error(error,
                    "clCreateCommandQueue with "
                    "CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE failed");
+
+        command_buffer =
+            clCreateCommandBufferKHR(1, &out_of_order_queue, nullptr, &error);
+        test_error(error, "clCreateCommandBufferKHR failed");
 
         return CL_SUCCESS;
     }


### PR DESCRIPTION
Adds CTS coverage for spec change https://github.com/KhronosGroup/OpenCL-Docs/pull/1588


## Negative Test
The error condition for
`CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR` is [already tested](https://github.com/KhronosGroup/OpenCL-CTS/blob/main/test_conformance/extensions/cl_khr_command_buffer/negative_command_buffer_enqueue.cpp#L351) for both a valid and nullptr queue parameter in the `negative_enqueue_queue_without_reqd_properties` test, so that doesn't need extra coverage.

```cpp
        error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                          nullptr, nullptr);
        test_failure_error_ret(error, CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
                               "clEnqueueCommandBufferKHR should return "
                               "CL_INCOMPATIBLE_COMMAND_QUEUE_KHR",
                               TEST_FAIL);

        error = clEnqueueCommandBufferKHR(1, &queue, command_buffer, 0, nullptr,
                                          nullptr);
        test_failure_error_ret(error, CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
                               "clEnqueueCommandBufferKHR should return "
                               "CL_INCOMPATIBLE_COMMAND_QUEUE_KHR",
                               TEST_FAIL);
```

However, the existing `negative_enqueue_with_unsupported_queue_property` test only verifies with a non-null queue parameter for the `CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR` check. So this PR extends that test case to also verify the correct error is reported when the queue parameter is nullptr.

## Positive Tests

Introduces explicit testing for 2 cases about using invalid command-buffer enqueue properties during command-buffer recording:
1) Recording into a command-buffer created from a command-queue with missing required properties,
   and then executing on a substitute queue with required properties.
2) Recording into a command-buffer created from a command-queue with unsupported properties,
   and then executing on a substitute queue with only required properties.

**Note:** I haven't got a device with non-zero required properties, or any unsupported queue properties, so review from a vendor that doesn't have these restrictions would be helpful.