### PR TITLE
relationals: print any/all function being tested

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -173,6 +173,12 @@
             "1D": "fail"
         }
     },
+    "test_relationals": {
+        "": {
+            "relational_all": "pass",
+            "relational_any": "pass"
+        }
+    },
     "test_select": {
         "--num-worker-threads 2": {
             "select_uchar_uchar": "pass",

--- a/test_conformance/relationals/test_relationals.cpp
+++ b/test_conformance/relationals/test_relationals.cpp
@@ -69,8 +69,8 @@ int test_any_all_kernel(cl_context context, cl_command_queue queue,
     } else {
         sprintf( sizeName, "%d", vecSize );
     }
-    log_info("Testing any/all on %s%s\n",
-             get_explicit_type_name( vecType ), sizeName);
+    log_info("Testing %s(%s%s)\n", fnName, get_explicit_type_name(vecType),
+             sizeName);
     if(DENSE_PACK_VECS && vecSize == 3) {
         // anyAllTestKernelPatternVload
         sprintf(


### PR DESCRIPTION
The function name is already available in `fnName`, so print it to make the output log clearer.

[run-test: test_relationals relational_all]
[run-test: test_relationals relational_any]