### PR TITLE
Update command-buffer version check to 1.0

### DIFF
--- a/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
+++ b/test_conformance/extensions/cl_khr_command_buffer/basic_command_buffer.h
@@ -157,10 +157,10 @@ int MakeAndRunTest(cl_device_id device, cl_context context,
         cl_version extension_version =
             get_extension_version(device, "cl_khr_command_buffer");
 
-        if (extension_version != CL_MAKE_VERSION(0, 9, 8))
+        if (extension_version < CL_MAKE_VERSION(1, 0, 0))
         {
-            log_info("cl_khr_command_buffer version 0.9.8 is required to run "
-                     "the test, skipping.\n ");
+            log_info("cl_khr_command_buffer version 1.0.0 or newer is required "
+                     "to run the test, skipping.\n ");
             return TEST_SKIPPED_ITSELF;
         }
     }


### PR DESCRIPTION
We currently have a version checking mechanism for cl_khr_command_buffer tests that verifies against an exact version number. This was due to the extension being experimental, which meant there was the breaking changes between version bumps

With the move of command-buffers to non-experimental status in https://github.com/KhronosGroup/OpenCL-Docs/pull/1614 we can update this check to compare against version 1.0 or newer, as API breaks will not be possible between minor version bumps.