### PR TITLE
vectors: skip unsigned types in wimpy vec_align tests

### DIFF
--- a/test_conformance/vectors/test_vec_align.cpp
+++ b/test_conformance/vectors/test_vec_align.cpp
@@ -17,6 +17,7 @@
 
 
 #include "harness/conversions.h"
+#include "harness/parseParameters.h"
 #include "harness/typeWrappers.h"
 #include "harness/testHarness.h"
 #include "harness/ThreadPool.h"
@@ -110,6 +111,14 @@ int test_vec_internal(cl_device_id deviceID, cl_context context,
 
     for (typeIdx = 0; types[typeIdx] != kNumExplicitTypes; ++typeIdx)
     {
+        // Signed and unsigned integer types have the same alignment, so one
+        // type from each pair is sufficient in wimpy mode.
+        if (gWimpyMode
+            && (types[typeIdx] == kUChar || types[typeIdx] == kUShort
+                || types[typeIdx] == kUInt || types[typeIdx] == kULong))
+        {
+            continue;
+        }
 
         // Skip doubles if it is not supported otherwise enable pragma
         if (types[typeIdx] == kDouble)


### PR DESCRIPTION
Unsigned and signed integer types have the same alignment, so only test signed integer types in wimpy mode.  This avoids up to 2180 kernel builds.

[run-test: test_vectors --wimpy]