### PR TITLE
atomics: fix check for non-empty reference vector

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -13,6 +13,11 @@
           "negative_set_kernel_arg_invalid_image": "fail"
         }
     },
+    "test_atomics": {
+        "": {
+            "atomic_add": "pass"
+        }
+    },
     "test_basic": {
         "": {
             "enqueue_map_image": "pass",

--- a/test_conformance/atomics/test_atomics.cpp
+++ b/test_conformance/atomics/test_atomics.cpp
@@ -281,11 +281,11 @@ int test_atomic_function(cl_device_id deviceID, cl_context context,
         log_error("ERROR: Creating output array failed!\n");
         return -1;
     }
-    streams[1] =
-        clCreateBuffer(context,
-                       ((startRefValues.data() != NULL ? CL_MEM_COPY_HOST_PTR
-                                                       : CL_MEM_READ_WRITE)),
-                       typeSize * threadSize, startRefValues.data(), NULL);
+    streams[1] = clCreateBuffer(
+        context,
+        (!startRefValues.empty() ? CL_MEM_COPY_HOST_PTR : CL_MEM_READ_WRITE),
+        typeSize * threadSize,
+        !startRefValues.empty() ? startRefValues.data() : NULL, NULL);
     if (!streams[1])
     {
         log_error("ERROR: Creating reference array failed!\n");

--- a/test_conformance/atomics/test_atomics.cpp
+++ b/test_conformance/atomics/test_atomics.cpp
@@ -283,9 +283,9 @@ int test_atomic_function(cl_device_id deviceID, cl_context context,
     }
     streams[1] = clCreateBuffer(
         context,
-        (!startRefValues.empty() ? CL_MEM_COPY_HOST_PTR : CL_MEM_READ_WRITE),
+        startRefValues.empty() ? CL_MEM_READ_WRITE : CL_MEM_COPY_HOST_PTR,
         typeSize * threadSize,
-        !startRefValues.empty() ? startRefValues.data() : NULL, NULL);
+        startRefValues.empty() ? NULL : startRefValues.data(), NULL);
     if (!streams[1])
     {
         log_error("ERROR: Creating reference array failed!\n");


### PR DESCRIPTION
An empty std::vector may still return a non-null data() pointer, leading to invalid host pointer buffer creation when creating reference buffers.

[run-test: test_atomics atomic_add]