### PR TITLE
do not print sub-test pass or fail when there are no sub-tests

### DIFF
--- a/test_common/harness/testHarness.cpp
+++ b/test_common/harness/testHarness.cpp
@@ -795,7 +795,7 @@ static void print_results(int failed, int count, const char *name)
         {
             log_info("PASSED %d of %d %ss.\n", count, count, name);
         }
-        else
+        else if (count > 0)
         {
             log_info("PASSED %s.\n", name);
         }


### PR DESCRIPTION
Currently, some CTS suites have "sub-tests", meaning that they increment `gTestCount` for each sub-test and `gFailCount` for each failed sub-test,  Many tests do not use this functionality, though, e.g. `test_basic`.  For test suites that do not have sub-tests, they will currently **unconditionally** print "PASSED sub-test" when reporting the test results.  This currently gets printed because there are no sub-test failures, because `gFailCount` is zero.

This is fine if the test suite otherwise passes, but if some tests fail, it can lead to rather confusing output like:

```
PASSED sub-test.
FAILED 1 of 238 tests.
```

When a CTS suite does not have sub-tests, meaning that `gTestCount` is also zero, let's just skip the output entirely to avoid the confusion.