### PR TITLE
Avoid signed overflow in randomized integer tests

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -15,7 +15,8 @@
           "min_max_samplers": "pass",
           "min_max_write_image_args": "pass",
           "negative_set_kernel_arg_invalid_image_msaa": "skip",
-          "negative_set_kernel_arg_invalid_image": "pass"
+          "negative_set_kernel_arg_invalid_image": "pass",
+          "set_kernel_arg_struct_array": "pass"
         }
     },
     "test_atomics": {
@@ -29,7 +30,10 @@
             "arraycopy": "pass",
             "host_numeric_constants": "pass",
             "kernel_numeric_constants": "pass",
-            "kernel_preprocessor_macros": "pass"
+            "kernel_preprocessor_macros": "pass",
+            "loop": "pass",
+            "local_arg_def": "pass",
+            "local_kernel_def": "pass"
         }
     },
     "test_bruteforce": {
@@ -210,6 +214,19 @@
         },
         "--num-worker-threads 2 CL_FILTER_NEAREST CL_R": {
             "1D": "fail"
+        }
+    },
+    "test_integer_ops": {
+        "": {
+            "int_math": "pass",
+            "quick_int_math": "pass",
+            "long_math": "pass",
+            "quick_long_math": "pass",
+            "ushort_math": "pass",
+            "quick_ushort_math": "pass",
+            "integer_addAssign": "pass",
+            "integer_subtractAssign": "pass",
+            "integer_multiplyAssign": "pass"
         }
     },
     "test_printf": {

--- a/test_common/harness/conversions.cpp
+++ b/test_common/harness/conversions.cpp
@@ -1440,6 +1440,39 @@ int random_in_range(int minV, int maxV, MTdata d)
     return (cl_uint)(r >> 32) + minV;
 }
 
+cl_ulong get_random_ulong(cl_ulong low, cl_ulong high, MTdata d)
+{
+    assert(low <= high && "Invalid random number range specified");
+
+    const cl_ulong width = high - low;
+    if (width == CL_ULONG_MAX) return genrand_int64(d);
+
+    const cl_ulong range = width + 1;
+
+    // Drop the incomplete trailing block of `range` values so that every
+    // result stays equally likely: the largest usable draw is
+    // CL_ULONG_MAX - (2^64 mod range), computed here without a 65-bit value.
+    const cl_ulong limit = CL_ULONG_MAX - (CL_ULONG_MAX % range + 1) % range;
+
+    cl_ulong r;
+    do
+    {
+        r = genrand_int64(d);
+    } while (r > limit);
+
+    return low + r % range;
+}
+
+cl_long get_random_long(cl_long low, cl_long high, MTdata d)
+{
+    assert(low <= high && "Invalid random number range specified");
+
+    // The width of the interval need not be representable as a cl_long, so
+    // offset the low bound in unsigned arithmetic and convert back.
+    const cl_ulong width = (cl_ulong)high - (cl_ulong)low;
+    return (cl_long)((cl_ulong)low + get_random_ulong(0, width, d));
+}
+
 size_t get_random_size_t(size_t low, size_t high, MTdata d)
 {
     enum

--- a/test_common/harness/conversions.h
+++ b/test_common/harness/conversions.h
@@ -95,6 +95,13 @@ extern double any_double(MTdata d);
 
 extern int random_in_range(int minV, int maxV, MTdata d);
 
+// Returns a value uniformly distributed over [low, high]. Unlike
+// random_in_range() the width of the interval is computed in unsigned
+// arithmetic, so the whole type range is usable, up to [CL_LONG_MIN,
+// CL_LONG_MAX] and [0, CL_ULONG_MAX].
+cl_long get_random_long(cl_long low, cl_long high, MTdata d);
+cl_ulong get_random_ulong(cl_ulong low, cl_ulong high, MTdata d);
+
 size_t get_random_size_t(size_t low, size_t high, MTdata d);
 
 // Note: though this takes a double, this is for use with single precision tests

--- a/test_conformance/api/test_kernels.cpp
+++ b/test_conformance/api/test_kernels.cpp
@@ -580,11 +580,16 @@ REGISTER_TEST(set_kernel_arg_struct_array)
     }
 
     /* Create some I/O streams */
