### PR TITLE
Remove MAX_DEVICE_MEMORY_SIZE_DIVISOR from min_max_mem_alloc test while quering maxAllocSize

### DIFF
--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -573,8 +573,7 @@ REGISTER_TEST(min_max_mem_alloc_size)
 
     /* Get the max mem alloc size, limit the alloc to half of the available
      * memory */
-    maxAllocSize = get_device_info_max_mem_alloc_size(
-        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    maxAllocSize = get_device_info_max_mem_alloc_size(device);
     memSize =
         get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
 


### PR DESCRIPTION
Removed `MAX_DEVICE_MEMORY_SIZE_DIVISOR` from `get_device_info_max_mem_alloc_size()` call so the test uses the actual reported max allocation size instead of a divided value.
This fixes an issue with devices with low memory as the test expects to allocate at least 128mb.