### PR TITLE
conversions: Return 0 when converting NaN to integer with saturation

### DIFF
--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -856,6 +856,24 @@ void DataInfoSpec<InType, OutType, InFP, OutFP>::conv_sat(OutType *out,
         cl_float inVal = *in;
         if (is_in_half()) inVal = HTF(*in);
 
+        if (!(std::is_floating_point<OutType>::value || is_out_half()))
+        {
+            bool is_nan = false;
+            if constexpr (std::is_same<InType, cl_half>::value && InFP)
+            {
+                is_nan = std::isnan(inVal);
+            }
+            else
+            {
+                is_nan = std::isnan(*in);
+            }
+            if (is_nan)
+            {
+                *out = 0;
+                return;
+            }
+        }
+
         if (std::is_floating_point<OutType>::value || is_out_half())
         { // in half/float/double, out half/float/double
             if (is_out_half())

--- a/test_conformance/conversions/conversions_data_info.h
+++ b/test_conformance/conversions/conversions_data_info.h
@@ -858,16 +858,7 @@ void DataInfoSpec<InType, OutType, InFP, OutFP>::conv_sat(OutType *out,
 
         if (!(std::is_floating_point<OutType>::value || is_out_half()))
         {
-            bool is_nan = false;
-            if constexpr (std::is_same<InType, cl_half>::value && InFP)
-            {
-                is_nan = std::isnan(inVal);
-            }
-            else
-            {
-                is_nan = std::isnan(*in);
-            }
-            if (is_nan)
+            if (std::isnan(inVal))
             {
                 *out = 0;
                 return;


### PR DESCRIPTION
Per the OpenCL C specification (section 6.4.3.3 "Out-of-Range Behavior and Saturated Conversions" [1]):
"When in saturated mode, values that are outside the representable range are clamped to the nearest representable value in the destination format, and NaN is converted to zero."

In DataInfoSpec::conv_sat, computing the reference values for cl_ulong and cl_long previously evaluated comparisons on NaN, resulting in undefined behavior when casting NaN to an integer type.

Explicitly check for NaN input when converting to integer types in conv_sat and set the output reference to 0.

[1] https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#out-of-range-behavior

[run-test: test_conversions -w]