### PR TITLE
Fix test_vulkan_interop_image descriptor/command-buffer reuse hazard in useSingleImageKernel path

### DIFF
--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -283,8 +283,8 @@ int run_test_with_two_queue(
     VulkanCommandPool vkCommandPool(vkDevice);
     VulkanCommandBuffer vkCopyCommandBuffer(vkDevice, vkCommandPool);
     VulkanCommandBuffer vkShaderCommandBuffer(vkDevice, vkCommandPool);
-    std::shared_ptr<VulkanFence> vkImageDispatchFence(
-        new VulkanFence(vkDevice));
+    std::shared_ptr<VulkanFence> vkImageDispatchFence =
+        std::make_shared<VulkanFence>(vkDevice);
     VulkanQueue &vkQueue = vkDevice.getQueue(getVulkanQueueFamily());
 
     VulkanSemaphore vkVk2CLSemaphore(vkDevice, vkExternalSemaphoreHandleType);
@@ -553,16 +553,6 @@ int run_test_with_two_queue(
                                 for (size_t i2DIdx = 0;
                                      i2DIdx < vkImage2DList->size(); i2DIdx++)
                                 {
-                                    if (i2DIdx > 0)
-                                    {
-                                        // synchronize reusing vkDescriptorSet
-                                        // (VUID-vkUpdateDescriptorSets-None-03047)
-                                        // and vkCopyCommandBuffer
-                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
-                                        vkImageDispatchFence->wait();
-                                        vkImageDispatchFence->reset();
-                                    }
-
                                     vkDescriptorSet.update(
                                         1, vkImage2DViewList[i2DIdx]);
                                     vkCopyCommandBuffer.begin();
@@ -598,6 +588,12 @@ int run_test_with_two_queue(
                                     {
                                         vkQueue.submit(vkShaderCommandBuffer,
                                                        vkImageDispatchFence);
+                                        // synchronize reusing vkDescriptorSet
+                                        // (VUID-vkUpdateDescriptorSets-None-03047)
+                                        // and vkCopyCommandBuffer
+                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
+                                        vkImageDispatchFence->wait();
+                                        vkImageDispatchFence->reset();
                                     }
                                 }
                             }
@@ -906,8 +902,8 @@ int run_test_with_one_queue(
     VulkanCommandPool vkCommandPool(vkDevice);
     VulkanCommandBuffer vkCopyCommandBuffer(vkDevice, vkCommandPool);
     VulkanCommandBuffer vkShaderCommandBuffer(vkDevice, vkCommandPool);
-    std::shared_ptr<VulkanFence> vkImageDispatchFence(
-        new VulkanFence(vkDevice));
+    std::shared_ptr<VulkanFence> vkImageDispatchFence =
+        std::make_shared<VulkanFence>(vkDevice);
     VulkanQueue &vkQueue = vkDevice.getQueue(getVulkanQueueFamily());
 
     VulkanSemaphore vkVk2CLSemaphore(vkDevice, vkExternalSemaphoreHandleType);
@@ -1181,16 +1177,6 @@ int run_test_with_one_queue(
                                 for (size_t i2DIdx = 0;
                                      i2DIdx < vkImage2DList->size(); i2DIdx++)
                                 {
-                                    if (i2DIdx > 0)
-                                    {
-                                        // synchronize reusing vkDescriptorSet
-                                        // (VUID-vkUpdateDescriptorSets-None-03047)
-                                        // and vkCopyCommandBuffer
-                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
-                                        vkImageDispatchFence->wait();
-                                        vkImageDispatchFence->reset();
-                                    }
-
                                     vkDescriptorSet.update(
                                         1, vkImage2DViewList[i2DIdx]);
                                     vkCopyCommandBuffer.begin();
@@ -1226,6 +1212,12 @@ int run_test_with_one_queue(
                                     {
                                         vkQueue.submit(vkShaderCommandBuffer,
                                                        vkImageDispatchFence);
+                                        // synchronize reusing vkDescriptorSet
+                                        // (VUID-vkUpdateDescriptorSets-None-03047)
+                                        // and vkCopyCommandBuffer
+                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
+                                        vkImageDispatchFence->wait();
+                                        vkImageDispatchFence->reset();
                                     }
                                 }
                             }

--- a/test_conformance/vulkan/test_vulkan_interop_image.cpp
+++ b/test_conformance/vulkan/test_vulkan_interop_image.cpp
@@ -283,6 +283,8 @@ int run_test_with_two_queue(
     VulkanCommandPool vkCommandPool(vkDevice);
     VulkanCommandBuffer vkCopyCommandBuffer(vkDevice, vkCommandPool);
     VulkanCommandBuffer vkShaderCommandBuffer(vkDevice, vkCommandPool);
+    std::shared_ptr<VulkanFence> vkImageDispatchFence(
+        new VulkanFence(vkDevice));
     VulkanQueue &vkQueue = vkDevice.getQueue(getVulkanQueueFamily());
 
     VulkanSemaphore vkVk2CLSemaphore(vkDevice, vkExternalSemaphoreHandleType);
@@ -551,6 +553,16 @@ int run_test_with_two_queue(
                                 for (size_t i2DIdx = 0;
                                      i2DIdx < vkImage2DList->size(); i2DIdx++)
                                 {
+                                    if (i2DIdx > 0)
+                                    {
+                                        // synchronize reusing vkDescriptorSet
+                                        // (VUID-vkUpdateDescriptorSets-None-03047)
+                                        // and vkCopyCommandBuffer
+                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
+                                        vkImageDispatchFence->wait();
+                                        vkImageDispatchFence->reset();
+                                    }
+
                                     vkDescriptorSet.update(
                                         1, vkImage2DViewList[i2DIdx]);
                                     vkCopyCommandBuffer.begin();
@@ -584,7 +596,8 @@ int run_test_with_two_queue(
                                     vkShaderCommandBuffer.end();
                                     if (i2DIdx < vkImage2DList->size() - 1)
                                     {
-                                        vkQueue.submit(vkShaderCommandBuffer);
+                                        vkQueue.submit(vkShaderCommandBuffer,
+                                                       vkImageDispatchFence);
                                     }
                                 }
                             }
@@ -893,6 +906,8 @@ int run_test_with_one_queue(
     VulkanCommandPool vkCommandPool(vkDevice);
     VulkanCommandBuffer vkCopyCommandBuffer(vkDevice, vkCommandPool);
     VulkanCommandBuffer vkShaderCommandBuffer(vkDevice, vkCommandPool);
+    std::shared_ptr<VulkanFence> vkImageDispatchFence(
+        new VulkanFence(vkDevice));
     VulkanQueue &vkQueue = vkDevice.getQueue(getVulkanQueueFamily());
 
     VulkanSemaphore vkVk2CLSemaphore(vkDevice, vkExternalSemaphoreHandleType);
@@ -1166,6 +1181,16 @@ int run_test_with_one_queue(
                                 for (size_t i2DIdx = 0;
                                      i2DIdx < vkImage2DList->size(); i2DIdx++)
                                 {
+                                    if (i2DIdx > 0)
+                                    {
+                                        // synchronize reusing vkDescriptorSet
+                                        // (VUID-vkUpdateDescriptorSets-None-03047)
+                                        // and vkCopyCommandBuffer
+                                        // (VUID-vkBeginCommandBuffer-commandBuffer-00049).
+                                        vkImageDispatchFence->wait();
+                                        vkImageDispatchFence->reset();
+                                    }
+
                                     vkDescriptorSet.update(
                                         1, vkImage2DViewList[i2DIdx]);
                                     vkCopyCommandBuffer.begin();
@@ -1199,7 +1224,8 @@ int run_test_with_one_queue(
                                     vkShaderCommandBuffer.end();
                                     if (i2DIdx < vkImage2DList->size() - 1)
                                     {
-                                        vkQueue.submit(vkShaderCommandBuffer);
+                                        vkQueue.submit(vkShaderCommandBuffer,
+                                                       vkImageDispatchFence);
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #2800

Environment: rusticl -> Zink -> Lavapipe (software), Mesa 26.3.0-devel, LLVM 17.0.6, VK_LAYER_KHRONOS_validation 1.4.313, Vulkan instance 1.4.358.

Fixes VUID-vkUpdateDescriptorSets-None-03047 and VUID-vkBeginCommandBuffer-commandBuffer-00049, only visible with options `--useSingleImageKernel --useValidationLayers` together.

`vkDescriptorSet` and `vkCopyCommandBuffer` were reused across the per-image loop in `run_test_with_one_queue` and `run_test_with_two_queue` without waiting for the previous iteration's dispatch to finish. Added a VulkanFence to synchronize reuse.