### PR TITLE
add testing for SPV_KHR_non_semantic_info

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -216,7 +216,7 @@
     "test_spirv_new": {
         "": {
             "basic_versions": "pass",
-            "extimport_nonsemantic": "skip"
+            "extinstimport_nonsemantic": "skip"
         }
     },
     "test_vectors": {

--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -213,6 +213,12 @@
             "select_double_long": "pass"
         }
     },
+    "test_spirv_new": {
+        "": {
+            "basic_versions": "pass",
+            "extimport_nonsemantic": "skip"
+        }
+    },
     "test_vectors": {
         "--wimpy": {
             "step_type": "pass",
@@ -224,11 +230,6 @@
             "vec_align_packed_struct": "pass",
             "vec_align_struct_arr": "pass",
             "vec_align_packed_struct_arr": "pass"
-        }
-    },
-    "test_spirv_new": {
-        "": {
-            "basic_versions": "pass"
         }
     }
 }

--- a/test_conformance/spirv_new/CMakeLists.txt
+++ b/test_conformance/spirv_new/CMakeLists.txt
@@ -6,6 +6,7 @@ set(${MODULE_NAME}_SOURCES
   test_cl_khr_expect_assume.cpp
   test_decorate.cpp
   test_extinst_printf.cpp
+  test_extinstimport_nonsemantic.cpp
   test_get_program_il.cpp
   test_linkage.cpp
   test_no_integer_wrap_decoration.cpp

--- a/test_conformance/spirv_new/spirv_asm/CMakeLists.txt
+++ b/test_conformance/spirv_new/spirv_asm/CMakeLists.txt
@@ -193,6 +193,8 @@ set(spirv_sources
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int.spvasm64
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint.spvasm32
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint.spvasm64
+    extinstimport_nonsemantic_none.spvasm64
+    extinstimport_nonsemantic_unknown.spvasm64
     fadd_double.spvasm32
     fadd_double.spvasm64
     fadd_double2.spvasm32

--- a/test_conformance/spirv_new/spirv_asm/CMakeLists.txt
+++ b/test_conformance/spirv_new/spirv_asm/CMakeLists.txt
@@ -193,7 +193,9 @@ set(spirv_sources
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int.spvasm64
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint.spvasm32
     ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint.spvasm64
+    extinstimport_nonsemantic_none.spvasm32
     extinstimport_nonsemantic_none.spvasm64
+    extinstimport_nonsemantic_unknown.spvasm32
     extinstimport_nonsemantic_unknown.spvasm64
     fadd_double.spvasm32
     fadd_double.spvasm64

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm32
@@ -1,0 +1,19 @@
+; Declare usage of the SPV_KHR_non_semantic_info extension, but do not declare
+; any non-semantic extended instruction sets.
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %kernel "non_semantic_info_test"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+      %value = OpConstant %uint 42
+ %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+               OpStore %dst %value Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm64
@@ -1,0 +1,19 @@
+; Declare usage of the SPV_KHR_non_semantic_info extension, but do not declare
+; any non-semantic extended instruction sets.
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "non_semantic_info_test"
+       %uint = OpTypeInt 32 0
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+      %value = OpConstant %uint 42
+       %void = OpTypeVoid
+ %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+               OpStore %dst %value Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_none.spvasm64
@@ -6,10 +6,10 @@
                OpExtension "SPV_KHR_non_semantic_info"
                OpMemoryModel Physical64 OpenCL
                OpEntryPoint Kernel %kernel "non_semantic_info_test"
+       %void = OpTypeVoid
        %uint = OpTypeInt 32 0
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
       %value = OpConstant %uint 42
-       %void = OpTypeVoid
  %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
      %kernel = OpFunction %void None %kernel_sig
         %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm32
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm32
@@ -1,0 +1,29 @@
+; Declare usage of the SPV_KHR_non_semantic_info extension and a few bogus
+; non-semantic extended instruction sets. This should still succeed, since the
+; extended instruction sets are non-semantic and can therefore be ignored.
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+          %X = OpExtInstImport "NonSemantic.X"
+         %XY = OpExtInstImport "NonSemantic.X.Y"
+        %XYZ = OpExtInstImport "NonSemantic.X.Y.Z"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %kernel "non_semantic_info_test"
+        %str = OpString "String Operand"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %no_result = OpExtInst %void %X 0       ; Call to unknown function with no operands and no result
+         %op = OpConstant %uint 31337
+   %X_result = OpExtInst %uint %X 1       ; Call to unknown function with no operands
+  %XY_result = OpExtInst %uint %XY 99 %op ; Call to unknown function with one operand
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+      %value = OpConstant %uint 42
+ %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+ %XYZ_result = OpExtInst %uint %XYZ 1000 %op %op %str ; Call with more operands
+               OpStore %dst %value Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm64
@@ -10,18 +10,20 @@
         %XYZ = OpExtInstImport "NonSemantic.X.Y.Z"
                OpMemoryModel Physical64 OpenCL
                OpEntryPoint Kernel %kernel "non_semantic_info_test"
+        %str = OpString "String Operand"
+       %void = OpTypeVoid
        %uint = OpTypeInt 32 0
+  %no_result = OpExtInst %void %X 0       ; Call to unknown function with no operands and no result
          %op = OpConstant %uint 31337
-   %X_result = OpExtInst %uint %X 0       ; Call to unknown function with no operands
+   %X_result = OpExtInst %uint %X 1       ; Call to unknown function with no operands
   %XY_result = OpExtInst %uint %XY 99 %op ; Call to unknown function with one operand
 %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
       %value = OpConstant %uint 42
-       %void = OpTypeVoid
  %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
      %kernel = OpFunction %void None %kernel_sig
         %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
- %XYZ_result = OpExtInst %uint %XYZ 1000 %op %op %op    ; Call with more operands
+ %XYZ_result = OpExtInst %uint %XYZ 1000 %op %op %str ; Call with more operands
                OpStore %dst %value Aligned 4
                OpReturn
                OpFunctionEnd

--- a/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm64
+++ b/test_conformance/spirv_new/spirv_asm/extinstimport_nonsemantic_unknown.spvasm64
@@ -1,0 +1,27 @@
+; Declare usage of the SPV_KHR_non_semantic_info extension and a few bogus
+; non-semantic extended instruction sets. This should still succeed, since the
+; extended instruction sets are non-semantic and can therefore be ignored.
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+          %X = OpExtInstImport "NonSemantic.X"
+         %XY = OpExtInstImport "NonSemantic.X.Y"
+        %XYZ = OpExtInstImport "NonSemantic.X.Y.Z"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "non_semantic_info_test"
+       %uint = OpTypeInt 32 0
+         %op = OpConstant %uint 31337
+   %X_result = OpExtInst %uint %X 0       ; Call to unknown function with no operands
+  %XY_result = OpExtInst %uint %XY 99 %op ; Call to unknown function with one operand
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+      %value = OpConstant %uint 42
+       %void = OpTypeVoid
+ %kernel_sig = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+ %XYZ_result = OpExtInst %uint %XYZ 1000 %op %op %op    ; Call with more operands
+               OpStore %dst %value Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/test_conformance/spirv_new/test_extinstimport_nonsemantic.cpp
+++ b/test_conformance/spirv_new/test_extinstimport_nonsemantic.cpp
@@ -103,7 +103,7 @@ static int test_nonsemantic_helper(cl_device_id device, cl_context context,
 
 REGISTER_TEST(extinstimport_nonsemantic)
 {
-    if (!is_spirv_extension_supported(device, "SPV_KHR_non_semantic_info") && false)
+    if (!is_spirv_extension_supported(device, "SPV_KHR_non_semantic_info"))
     {
         log_info("SPIR-V extension SPV_KHR_non_semantic_info not supported; "
                  "skipping tests.\n");

--- a/test_conformance/spirv_new/test_extinstimport_nonsemantic.cpp
+++ b/test_conformance/spirv_new/test_extinstimport_nonsemantic.cpp
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2016-2023 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testBase.h"
+#include "types.hpp"
+
+#include <sstream>
+#include <string>
+
+// TODO: move this to a shared location
+static bool is_spirv_extension_supported(cl_device_id device,
+                                         const char* extension)
+{
+    if (!is_extension_available(device, "cl_khr_spirv_queries"))
+    {
+        return false;
+    }
+
+
+    cl_int error = CL_SUCCESS;
+
+    size_t size{};
+    error = clGetDeviceInfo(device, CL_DEVICE_SPIRV_EXTENSIONS_KHR, 0, nullptr,
+                            &size);
+    test_error_ret(
+        error,
+        "clGetDeviceInfo failed for CL_DEVICE_SPIRV_EXTENSIONS_KHR size\n",
+        false);
+
+    std::vector<const char*> spirvExtensions(size / sizeof(const char*));
+    error = clGetDeviceInfo(device, CL_DEVICE_SPIRV_EXTENSIONS_KHR, size,
+                            spirvExtensions.data(), nullptr);
+    test_error_ret(
+        error, "clGetDeviceInfo failed for CL_DEVICE_SPIRV_EXTENSIONS_KHR\n",
+        false);
+
+    for (auto check : spirvExtensions)
+    {
+        if (!strcmp(check, extension))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int test_nonsemantic_helper(cl_device_id device, cl_context context,
+                                   cl_command_queue queue, const char* filename)
+{
+    cl_int error = 0;
+
+    clProgramWrapper program;
+    error = get_program_with_il(program, device, context, filename);
+    test_error_fail(error, "Unable to build SPIR-V program");
+
+    clKernelWrapper kernel =
+        clCreateKernel(program, "non_semantic_info_test", &error);
+    test_error_fail(error, "Unable to create SPIR-V kernel");
+
+    clMemWrapper dst = clCreateBuffer(context, CL_MEM_READ_WRITE,
+                                      sizeof(cl_int), nullptr, &error);
+    test_error_fail(error, "Unable to create dst buffer");
+
+    const cl_int zero = 0;
+    error = clEnqueueFillBuffer(queue, dst, &zero, sizeof(zero), 0,
+                                sizeof(cl_int), 0, NULL, NULL);
+    test_error_fail(error, "Unable to initialize destination buffer");
+
+    error |= clSetKernelArg(kernel, 0, sizeof(dst), &dst);
+    test_error_fail(error, "Unable to set kernel arguments");
+
+    const size_t global = 1;
+    error = clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global, NULL, 0,
+                                   NULL, NULL);
+    test_error_fail(error, "Unable to enqueue kernel");
+
+    cl_int result = 0;
+    error = clEnqueueReadBuffer(queue, dst, CL_TRUE, 0, sizeof(cl_int), &result,
+                                0, NULL, NULL);
+    test_error_fail(error, "Unable to read destination buffer");
+
+    if (result != 42)
+    {
+        test_fail("Unxpected result: wanted 42, got %d!\n", result);
+    }
+
+    return TEST_PASS;
+}
+
+REGISTER_TEST(extinstimport_nonsemantic)
+{
+    if (!is_spirv_extension_supported(device, "SPV_KHR_non_semantic_info") && false)
+    {
+        log_info("SPIR-V extension SPV_KHR_non_semantic_info not supported; "
+                 "skipping tests.\n");
+        return TEST_SKIPPED_ITSELF;
+    }
+
+    int result = TEST_PASS;
+
+    // Test with a SPIR-V module that only declares the
+    // SPV_KHR_non_semantic_info extension, but does not import any non-semantic
+    // extended instruction sets.
+    result |= test_nonsemantic_helper(device, context, queue,
+                                      "extinstimport_nonsemantic_none");
+
+    // Test with a SPIR-V module that declares the SPV_KHR_non_semantic_info and
+    // imports a few unknown non-semantic extended instruction sets.
+    result |= test_nonsemantic_helper(device, context, queue,
+                                      "extinstimport_nonsemantic_unknown");
+
+    return result;
+}


### PR DESCRIPTION
Adds targeted SPIR-V testing for the SPV_KHR_non_semantic_info extension, and specifically for SPIR-V modules that declare unknown (bogus) non-semantic extended instruction sets.

The testing on PoCL is skipped right now because PoCL does not currently advertise support for the SPV_KHR_non_semantic_info extension (via SPIR-V queries).

Even if PoCL did advertise support for SPV_KHR_non_semantic_info, the test will currently fail, because the fix for unknown non-semantic extended instruction sets has not been back-ported to all of the release branches.  This should be fixed shortly, though, see e.g.: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3958

[run-test: test_spirv_new extinstimport_nonsemantic]

