### PR TITLE
fix test_conversions argument parsing

### DIFF
--- a/test_conformance/conversions/basic_test_conversions.cpp
+++ b/test_conformance/conversions/basic_test_conversions.cpp
@@ -95,7 +95,7 @@ int vectorSizes[] = { 1, 1, 2, 3, 4, 8, 16 };
 int gMinVectorSize = 0;
 int gMaxVectorSize = sizeof(vectorSizes) / sizeof(vectorSizes[0]);
 MTdata gMTdata;
-std::vector<const char *> argList;
+std::vector<const char *> customTestList;
 bool gTestAll = false;
 
 cl_half_rounding_mode DataInitInfo::halfRoundingMode = CL_HALF_RTE;
@@ -223,13 +223,14 @@ cl_int CustomConversionsTest::Run()
     RoundingMode round;
     SaturationMode sat;
 
-    for (int i = 2; i < argList.size(); i++)
+    for (size_t i = 0; i < customTestList.size(); i++)
     {
-        if (conv_test::GetTestCase(argList[i], &outType, &inType, &sat, &round))
+        if (conv_test::GetTestCase(customTestList[i], &outType, &inType, &sat,
+                                   &round))
         {
             vlog_error("\n\t\t**** ERROR:  Unable to parse function name "
                        "%s.  Skipping....  *****\n\n",
-                       argList[i]);
+                       customTestList[i]);
             continue;
         }
 

--- a/test_conformance/conversions/basic_test_conversions.h
+++ b/test_conformance/conversions/basic_test_conversions.h
@@ -95,7 +95,7 @@ extern void *gRef;
 extern void *gAllowZ;
 extern void *gOut[];
 
-extern std::vector<const char *> argList;
+extern std::vector<const char *> customTestList;
 
 extern bool gTestAll;
 

--- a/test_conformance/conversions/test_conversions.cpp
+++ b/test_conformance/conversions/test_conversions.cpp
@@ -91,7 +91,7 @@ size_t gTypeSizes[kTypeCount] = {
 
 REGISTER_TEST(conversions)
 {
-    if (argList.size() > 2)
+    if (!customTestList.empty())
     {
         return MakeAndRunTest<CustomConversionsTest>(device, context, queue,
                                                      num_elements);
@@ -179,6 +179,10 @@ Test names:
           char_sat_rte_float   converts float to char with saturated clipping in round to nearest rounding mode
 )";
 
+    // TODO: This code is currently unreachable, because the test harness lists
+    // the tests it knows about and exits before ParseArgs is called.  Since the
+    // tests to run are specified by the name of a conversion, the conversions
+    // below should be listed instead of the single registered test name.
     if (gListTests)
     {
         for (unsigned dst = 0; dst < kTypeCount; dst++)
@@ -209,8 +213,10 @@ Test names:
         return TEST_PASS;
     }
 
-    argList.push_back(argv[0]);
-    argList.push_back("all");
+    // Arguments that are not handled here are passed to the harness to parse.
+    std::vector<const char *> harnessArgs;
+    harnessArgs.push_back(argv[0]); // always pass the test executable name
+
     for (i = 1; i < argc; i++)
     {
         const char *arg = argv[i];
@@ -290,12 +296,29 @@ Test names:
             }
             else
             {
-                removed_args.push_back(argv[i]);
-                argList.push_back(arg);
+                Type outType, inType;
+                SaturationMode sat;
+                RoundingMode round;
+                if (conv_test::GetTestCase(arg, &outType, &inType, &sat,
+                                           &round))
+                {
+                    // This is not a conversion test name, so let the test
+                    // harness parse it instead.
+                    harnessArgs.push_back(argv[i]);
+                }
+                else
+                {
+                    // This is a conversion test name, so add it to the custom
+                    // test list, and mark it as a removed argument.  It is not
+                    // parsed by the harness.
+                    removed_args.push_back(argv[i]);
+                    customTestList.push_back(arg);
+                }
             }
         }
     }
-    update_argc_argv_from_args_list(argList, argc, argv);
+
+    update_argc_argv_from_args_list(harnessArgs, argc, argv);
 
     vlog("\n");
 


### PR DESCRIPTION
fixes #281 

There's still a LOT of additional improvements that could be made here, but I think this is progress in the right direction and it fixes the specific issues.

I can kick off PoCL testing, but I'm not sure what command lines would be most useful. Right now, we're not able to list tests for this suite, so there's just one entry in the output json for "conversions" no matter how many tests run.

In case it's helpful, here are the cases I tested manually, and the behavior I observed:

| Command | Result |
| --- | --- |
| `test_conversions CL_DEVICE_TYPE_CPU` | Requests CPU device, runs the full suite from test 0 |
| `test_conversions uchar_char CL_DEVICE_TYPE_CPU` | Requests CPU device, runs `convert_uchar( char )`, `PASSED sub-test.` |
| `test_conversions uchar_char ulong_sat_rtp_float CL_DEVICE_TYPE_CPU` | Requests CPU device, runs both conversions, `PASSED 2 of 2 sub-tests.` |
| `test_conversions uchar_char pid0 id0 CL_DEVICE_TYPE_CPU` | Uses platform index 0 and device index 0, runs `convert_uchar( char )`, `PASSED sub-test.` |
| `test_conversions 100 CL_DEVICE_TYPE_CPU` | Requests CPU device, starts at test 100, `100) Testing convert_ucharn( longn )` |
| `test_conversions conversions CL_DEVICE_TYPE_CPU` | Requests CPU device, runs the full suite from test 0, not sure if this is the desired behavior but this is unchanged |
| `test_conversions uchar_chr CL_DEVICE_TYPE_CPU` | `ERROR: The argument 'uchar_chr' did not match any test names.` |
| `test_conversions` | Requests default device, runs the full suite from test 0 |
| `CL_DEVICE_TYPE=cpu test_conversions` | Requests CPU device based on environment variable, runs the full suite from test 0 |
| `test_conversions -[12] id0` | Uses device index 0 and a wimpy reduction factor of 12, runs the full suite from test 0 |
| `test_conversions --list` | Lists `conversions`, unchanged, **this is something we should fix!** |
| `test_conversions -q` | `-q <-- unknown flag: q (0x71)` followed by the usage message, unchanged |

