### PR TITLE
ci: PoCL build changes to pass more tests

### DIFF
--- a/.github/actions/install-pocl-deps/action.yml
+++ b/.github/actions/install-pocl-deps/action.yml
@@ -10,6 +10,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
+        echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-${{ inputs.llvm-version }} main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install -y \
           python3-dev libpython3-dev build-essential ocl-icd-libopencl1 \

--- a/.github/workflows/pocl.yml
+++ b/.github/workflows/pocl.yml
@@ -6,8 +6,8 @@ permissions:
   pull-requests: read
 
 env:
-  LLVM_VERSION: 20
-  TRANSLATOR_BRANCH: llvm_release_200
+  LLVM_VERSION: 22
+  TRANSLATOR_BRANCH: llvm_release_220
   POCL_VERSION: v7.2
   VULKAN_SDK_VERSION: 1.4.309.0
 

--- a/.github/workflows/pocl.yml
+++ b/.github/workflows/pocl.yml
@@ -123,6 +123,7 @@ jobs:
             -DLLVM_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm \
             -DLLVM_SPIRV_LIB=${SPIRV_LLVM_TRANSLATOR_PATH}/lib/libLLVMSPIRVLib.a \
             -DLLVM_SPIRV_INCLUDEDIR=${SPIRV_LLVM_TRANSLATOR_PATH}/include/LLVMSPIRVLib \
+            -DENABLE_CONFORMANCE=ON \
             -DENABLE_ICD=ON
           cmake --build pocl/build
           cmake --install pocl/build


### PR DESCRIPTION
This PR includes several changes that might enable more tests to pass with PoCL:

1. Update to LLVM 22. This didn't have as big of an effect as I thought it might have when I tested locally, but it couldn't hurt. We could also try moving to LLVM 23.
2. Add the `ENABLE_CONFORMANCE` flag according to the [PoCL documentation](https://portablecl.org/docs/html/conformance.html#pocl-conformance). This did seem to have a big effect, but it also has some tradeoffs.  In particular it disables cl_khr_fp16 support, so we should carefully consider whether this is the right tradeoff. If we decide not to do this, I'll just drop the second commit.