### PR TITLE
Add support for svm types without single address space to cl_khr_unified_svm test

### DIFF
--- a/test_conformance/SVM/test_unified_svm_capabilities.cpp
+++ b/test_conformance/SVM/test_unified_svm_capabilities.cpp
@@ -291,8 +291,7 @@ struct UnifiedSVMCapabilities : UnifiedSVMBase
         test_error(err, "could not write to usvm memory");
 
         cl_int check;
-        err = clEnqueueSVMMemcpy(queue, CL_TRUE, &check, mem->get_ptr(),
-                                 sizeof(value), 0, nullptr, nullptr);
+        err = mem->read(check);
         test_error(err, "could not read from usvm memory with memcpy");
 
         test_assert_error(check == value,
@@ -351,6 +350,9 @@ struct UnifiedSVMCapabilities : UnifiedSVMBase
                                   sizeof(value), 0, nullptr, nullptr);
         test_error(err, "could not write to usvm memory with memfill");
 
+        err = clFinish(queue);
+        test_error(err, "clFinish failed");
+
         cl_int check;
         err = mem->read(check);
         test_error(err, "could not read from usvm memory");
@@ -359,17 +361,20 @@ struct UnifiedSVMCapabilities : UnifiedSVMBase
                           "read value with memfill does not match");
 
         // test writing via memcpy
