### PR TITLE
remove unused kernel helper prototype

### DIFF
--- a/test_common/harness/kernelHelpers.h
+++ b/test_common/harness/kernelHelpers.h
@@ -60,11 +60,6 @@ extern int create_single_kernel_helper_create_program(
     cl_context context, cl_program *outProgram, unsigned int numKernelLines,
     const char **kernelProgram, const char *buildOptions = NULL);
 
-extern int create_single_kernel_helper_create_program_for_device(
-    cl_context context, cl_device_id device, cl_program *outProgram,
-    unsigned int numKernelLines, const char **kernelProgram,
-    const char *buildOptions = NULL);
-
 /* Builds program (outProgram) and creates one kernel */
 int build_program_create_kernel_helper(
     cl_context context, cl_program *outProgram, cl_kernel *outKernel,


### PR DESCRIPTION
The function `create_single_kernel_helper_create_program_for_device` no longer exists, so we should remove the function declaration to reduce confusion.