### PR TITLE
commonfns: fix signed-zero verification

### DIFF
--- a/ci/pocl/golden.json
+++ b/ci/pocl/golden.json
@@ -164,8 +164,23 @@
         "": {
             "clamp": "pass",
             "clamp_scalar_bounds": "pass",
+            "degrees": "fail",
+            "fmax": "pass",
+            "fmaxf": "pass",
+            "fmin": "pass",
+            "fminf": "pass",
+            "max": "pass",
+            "maxf": "pass",
+            "min": "pass",
+            "minf": "pass",
             "mix": "pass",
-            "mixf": "pass"
+            "mixf": "pass",
+            "radians": "fail",
+            "sign": "pass",
+            "smoothstep": "pass",
+            "smoothstepf": "pass",
+            "step": "pass",
+            "stepf": "pass"
         }
     },
     "test_computeinfo": {

--- a/test_conformance/commonfns/test_base.h
+++ b/test_conformance/commonfns/test_base.h
@@ -175,6 +175,17 @@ template <typename T> inline float conv_to_flt(const T &val)
         return (float)val;
 }
 
+// Unlike ordinary equality, distinguish positive and negative zero.
+template <typename Expected, typename Actual>
+inline bool fp_value_equals(const Expected &expected, const Actual &actual)
+{
+    const double expected_value = conv_to_dbl(expected);
+    const double actual_value = conv_to_dbl(actual);
+    if (expected_value != actual_value) return false;
+    return expected_value != 0.0
+        || std::signbit(expected_value) == std::signbit(actual_value);
+}
+
 template <typename T> inline half conv_to_half(const T &val)
 {
     if (std::is_floating_point<T>::value)

--- a/test_conformance/commonfns/test_binary_fn.cpp
+++ b/test_conformance/commonfns/test_binary_fn.cpp
@@ -213,7 +213,7 @@ int max_verify(const T* const x, const T* const y, const T* const out,
             int k = i * vecSize + j;
             int l = (k * vecParam + i * (1 - vecParam));
             T v = (conv_to_dbl(x[k]) < conv_to_dbl(y[l])) ? y[l] : x[k];
-            if (v != out[k])
+            if (!fp_value_equals(v, out[k]))
             {
                 if (std::is_same<T, half>::value)
                     log_error("x[%d]=%g y[%d]=%g out[%d]=%g, expected %g. "
@@ -247,7 +247,7 @@ int min_verify(const T* const x, const T* const y, const T* const out,
             int k = i * vecSize + j;
             int l = (k * vecParam + i * (1 - vecParam));
             T v = (conv_to_dbl(x[k]) > conv_to_dbl(y[l])) ? y[l] : x[k];
-            if (v != out[k])
+            if (!fp_value_equals(v, out[k]))
             {
                 if (std::is_same<T, half>::value)
                     log_error("x[%d]=%g y[%d]=%g out[%d]=%g, expected %g. "

--- a/test_conformance/commonfns/test_clamp.cpp
+++ b/test_conformance/commonfns/test_clamp.cpp
@@ -172,7 +172,7 @@ int verify_clamp(const T *const x, const T *const minval, const T *const maxval,
             t = std::min(std::max(cl_half_to_float(x[i]),
                                   cl_half_to_float(minval[boundIndex])),
                          cl_half_to_float(maxval[boundIndex]));
-            if (t != cl_half_to_float(outptr[i]))
+            if (!fp_value_equals(t, outptr[i]))
             {
                 log_error(
                     "%d) verification error: clamp( %a, %a, %a) = *%a vs. %a\n",
@@ -192,7 +192,7 @@ int verify_clamp(const T *const x, const T *const minval, const T *const maxval,
             const int boundIndex = hasScalarBounds ? i / veclen : i;
             t = std::min(std::max(x[i], minval[boundIndex]),
                          maxval[boundIndex]);
-            if (t != outptr[i])
+            if (!fp_value_equals(t, outptr[i]))
             {
                 log_error(
                     "%d) verification error: clamp( %a, %a, %a) = *%a vs. %a\n",

--- a/test_conformance/commonfns/test_smoothstep.cpp
+++ b/test_conformance/commonfns/test_smoothstep.cpp
@@ -76,6 +76,15 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
             else if (t > 1.0)
                 t = 1.0;
             r = t * t * (3.0 - 2.0 * t);
+            if (r == 0.0 && !fp_value_equals(r, outptr[i]))
+            {
+                log_error(
+                    "%d) verification error: smoothstep(%a, %a, %a) = *%a "
+                    "vs. %a\n",
+                    i, conv_to_flt(edge0[i]), conv_to_flt(edge1[i]),
+                    conv_to_flt(x[i]), r, conv_to_flt(outptr[i]));
+                return -1;
+            }
             delta = (float)fabs(r - conv_to_dbl(outptr[i]));
             if (!std::is_same<T, half>::value)
             {
@@ -84,8 +93,8 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
                     log_error(
                         "%d) verification error: smoothstep(%a, %a, %a) = "
                         "*%a vs. %a\n",
-                        i, conv_to_flt(x[i]), conv_to_flt(edge0[i]),
-                        conv_to_flt(edge1[i]), r, conv_to_flt(outptr[i]));
+                        i, conv_to_flt(edge0[i]), conv_to_flt(edge1[i]),
+                        conv_to_flt(x[i]), r, conv_to_flt(outptr[i]));
                     return -1;
                 }
             }
@@ -108,6 +117,15 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
                 else if (t > 1.0)
                     t = 1.0;
                 r = t * t * (3.0 - 2.0 * t);
+                if (r == 0.0 && !fp_value_equals(r, outptr[vi]))
+                {
+                    log_error("{%d, element %d}) verification error: "
+                              "smoothstep(%a, %a, %a) = *%a vs. %a\n",
+                              ii, j, conv_to_flt(edge0[i]),
+                              conv_to_flt(edge1[i]), conv_to_flt(x[vi]), r,
+                              conv_to_flt(outptr[vi]));
+                    return -1;
+                }
                 delta = (float)fabs(r - conv_to_dbl(outptr[vi]));
 
                 if (!std::is_same<T, half>::value)
@@ -116,9 +134,9 @@ int verify_smoothstep(const T *const edge0, const T *const edge1,
                     {
                         log_error("{%d, element %d}) verification error: "
                                   "smoothstep(%a, %a, %a) = *%a vs. %a\n",
-                                  ii, j, conv_to_flt(x[vi]),
-                                  conv_to_flt(edge0[i]), conv_to_flt(edge1[i]),
-                                  r, conv_to_flt(outptr[vi]));
+                                  ii, j, conv_to_flt(edge0[i]),
+                                  conv_to_flt(edge1[i]), conv_to_flt(x[vi]), r,
+                                  conv_to_flt(outptr[vi]));
                         return -1;
                     }
                 }

--- a/test_conformance/commonfns/test_step.cpp
+++ b/test_conformance/commonfns/test_step.cpp
@@ -55,14 +55,20 @@ int verify_step(const T *const inptrA, const T *const inptrB,
                 const T *const outptr, const int n, const int veclen,
                 const bool vecParam)
 {
-    T r;
+    double r;
 
     if (vecParam)
     {
         for (int i = 0; i < n * veclen; i++)
         {
             r = (conv_to_dbl(inptrB[i]) < conv_to_dbl(inptrA[i])) ? 0.0 : 1.0;
-            if (r != conv_to_dbl(outptr[i])) return -1;
+            if (!fp_value_equals(r, outptr[i]))
+            {
+                log_error("Failure @ %d: step(%a,%a) -> *%a vs %a\n", i,
+                          conv_to_flt(inptrA[i]), conv_to_flt(inptrB[i]), r,
+                          conv_to_flt(outptr[i]));
+                return -1;
+            }
         }
     }
     else
@@ -74,7 +80,7 @@ int verify_step(const T *const inptrA, const T *const inptrB,
             {
                 r = (conv_to_dbl(inptrB[i]) < conv_to_dbl(inptrA[ii])) ? 0.0f
                                                                        : 1.0f;
-                if (r != conv_to_dbl(outptr[i]))
+                if (!fp_value_equals(r, outptr[i]))
                 {
                     if (std::is_same<T, half>::value)
                         log_error(

--- a/test_conformance/commonfns/test_unary_fn.cpp
+++ b/test_conformance/commonfns/test_unary_fn.cpp
@@ -63,8 +63,15 @@ int verify_degrees(const T *const inptr, const T *const outptr, int n)
 
     for (int i = 0; i < n; i++)
     {
-        r = (180.0 / M_PI) * conv_to_dbl(inptr[i]);
+        if (conv_to_dbl(inptr[i]) == 0.0
+            && !fp_value_equals(inptr[i], outptr[i]))
+        {
+            log_error("%d) Error @ %a: expected signed zero, got %a\n", i,
+                      conv_to_flt(inptr[i]), conv_to_flt(outptr[i]));
+            return 1;
+        }
 
+        r = (180.0 / M_PI) * conv_to_dbl(inptr[i]);
         error = UlpFn(outptr[i], r);
 
         if (fabsf(error) > max_error)
@@ -114,8 +121,15 @@ int verify_radians(const T *const inptr, const T *const outptr, int n)
 
     for (int i = 0; i < n; i++)
     {
-        r = (M_PI / 180.0) * conv_to_dbl(inptr[i]);
+        if (conv_to_dbl(inptr[i]) == 0.0
+            && !fp_value_equals(inptr[i], outptr[i]))
+        {
+            log_error("%d) Error @ %a: expected signed zero, got %a\n", i,
+                      conv_to_flt(inptr[i]), conv_to_flt(outptr[i]));
+            return 1;
+        }
 
+        r = (M_PI / 180.0) * conv_to_dbl(inptr[i]);
         error = UlpFn(outptr[i], r);
 
         if (fabsf(error) > max_error)
@@ -162,13 +176,30 @@ int verify_sign(const T *const inptr, const T *const outptr, int n)
     double r = 0;
     for (int i = 0; i < n; i++)
     {
+        // sign preserves the sign of zero.
+        if (conv_to_dbl(inptr[i]) == 0.0)
+        {
+            if (!fp_value_equals(inptr[i], outptr[i]))
+            {
+                log_error("%d) Error: sign(%a) returned %a\n", i,
+                          conv_to_flt(inptr[i]), conv_to_flt(outptr[i]));
+                return -1;
+            }
+            continue;
+        }
+
         if (conv_to_dbl(inptr[i]) > 0.0f)
             r = 1.0;
         else if (conv_to_dbl(inptr[i]) < 0.0f)
             r = -1.0;
-        else
+        else // NaN
             r = 0.0;
-        if (r != conv_to_dbl(outptr[i])) return -1;
+        if (!fp_value_equals(r, outptr[i]))
+        {
+            log_error("%d) Error: sign(%a) returned %a\n", i,
+                      conv_to_flt(inptr[i]), conv_to_flt(outptr[i]));
+            return -1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Positive and negative zero compare equal in C++, which allowed results of 0 with the wrong sign to pass.  Fix with sign-aware comparisons.

Also fix smoothstep diagnostics to report arguments in the official function signature order.

This is preparatory work for improving the test's input ranges.

[run-test: test_commonfns]