-        value = genrand_int32(d);
-        err = clEnqueueSVMMemcpy(queue, CL_TRUE, mem->get_ptr(), &value,
-                                 sizeof(value), 0, nullptr, nullptr);
-        test_error(err, "could not write to usvm memory with memcpy");
+        if (mem->getCapabilities() & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
+        {
+            value = genrand_int32(d);
+            err = clEnqueueSVMMemcpyWithPropertiesKHR(
+                queue, NULL, CL_TRUE, mem->get_ptr(), &value, sizeof(value), 0,
+                nullptr, nullptr);
+            test_error(err, "could not write to usvm memory with memcpy");
 
-        err = mem->read(check);
-        test_error(err, "could not read from usvm memory");
+            err = mem->read(check);
+            test_error(err, "could not read from usvm memory");
 
-        test_assert_error(check == value,
-                          "read value with memcpy does not match");
-
+            test_assert_error(check == value,
+                              "read value with memcpy does not match");
+        }
         // test writing via kernel
         value = genrand_int32(d);
         clMemWrapper in =
@@ -586,7 +591,7 @@ struct UnifiedSVMCapabilities : UnifiedSVMBase
             if (caps & CL_SVM_CAPABILITY_DEVICE_WRITE_KHR)
             {
                 log_info("     testing CL_SVM_CAPABILITY_DEVICE_WRITE\n");
-                err = test_CL_SVM_CAPABILITY_DEVICE_READ_KHR(ti);
+                err = test_CL_SVM_CAPABILITY_DEVICE_WRITE_KHR(ti);
                 test_error(err, "CL_SVM_CAPABILITY_DEVICE_READ failed");
             }
             if (caps & CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR)

--- a/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
+++ b/test_conformance/SVM/test_unified_svm_mem_cpy.cpp
@@ -27,7 +27,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
     // Test the clEnqueueSVMMemcpy function for random ranges
     // of a USM allocation and validate the results.
     cl_int test_SVMMemcpy(USVMWrapper<cl_uchar> *src,
-                          USVMWrapper<cl_uchar> *dst)
+                          USVMWrapper<cl_uchar> *dst, bool use_new_api)
     {
         cl_int err = CL_SUCCESS;
 
@@ -54,9 +54,19 @@ struct UnifiedSVMOPs : UnifiedSVMBase
             void *dst_ptr = &dst->get_ptr()[offset];
 
             clEventWrapper event;
-            err = clEnqueueSVMMemcpy(queue, CL_BLOCKING, dst_ptr, src_ptr,
-                                     length, 0, nullptr, &event);
-            test_error(err, "clEnqueueSVMMemcpy failed");
+            if (!use_new_api)
+            {
+                err = clEnqueueSVMMemcpy(queue, CL_BLOCKING, dst_ptr, src_ptr,
+                                         length, 0, nullptr, &event);
+                test_error(err, "clEnqueueSVMMemcpy failed");
+            }
+            else
+            {
+                err = clEnqueueSVMMemcpyWithPropertiesKHR(
+                    queue, NULL, CL_BLOCKING, dst_ptr, src_ptr, length, 0,
+                    nullptr, &event);
+                test_error(err, "clEnqueueSVMMemcpyWithPropertiesKHR failed");
+            }
 
             err = check_event_type(event, CL_COMMAND_SVM_MEMCPY);
             test_error(err,
@@ -95,7 +105,8 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         return CL_SUCCESS;
     }
 
-    cl_int test_svm_memcpy(cl_uint srcTypeIndex, cl_uint dstTypeIndex)
+    cl_int test_svm_memcpy(cl_uint srcTypeIndex, cl_uint dstTypeIndex,
+                           bool use_new_api = false)
     {
         cl_int err;
 
@@ -108,7 +119,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         err = dstMem->allocate(alloc_count);
         test_error(err, "SVM allocation failed");
 
-        err = test_SVMMemcpy(srcMem.get(), dstMem.get());
+        err = test_SVMMemcpy(srcMem.get(), dstMem.get(), use_new_api);
         test_error(err, "test_SVMMemcpy");
 
         err = srcMem->free();
@@ -119,7 +130,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         return CL_SUCCESS;
     }
 
-    cl_int test_svm_memcpy(cl_uint TypeIndex)
+    cl_int test_svm_memcpy(cl_uint TypeIndex, bool use_new_api = false)
     {
         cl_int err;
         const auto caps = deviceUSVMCaps[TypeIndex];
@@ -137,7 +148,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         if (caps & CL_SVM_CAPABILITY_HOST_READ_KHR
             || caps & PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR)
         {
-            err = test_SVMMemcpy(mem.get(), hostMem.get());
+            err = test_SVMMemcpy(mem.get(), hostMem.get(), use_new_api);
             test_error(err, "test_SVMMemcpy");
         }
 
@@ -145,7 +156,7 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         if (caps & CL_SVM_CAPABILITY_HOST_WRITE_KHR
             || caps & PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR)
         {
-            err = test_SVMMemcpy(hostMem.get(), mem.get());
+            err = test_SVMMemcpy(hostMem.get(), mem.get(), use_new_api);
             test_error(err, "test_SVMMemcpy");
         }
 
@@ -175,13 +186,20 @@ struct UnifiedSVMOPs : UnifiedSVMBase
                         src_ti, dst_ti);
                     err = test_svm_memcpy(src_ti, dst_ti);
                     test_error(err, "test_svm_memcpy failed");
+                    log_info("   testing clEnqueueSVMMemcpyWithPropertiesKHR() "
+                             "SVM type %u -> SVM "
+                             "type %u\n",
+                             src_ti, dst_ti);
+                    err = test_svm_memcpy(src_ti, dst_ti, true);
+                    test_error(err, "test_svm_memcpy failed");
                 }
                 else
                 {
-                    log_info(
-                        "   skipping clEnqueueSVMMemcpy() SVM type %u -> SVM "
-                        "type %u\n",
-                        src_ti, dst_ti);
+                    log_info("   skipping clEnqueueSVMMemcpy() & "
+                             "clEnqueueSVMMemcpyWithPropertiesKHR() for SVM "
+                             "type %u -> SVM "
+                             "type %u\n",
+                             src_ti, dst_ti);
                 }
             }
         }