+    // The kernel and the host reference both compute A + B as a plain int, so
+    // keep every operand in [-CL_INT_MAX / 2, CL_INT_MAX / 2]: the sum then
+    // stays representable and the arithmetic stays defined.
+    const cl_int max_addend = CL_INT_MAX / 2;
+
     d = init_genrand( gRandomSeed );
     for (i = 0; i < num_elements; i++)
     {
-        image_pair[i].A = (cl_int)genrand_int32(d);
-        image_pair[i].B = (cl_int)genrand_int32(d);
+        image_pair[i].A = (cl_int)get_random_long(-max_addend, max_addend, d);
+        image_pair[i].B = (cl_int)get_random_long(-max_addend, max_addend, d);
     }
     free_mtdata(d); d = NULL;
 

--- a/test_conformance/basic/test_local.cpp
+++ b/test_conformance/basic/test_local.cpp
@@ -114,6 +114,15 @@ verify_sum(int *inptr, int *outptr, int n)
     return 0;
 }
 
+// The kernel reduces all `count` inputs into a single int, so bound every
+// value to +/- CL_INT_MAX / count. Each partial sum, and the total, then stays
+// representable and the accumulation stays defined.
+static cl_int generate_sum_input(MTdata d, int count)
+{
+    const cl_long maximum = CL_INT_MAX / (count > 0 ? count : 1);
+    return (cl_int)get_random_long(-maximum, maximum, d);
+}
+
 REGISTER_TEST(local_arg_def)
 {
     cl_mem streams[2];
@@ -156,7 +165,7 @@ REGISTER_TEST(local_arg_def)
     }
 
     for (i=0; i<num_elements; i++)
-        input_ptr[i] = (int)genrand_int32(d);
+        input_ptr[i] = generate_sum_input(d, num_elements);
 
     free_mtdata(d); d = NULL;
 
@@ -274,7 +283,7 @@ REGISTER_TEST(local_kernel_def)
     }
 
     for (i=0; i<num_elements; i++)
-        input_ptr[i] = (cl_int) genrand_int32(d);
+        input_ptr[i] = generate_sum_input(d, num_elements);
 
     free_mtdata(d); d = NULL;
 

--- a/test_conformance/basic/test_loop.cpp
+++ b/test_conformance/basic/test_loop.cpp
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "testBase.h"
@@ -89,14 +90,26 @@ REGISTER_TEST(loop)
     }
 
     RandomSeed seed(gRandomSeed);
+    int max_loop_count = 0;
     for (int i = 0; i < num_elements; i++)
     {
-        input[i] = static_cast<int>(genrand_int32(seed));
         loop_indx[i] =
             static_cast<int>(get_random_float(0, num_elements - 1, seed));
         loop_cnt[i] =
             static_cast<int>(get_random_float(0, num_elements / 32, seed));
-    };
+        max_loop_count = std::max(max_loop_count, loop_cnt[i]);
+    }
+
+    // The kernel accumulates up to max_loop_count inputs into a single int, so
+    // bound every value to +/- CL_INT_MAX / max_loop_count. Every accumulation
+    // is then representable and the arithmetic stays defined.
+    const cl_long max_input =
+        max_loop_count == 0 ? CL_INT_MAX : CL_INT_MAX / max_loop_count;
+    for (int i = 0; i < num_elements; i++)
+    {
+        input[i] =
+            static_cast<cl_int>(get_random_long(-max_input, max_input, seed));
+    }
 
     err = clEnqueueWriteBuffer(queue, streams[0], CL_TRUE, 0, length,
                                input.data(), 0, nullptr, nullptr);

--- a/test_conformance/integer_ops/testBase.h
+++ b/test_conformance/integer_ops/testBase.h
@@ -17,6 +17,7 @@
 #define _testBase_h
 
 #include "harness/compat.h"
+#include "harness/conversions.h"
 #include "harness/errorHelpers.h"
 #include "harness/kernelHelpers.h"
 #include "harness/testHarness.h"
@@ -27,11 +28,45 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <optional>
+
 // The number of errors to print out for each test
 #define MAX_ERRORS_TO_PRINT 10
 
 extern void fill_test_values(cl_long *outBufferA, cl_long *outBufferB,
                              size_t numElements, MTdata d);
