### PR TITLE
compiler: Add test for CL_PROGRAM_SOURCE with clCreateProgramWithBinary

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -247,6 +247,8 @@
         }
     },
     "test_compiler": {
-        "get_program_source_from_binary": "pass"
+        "": {
+            "get_program_source_from_binary": "pass"
+        }
     }
 }

--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -245,5 +245,8 @@
             "vec_align_struct_arr": "pass",
             "vec_align_packed_struct_arr": "pass"
         }
+    },
+    "test_compiler": {
+        "get_program_source_from_binary": "pass"
     }
 }

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -1146,25 +1146,25 @@ REGISTER_TEST(get_program_source_from_binary)
     }
 
     std::vector<unsigned char> binary(binary_size);
-    unsigned char* binary_ptr = binary.data();
+    unsigned char *binary_ptr = binary.data();
 
-    error = clGetProgramInfo(program, CL_PROGRAM_BINARIES,
-                             sizeof(binary_ptr), &binary_ptr, nullptr);
+    error = clGetProgramInfo(program, CL_PROGRAM_BINARIES, sizeof(binary_ptr),
+                             &binary_ptr, nullptr);
     test_error(error, "clGetProgramInfo for binary failed");
 
-    const unsigned char* binary_data = binary.data();
+    const unsigned char *binary_data = binary.data();
     cl_int binary_status = CL_SUCCESS;
 
-    program_from_binary = clCreateProgramWithBinary(
-        context, 1, &device, &binary_size, &binary_data, &binary_status,
-        &error);
+    program_from_binary =
+        clCreateProgramWithBinary(context, 1, &device, &binary_size,
+                                  &binary_data, &binary_status, &error);
     test_error(error, "clCreateProgramWithBinary failed");
     test_assert_error(binary_status == CL_SUCCESS,
                       "Binary status is not CL_SUCCESS");
 
     size_t src_size = 0;
-    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE,
-                             0, nullptr, &src_size);
+    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE, 0, nullptr,
+                             &src_size);
     test_error(error, "clGetProgramInfo for source size failed");
 
     if (src_size == 0)
@@ -1175,8 +1175,8 @@ REGISTER_TEST(get_program_source_from_binary)
 
     std::vector<char> src(src_size, static_cast<char>(0x7f));
 
-    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE,
-                             src_size, src.data(), nullptr);
+    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE, src_size,
+                             src.data(), nullptr);
     test_error(error, "clGetProgramInfo for source failed");
 
     if (src.back() != '\0')
@@ -1187,8 +1187,8 @@ REGISTER_TEST(get_program_source_from_binary)
 
     if (src_size != 1
         && (src_size != strlen(sample_kernel_code_single_line[0]) + 1
-            || memcmp(src.data(), sample_kernel_code_single_line[0],
-                      src_size) != 0))
+            || memcmp(src.data(), sample_kernel_code_single_line[0], src_size)
+                != 0))
     {
         log_error("CL_PROGRAM_SOURCE returned unexpected content\n");
         return TEST_FAIL;

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -1129,7 +1129,8 @@ REGISTER_TEST(get_program_source_from_binary)
     clProgramWrapper program_from_binary;
 
     error = create_single_kernel_helper(context, &program, &kernel, 1,
-                                        sample_kernel_code_single_line, "test");
+                                        sample_kernel_code_single_line,
+                                        "sample_test");
     test_error(error, "create_single_kernel_helper failed");
 
     size_t binary_size = 0;

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -1128,8 +1128,8 @@ REGISTER_TEST(get_program_source_from_binary)
     clKernelWrapper kernel;
     clProgramWrapper program_from_binary;
 