@@ -190,13 +208,25 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         // ptr
         for (cl_uint ti = 0; ti < max_ti; ti++)
         {
-            log_info(
-                "   testing clEnqueueSVMMemcpy() SVM type %u <-> host ptr \n",
-                ti);
-            err = test_svm_memcpy(ti);
-            if (CL_SUCCESS != err)
+            if (deviceUSVMCaps[ti] & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
             {
-                return err;
+                log_info("   testing clEnqueueSVMMemcpy() SVM type %u <-> host "
+                         "ptr \n",
+                         ti);
+                err = test_svm_memcpy(ti);
+                test_error(err, "test_svm_memcpy failed");
+                log_info("   testing clEnqueueSVMMemcpyWithPropertiesKHR() SVM "
+                         "type %u <-> host ptr \n",
+                         ti);
+                err = test_svm_memcpy(ti, true);
+                test_error(err, "test_svm_memcpy failed");
+            }
+            else
+            {
+                log_info("   skipping clEnqueueSVMMemcpy() & "
+                         "clEnqueueSVMMemcpyWithPropertiesKHR() for SVM type "
+                         "%u <-> host_ptr \n",
+                         ti);
             }
         }
 
@@ -206,12 +236,12 @@ struct UnifiedSVMOPs : UnifiedSVMBase
     template <typename T>
     std::unique_ptr<USVMWrapper<T>> get_hostptr_usvm_wrapper()
     {
-        return std::unique_ptr<USVMWrapper<T>>(
-            new USVMWrapper<T>(nullptr, nullptr, nullptr, CL_UINT_MAX,
-                               PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR
-                                   | CL_SVM_CAPABILITY_HOST_READ_KHR
-                                   | CL_SVM_CAPABILITY_HOST_WRITE_KHR,
-                               0, nullptr, nullptr, nullptr, nullptr));
+        return std::unique_ptr<USVMWrapper<T>>(new USVMWrapper<T>(
+            nullptr, nullptr, nullptr, nullptr, nullptr, CL_UINT_MAX,
+            PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR
+                | CL_SVM_CAPABILITY_HOST_READ_KHR
+                | CL_SVM_CAPABILITY_HOST_WRITE_KHR,
+            0, nullptr, nullptr, nullptr, nullptr, nullptr));
     }
 
     bool caps_compatibility_check(cl_uint srcTypeIndex, cl_uint dstTypeIndex)
@@ -219,7 +249,9 @@ struct UnifiedSVMOPs : UnifiedSVMBase
         const auto srcCaps = deviceUSVMCaps[srcTypeIndex];
         const auto dstCaps = deviceUSVMCaps[dstTypeIndex];
 
-        return (srcCaps & CL_SVM_CAPABILITY_DEVICE_READ_KHR)
+        return (srcCaps & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
+            && (dstCaps & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
+            && (srcCaps & CL_SVM_CAPABILITY_DEVICE_READ_KHR)
             && (dstCaps & CL_SVM_CAPABILITY_DEVICE_WRITE_KHR);
     }
 

--- a/test_conformance/SVM/test_unified_svm_setarg.cpp
+++ b/test_conformance/SVM/test_unified_svm_setarg.cpp
@@ -72,7 +72,8 @@ struct UnifiedSVMSetArg : UnifiedSVMBase
             test_error(err, "clEnqueueReadBuffer failed");
 
             // Validate result
-            const cl_uchar *expected_data = src_data.data() + offset;
+            std::vector<cl_uchar> expected_data(length, 0);
+            src->read(expected_data, offset);
 
             for (size_t i = 0; i < length; i++)
             {

--- a/test_conformance/SVM/unified_svm_fixture.h
+++ b/test_conformance/SVM/unified_svm_fixture.h
@@ -22,6 +22,21 @@
 constexpr cl_bitfield PSEUDO_CAPABILITY_USE_SYSTEM_ALLOCATOR =
     ((cl_bitfield)1 << 63);
 
+typedef cl_properties cl_svm_memcpy_properties_khr;
+
+// clang-format off
+typedef cl_int CL_API_CALL clEnqueueSVMMemcpyWithPropertiesKHR_t(
+                                cl_command_queue command_queue,
+                                const cl_svm_memcpy_properties_khr *properties,
+                                cl_bool blocking_copy, void *dst_ptr,
+                                const void *src_ptr, size_t size,
+                                cl_uint num_events_in_wait_list,
+                                const cl_event *event_wait_list,
+                                cl_event *event);
+typedef clEnqueueSVMMemcpyWithPropertiesKHR_t
+    *clEnqueueSVMMemcpyWithPropertiesKHR_fn;
+// clang-format on
+
 static inline void parseSVMAllocProperties(
     std::vector<cl_svm_alloc_properties_khr> props, cl_device_id& device,
     cl_svm_alloc_access_flags_khr& accessFlags, size_t& alignment)
@@ -60,22 +75,30 @@ static inline void parseSVMAllocProperties(
 template <typename T> class USVMWrapper {
 public:
     USVMWrapper(cl_context context_, cl_device_id device_,
-                cl_command_queue queue_, cl_uint typeIndex_,
+                cl_command_queue queue_, cl_kernel kernel_WriteOp_,
+                cl_kernel kernel_ReadOp_, cl_uint typeIndex_,
                 cl_svm_capabilities_khr caps_, size_t deviceMaxAlignment_,
                 clSVMAllocWithPropertiesKHR_fn clSVMAllocWithPropertiesKHR_,
                 clSVMFreeWithPropertiesKHR_fn clSVMFreeWithPropertiesKHR_,
                 clGetSVMPointerInfoKHR_fn clGetSVMPointerInfoKHR_,
-                clGetSVMSuggestedTypeIndexKHR_fn clGetSVMSuggestedTypeIndexKHR_)
+                clGetSVMSuggestedTypeIndexKHR_fn clGetSVMSuggestedTypeIndexKHR_,
+                clEnqueueSVMMemcpyWithPropertiesKHR_fn
+                    clEnqueueSVMMemcpyWithPropertiesKHR_)
         : context(context_), device(device_), queue(queue_),
+          kernel_WriteOp(kernel_WriteOp_), kernel_ReadOp(kernel_ReadOp_),
           typeIndex(typeIndex_), caps(caps_),
           deviceMaxAlignment(deviceMaxAlignment_),
           clSVMAllocWithPropertiesKHR(clSVMAllocWithPropertiesKHR_),
           clSVMFreeWithPropertiesKHR(clSVMFreeWithPropertiesKHR_),
           clGetSVMPointerInfoKHR(clGetSVMPointerInfoKHR_),
-          clGetSVMSuggestedTypeIndexKHR(clGetSVMSuggestedTypeIndexKHR_)
+          clGetSVMSuggestedTypeIndexKHR(clGetSVMSuggestedTypeIndexKHR_),
+          clEnqueueSVMMemcpyWithPropertiesKHR(
+              clEnqueueSVMMemcpyWithPropertiesKHR_)
     {}
 
     ~USVMWrapper() { free(); }
+
+    cl_svm_capabilities_khr getCapabilities() { return caps; }
 
     cl_int allocate(const size_t count,
                     const std::vector<cl_svm_alloc_properties_khr> props_ = {})
@@ -184,11 +207,34 @@ public:
             err = clFinish(queue);
             test_error(err, "clFinish failed");
         }
+        else if ((caps & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
+                 && (caps & CL_SVM_CAPABILITY_DEVICE_WRITE_KHR))
+        {
+            err = clEnqueueSVMMemcpyWithPropertiesKHR(
+                queue, NULL, CL_TRUE, data + offset, source, count * sizeof(T),
+                0, nullptr, nullptr);
+            test_error(err, "clEnqueueSVMMemcpyWithPropertiesKHR failed");
+        }
         else if (caps & CL_SVM_CAPABILITY_DEVICE_WRITE_KHR)
         {
-            err = clEnqueueSVMMemcpy(queue, CL_TRUE, data + offset, source,
-                                     count * sizeof(T), 0, nullptr, nullptr);
-            test_error(err, "clEnqueueSVMMemcpy failed");
+            size_t char_count = sizeof(T);
+            cl_mem source_obj =
+                clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                               count * char_count * sizeof(unsigned char),
+                               (void*)source, &err);
+            test_error(err, "could not create source buffer");
+            err |= clSetKernelArgSVMPointer(kernel_WriteOp, 0, (data + offset));
+            err |= clSetKernelArg(kernel_WriteOp, 1, sizeof(source_obj),
+                                  &source_obj);
+            test_error(err, "could not set kernel arguments");
+            size_t global_size = count * char_count;
+            err = clEnqueueNDRangeKernel(queue, kernel_WriteOp, 1, nullptr,
+                                         &global_size, nullptr, 0, nullptr,
+                                         nullptr);
+            test_error(
+                err, "clEnqueueNDRangeKernel failed. Write operation failed.");
+            err = clFinish(queue);
+            test_error(err, "clFinish failed.");
         }
         else
         {
@@ -237,11 +283,37 @@ public:
             err = clFinish(queue);
             test_error(err, "clFinish failed");
         }
+        else if ((caps & CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR)
+                 && (caps & CL_SVM_CAPABILITY_DEVICE_READ_KHR))
+        {
+            err = clEnqueueSVMMemcpyWithPropertiesKHR(
+                queue, NULL, CL_TRUE, dst, data + offset, count * sizeof(T), 0,
+                nullptr, nullptr);
+            test_error(err, "clEnqueueSVMMemcpyWithPropertiesKHR failed");
+        }
         else if (caps & CL_SVM_CAPABILITY_DEVICE_READ_KHR)
         {
-            err = clEnqueueSVMMemcpy(queue, CL_TRUE, dst, data + offset,
-                                     count * sizeof(T), 0, nullptr, nullptr);
-            test_error(err, "clEnqueueSVMMemcpy failed");
+            size_t char_count = sizeof(T);
+            cl_mem dst_obj = clCreateBuffer(
+                context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
+                count * char_count * sizeof(unsigned char), (void*)dst, &err);
+            test_error(err, "could not create dst buffer");
+            err |= clSetKernelArgSVMPointer(kernel_ReadOp, 0, &data[offset]);
+            err |= clSetKernelArg(kernel_ReadOp, 1, sizeof(dst_obj), &dst_obj);
+            test_error(err, "could not set kernel arguments");
+            size_t global_size = count * char_count;
+            err = clEnqueueNDRangeKernel(queue, kernel_ReadOp, 1, nullptr,
+                                         &global_size, nullptr, 0, nullptr,
+                                         nullptr);
+            test_error(err, "clEnqueueNDRangeKernel failed.");
+            err = clFinish(queue);
+            test_error(err, "clFinish failed.");
+            err =
+                clEnqueueReadBuffer(queue, dst_obj, CL_TRUE, 0,
+                                    count * char_count * sizeof(unsigned char),
+                                    dst, 0, nullptr, nullptr);
+            test_error(err,
+                       "clEnqueueReadBuffer failed. Read operation failed.");
         }
         else
         {
@@ -266,6 +338,8 @@ private:
     cl_context context = nullptr;
     cl_device_id device = nullptr;
     cl_command_queue queue = nullptr;
+    cl_kernel kernel_WriteOp = nullptr;
+    cl_kernel kernel_ReadOp = nullptr;
     cl_uint typeIndex = 0;
     cl_svm_capabilities_khr caps = 0;
     size_t deviceMaxAlignment = 0;
@@ -274,6 +348,8 @@ private:
     clSVMFreeWithPropertiesKHR_fn clSVMFreeWithPropertiesKHR = nullptr;
     clGetSVMPointerInfoKHR_fn clGetSVMPointerInfoKHR = nullptr;
     clGetSVMSuggestedTypeIndexKHR_fn clGetSVMSuggestedTypeIndexKHR = nullptr;
+    clEnqueueSVMMemcpyWithPropertiesKHR_fn clEnqueueSVMMemcpyWithPropertiesKHR =
+        nullptr;
 
     T* data = nullptr;
 };
@@ -289,6 +365,27 @@ struct UnifiedSVMBase
     virtual cl_int setup()
     {
         cl_int err;
+
+        const char* programString = R"(
+            kernel void test_WriteOp(global unsigned char* dst, const global unsigned char* src)
+            {
+                dst[get_global_id(0)] = src[get_global_id(0)];
+            }
+
+            kernel void test_ReadOp(const global unsigned char* src, global unsigned char* dst)
+            {
+                dst[get_global_id(0)] = src[get_global_id(0)];
+            }
+        )";
+
+        clProgramWrapper program;
+        err = create_single_kernel_helper(context, &program, &kernel_WriteOp, 1,
+                                          &programString, "test_WriteOp");
+        test_error(err, "could not create WriteOp kernel");
+
+        err = create_single_kernel_helper(context, &program, &kernel_ReadOp, 1,
+                                          &programString, "test_ReadOp");
+        test_error(err, "could not create ReadOp kernel");
 
         cl_platform_id platform{};
         err = clGetDeviceInfo(device, CL_DEVICE_PLATFORM,
@@ -386,6 +483,14 @@ struct UnifiedSVMBase
                               "clGetSVMSuggestedTypeIndexKHR not found",
                               CL_INVALID_OPERATION);
 
+        clEnqueueSVMMemcpyWithPropertiesKHR =
+            (clEnqueueSVMMemcpyWithPropertiesKHR_fn)
+                clGetExtensionFunctionAddressForPlatform(
+                    platform, "clEnqueueSVMMemcpyWithPropertiesKHR");
+        test_assert_error_ret(clEnqueueSVMMemcpyWithPropertiesKHR != nullptr,
+                              "clEnqueueSVMMemcpyWithPropertiesKHR not found",
+                              CL_INVALID_OPERATION);
+
         // The maximum supported alignment is equal to the size of the largest
         // data type supported by the device
         if (gHasLong || is_extension_available(device, "cl_khr_fp64"))
@@ -406,16 +511,19 @@ struct UnifiedSVMBase
     std::unique_ptr<USVMWrapper<T>> get_usvm_wrapper(cl_uint typeIndex)
     {
         return std::unique_ptr<USVMWrapper<T>>(new USVMWrapper<T>(
-            context, device, queue, typeIndex, deviceUSVMCaps[typeIndex],
-            deviceMaxAlignment, clSVMAllocWithPropertiesKHR,
-            clSVMFreeWithPropertiesKHR, clGetSVMPointerInfoKHR,
-            clGetSVMSuggestedTypeIndexKHR));
+            context, device, queue, kernel_WriteOp, kernel_ReadOp, typeIndex,
+            deviceUSVMCaps[typeIndex], deviceMaxAlignment,
+            clSVMAllocWithPropertiesKHR, clSVMFreeWithPropertiesKHR,
+            clGetSVMPointerInfoKHR, clGetSVMSuggestedTypeIndexKHR,
+            clEnqueueSVMMemcpyWithPropertiesKHR));
     }
 
     MTdataHolder d;
     cl_context context = nullptr;
     cl_device_id device = nullptr;
     cl_command_queue queue = nullptr;
+    cl_kernel kernel_WriteOp = nullptr;
+    cl_kernel kernel_ReadOp = nullptr;
     int num_elements = 0;
 
     std::vector<cl_svm_capabilities_khr> platformUSVMCaps;
@@ -426,4 +534,6 @@ struct UnifiedSVMBase
     clSVMFreeWithPropertiesKHR_fn clSVMFreeWithPropertiesKHR = nullptr;
     clGetSVMPointerInfoKHR_fn clGetSVMPointerInfoKHR = nullptr;
     clGetSVMSuggestedTypeIndexKHR_fn clGetSVMSuggestedTypeIndexKHR = nullptr;
+    clEnqueueSVMMemcpyWithPropertiesKHR_fn clEnqueueSVMMemcpyWithPropertiesKHR =
+        nullptr;
 };


### PR DESCRIPTION
- Adds the mechanisms to read and write from a Unified SVM allocation when it does not support `CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR`.
- Fixes `CL_SVM_CAPABILITY_DEVICE_WRITE_KHR` test calling `test_CL_SVM_CAPABILITY_DEVICE_READ_KHR` instead.
- Adds test for `clEnqueueSVMMemcpyWithPropertiesKHR`.
- Adds missing `clFinish` in `test_SVMMemfill` test.