+
+// The "+", "-" and "*" integer tests fill both operands with full range random
+// values. OpenCL C section 6.3 applies the C99 usual arithmetic conversions, so
+// an operation whose signed result is not representable is undefined; the
+// wrap-around guarantee of section 6.3.11 is scoped to atomics. Only three
+// cases can actually get there:
+//
+//   int, long  operands keep their own width, so "+", "-" and "*" all overflow.
+//   ushort     a scalar operand is promoted to int, and only the product of two
+//              ushorts can leave the int range.
+//
+// char, uchar and short are promoted to int as well and their results always
+// fit; uint and ulong wrap by definition. Those five types are left alone so
+// that their full range and corner case coverage is preserved.
+enum DefinedArithmeticOp
+{
+    kDefinedAdd,
+    kDefinedSub,
+    kDefinedMul
+};
+
+// Maps an operator spelling onto the enum above. Returns an empty optional for
+// every operator whose operands do not need to be bounded.
+std::optional<DefinedArithmeticOp>
+get_defined_arithmetic_op(const char *opName);
+
+// Rewrites both operands in place with random values whose combination under
+// `op` is representable, and leaves them untouched for the types that cannot
+// overflow.
+void init_defined_arithmetic_data(ExplicitType type, DefinedArithmeticOp op,
+                                  size_t num_elements, void *inputA,
+                                  void *inputB, MTdata d);
 
 #endif // _testBase_h
 

--- a/test_conformance/integer_ops/test_int_basic_ops.cpp
+++ b/test_conformance/integer_ops/test_int_basic_ops.cpp
@@ -664,6 +664,13 @@ test_integer_ops(cl_device_id deviceID, cl_context context,
                     break;
             }
 
+            if (auto definedOp = get_defined_arithmetic_op(tests[i]))
+            {
+                init_defined_arithmetic_data(
+                    type, *definedOp, num_elements * vectorSize,
+                    pThreadData->m_input_ptr[0], pThreadData->m_input_ptr[1],
+                    randDataIn);
+            }
 
             err = clEnqueueWriteBuffer(queue, pThreadData->m_streams[0], CL_FALSE, 0, pThreadData->m_type_size*num_elements * inputAVecSize, (void *)pThreadData->m_input_ptr[0], 0, NULL, NULL);
             test_error(err, "clEnqueueWriteBuffer failed");

