### PR TITLE
vectors: reduce test execution time by shrinking NDRanges

### DIFF
--- a/test_conformance/vectors/defines.h
+++ b/test_conformance/vectors/defines.h
@@ -30,10 +30,6 @@ extern const int g_arrVecSteps[NUM_VECTOR_SIZES];
 extern const char* const g_arrVecSizeNames[NUM_VECTOR_SIZES];
 extern const size_t g_arrVecAlignMasks[NUM_VECTOR_SIZES];
 
-// Define the buffer size that we want to block our test with
-#define BUFFER_SIZE (1024 * 1024)
-#define KPAGESIZE 4096
-
 extern const ExplicitType types[];
 
 extern const char* const g_arrTypeNames[];

--- a/test_conformance/vectors/test_step.cpp
+++ b/test_conformance/vectors/test_step.cpp
@@ -26,6 +26,15 @@
 
 #include "type_replacer.h"
 
+// vec_step depends only on its argument's type, so one work-item is sufficient.
+constexpr size_t STEP_WORK_ITEMS = 1;
+
+// Accommodate one instance of the widest tested type.
+constexpr size_t STEP_INPUT_BUFFER_SIZE = sizeof(cl_double16);
+
+// Store one cl_int result.
+constexpr size_t STEP_OUTPUT_BUFFER_SIZE = sizeof(cl_int);
+
 
 /*
  test_step_type,
@@ -45,8 +54,8 @@ int test_step_internal(cl_device_id deviceID, cl_context context,
     char tempBuffer[2048];
 
     clState* pClState = newClState(deviceID, context, queue);
-    bufferStruct* pBuffers =
-        newBufferStruct(BUFFER_SIZE, BUFFER_SIZE, pClState);
+    bufferStruct* pBuffers = newBufferStruct(STEP_INPUT_BUFFER_SIZE,
+                                             STEP_OUTPUT_BUFFER_SIZE, pClState);
 
     if (pBuffers == NULL)
     {
@@ -125,7 +134,7 @@ int test_step_internal(cl_device_id deviceID, cl_context context,
             }
 
             // now we run the kernel
-            err = runKernel(pClState, 1024);
+            err = runKernel(pClState, STEP_WORK_ITEMS);
             if (err != 0)
             {
                 vlog_error("%s: runKernel fail (%zu threads) %s%s\n", testName,

--- a/test_conformance/vectors/test_vec_align.cpp
+++ b/test_conformance/vectors/test_vec_align.cpp
@@ -29,6 +29,13 @@
 
 #include <array>
 
+// Each work-item checks another instance of the same compile-time layout, so a
+// small number is sufficient.
+constexpr size_t ALIGNMENT_WORK_ITEMS = 64;
+
+// Reserve 512 bytes per work-item for generated structures.
+constexpr size_t BUFFER_SIZE = ALIGNMENT_WORK_ITEMS * 512;
+
 size_t get_align(size_t vecSize)
 {
     if (vecSize == 3)
@@ -91,7 +98,7 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
 
     clState* pClState = newClState(deviceID, context, queue);
     bufferStruct* pBuffers = newBufferStruct(
-        bufSize, bufSize * sizeof(cl_uint) / sizeof(cl_char), pClState);
+        bufSize, ALIGNMENT_WORK_ITEMS * sizeof(cl_uint), pClState);
 
     if (pBuffers == NULL)
     {
@@ -179,10 +186,7 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
 
             // log_info("About to Run kernel\n"); fflush(stdout);
             // now we run the kernel
-            err = runKernel(
-                pClState,
-                bufSize
-                    / (g_arrVecSizes[vecSizeIdx] * g_arrTypeSizes[typeIdx]));
+            err = runKernel(pClState, ALIGNMENT_WORK_ITEMS);
             if (err != 0)
             {
                 vlog_error("%s: runKernel fail (%zu threads) %s%s\n", testName,


### PR DESCRIPTION
The result of `vec_step` depends only on its argument type.  Running 1024 work-items just repeats the same check, so use one work-item and shrink the buffers accordingly.

The alignment tests were launching up to 524288 work-items for each kernel, which resulted in a lot of repetition of the same compile-time layouts without adding meaningful coverage.  Limit NDRanges and shrink the buffers accordingly.

[run-test: test_vectors --wimpy]