### PR TITLE
Fix test_vulkan_interop_image validation errors for semaphore reimport and resource destruction

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -739,12 +739,16 @@ int run_test_with_two_queue(
 
                             clFinish(cmd_queue2);
 
-                            vkQueue.waitIdle();
+                            if (iter != innerIterations - 1)
+                            {
+                                vkQueue.waitIdle();
 
-                            err = clCl2VkExternalSemaphore->signal(cmd_queue2);
-                            test_error_and_cleanup(
-                                err, CLEANUP,
-                                "Failed to signal CL semaphore\n");
+                                err = clCl2VkExternalSemaphore->signal(
+                                    cmd_queue2);
+                                test_error_and_cleanup(
+                                    err, CLEANUP,
+                                    "Failed to signal CL semaphore\n");
+                            }
                         }
 
                         vkQueue.waitIdle();
@@ -821,9 +825,10 @@ int run_test_with_two_queue(
         vkImage2DShader.clear();
     }
 
+CLEANUP:
+
     vkDevice.waitIdle();
 
-CLEANUP:
     if (clVk2CLExternalSemaphore) delete clVk2CLExternalSemaphore;
     if (clCl2VkExternalSemaphore) delete clCl2VkExternalSemaphore;
 
@@ -1282,12 +1287,16 @@ int run_test_with_one_queue(
                             test_error_and_cleanup(err, CLEANUP,
                                                    "Failed to release images");
 
-                            vkQueue.waitIdle();
+                            if (iter != innerIterations - 1)
+                            {
+                                vkQueue.waitIdle();
 
-                            err = clCl2VkExternalSemaphore->signal(cmd_queue1);
-                            test_error_and_cleanup(
-                                err, CLEANUP,
-                                "Failed to signal CL semaphore\n");
+                                err = clCl2VkExternalSemaphore->signal(
+                                    cmd_queue1);
+                                test_error_and_cleanup(
+                                    err, CLEANUP,
+                                    "Failed to signal CL semaphore\n");
+                            }
                         }
 
                         vkQueue.waitIdle();
@@ -1360,9 +1369,10 @@ int run_test_with_one_queue(
         vkImage2DShader.clear();
     }
 
+CLEANUP:
+
     vkDevice.waitIdle();
 
-CLEANUP:
     if (clVk2CLExternalSemaphore) delete clVk2CLExternalSemaphore;
     if (clCl2VkExternalSemaphore) delete clCl2VkExternalSemaphore;
 

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -738,11 +738,16 @@ int run_test_with_two_queue(
                                                    "Failed to release images");
 
                             clFinish(cmd_queue2);
+
+                            vkQueue.waitIdle();
+
                             err = clCl2VkExternalSemaphore->signal(cmd_queue2);
                             test_error_and_cleanup(
                                 err, CLEANUP,
                                 "Failed to signal CL semaphore\n");
                         }
+
+                        vkQueue.waitIdle();
 
                         clFinish(cmd_queue2);
                         for (uint32_t i = 0; i < num2DImages; i++)
@@ -815,6 +820,9 @@ int run_test_with_two_queue(
 
         vkImage2DShader.clear();
     }
+
+    vkDevice.waitIdle();
+
 CLEANUP:
     if (clVk2CLExternalSemaphore) delete clVk2CLExternalSemaphore;
     if (clCl2VkExternalSemaphore) delete clCl2VkExternalSemaphore;
@@ -1274,11 +1282,15 @@ int run_test_with_one_queue(
                             test_error_and_cleanup(err, CLEANUP,
                                                    "Failed to release images");
 
+                            vkQueue.waitIdle();
+
                             err = clCl2VkExternalSemaphore->signal(cmd_queue1);
                             test_error_and_cleanup(
                                 err, CLEANUP,
                                 "Failed to signal CL semaphore\n");
                         }
+
+                        vkQueue.waitIdle();
 
                         for (uint32_t i = 0; i < num2DImages; i++)
                         {
@@ -1347,6 +1359,9 @@ int run_test_with_one_queue(
         }
         vkImage2DShader.clear();
     }
+
+    vkDevice.waitIdle();
+
 CLEANUP:
     if (clVk2CLExternalSemaphore) delete clVk2CLExternalSemaphore;
     if (clCl2VkExternalSemaphore) delete clCl2VkExternalSemaphore;


### PR DESCRIPTION
Related to #2623

Fixes VUID-vkImportSemaphoreFdKHR-semaphore-01142, VUID-vkDestroyPipeline-pipeline-00765, VUID-vkDestroyImage-image-01000, VUID-vkBeginCommandBuffer-commandBuffer-00049, VUID-vkFreeCommandBuffers-pCommandBuffers-00047, VUID-vkDestroySemaphore-semaphore-05149 (VK_LAYER_KHRONOS_validation 1.4.313).

Same root cause and fix pattern as #2676 for `test_vulkan_interop_buffer`: added vkQueue::waitIdle()/vkDevice::waitIdle() calls before semaphore reimport and before resource cleanup in `run_test_with_one_queue` and `run_test_with_two_queue`.