--- a/test_conformance/integer_ops/test_integers.cpp
+++ b/test_conformance/integer_ops/test_integers.cpp
@@ -92,6 +92,22 @@ int test_single_param_integer_kernel(cl_command_queue queue, cl_context context,
     /* Generate some streams */
     generate_random_data( vecType, vecSize * TEST_SIZE, d, inDataA );
 
+    if (useOpKernel)
+    {
+        // Op kernels use an r/w buffer for the second param, so we need to init
+        // it with data.
+        //
+        // Both operands are filled here, before either of them is handed to
+        // clCreateBuffer() below, so that a pair can still be bounded.
+        generate_random_data(vecType, vecSize * TEST_SIZE, d, inDataB);
+
+        if (auto definedOp = get_defined_arithmetic_op(fnName))
+        {
+            init_defined_arithmetic_data(
+                vecType, *definedOp, vecSize * TEST_SIZE, inDataA, inDataB, d);
+        }
+    }
+
     streams[0] = clCreateBuffer(
         context, CL_MEM_COPY_HOST_PTR,
         get_explicit_type_size(vecType) * vecSize * TEST_SIZE, inDataA, NULL);
@@ -101,11 +117,6 @@ int test_single_param_integer_kernel(cl_command_queue queue, cl_context context,
         return -1;
     }
 
-    if( useOpKernel )
-    {
-        // Op kernels use an r/w buffer for the second param, so we need to init it with data
-        generate_random_data( vecType, vecSize * TEST_SIZE, d, inDataB );
-    }
     streams[1] = clCreateBuffer(
         context, (CL_MEM_READ_WRITE | (useOpKernel ? CL_MEM_COPY_HOST_PTR : 0)),
         get_explicit_type_size(vecType) * vecSize * TEST_SIZE,

--- a/test_conformance/integer_ops/verification_and_generation_functions.cpp
+++ b/test_conformance/integer_ops/verification_and_generation_functions.cpp
@@ -81,6 +81,106 @@ const char *test_names[] = {
 };
 
 // =======================================
+// defined arithmetic inputs
+// =======================================
+
+// floor(sqrt(TYPE_MAX)): the largest operand whose square is representable.
+constexpr cl_long kIntMulBound = 46340;
+constexpr cl_long kLongMulBound = 3037000499LL;
+// A scalar ushort is promoted to int before the multiply, so the product has to
+// fit in an int rather than in a ushort.
+constexpr cl_ulong kUShortMulBound = 46340;
+
+// Writes `count` random values in [-bound, bound] to each operand, then seeds
+// the leading elements with the cross product of the corner values, mirroring
+// what the unbounded init_*_data() generators do.
+template <typename T>
+static void fill_bounded_signed(void *inputA, void *inputB, size_t count,
+                                cl_long bound, MTdata d)
+{
+    T *a = (T *)inputA;
+    T *b = (T *)inputB;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        a[i] = (T)get_random_long(-bound, bound, d);
+        b[i] = (T)get_random_long(-bound, bound, d);
+    }
+
+    const cl_long corners[] = { 0, -1, 1, -bound, bound };
+    const size_t num_corners = sizeof(corners) / sizeof(corners[0]);
+    size_t index = 0;
+    for (size_t x = 0; x < num_corners; x++)
+        for (size_t y = 0; y < num_corners && index < count; y++)
+        {
+            a[index] = (T)corners[x];
+            b[index] = (T)corners[y];
+            index++;
+        }
+}
+
+template <typename T>
+static void fill_bounded_unsigned(void *inputA, void *inputB, size_t count,
+                                  cl_ulong bound, MTdata d)
+{
+    T *a = (T *)inputA;
+    T *b = (T *)inputB;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        a[i] = (T)get_random_ulong(0, bound, d);
+        b[i] = (T)get_random_ulong(0, bound, d);
+    }
+
+    const cl_ulong corners[] = { 0, 1, bound };
+    const size_t num_corners = sizeof(corners) / sizeof(corners[0]);
+    size_t index = 0;
+    for (size_t x = 0; x < num_corners; x++)
+        for (size_t y = 0; y < num_corners && index < count; y++)
+        {
+            a[index] = (T)corners[x];
+            b[index] = (T)corners[y];
+            index++;
+        }
+}
+
+std::optional<DefinedArithmeticOp> get_defined_arithmetic_op(const char *opName)
+{
+    if (strcmp(opName, "+") == 0) return kDefinedAdd;
+    if (strcmp(opName, "-") == 0) return kDefinedSub;
+    if (strcmp(opName, "*") == 0) return kDefinedMul;
+
+    return std::nullopt;
+}
+
+void init_defined_arithmetic_data(ExplicitType type, DefinedArithmeticOp op,
+                                  size_t num_elements, void *inputA,
+                                  void *inputB, MTdata d)
+{
+    switch (type)
+    {
+        case kInt:
+            fill_bounded_signed<cl_int>(
+                inputA, inputB, num_elements,
+                op == kDefinedMul ? kIntMulBound : CL_INT_MAX / 2, d);
+            break;
+        case kLong:
+            fill_bounded_signed<cl_long>(
+                inputA, inputB, num_elements,
+                op == kDefinedMul ? kLongMulBound : CL_LONG_MAX / 2, d);
+            break;
+        case kUShort:
+            if (op == kDefinedMul)
+                fill_bounded_unsigned<cl_ushort>(inputA, inputB, num_elements,
+                                                 kUShortMulBound, d);
+            break;
+        default:
+            // Cannot overflow: keep the unbounded inputs.
+            break;
+    }
+}
+
+// =======================================
 // long
 // =======================================
 int


### PR DESCRIPTION
Randomized inputs in ten CTS cases can overflow signed arithmetic even though overflow is not what those tests exercise. Limit operands so additions, subtractions, multiplications, reductions, and loop accumulations remain representable.

This keeps the device kernels and host references defined while preserving randomized coverage, and lets the affected cases run with device UBSan enabled.

[run-test: test_api set_kernel_arg_struct_array]
[run-test: test_basic local_arg_def]
[run-test: test_basic local_kernel_def]
[run-test: test_basic loop]
[run-test: test_integer_ops integer_addAssign]
[run-test: test_integer_ops integer_multiplyAssign]
[run-test: test_integer_ops integer_subtractAssign]
[run-test: test_integer_ops quick_int_math]
[run-test: test_integer_ops quick_long_math]
[run-test: test_integer_ops quick_ushort_math]
[run-test: test_integer_ops int_math]
[run-test: test_integer_ops long_math]
[run-test: test_integer_ops ushort_math]