### PR TITLE
math_brute_force: increase buffer size for math_brute_force/fma case

### DIFF
--- a/test_conformance/math_brute_force/utility.h
+++ b/test_conformance/math_brute_force/utility.h
@@ -26,7 +26,7 @@
 #include "harness/parseParameters.h"
 #include "CL/cl_half.h"
 
-#define BUFFER_SIZE (1024 * 1024 * 2)
+#define BUFFER_SIZE (1024 * 1024 * 10)
 #define EMBEDDED_REDUCTION_FACTOR (64)
 
 #if defined(__GNUC__)


### PR DESCRIPTION
The ternary tests (e.g., fma, mad) enumerate the full cartesian product of special values across their three operands into a single BUFFER_SIZE input buffer. For each data type, this requires:
   specialValuesCount^3 <= BUFFER_SIZE / sizeof(type)

The biggest gap comes from double type. There are 106 special values. so 106^3 * sizeof(double) / (1024 * 1024) = 10

So we increase it from 2 to 10.