### PR TITLE
Fix test_vulkan_interop_image validation error for oversized image2DList descriptor array

### DIFF
--- a/test_conformance/vulkan/shaders/image2D.comp.in
+++ b/test_conformance/vulkan/shaders/image2D.comp.in
@@ -2,7 +2,6 @@
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_int32 : enable
 
-#define MAX_2D_IMAGE_MIP_LEVELS     11
 
 layout(binding = 0) buffer Params
 {
@@ -10,6 +9,7 @@ layout(binding = 0) buffer Params
 };
 
 layout(constant_id = 0) const uint MAX_2D_IMAGES = 5;
+layout(constant_id = 1) const uint MAX_2D_IMAGE_MIP_LEVELS = 1;
 
 layout(binding = 1, ${GLSL_FORMAT}) uniform ${GLSL_TYPE_PREFIX}image2D image2DList[MAX_2D_IMAGES * MAX_2D_IMAGE_MIP_LEVELS];
 layout(local_size_x = 32, local_size_y = 32) in;

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -266,12 +266,13 @@ int run_test_with_two_queue(
     srcBufferPtr = (char *)malloc(maxImage2DSize);
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
+    const uint32_t numMipLevels = 1;
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
     vkDescriptorSetLayoutBindingList.addBinding(
         0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
     vkDescriptorSetLayoutBindingList.addBinding(
         1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        MAX_2D_IMAGE_MIP_LEVELS * (useSingleImageKernel ? 1 : num2DImages));
+        (useSingleImageKernel ? 1 : num2DImages) * numMipLevels);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -318,16 +319,23 @@ int run_test_with_two_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        VkSpecializationMapEntry entry;
-        entry.constantID = 0;
-        entry.offset = 0;
-        entry.size = sizeof(uint32_t);
+        struct
+        {
+            uint32_t num2DImages;
+            uint32_t numMipLevels;
+        } specData = { num2DImages, numMipLevels };
+
+        VkSpecializationMapEntry entries[2];
+        entries[0] = { 0, offsetof(decltype(specData), num2DImages),
+                       sizeof(uint32_t) };
+        entries[1] = { 1, offsetof(decltype(specData), numMipLevels),
+                       sizeof(uint32_t) };
 
         VkSpecializationInfo spec;
-        spec.mapEntryCount = 1;
-        spec.pMapEntries = &entry;
-        spec.dataSize = sizeof(uint32_t);
-        spec.pData = &num2DImages;
+        spec.mapEntryCount = 2;
+        spec.pMapEntries = entries;
+        spec.dataSize = sizeof(specData);
+        spec.pData = &specData;
 
         VulkanComputePipeline vkComputePipeline(
             vkDevice, vkPipelineLayout, vkImage2DShaderModule, "main", &spec);
@@ -345,7 +353,6 @@ int run_test_with_two_queue(
                 if (height > max_height) continue;
                 region[1] = height;
 
-                uint32_t numMipLevels = 1;
                 log_info("Number of mipmap levels: %d\n", numMipLevels);
 
                 magicValue++;
@@ -511,8 +518,9 @@ int run_test_with_two_queue(
 
                         if (!useSingleImageKernel)
                         {
-                            vkDescriptorSet.updateArray(1, num2DImages,
-                                                        vkImage2DViewList);
+                            vkDescriptorSet.updateArray(
+                                1, vkImage2DViewList.size(), vkImage2DViewList);
+
                             vkCopyCommandBuffer.begin();
                             vkCopyCommandBuffer.pipelineBarrier(
                                 (*vkImage2DList), VULKAN_IMAGE_LAYOUT_UNDEFINED,
@@ -861,12 +869,13 @@ int run_test_with_one_queue(
     srcBufferPtr = (char *)malloc(maxImage2DSize);
     dstBufferPtr = (char *)malloc(maxImage2DSize);
 
+    const uint32_t numMipLevels = 1;
     VulkanDescriptorSetLayoutBindingList vkDescriptorSetLayoutBindingList;
     vkDescriptorSetLayoutBindingList.addBinding(
         0, VULKAN_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
     vkDescriptorSetLayoutBindingList.addBinding(
         1, VULKAN_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        MAX_2D_IMAGE_MIP_LEVELS * (useSingleImageKernel ? 1 : num2DImages));
+        (useSingleImageKernel ? 1 : num2DImages) * numMipLevels);
     VulkanDescriptorSetLayout vkDescriptorSetLayout(
         vkDevice, vkDescriptorSetLayoutBindingList);
     VulkanPipelineLayout vkPipelineLayout(vkDevice, vkDescriptorSetLayout);
@@ -913,16 +922,23 @@ int run_test_with_one_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        VkSpecializationMapEntry entry;
-        entry.constantID = 0;
-        entry.offset = 0;
-        entry.size = sizeof(uint32_t);
+        struct
+        {
+            uint32_t num2DImages;
+            uint32_t numMipLevels;
+        } specData = { num2DImages, numMipLevels };
+
+        VkSpecializationMapEntry entries[2];
+        entries[0] = { 0, offsetof(decltype(specData), num2DImages),
+                       sizeof(uint32_t) };
+        entries[1] = { 1, offsetof(decltype(specData), numMipLevels),
+                       sizeof(uint32_t) };
 
         VkSpecializationInfo spec;
-        spec.mapEntryCount = 1;
-        spec.pMapEntries = &entry;
-        spec.dataSize = sizeof(uint32_t);
-        spec.pData = &num2DImages;
+        spec.mapEntryCount = 2;
+        spec.pMapEntries = entries;
+        spec.dataSize = sizeof(specData);
+        spec.pData = &specData;
 
         VulkanComputePipeline vkComputePipeline(
             vkDevice, vkPipelineLayout, vkImage2DShaderModule, "main", &spec);
@@ -940,7 +956,6 @@ int run_test_with_one_queue(
                 if (height > max_height) continue;
                 region[1] = height;
 
-                uint32_t numMipLevels = 1;
                 log_info("Number of mipmap levels: %d\n", numMipLevels);
 
                 magicValue++;
@@ -1112,8 +1127,8 @@ int run_test_with_one_queue(
 
                         if (!useSingleImageKernel)
                         {
-                            vkDescriptorSet.updateArray(1, num_2D_image,
-                                                        vkImage2DViewList);
+                            vkDescriptorSet.updateArray(
+                                1, vkImage2DViewList.size(), vkImage2DViewList);
                             vkCopyCommandBuffer.begin();
                             vkCopyCommandBuffer.pipelineBarrier(
                                 *vkImage2DList, VULKAN_IMAGE_LAYOUT_UNDEFINED,

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -30,8 +30,6 @@ namespace {
 #define MAX_2D_IMAGE_WIDTH 1024
 #define MAX_2D_IMAGE_HEIGHT 1024
 #define MAX_2D_IMAGE_ELEMENT_SIZE 16
-#define MAX_2D_IMAGE_MIP_LEVELS 11
-#define MAX_2D_IMAGE_DESCRIPTORS MAX_2D_IMAGES *MAX_2D_IMAGE_MIP_LEVELS
 #define NUM_THREADS_PER_GROUP_X 32
 #define NUM_THREADS_PER_GROUP_Y 32
 #define NUM_BLOCKS(size, blockSize)                                            \
@@ -319,17 +317,10 @@ int run_test_with_two_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        struct
-        {
-            uint32_t num2DImages;
-            uint32_t numMipLevels;
-        } specData = { num2DImages, numMipLevels };
-
+        uint32_t specData[2] = { num2DImages, numMipLevels };
         VkSpecializationMapEntry entries[2];
-        entries[0] = { 0, offsetof(decltype(specData), num2DImages),
-                       sizeof(uint32_t) };
-        entries[1] = { 1, offsetof(decltype(specData), numMipLevels),
-                       sizeof(uint32_t) };
+        entries[0] = { 0, 0, sizeof(uint32_t) };
+        entries[1] = { 1, sizeof(uint32_t), sizeof(uint32_t) };
 
         VkSpecializationInfo spec;
         spec.mapEntryCount = 2;
@@ -922,17 +913,10 @@ int run_test_with_one_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        struct
-        {
-            uint32_t num2DImages;
-            uint32_t numMipLevels;
-        } specData = { num2DImages, numMipLevels };
-
+        uint32_t specData[2] = { num2DImages, numMipLevels };
         VkSpecializationMapEntry entries[2];
-        entries[0] = { 0, offsetof(decltype(specData), num2DImages),
-                       sizeof(uint32_t) };
-        entries[1] = { 1, offsetof(decltype(specData), numMipLevels),
-                       sizeof(uint32_t) };
+        entries[0] = { 0, 0, sizeof(uint32_t) };
+        entries[1] = { 1, sizeof(uint32_t), sizeof(uint32_t) };
 
         VkSpecializationInfo spec;
         spec.mapEntryCount = 2;

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -317,7 +317,8 @@ int run_test_with_two_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        uint32_t specData[2] = { num2DImages, numMipLevels };
+        const uint32_t numImages = useSingleImageKernel ? 1 : num2DImages;
+        uint32_t specData[2] = { numImages, numMipLevels };
         VkSpecializationMapEntry entries[2];
         entries[0] = { 0, 0, sizeof(uint32_t) };
         entries[1] = { 1, sizeof(uint32_t), sizeof(uint32_t) };
@@ -913,7 +914,8 @@ int run_test_with_one_queue(
         VulkanShaderModule vkImage2DShaderModule(vkDevice, vkImage2DShader);
 
         // add shader constant
-        uint32_t specData[2] = { num2DImages, numMipLevels };
+        const uint32_t numImages = useSingleImageKernel ? 1 : num2DImages;
+        uint32_t specData[2] = { numImages, numMipLevels };
         VkSpecializationMapEntry entries[2];
         entries[0] = { 0, 0, sizeof(uint32_t) };
         entries[1] = { 1, sizeof(uint32_t), sizeof(uint32_t) };


### PR DESCRIPTION
Related to #2487

Fixes VUID-vkCmdDispatch-None-08114, reported by VK_LAYER_KHRONOS_validation 1.4.313.

The `image2DList` descriptor array in `run_test_with_one_queue` and `run_test_with_two_queue` was sized for hardcoded 11 mipmap levels while every image in this test is created with a single mip level. Added another specialization constant to address that problem.