### PR TITLE
api: Fix min_max_mem_alloc_size minimum requirement check

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -11,6 +11,7 @@
         "": {
           "consistency_read_write_images": "pass",
           "min_max_image_array_size": "pass",
+          "min_max_mem_alloc_size": "pass",
           "min_max_read_image_args": "pass",
           "min_max_write_image_args": "pass",
           "negative_set_kernel_arg_invalid_image_msaa": "skip",

--- a/test_conformance/api/test_api_min_max.cpp
+++ b/test_conformance/api/test_api_min_max.cpp
@@ -564,12 +564,8 @@ REGISTER_TEST(min_max_mem_alloc_size)
     else
         requiredAllocSize = 128 * 1024 * 1024;
 
-    /* Get the max mem alloc size, limit the alloc to half of the available
-     * memory */
-    maxAllocSize = get_device_info_max_mem_alloc_size(
-        device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
-    memSize =
-        get_device_info_global_mem_size(device, MAX_DEVICE_MEMORY_SIZE_DIVISOR);
+    maxAllocSize = get_device_info_max_mem_alloc_size(device);
+    memSize = get_device_info_global_mem_size(device);
 
     if (memSize < maxAllocSize)
     {
@@ -585,7 +581,8 @@ REGISTER_TEST(min_max_mem_alloc_size)
 
     if (maxAllocSize < requiredAllocSize)
     {
-        log_error("ERROR: Reported max allocation size is less than required");
+        log_error(
+            "ERROR: Reported max allocation size is less than required\n");
         return -1;
     }
 
@@ -595,9 +592,10 @@ REGISTER_TEST(min_max_mem_alloc_size)
              maxAllocSize, maxAllocSize / (1024.0 * 1024.0), memSize,
              memSize / (1024.0 * 1024.0));
 
-    minSizeToTry = maxAllocSize / 16;
-    currentSize = maxAllocSize;
-    while (currentSize >= maxAllocSize / MAX_REDUCTION_FACTOR)
+    cl_ulong maxAllocToAttempt = maxAllocSize / MAX_DEVICE_MEMORY_SIZE_DIVISOR;
+    minSizeToTry = maxAllocToAttempt / 16;
+    currentSize = maxAllocToAttempt;
+    while (currentSize >= maxAllocToAttempt / MAX_REDUCTION_FACTOR)
     {
 
         log_info("Trying to create a buffer of size of %" PRIu64


### PR DESCRIPTION
Previously, get_device_info_max_mem_alloc_size was called with MAX_DEVICE_MEMORY_SIZE_DIVISOR (2), halving the reported size before checking whether it satisfied requiredAllocSize. For compliant devices reporting the exact specification minimum (e.g. 128 MB on full profile), this caused the test to falsely fail with:
"ERROR: Reported max allocation size is less than required"

Fix this by querying the reported device limits without a divisor, and then applying MAX_DEVICE_MEMORY_SIZE_DIVISOR to compute maxAllocToAttempt so that the buffer allocation retry loop preserves its original behavior.

Also add a missing newline to the log_error call.

[run-test: test_api min_max_mem_alloc_size]