### PR TITLE
compiler: skip options_uniform_work_group_size in SPIR-V mode

### DIFF
--- a/test_conformance/compiler/test_build_options.cpp
+++ b/test_conformance/compiler/test_build_options.cpp
@@ -17,6 +17,7 @@
 #include "harness/kernelHelpers.h"
 #include "harness/os_helpers.h"
 #include "harness/testHarness.h"
+#include "harness/parseParameters.h"
 
 extern std::string spvIncludeTestDirectory;
 extern std::string spvSecondIncludeTestDirectory;
@@ -433,6 +434,13 @@ REGISTER_TEST(options_uniform_work_group_size)
 {
     if (get_device_cl_version(device) < Version(2, 0))
     {
+        return TEST_SKIPPED_ITSELF;
+    }
+    if (gCompilationMode == kSpir_v)
+    {
+        log_info("Test not supported in SPIR-V compilation mode: "
+                 "-cl-uniform-work-group-size has no corresponding "
+                 "representation in the OpenCL SPIR-V environment spec.\n");
         return TEST_SKIPPED_ITSELF;
     }
     std::string build_options = "-cl-std=CL"


### PR DESCRIPTION
The -cl-uniform-work-group-size flag has no standard representation in SPIR-V: the OpenCL SPIR-V environment spec defines no ExecutionMode that carries this constraint, so when building from SPIR-V the runtime cannot enforce uniform work-group sizes and the negative path of this test (expecting CL_INVALID_WORK_GROUP_SIZE) will always fail.

Skip the test when gCompilationMode == kSpir_v so that it is reported as skipped rather than as a spurious failure.