-    error = create_single_kernel_helper(
-        context, &program, &kernel, 1, sample_kernel_code_single_line, "test");
+    error = create_single_kernel_helper(context, &program, &kernel, 1,
+                                        sample_kernel_code_single_line, "test");
     test_error(error, "create_single_kernel_helper failed");
 
     size_t binary_size = 0;

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -1125,14 +1125,12 @@ REGISTER_TEST(get_program_source_from_binary)
 {
     cl_int error = CL_SUCCESS;
     clProgramWrapper program;
+    clKernelWrapper kernel;
     clProgramWrapper program_from_binary;
 
-    program = clCreateProgramWithSource(
-        context, 1, sample_kernel_code_single_line, nullptr, &error);
-    test_error(error, "clCreateProgramWithSource failed");
-
-    error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
-    test_error(error, "clBuildProgram failed");
+    error = create_single_kernel_helper(
+        context, &program, &kernel, 1, sample_kernel_code_single_line, "test");
+    test_error(error, "create_single_kernel_helper failed");
 
     size_t binary_size = 0;
     error = clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
@@ -1159,8 +1157,7 @@ REGISTER_TEST(get_program_source_from_binary)
         clCreateProgramWithBinary(context, 1, &device, &binary_size,
                                   &binary_data, &binary_status, &error);
     test_error(error, "clCreateProgramWithBinary failed");
-    test_assert_error(binary_status == CL_SUCCESS,
-                      "Binary status is not CL_SUCCESS");
+    test_error(binary_status, "Binary status is not CL_SUCCESS");
 
     size_t src_size = 0;
     error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE, 0, nullptr,
@@ -1169,8 +1166,7 @@ REGISTER_TEST(get_program_source_from_binary)
 
     if (src_size == 0)
     {
-        log_error("Source size is zero\n");
-        return TEST_FAIL;
+        return TEST_PASS;
     }
 
     std::vector<char> src(src_size, static_cast<char>(0x7f));
@@ -1187,10 +1183,11 @@ REGISTER_TEST(get_program_source_from_binary)
 
     if (src_size != 1
         && (src_size != strlen(sample_kernel_code_single_line[0]) + 1
-            || memcmp(src.data(), sample_kernel_code_single_line[0], src_size)
-                != 0))
+            || strcmp(src.data(), sample_kernel_code_single_line[0]) != 0))
     {
-        log_error("CL_PROGRAM_SOURCE returned unexpected content\n");
+        log_error(
+            "CL_PROGRAM_SOURCE returned unexpected content (size %zu):\n%s\n",
+            src_size, src.data());
         return TEST_FAIL;
     }
 

--- a/test_conformance/compiler/test_build_helpers.cpp
+++ b/test_conformance/compiler/test_build_helpers.cpp
@@ -1120,3 +1120,79 @@ REGISTER_TEST(kernel_name_size)
     }
     return TEST_PASS;
 }
+
+REGISTER_TEST(get_program_source_from_binary)
+{
+    cl_int error = CL_SUCCESS;
+    clProgramWrapper program;
+    clProgramWrapper program_from_binary;
+
+    program = clCreateProgramWithSource(
+        context, 1, sample_kernel_code_single_line, nullptr, &error);
+    test_error(error, "clCreateProgramWithSource failed");
+
+    error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
+    test_error(error, "clBuildProgram failed");
+
+    size_t binary_size = 0;
+    error = clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
+                             sizeof(binary_size), &binary_size, nullptr);
+    test_error(error, "clGetProgramInfo for binary size failed");
+
+    if (binary_size == 0)
+    {
+        log_error("Binary size is zero\n");
+        return TEST_FAIL;
+    }
+
+    std::vector<unsigned char> binary(binary_size);
+    unsigned char* binary_ptr = binary.data();
+
+    error = clGetProgramInfo(program, CL_PROGRAM_BINARIES,
+                             sizeof(binary_ptr), &binary_ptr, nullptr);
+    test_error(error, "clGetProgramInfo for binary failed");
+
+    const unsigned char* binary_data = binary.data();
+    cl_int binary_status = CL_SUCCESS;
+
+    program_from_binary = clCreateProgramWithBinary(
+        context, 1, &device, &binary_size, &binary_data, &binary_status,
+        &error);
+    test_error(error, "clCreateProgramWithBinary failed");
+    test_assert_error(binary_status == CL_SUCCESS,
+                      "Binary status is not CL_SUCCESS");
+
+    size_t src_size = 0;
+    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE,
+                             0, nullptr, &src_size);
+    test_error(error, "clGetProgramInfo for source size failed");
+
+    if (src_size == 0)
+    {
+        log_error("Source size is zero\n");
+        return TEST_FAIL;
+    }
+
+    std::vector<char> src(src_size, static_cast<char>(0x7f));
+
+    error = clGetProgramInfo(program_from_binary, CL_PROGRAM_SOURCE,
+                             src_size, src.data(), nullptr);
+    test_error(error, "clGetProgramInfo for source failed");
+
+    if (src.back() != '\0')
+    {
+        log_error("CL_PROGRAM_SOURCE is not null-terminated\n");
+        return TEST_FAIL;
+    }
+
+    if (src_size != 1
+        && (src_size != strlen(sample_kernel_code_single_line[0]) + 1
+            || memcmp(src.data(), sample_kernel_code_single_line[0],
+                      src_size) != 0))
+    {
+        log_error("CL_PROGRAM_SOURCE returned unexpected content\n");
+        return TEST_FAIL;
+    }
+
+    return TEST_PASS;
+}


### PR DESCRIPTION
The test verifies that `clGetProgramInfo` with `CL_PROGRAM_SOURCE` returns either an empty string or the source code for programs created from a binary file (per OpenCL spec).

[run-test: test_compiler get_program_source_from_binary]